### PR TITLE
oneDPL samples README/samples.json - Updated DPC++/C++ Compiler labels

### DIFF
--- a/Libraries/oneDPL/gamma-correction/README.md
+++ b/Libraries/oneDPL/gamma-correction/README.md
@@ -5,7 +5,7 @@ Gamma correction is a nonlinear operation used to encode and decode the luminanc
 |---------------------------------|----------------------------------------------------------------------------------|
 | OS                              | Linux* Ubuntu* 18.04, Windows 10                                                 |
 | Hardware                        | Skylake with GEN9 or newer                                                       |
-| Software                        | Intel&reg; oneAPI DPC++ Compiler beta; Intel&reg; oneAPI DPC++ Library (oneDPL)  |
+| Software                        | Intel&reg; oneAPI DPC++/C++ Compiler; Intel&reg; oneAPI DPC++ Library (oneDPL)   |
 | What you will learn             | How to offload the computation to GPU using Intel&reg; oneAPI DPC++ Library      |
 | Time to complete                | At most 5 minutes                                                                |
 

--- a/Libraries/oneDPL/gamma-correction/sample.json
+++ b/Libraries/oneDPL/gamma-correction/sample.json
@@ -1,6 +1,6 @@
 {
   "name": "Gamma Correction",
-  "categories": ["Toolkit/Intel® oneAPI Base Toolkit/oneAPI DPC++ Compiler/oneAPI DPC++ Library/CPU and GPU"],
+  "categories": ["Toolkit/Intel® oneAPI Base Toolkit/Intel® oneAPI DPC++/C++ Compiler /oneAPI DPC++ Library/CPU and GPU"],
   "description": "gamma correction - a nonlinear operation used to encode and decode the luminance of each image pixel.",
   "toolchain": ["dpcpp"],
   "languages": [{"cpp":{}}],

--- a/Libraries/oneDPL/gamma-correction/sample.json
+++ b/Libraries/oneDPL/gamma-correction/sample.json
@@ -1,6 +1,6 @@
 {
   "name": "Gamma Correction",
-  "categories": ["Toolkit/Intel® oneAPI Base Toolkit/Intel® oneAPI DPC++/C++ Compiler /oneAPI DPC++ Library/CPU and GPU"],
+  "categories": ["Toolkit/Intel® oneAPI Base Toolkit/Intel® oneAPI DPC++/C++ Compiler/oneAPI DPC++ Library/CPU and GPU"],
   "description": "gamma correction - a nonlinear operation used to encode and decode the luminance of each image pixel.",
   "toolchain": ["dpcpp"],
   "languages": [{"cpp":{}}],

--- a/Libraries/oneDPL/stable_sort_by_key/README.md
+++ b/Libraries/oneDPL/stable_sort_by_key/README.md
@@ -7,7 +7,7 @@ Stable sort by key is a sorting operation when sorting of 2 sequences (keys and 
 |---------------------------------|----------------------------------------------------------------------------------|
 | OS                              | Linux* Ubuntu* 18.04                                                             |
 | Hardware                        | Skylake with GEN9 or newer                                                       |
-| Software                        | Intel&reg; oneAPI DPC++ Compiler beta; Intel&reg; oneAPI DPC++ Library (oneDPL)  |
+| Software                        | Intel&reg; oneAPI DPC++/C++ Compiler; Intel&reg; oneAPI DPC++ Library (oneDPL)   |
 | What you will learn             | How to use `counting_iterator` and `zip_iterator`                                |
 | Time to complete                | At most 5 minutes                                                                |
 

--- a/Libraries/oneDPL/stable_sort_by_key/sample.json
+++ b/Libraries/oneDPL/stable_sort_by_key/sample.json
@@ -1,6 +1,6 @@
 {
   "name": "Stable sort by key",
-  "categories": ["Toolkit/Intel® oneAPI Base Toolkit/Intel® oneAPI DPC++/C++ Compiler /oneAPI DPC++ Library/CPU and GPU"],
+  "categories": ["Toolkit/Intel® oneAPI Base Toolkit/Intel® oneAPI DPC++/C++ Compiler/oneAPI DPC++ Library/CPU and GPU"],
   "description": "It models stable sort by key: during the sorting of 2 sequences (keys and values) only keys are compared but both keys and values are swapped",
   "toolchain": ["dpcpp"],
   "languages": [{"cpp":{}}],

--- a/Libraries/oneDPL/stable_sort_by_key/sample.json
+++ b/Libraries/oneDPL/stable_sort_by_key/sample.json
@@ -1,6 +1,6 @@
 {
   "name": "Stable sort by key",
-  "categories": ["Toolkit/Intel® oneAPI Base Toolkit/oneAPI DPC++ Compiler/oneAPI DPC++ Library/CPU and GPU"],
+  "categories": ["Toolkit/Intel® oneAPI Base Toolkit/Intel® oneAPI DPC++/C++ Compiler /oneAPI DPC++ Library/CPU and GPU"],
   "description": "It models stable sort by key: during the sorting of 2 sequences (keys and values) only keys are compared but both keys and values are swapped",
   "toolchain": ["dpcpp"],
   "languages": [{"cpp":{}}],


### PR DESCRIPTION
# Description

Updated all references of the DPC++ Compiler to the "Intel® oneAPI DPC++/C++ Compiler" under Libraries/oneDPL
- This change only affects samples' readmes and sample.json

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
Must be tested via the CI pipeline as the only possible breaking changes were to sample.json files

