### PR TITLE
system debug: remove trailing 's' in git command

### DIFF
--- a/Tools/SystemDebug/docs/EFIApplication.rst
+++ b/Tools/SystemDebug/docs/EFIApplication.rst
@@ -89,7 +89,7 @@ build Process
 
 To build the efi applcation, please clone the repository.
 
-``git clone https://github.com/oneapi-src/oneAPI-samples.gits``
+``git clone https://github.com/oneapi-src/oneAPI-samples.git``
 
 Then, cd to the folder `Tools/SystemDebug/`.
 


### PR DESCRIPTION
# Description

Fixes type-o on git command pulling this repo. 

## Type of change


- [x ] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] Command Line
- [ ] oneapi-cli
- [ ] Visual Studio
- [ ] Eclipse IDE
- [ ] VSCode


