### PR TITLE
Add W/A to README of histogram sample to avoid some issues on GPU

### DIFF
--- a/DirectProgramming/DPC++/ParallelPatterns/histogram/README.md
+++ b/DirectProgramming/DPC++/ParallelPatterns/histogram/README.md
@@ -57,6 +57,15 @@ Error 'dpc_common.hpp' file not found
 ```
 You need to add the following directory to the list of include folders, that are required by your project, in your project's Visual Studio project property panel. The missing include folder is located at `%ONEAPI_ROOT%\dev-utilities\latest\include` on your development system.
 
+## Known issues
+
+The sample is prone to ``Floating point exception`` and `CL_INVALID_WORK_GROUP_SIZE` errors on GPU with DPC++ L0 backend, which can be avoided
+by setting `_PSTL_COMPILE_KERNEL` macro to `0`. You can do it using the following command before running `cmake`:
+
+```
+export CXXFLAGS=-D_PSTL_COMPILE_KERNEL=0
+```
+
 ## Running the Sample
 
 Application Parameters


### PR DESCRIPTION
Add W/A to README of histogram sample to avoid some issues on GPU

Signed-off-by: Sobolev, Dmitriy <dmitriy.sobolev@intel.com>

# Description

The W/A has been added to be able to run the sample on GPU with L0 using oneAPI beta09.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Must be tested via the CI pipeline as the only possible breaking changes were to README.md file
