### PR TITLE
system debug: make documentation clearer that X64 option is required

### DIFF
--- a/Tools/SystemDebug/docs/EFIApplication.rst
+++ b/Tools/SystemDebug/docs/EFIApplication.rst
@@ -163,6 +163,12 @@ We do this with:
 
 ``cmake ..``
 
+.. note::
+    On Windows, when using Visual Studio 2017 or older, you will need to specify the architecture.
+    Please use the following cmake command:
+
+    ``cmake .. -AX64``
+
 then - on windows you will see a Visual Studio solution in the ``build``
 directory, uxdbgapp.sln, on POSIX systems you will see a MakeFile in the
 build folder.
@@ -233,30 +239,30 @@ follows:
 ``./make_boot_media.sh uxdbgapp.efi <dev/disk>``
 
 
-NOTE
-----
+.. note::
+    if you have issues with permissions, you might have to make the script
+    executable.
 
-if you have issues with permissions, you might have to make the script
-executable.
+    you can do this by issueing the following command in terminal:
 
-you can do this by issueing the following command in terminal:
-
-``chmod +x make_boot_media.sh``
+    ``chmod +x make_boot_media.sh``
 
 you can find information on the disks by using the following:
 
 mac OS
---------
+^^^^^^^^^^^^^^
+
 
 ``diskutil list``
 
 linux
---------
+^^^^^^^^^^^^^^
+
 
 ``sudo fdisk -l``
 
 Windows
-------------
+^^^^^^^^^^^^^^
 
 Start the powershell script, from a powershell prompt.
 

--- a/Tools/SystemDebug/efi_application/README.md
+++ b/Tools/SystemDebug/efi_application/README.md
@@ -55,6 +55,7 @@ To build the efi application, we use the `cmake` build system to generate the bu
 We do this with:
 
 ```cmake ..```
+> :warning: **If you are using Visual Studio 2017**: You will need to specify architecture. This can be done with `cmake .. -AX64`
 
 then - on windows you will see a Visual Studio solution in the `build` directory, uxdbgapp.sln, on POSIX systems you will see a MakeFile in the build folder.
 
@@ -63,19 +64,17 @@ You can then build this by issuing the following command:
 
 ```cmake --build .```
 
-Or,
-
 on Windows, you can open the visual studio solution, and build the uxdbgapp target.
 
 On POSIX, you can run the makefile with `make -j`.
 
 
-##### windows builders
+#### __windows builders__
 
 On windows, the output will be in the `Debug` folder in the build directory.
 
 
-#### Edk2 basetools
+#### __Edk2 basetools__
 
 On windows, you will either need to build edk2 basetools, or get the prebuilt binaries.
 
@@ -172,7 +171,7 @@ Then, select the .efi file using the file browser.
 
 Next, select the usb device you would like to flash to.
 
-
+> :warning: **If you recieve Execution Errors** You might have to change your powershell execution policy. This can be done with the following comman in powershell: `Set-ExecutionPolicy Unrestricted `
 
 ### Example Steps (Linux)
 
@@ -185,8 +184,7 @@ chmod +x make_boot_media.sh
 ../make_boot_media.sh uxdbgapp.efi /dev/sdb
 ```
 
-##### if you recieve execution errors
-You might have to change your powershell execution policy. This can be done with the following comman in powershell: `Set-ExecutionPolicy Unrestricted `
+
 
 ## Disclaimer
 IMPORTANT NOTICE: This software is sample software. It is not designed or intended for use in any medical, life-saving or life-sustaining systems, transportation systems, nuclear systems, or for any other mission-critical application in which the failure of the system could lead to critical injury or death. The software may not be fully tested and may contain bugs or errors; it may not be intended or suitable for commercial release. No regulatory approvals for the software have been obtained, and therefore software may not be certified for use in certain countries or environments.


### PR DESCRIPTION

# Description

Clarifies need for 64 bit builds on windows builders. 
Fixes # (issue) 

## Type of change

Please delete options that are not relevant. Add a 'X' to the one that is applicable. 

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Sample Migration (Moving sample from old repository after completing checklist established)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [X] Command Line
- [ ] oneapi-cli
- [ ] Visual Studio
- [ ] Eclipse IDE
- [ ] VSCode

