### PR TITLE
Add workaround flag to oneMKL RNG device API samples

### DIFF
--- a/Libraries/oneMKL/black_scholes/GNUmakefile
+++ b/Libraries/oneMKL/black_scholes/GNUmakefile
@@ -14,7 +14,7 @@ mkl_path   := $(MKL)
 acc        := $(strip $(ACC))
 headers    := $(wildcard *.hpp)
 
-cxx_flags  := -O3 -DMKL_ILP64 -I$(MKLROOT)/include
+cxx_flags  := -O3 -DMKL_ILP64 -I$(MKLROOT)/include -fno-sycl-early-optimizations
 ldxx_flags := -mkl -fsycl-device-code-split=per_kernel
 cxx        := dpcpp
 

--- a/Libraries/oneMKL/black_scholes/makefile
+++ b/Libraries/oneMKL/black_scholes/makefile
@@ -15,7 +15,7 @@
 N = 10000000
 ACC = ha
 
-CFLAGS = -I"$(MKLROOT)\include" -Qmkl -EHsc -O2 -fsycl-device-code-split=per_kernel -DACC_$(ACC)
+CFLAGS = -I"$(MKLROOT)\include" -Qmkl -EHsc -O2 -fsycl-device-code-split=per_kernel -DACC_$(ACC) -fno-sycl-early-optimizations
 LIBS = OpenCL.lib
 
 all: black_scholes.run

--- a/Libraries/oneMKL/monte_carlo_pi/GNUmakefile
+++ b/Libraries/oneMKL/monte_carlo_pi/GNUmakefile
@@ -7,7 +7,7 @@ run_all: mc_pi mc_pi_usm mc_pi_device_api
 	./mc_pi_usm
 	./mc_pi_device_api
 
-DPCPP_OPTS = -I${MKLROOT}/include -mkl -DMKL_ILP64 -fsycl-device-code-split=per_kernel
+DPCPP_OPTS = -I${MKLROOT}/include -mkl -DMKL_ILP64 -fsycl-device-code-split=per_kernel -fno-sycl-early-optimizations
 
 mc_pi: mc_pi.cpp
 	dpcpp $< -o $@ $(DPCPP_OPTS)

--- a/Libraries/oneMKL/monte_carlo_pi/makefile
+++ b/Libraries/oneMKL/monte_carlo_pi/makefile
@@ -7,7 +7,7 @@ run_all: mc_pi.exe mc_pi_usm.exe mc_pi_device_api.exe
 	.\mc_pi_usm
 	.\mc_pi_device_api
 
-DPCPP_OPTS=/I"$(MKLROOT)\include" /Qmkl /DMKL_ILP64 /EHsc -fsycl-device-code-split=per_kernel OpenCL.lib
+DPCPP_OPTS=/I"$(MKLROOT)\include" /Qmkl /DMKL_ILP64 /EHsc -fsycl-device-code-split=per_kernel -fno-sycl-early-optimizations OpenCL.lib
 
 mc_pi.exe: mc_pi.cpp
 	dpcpp mc_pi.cpp /Femc_pi.exe $(DPCPP_OPTS)


### PR DESCRIPTION
# Description

This PR adds -fno-sycl-early-optimizations to the command line of oneMKL samples using RNG device APIs to work around a known issue in the beta09 compiler. 

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [X] Command Line