### PR TITLE
black_scholes: omit RNG device APIs on Windows

### DIFF
--- a/Libraries/oneMKL/black_scholes/black_scholes.cpp
+++ b/Libraries/oneMKL/black_scholes/black_scholes.cpp
@@ -148,6 +148,10 @@ void run(int64_t nopt, sycl::device & dev) {
 
     for (int var = 0; var < 4; ++var) {
 
+#ifdef _WIN32
+        if (var & 1) continue; // Skip RNG device APIs on Windows for now.
+#endif
+
         std::fill(s0.begin(), s0.end(), static_cast<T>(0.0));
         std::fill(x.begin(), x.end(), static_cast<T>(0.0));
         std::fill(t.begin(), t.end(), static_cast<T>(0.0));


### PR DESCRIPTION
# Description

Removes device API tests from black_scholes on Windows, where it is hanging with beta09 RC2 (root cause TBD).

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
