### PR TITLE
ApplicationDebugger/array-transform: apply minor style improvements

### DIFF
--- a/Tools/ApplicationDebugger/array-transform/src/array-transform.cpp
+++ b/Tools/ApplicationDebugger/array-transform/src/array-transform.cpp
@@ -47,8 +47,8 @@ int main(int argc, char *argv[]) {
     buffer buffer_out{output, data_range};
 
     q.submit([&](auto &h) {
-      auto in = buffer_in.get_access<access::mode::read>(h);
-      auto out = buffer_out.get_access<access::mode::write>(h);
+      accessor in(buffer_in, h, read_only);
+      accessor out(buffer_out, h, write_only);
 
       // kernel-start
       h.parallel_for(data_range, [=](auto index) {

--- a/Tools/ApplicationDebugger/array-transform/src/array-transform.cpp
+++ b/Tools/ApplicationDebugger/array-transform/src/array-transform.cpp
@@ -20,7 +20,7 @@ using namespace std;
 using namespace sycl;
 
 // A device function, called from inside the kernel.
-static int GetDim(id<1> wi, int dim) {
+static size_t GetDim(id<1> wi, int dim) {
   return wi[dim];
 }
 
@@ -52,7 +52,7 @@ int main(int argc, char *argv[]) {
 
       // kernel-start
       h.parallel_for(data_range, [=](auto index) {
-        int id0 = GetDim(index, 0);
+        size_t id0 = GetDim(index, 0);
         int element = in[index];  // breakpoint-here
         int result = element + 50;
         if (id0 % 2 == 0) {

--- a/Tools/ApplicationDebugger/array-transform/src/array-transform.cpp
+++ b/Tools/ApplicationDebugger/array-transform/src/array-transform.cpp
@@ -51,7 +51,7 @@ int main(int argc, char *argv[]) {
       auto out = buffer_out.get_access<access::mode::write>(h);
 
       // kernel-start
-      h.parallel_for(data_range, [=](id<1> index) {
+      h.parallel_for(data_range, [=](auto index) {
         int id0 = GetDim(index, 0);
         int element = in[index];  // breakpoint-here
         int result = element + 50;


### PR DESCRIPTION
# Description

* Use the `auto` keyword for the `parallel_for` parameter.
* Correct the type of a variable.
* Use the simplified accessor definition.

## Type of change

Minor style improvement.

# How Has This Been Tested?

- [X] Command Line
- [ ] oneapi-cli
- [ ] Visual Studio
- [ ] Eclipse IDE
- [ ] VSCode

