### PR TITLE
sparse_conjugate_gradient: fix Windows path separator

### DIFF
--- a/Libraries/oneMKL/sparse_conjugate_gradient/makefile
+++ b/Libraries/oneMKL/sparse_conjugate_gradient/makefile
@@ -3,7 +3,7 @@
 default: run
 
 run: sparse_cg.exe
-	./sparse_cg.exe
+	.\sparse_cg
 
 DPCPP_OPTS=/I"$(MKLROOT)\include" /Qmkl /EHsc -fsycl-device-code-split=per_kernel OpenCL.lib
 


### PR DESCRIPTION
# Description

There was a missed Linux-style path separator in the Windows makefile for sparse_conjugate_gradient.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)


