### PR TITLE
[oneMKL][RNG] Samples clean up for RNG, add new sample.

### DIFF
--- a/Libraries/oneMKL/monte_carlo_european_opt/README.md
+++ b/Libraries/oneMKL/monte_carlo_european_opt/README.md
@@ -52,12 +52,20 @@ If everything is working correctly, both buffer and USM versions of the program 
 
 ```
 ./mc_european
+
+Monte Carlo European Option Pricing Simulation
+Buffer Api
+----------------------------------------------
 Number of options = 2048
 Number of samples = 262144
 put_abs_err  = 0.0372205
 call_abs_err = 0.0665814
 
 ./mc_european_usm
+
+Monte Carlo European Option Pricing Simulation
+Unified Shared Memory Api
+----------------------------------------------
 Number of options = 2048
 Number of samples = 262144
 put_abs_err  = 0.0372205

--- a/Libraries/oneMKL/monte_carlo_european_opt/mc_european.cpp
+++ b/Libraries/oneMKL/monte_carlo_european_opt/mc_european.cpp
@@ -33,49 +33,52 @@ using sycl::ONEAPI::reduce;
 #endif
 
 // Default number of options
-static const auto n_opt_default = 2048;
+static const auto num_options_default = 2048;
 // Default number of independent samples
-static const auto n_samples_default = 262144;
+static const auto num_samples_default = 262144;
 
 // Initialization value for random number generator
 static const auto seed = 7777;
 
 // European options pricing parameters
-static const auto s0_l = 10.0;
-static const auto s0_h = 50.0;
-static const auto x_l = 10.0;
-static const auto x_h = 50.0;
+static const auto initial_stock_price_l = 10.0;
+static const auto initial_stock_price_h = 50.0;
+static const auto strike_price_l = 10.0;
+static const auto strike_price_h = 50.0;
 static const auto t_l = 0.2;
 static const auto t_h = 2.0;
-static const auto risk_free = 0.05;
-static const auto volatility = 0.2;
+static const auto default_risk_neutral_rate = 0.05;
+static const auto default_volatility = 0.2;
 
-void init_data(std::vector<double>& s0, std::vector<double>& x, std::vector<double>& t,
-                std::vector<double>& vcall, std::vector<double>& vput);
+void init_data(std::vector<double>& initial_stock_price, std::vector<double>& strike_price,
+               std::vector<double>& t, std::vector<double>& vcall, std::vector<double>& vput);
 
 // Black-Scholes formula to verify Monte Carlo computation
-void bs_ref(double r, double sig, std::vector<double>& s0, std::vector<double>& x, std::vector<double>& t,
-            std::vector<double>& vcall, std::vector<double>& vput);
+void bs_ref(double risk_neutral_rate, double volatility, std::vector<double>& initial_stock_price,
+            std::vector<double>& strike_price, std::vector<double>& t, std::vector<double>& vcall,
+            std::vector<double>& vput);
 
 double estimate_error(std::vector<double>& v_put_ref, std::vector<double>& v_put);
 
-template<typename EngineType>
-static void mc_kernel(sycl::queue& q, EngineType& engine, size_t n_samples,
-                        double r, double sig, double s0, double x, double t, double& vcall, double& vput,
-                        sycl::buffer<double>& rng_buf ) {
+template <typename EngineType>
+static void mc_kernel(sycl::queue& q, EngineType& engine, size_t num_samples,
+                      double risk_neutral_rate, double volatility, double initial_stock_price,
+                      double strike_price, double t, double& vcall, double& vput,
+                      sycl::buffer<double>& rng_buf) {
     double a, nu;
     double sc_dp, sp_dp;
     double st;
 
-    a  = (r - sig * sig * 0.5) * t;
-    nu = sig * sqrt(t);
+    a = (risk_neutral_rate - volatility * volatility * 0.5) * t;
+    nu = volatility * sqrt(t);
 
     mkl::rng::lognormal<double, mkl::rng::lognormal_method::box_muller2> distr(a, nu);
 
-    mkl::rng::generate(distr, engine, n_samples, rng_buf);
+    mkl::rng::generate(distr, engine, num_samples, rng_buf);
 
-    size_t wg_size = std::min(q.get_device().get_info<sycl::info::device::max_work_group_size>(), n_samples);
-    size_t wg_num = n_samples / wg_size;
+    size_t wg_size =
+        std::min(q.get_device().get_info<sycl::info::device::max_work_group_size>(), num_samples);
+    size_t wg_num = num_samples / wg_size;
 
     std::vector<double> count_sc(wg_num);
     std::vector<double> count_sp(wg_num);
@@ -84,96 +87,99 @@ static void mc_kernel(sycl::queue& q, EngineType& engine, size_t n_samples,
         sycl::buffer<double, 1> count_sc_buf(count_sc.data(), count_sc.size());
         sycl::buffer<double, 1> count_sp_buf(count_sp.data(), count_sp.size());
 
-        q.submit([&](sycl::handler &h) {
-
+        q.submit([&](sycl::handler& h) {
             auto rng_acc = rng_buf.get_access<sycl::access::mode::read>(h);
             auto count_sc_acc = count_sc_buf.get_access<sycl::access::mode::write>(h);
 
             h.parallel_for(sycl::nd_range<1>(wg_size * wg_num, wg_size),
-                [=](sycl::nd_item<1> item) {
-                double rng;
-                double sc;
+                           [=](sycl::nd_item<1> item) {
+                               double rng;
+                               double sc;
 
-                rng = rng_acc[item.get_global_linear_id()] * s0;
-                sc = sycl::max(rng - x, 0.0);
+                               rng = rng_acc[item.get_global_linear_id()] * initial_stock_price;
+                               sc = sycl::max(rng - strike_price, 0.0);
 
-                count_sc_acc[item.get_group_linear_id()] = reduce(item.get_group(), sc, std::plus<double>());
-            });
+                               count_sc_acc[item.get_group_linear_id()] =
+                                   reduce(item.get_group(), sc, std::plus<double>());
+                           });
         });
 
-        q.submit([&](sycl::handler &h) {
-
+        q.submit([&](sycl::handler& h) {
             auto rng_acc = rng_buf.get_access<sycl::access::mode::read>(h);
             auto count_sp_acc = count_sp_buf.get_access<sycl::access::mode::write>(h);
 
             h.parallel_for(sycl::nd_range<1>(wg_size * wg_num, wg_size),
-                [=](sycl::nd_item<1> item) {
-                double rng;
-                double sp;
+                           [=](sycl::nd_item<1> item) {
+                               double rng;
+                               double sp;
 
-                rng = rng_acc[item.get_global_linear_id()] * s0;
-                sp = sycl::max(x - rng, 0.0);
+                               rng = rng_acc[item.get_global_linear_id()] * initial_stock_price;
+                               sp = sycl::max(strike_price - rng, 0.0);
 
-                count_sp_acc[item.get_group_linear_id()] = reduce(item.get_group(), sp, std::plus<double>());
-            });
+                               count_sp_acc[item.get_group_linear_id()] =
+                                   reduce(item.get_group(), sp, std::plus<double>());
+                           });
         });
     }
 
     sc_dp = std::accumulate(count_sc.begin(), count_sc.end(), 0);
     sp_dp = std::accumulate(count_sp.begin(), count_sp.end(), 0);
 
-    vcall = sc_dp / n_samples * exp(-r * t);
-    vput  = sp_dp / n_samples * exp(-r * t);
+    vcall = sc_dp / num_samples * exp(-risk_neutral_rate * t);
+    vput = sp_dp / num_samples * exp(-risk_neutral_rate * t);
 }
 
-void mc_calculate(sycl::queue& q, size_t n_opt, size_t n_samples, double r, double sig,
-    std::vector<double>& s0, std::vector<double>& x, std::vector<double>& t,
-    std::vector<double>& vcall, std::vector<double>& vput) {
+void mc_calculate(sycl::queue& q, size_t num_options, size_t num_samples, double risk_neutral_rate,
+                  double volatility, std::vector<double>& initial_stock_price,
+                  std::vector<double>& strike_price, std::vector<double>& t,
+                  std::vector<double>& vcall, std::vector<double>& vput) {
     // Creating random number engine
     mkl::rng::philox4x32x10 engine(q, seed);
     // Create buffer for random numbers
-    sycl::buffer<double> rng_buf(n_samples);
+    sycl::buffer<double> rng_buf(num_samples);
     // Price options
-    for (size_t j = 0; j < n_opt; j++) {
-        mc_kernel(q, engine, n_samples, r, sig, s0[j], x[j], t[j], vcall[j], vput[j], rng_buf);
+    for (size_t j = 0; j < num_options; j++) {
+        mc_kernel(q, engine, num_samples, risk_neutral_rate, volatility, initial_stock_price[j],
+                  strike_price[j], t[j], vcall[j], vput[j], rng_buf);
     }
 }
 
-int main(int argc, char ** argv) {
-
+int main(int argc, char** argv) {
     std::cout << std::endl;
     std::cout << "Monte Carlo European Option Pricing Simulation" << std::endl;
     std::cout << "Buffer Api" << std::endl;
     std::cout << "----------------------------------------------" << std::endl;
 
-    size_t n_opt = n_opt_default;
-    size_t n_samples = n_samples_default;
-    if(argc >= 2) {
-        n_opt = atol(argv[1]);
-        if(n_opt == 0) {
-            n_opt = n_opt_default;
+    size_t num_options = num_options_default;
+    size_t num_samples = num_samples_default;
+    if (argc >= 2) {
+        num_options = atol(argv[1]);
+        if (num_options == 0) {
+            num_options = num_options_default;
         }
-        if(argc >= 3) {
-            n_samples = atol(argv[2]);
-            if(n_samples == 0) {
-                n_samples = n_samples_default;
+        if (argc >= 3) {
+            num_samples = atol(argv[2]);
+            if (num_samples == 0) {
+                num_samples = num_samples_default;
             }
         }
     }
-    std::cout << "Number of options = " << n_opt << std::endl;
-    std::cout << "Number of samples = " << n_samples << std::endl;
+    std::cout << "Number of options = " << num_options << std::endl;
+    std::cout << "Number of samples = " << num_samples << std::endl;
 
-    std::vector<double> s0(n_opt), x(n_opt), t(n_opt), vcall(n_opt), vput(n_opt);
-    std::vector<double> vcall_ref(n_opt), vput_ref(n_opt);
+    std::vector<double> initial_stock_price(num_options), strike_price(num_options), t(num_options),
+        vcall(num_options), vput(num_options);
+    std::vector<double> vcall_ref(num_options), vput_ref(num_options);
 
-    init_data(s0, x, t, vcall, vput);
+    init_data(initial_stock_price, strike_price, t, vcall, vput);
 
     // This exception handler with catch async exceptions
     auto exception_handler = [&](sycl::exception_list exceptions) {
-        for(std::exception_ptr const& e : exceptions) {
+        for (std::exception_ptr const& e : exceptions) {
             try {
                 std::rethrow_exception(e);
-            } catch (sycl::exception const& e) {
+            }
+            catch (sycl::exception const& e) {
                 std::cout << "Caught asynchronous SYCL exception:\n" << e.what() << std::endl;
                 std::terminate();
             }
@@ -191,17 +197,20 @@ int main(int argc, char ** argv) {
             std::cerr << "by the selected device. Quitting." << std::endl;
             return 0;
         }
-        
+
         // Launch Monte Carlo calculation
-        mc_calculate(q, n_opt, n_samples, risk_free, volatility, s0, x, t, vcall, vput);
-    } catch (...) {
+        mc_calculate(q, num_options, num_samples, default_risk_neutral_rate, default_volatility,
+                     initial_stock_price, strike_price, t, vcall, vput);
+    }
+    catch (...) {
         // Some other exception detected
         std::cout << "Failure" << std::endl;
         std::terminate();
     }
 
     // Validate results
-    bs_ref(risk_free, volatility, s0, x, t, vcall_ref, vput_ref);
+    bs_ref(default_risk_neutral_rate, default_volatility, initial_stock_price, strike_price, t,
+           vcall_ref, vput_ref);
 
     std::cout << "put_abs_err  = " << estimate_error(vput_ref, vput) << std::endl;
     std::cout << "call_abs_err = " << estimate_error(vcall_ref, vcall) << std::endl;
@@ -210,19 +219,18 @@ int main(int argc, char ** argv) {
 }
 
 static double RandDouble(double a, double b) {
-    return rand()/(double)RAND_MAX*(b-a) + a;
+    return rand() / (double)RAND_MAX * (b - a) + a;
 }
 
-void init_data(std::vector<double>& s0, std::vector<double>& x, std::vector<double>& t,
-    std::vector<double>& vcall, std::vector<double>& vput) {
-
+void init_data(std::vector<double>& initial_stock_price, std::vector<double>& strike_price,
+               std::vector<double>& t, std::vector<double>& vcall, std::vector<double>& vput) {
     srand(seed);
 
     // Initialize data
-    for(size_t i = 0; i < s0.size(); i++) {
-        s0[i] = RandDouble(s0_l, s0_h);
-        x[i]  = RandDouble(x_l, x_h);
-        t[i]  = RandDouble(t_l, t_h);
+    for (size_t i = 0; i < initial_stock_price.size(); i++) {
+        initial_stock_price[i] = RandDouble(initial_stock_price_l, initial_stock_price_h);
+        strike_price[i] = RandDouble(strike_price_l, strike_price_h);
+        t[i] = RandDouble(t_l, t_h);
 
         vcall[i] = 0.0;
         vput[i] = 0.0;
@@ -230,46 +238,44 @@ void init_data(std::vector<double>& s0, std::vector<double>& x, std::vector<doub
 }
 
 static double CNDF(double x) {
-    const double b1 =  0.319381530;
+    const double b1 = 0.319381530;
     const double b2 = -0.356563782;
-    const double b3 =  1.781477937;
+    const double b3 = 1.781477937;
     const double b4 = -1.821255978;
-    const double b5 =  1.330274429;
-    const double p  =  0.2316419;
-    const double c  =  0.39894228;
+    const double b5 = 1.330274429;
+    const double p = 0.2316419;
+    const double c = 0.39894228;
 
-    if(x >= 0.0) {
-        double t = 1.0 / ( 1.0 + p * x );
-        return (1.0 - c * exp( -x * x / 2.0 ) * t *
-        (t *(t * (t * (t * b5 + b4 ) + b3 ) + b2 ) + b1 ));
+    if (x >= 0.0) {
+        double t = 1.0 / (1.0 + p * x);
+        return (1.0 - c * exp(-x * x / 2.0) * t * (t * (t * (t * (t * b5 + b4) + b3) + b2) + b1));
     }
     else {
-        double t = 1.0 / ( 1.0 - p * x );
-        return (c * exp( -x * x / 2.0 ) * t *
-        (t *(t * (t * (t * b5 + b4 ) + b3 ) + b2 ) + b1 ));
+        double t = 1.0 / (1.0 - p * x);
+        return (c * exp(-x * x / 2.0) * t * (t * (t * (t * (t * b5 + b4) + b3) + b2) + b1));
     }
 }
 
 static double erf_ref(double x) {
-    return 2.0 * CNDF(1.4142135623730950488016887242097*x) - 1.0;
+    return 2.0 * CNDF(1.4142135623730950488016887242097 * x) - 1.0;
 }
 
 static const auto inv_sqrt2 = 0.7071067811865475727373109293694142252207;
 
-void bs_ref(double r, double sig, std::vector<double>& s0, std::vector<double>& x, std::vector<double>& t,
-            std::vector<double>& vcall, std::vector<double>& vput) {
-
+void bs_ref(double risk_neutral_rate, double volatility, std::vector<double>& initial_stock_price,
+            std::vector<double>& strike_price, std::vector<double>& t, std::vector<double>& vcall,
+            std::vector<double>& vput) {
     double a, b, c, y, z, e, d1, d2, w1, w2;
 
-    for(size_t i = 0; i < s0.size(); i++) {
-        a = log(s0[i] / x[i]);
-        b = t[i] * r;
-        z = t[i]*sig*sig;
-    
+    for (size_t i = 0; i < initial_stock_price.size(); i++) {
+        a = log(initial_stock_price[i] / strike_price[i]);
+        b = t[i] * risk_neutral_rate;
+        z = t[i] * volatility * volatility;
+
         c = 0.5 * z;
         e = exp(-b);
         y = 1.0 / sqrt(z);
-                         
+
         w1 = (a + b + c) * y;
         w2 = (a + b - c) * y;
         d1 = erf_ref(inv_sqrt2 * w1);
@@ -277,8 +283,8 @@ void bs_ref(double r, double sig, std::vector<double>& s0, std::vector<double>& 
         d1 = 0.5 + 0.5 * d1;
         d2 = 0.5 + 0.5 * d2;
 
-        vcall[i] = s0[i] * d1 - x[i] * e * d2;
-        vput[i]  = vcall[i] - s0[i] + x[i] * e;
+        vcall[i] = initial_stock_price[i] * d1 - strike_price[i] * e * d2;
+        vput[i] = vcall[i] - initial_stock_price[i] + strike_price[i] * e;
     }
 }
 
@@ -286,12 +292,12 @@ double estimate_error(std::vector<double>& v_put_ref, std::vector<double>& v_put
     double abs_err = 0.0;
     double abs_err_res = 0.0;
 
-    for(size_t i = 0; i < v_put_ref.size(); ++i) {
+    for (size_t i = 0; i < v_put_ref.size(); ++i) {
         abs_err = (v_put_ref[i] - v_put[i]);
-        if(abs_err < 0) {
+        if (abs_err < 0) {
             abs_err = -abs_err;
         }
-        if(abs_err_res < abs_err) {
+        if (abs_err_res < abs_err) {
             abs_err_res = abs_err;
         }
     }

--- a/Libraries/oneMKL/monte_carlo_european_opt/mc_european.cpp
+++ b/Libraries/oneMKL/monte_carlo_european_opt/mc_european.cpp
@@ -24,22 +24,31 @@
 namespace oneapi {}
 using namespace oneapi;
 
+// Temporary code for beta08 compatibility. Reduce routine is moved from intel::
+// to ONEAPI:: namespace
+#if __SYCL_COMPILER_VERSION < 20200902L
+using sycl::intel::reduce;
+#else
+using sycl::ONEAPI::reduce;
+#endif
+
 // Default number of options
-#define N_OPT  2048
+static const auto n_opt_default = 2048;
 // Default number of independent samples
-#define N_SAMPLES 262144
+static const auto n_samples_default = 262144;
 
 // Initialization value for random number generator
-#define SEED        7777
+static const auto seed = 7777;
 
-#define S0L     10.0
-#define S0H     50.0
-#define XL      10.0
-#define XH      50.0
-#define TLL      0.2
-#define TH       2.0
-#define RISK_FREE  0.05
-#define VOLATILITY  0.2
+// European options pricing parameters
+static const auto s0_l = 10.0;
+static const auto s0_h = 50.0;
+static const auto x_l = 10.0;
+static const auto x_h = 50.0;
+static const auto t_l = 0.2;
+static const auto t_h = 2.0;
+static const auto risk_free = 0.05;
+static const auto volatility = 0.2;
 
 void init_data(std::vector<double>& s0, std::vector<double>& x, std::vector<double>& t,
                 std::vector<double>& vcall, std::vector<double>& vput);
@@ -88,7 +97,7 @@ static void mc_kernel(sycl::queue& q, EngineType& engine, size_t n_samples,
                 rng = rng_acc[item.get_global_linear_id()] * s0;
                 sc = sycl::max(rng - x, 0.0);
 
-                count_sc_acc[item.get_group_linear_id()] = sycl::intel::reduce(item.get_group(), sc, std::plus<double>());
+                count_sc_acc[item.get_group_linear_id()] = reduce(item.get_group(), sc, std::plus<double>());
             });
         });
 
@@ -105,7 +114,7 @@ static void mc_kernel(sycl::queue& q, EngineType& engine, size_t n_samples,
                 rng = rng_acc[item.get_global_linear_id()] * s0;
                 sp = sycl::max(x - rng, 0.0);
 
-                count_sp_acc[item.get_group_linear_id()] = sycl::intel::reduce(item.get_group(), sp, std::plus<double>());
+                count_sp_acc[item.get_group_linear_id()] = reduce(item.get_group(), sp, std::plus<double>());
             });
         });
     }
@@ -121,7 +130,7 @@ void mc_calculate(sycl::queue& q, size_t n_opt, size_t n_samples, double r, doub
     std::vector<double>& s0, std::vector<double>& x, std::vector<double>& t,
     std::vector<double>& vcall, std::vector<double>& vput) {
     // Creating random number engine
-    mkl::rng::philox4x32x10 engine(q, SEED);
+    mkl::rng::philox4x32x10 engine(q, seed);
     // Create buffer for random numbers
     sycl::buffer<double> rng_buf(n_samples);
     // Price options
@@ -132,17 +141,22 @@ void mc_calculate(sycl::queue& q, size_t n_opt, size_t n_samples, double r, doub
 
 int main(int argc, char ** argv) {
 
-    size_t n_opt = N_OPT;
-    size_t n_samples = N_SAMPLES;
+    std::cout << std::endl;
+    std::cout << "Monte Carlo European Option Pricing Simulation" << std::endl;
+    std::cout << "Buffer Api" << std::endl;
+    std::cout << "----------------------------------------------" << std::endl;
+
+    size_t n_opt = n_opt_default;
+    size_t n_samples = n_samples_default;
     if(argc >= 2) {
         n_opt = atol(argv[1]);
         if(n_opt == 0) {
-            n_opt = N_OPT;
+            n_opt = n_opt_default;
         }
         if(argc >= 3) {
             n_samples = atol(argv[2]);
             if(n_samples == 0) {
-                n_samples = N_SAMPLES;
+                n_samples = n_samples_default;
             }
         }
     }
@@ -179,7 +193,7 @@ int main(int argc, char ** argv) {
         }
         
         // Launch Monte Carlo calculation
-        mc_calculate(q, n_opt, n_samples, RISK_FREE, VOLATILITY, s0, x, t, vcall, vput);
+        mc_calculate(q, n_opt, n_samples, risk_free, volatility, s0, x, t, vcall, vput);
     } catch (...) {
         // Some other exception detected
         std::cout << "Failure" << std::endl;
@@ -187,7 +201,7 @@ int main(int argc, char ** argv) {
     }
 
     // Validate results
-    bs_ref(RISK_FREE, VOLATILITY, s0, x, t, vcall_ref, vput_ref);
+    bs_ref(risk_free, volatility, s0, x, t, vcall_ref, vput_ref);
 
     std::cout << "put_abs_err  = " << estimate_error(vput_ref, vput) << std::endl;
     std::cout << "call_abs_err = " << estimate_error(vcall_ref, vcall) << std::endl;
@@ -202,13 +216,13 @@ static double RandDouble(double a, double b) {
 void init_data(std::vector<double>& s0, std::vector<double>& x, std::vector<double>& t,
     std::vector<double>& vcall, std::vector<double>& vput) {
 
-    srand(SEED);
+    srand(seed);
 
     // Initialize data
     for(size_t i = 0; i < s0.size(); i++) {
-        s0[i] = RandDouble(S0L, S0H);
-        x[i]  = RandDouble(XL, XH);
-        t[i]  = RandDouble(TLL, TH);
+        s0[i] = RandDouble(s0_l, s0_h);
+        x[i]  = RandDouble(x_l, x_h);
+        t[i]  = RandDouble(t_l, t_h);
 
         vcall[i] = 0.0;
         vput[i] = 0.0;
@@ -240,7 +254,7 @@ static double erf_ref(double x) {
     return 2.0 * CNDF(1.4142135623730950488016887242097*x) - 1.0;
 }
 
-#define INV_SQRT2 0.7071067811865475727373109293694142252207
+static const auto inv_sqrt2 = 0.7071067811865475727373109293694142252207;
 
 void bs_ref(double r, double sig, std::vector<double>& s0, std::vector<double>& x, std::vector<double>& t,
             std::vector<double>& vcall, std::vector<double>& vput) {
@@ -258,8 +272,8 @@ void bs_ref(double r, double sig, std::vector<double>& s0, std::vector<double>& 
                          
         w1 = (a + b + c) * y;
         w2 = (a + b - c) * y;
-        d1 = erf_ref(INV_SQRT2 * w1);
-        d2 = erf_ref(INV_SQRT2 * w2);
+        d1 = erf_ref(inv_sqrt2 * w1);
+        d2 = erf_ref(inv_sqrt2 * w2);
         d1 = 0.5 + 0.5 * d1;
         d2 = 0.5 + 0.5 * d2;
 

--- a/Libraries/oneMKL/monte_carlo_european_opt/mc_european_usm.cpp
+++ b/Libraries/oneMKL/monte_carlo_european_opt/mc_european_usm.cpp
@@ -33,80 +33,82 @@ using sycl::ONEAPI::reduce;
 #endif
 
 // Default number of options
-static const auto n_opt_default = 2048;
+static const auto num_options_default = 2048;
 // Default number of independent samples
-static const auto n_samples_default = 262144;
+static const auto num_samples_default = 262144;
 
 // Initialization value for random number generator
 static const auto seed = 7777;
 
 // European options pricing parameters
-static const auto s0_l = 10.0;
-static const auto s0_h = 50.0;
-static const auto x_l = 10.0;
-static const auto x_h = 50.0;
+static const auto initial_stock_price_l = 10.0;
+static const auto initial_stock_price_h = 50.0;
+static const auto strike_price_l = 10.0;
+static const auto strike_price_h = 50.0;
 static const auto t_l = 0.2;
 static const auto t_h = 2.0;
-static const auto risk_free = 0.05;
-static const auto volatility = 0.2;
+static const auto default_risk_neutral_rate = 0.05;
+static const auto default_volatility = 0.2;
 
-void init_data(std::vector<double>& s0, std::vector<double>& x, std::vector<double>& t,
-                std::vector<double>& vcall, std::vector<double>& vput);
+void init_data(std::vector<double>& initial_stock_price, std::vector<double>& strike_price,
+               std::vector<double>& t, std::vector<double>& vcall, std::vector<double>& vput);
 
 // Black-Scholes formula to verify Monte Carlo computation
-void bs_ref(double r, double sig, std::vector<double>& s0, std::vector<double>& x, std::vector<double>& t,
-            std::vector<double>& vcall, std::vector<double>& vput);
+void bs_ref(double risk_neutral_rate, double volatility, std::vector<double>& initial_stock_price,
+            std::vector<double>& strike_price, std::vector<double>& t, std::vector<double>& vcall,
+            std::vector<double>& vput);
 
 double estimate_error(std::vector<double>& v_put_ref, std::vector<double>& v_put);
 
-template<typename EngineType>
-static void mc_kernel(sycl::queue& q, EngineType& engine, size_t n_samples,
-                        double r, double sig, double s0, double x, double t, double& vcall, double& vput,
-                        double* rng_ptr) {
+template <typename EngineType>
+static void mc_kernel(sycl::queue& q, EngineType& engine, size_t num_samples,
+                      double risk_neutral_rate, double volatility, double initial_stock_price,
+                      double strike_price, double t, double& vcall, double& vput, double* rng_ptr) {
     double a, nu;
     double sc_dp, sp_dp;
     double st;
 
-    a  = (r - sig * sig * 0.5) * t;
-    nu = sig * sqrt(t);
+    a = (risk_neutral_rate - volatility * volatility * 0.5) * t;
+    nu = volatility * sqrt(t);
 
     mkl::rng::lognormal<double, mkl::rng::lognormal_method::box_muller2> distr(a, nu);
 
-    auto event = mkl::rng::generate(distr, engine, n_samples, rng_ptr);
+    auto event = mkl::rng::generate(distr, engine, num_samples, rng_ptr);
 
-    size_t wg_size = std::min(q.get_device().get_info<sycl::info::device::max_work_group_size>(), n_samples);
-    size_t wg_num = n_samples / wg_size;
+    size_t wg_size =
+        std::min(q.get_device().get_info<sycl::info::device::max_work_group_size>(), num_samples);
+    size_t wg_num = num_samples / wg_size;
 
-    double* count_sc  = sycl::malloc_shared<double>(wg_num, q);
-    double* count_sp  = sycl::malloc_shared<double>(wg_num, q);
+    double* count_sc = sycl::malloc_shared<double>(wg_num, q);
+    double* count_sp = sycl::malloc_shared<double>(wg_num, q);
 
     event.wait_and_throw();
 
-    q.submit([&](sycl::handler &h) {
-        h.parallel_for(sycl::nd_range<1>(wg_size * wg_num, wg_size),
-            [=](sycl::nd_item<1> item) {
+    q.submit([&](sycl::handler& h) {
+        h.parallel_for(sycl::nd_range<1>(wg_size * wg_num, wg_size), [=](sycl::nd_item<1> item) {
             double rng;
             double sc;
 
             rng = rng_ptr[item.get_global_linear_id()];
-            rng *= s0;
-            sc = sycl::max(rng - x, 0.0);
+            rng *= initial_stock_price;
+            sc = sycl::max(rng - strike_price, 0.0);
 
-            count_sc[item.get_group_linear_id()] = reduce(item.get_group(), sc, std::plus<double>());
+            count_sc[item.get_group_linear_id()] =
+                reduce(item.get_group(), sc, std::plus<double>());
         });
     });
 
-    q.submit([&](sycl::handler &h) {
-        h.parallel_for(sycl::nd_range<1>(wg_size * wg_num, wg_size),
-            [=](sycl::nd_item<1> item) {
+    q.submit([&](sycl::handler& h) {
+        h.parallel_for(sycl::nd_range<1>(wg_size * wg_num, wg_size), [=](sycl::nd_item<1> item) {
             double rng;
             double sp;
 
             rng = rng_ptr[item.get_global_linear_id()];
-            rng *= s0;
-            sp = sycl::max(x - rng, 0.0);
+            rng *= initial_stock_price;
+            sp = sycl::max(strike_price - rng, 0.0);
 
-            count_sp[item.get_group_linear_id()] = reduce(item.get_group(), sp, std::plus<double>());
+            count_sp[item.get_group_linear_id()] =
+                reduce(item.get_group(), sp, std::plus<double>());
         });
     });
     q.wait_and_throw();
@@ -114,62 +116,65 @@ static void mc_kernel(sycl::queue& q, EngineType& engine, size_t n_samples,
     sc_dp = std::accumulate(count_sc, count_sc + wg_num, 0);
     sp_dp = std::accumulate(count_sp, count_sp + wg_num, 0);
 
-    vcall = sc_dp / n_samples * exp(-r * t);
-    vput  = sp_dp / n_samples * exp(-r * t);
+    vcall = sc_dp / num_samples * exp(-risk_neutral_rate * t);
+    vput = sp_dp / num_samples * exp(-risk_neutral_rate * t);
 
     sycl::free(count_sc, q);
     sycl::free(count_sp, q);
 }
 
-void mc_calculate(sycl::queue& q, size_t n_opt, size_t n_samples, double r, double sig,
-    std::vector<double>& s0, std::vector<double>& x, std::vector<double>& t,
-    std::vector<double>& vcall, std::vector<double>& vput) {
+void mc_calculate(sycl::queue& q, size_t num_options, size_t num_samples, double risk_neutral_rate,
+                  double volatility, std::vector<double>& initial_stock_price,
+                  std::vector<double>& strike_price, std::vector<double>& t,
+                  std::vector<double>& vcall, std::vector<double>& vput) {
     // Creating random number engine
     mkl::rng::philox4x32x10 engine(q, seed);
     // Allocate memory for random numbers
-    double* rng_ptr = sycl::malloc_device<double>(n_samples, q);
+    double* rng_ptr = sycl::malloc_device<double>(num_samples, q);
     // Price options
-    for (size_t j = 0; j < n_opt; j++) {
-        mc_kernel(q, engine, n_samples, r, sig, s0[j], x[j], t[j], vcall[j], vput[j], rng_ptr);
+    for (size_t j = 0; j < num_options; j++) {
+        mc_kernel(q, engine, num_samples, risk_neutral_rate, volatility, initial_stock_price[j],
+                  strike_price[j], t[j], vcall[j], vput[j], rng_ptr);
     }
     sycl::free(rng_ptr, q);
 }
 
-int main(int argc, char ** argv) {
-
+int main(int argc, char** argv) {
     std::cout << std::endl;
     std::cout << "Monte Carlo European Option Pricing Simulation" << std::endl;
     std::cout << "Unified Shared Memory Api" << std::endl;
     std::cout << "----------------------------------------------" << std::endl;
 
-    size_t n_opt = n_opt_default;
-    size_t n_samples = n_samples_default;
-    if(argc >= 2) {
-        n_opt = atol(argv[1]);
-        if(n_opt == 0) {
-            n_opt = n_opt_default;
+    size_t num_options = num_options_default;
+    size_t num_samples = num_samples_default;
+    if (argc >= 2) {
+        num_options = atol(argv[1]);
+        if (num_options == 0) {
+            num_options = num_options_default;
         }
-        if(argc >= 3) {
-            n_samples = atol(argv[2]);
-            if(n_samples == 0) {
-                n_samples = n_samples_default;
+        if (argc >= 3) {
+            num_samples = atol(argv[2]);
+            if (num_samples == 0) {
+                num_samples = num_samples_default;
             }
         }
     }
-    std::cout << "Number of options = " << n_opt << std::endl;
-    std::cout << "Number of samples = " << n_samples << std::endl;
+    std::cout << "Number of options = " << num_options << std::endl;
+    std::cout << "Number of samples = " << num_samples << std::endl;
 
-    std::vector<double> s0(n_opt), x(n_opt), t(n_opt), vcall(n_opt), vput(n_opt);
-    std::vector<double> vcall_ref(n_opt), vput_ref(n_opt);
+    std::vector<double> initial_stock_price(num_options), strike_price(num_options), t(num_options),
+        vcall(num_options), vput(num_options);
+    std::vector<double> vcall_ref(num_options), vput_ref(num_options);
 
-    init_data(s0, x, t, vcall, vput);
+    init_data(initial_stock_price, strike_price, t, vcall, vput);
 
     // This exception handler with catch async exceptions
     auto exception_handler = [&](sycl::exception_list exceptions) {
-        for(std::exception_ptr const& e : exceptions) {
+        for (std::exception_ptr const& e : exceptions) {
             try {
                 std::rethrow_exception(e);
-            } catch (sycl::exception const& e) {
+            }
+            catch (sycl::exception const& e) {
                 std::cout << "Caught asynchronous SYCL exception:\n" << e.what() << std::endl;
                 std::terminate();
             }
@@ -179,7 +184,7 @@ int main(int argc, char ** argv) {
     try {
         // Queue constructor passed exception handler
         sycl::queue q(sycl::default_selector{}, exception_handler);
-        
+
         // Check for double precision support
         auto device = q.get_device();
         if (device.get_info<sycl::info::device::double_fp_config>().empty()) {
@@ -187,17 +192,20 @@ int main(int argc, char ** argv) {
             std::cerr << "by the selected device. Quitting." << std::endl;
             return 0;
         }
-        
+
         // Launch Monte Carlo calculation
-        mc_calculate(q, n_opt, n_samples, risk_free, volatility, s0, x, t, vcall, vput);
-    } catch (...) {
+        mc_calculate(q, num_options, num_samples, default_risk_neutral_rate, default_volatility,
+                     initial_stock_price, strike_price, t, vcall, vput);
+    }
+    catch (...) {
         // Some other exception detected
         std::cout << "Failure" << std::endl;
         std::terminate();
     }
 
     // Validate results
-    bs_ref(risk_free, volatility, s0, x, t, vcall_ref, vput_ref);
+    bs_ref(default_risk_neutral_rate, default_volatility, initial_stock_price, strike_price, t,
+           vcall_ref, vput_ref);
 
     std::cout << "put_abs_err  = " << estimate_error(vput_ref, vput) << std::endl;
     std::cout << "call_abs_err = " << estimate_error(vcall_ref, vcall) << std::endl;
@@ -206,19 +214,18 @@ int main(int argc, char ** argv) {
 }
 
 static double RandDouble(double a, double b) {
-    return rand()/(double)RAND_MAX*(b-a) + a;
+    return rand() / (double)RAND_MAX * (b - a) + a;
 }
 
-void init_data(std::vector<double>& s0, std::vector<double>& x, std::vector<double>& t,
-    std::vector<double>& vcall, std::vector<double>& vput) {
-
+void init_data(std::vector<double>& initial_stock_price, std::vector<double>& strike_price,
+               std::vector<double>& t, std::vector<double>& vcall, std::vector<double>& vput) {
     srand(seed);
 
     // Initialize data
-    for(size_t i = 0; i < s0.size(); i++) {
-        s0[i] = RandDouble(s0_l, s0_h);
-        x[i]  = RandDouble(x_l, x_h);
-        t[i]  = RandDouble(t_l, t_h);
+    for (size_t i = 0; i < initial_stock_price.size(); i++) {
+        initial_stock_price[i] = RandDouble(initial_stock_price_l, initial_stock_price_h);
+        strike_price[i] = RandDouble(strike_price_l, strike_price_h);
+        t[i] = RandDouble(t_l, t_h);
 
         vcall[i] = 0.0;
         vput[i] = 0.0;
@@ -226,46 +233,44 @@ void init_data(std::vector<double>& s0, std::vector<double>& x, std::vector<doub
 }
 
 static double CNDF(double x) {
-    const double b1 =  0.319381530;
+    const double b1 = 0.319381530;
     const double b2 = -0.356563782;
-    const double b3 =  1.781477937;
+    const double b3 = 1.781477937;
     const double b4 = -1.821255978;
-    const double b5 =  1.330274429;
-    const double p  =  0.2316419;
-    const double c  =  0.39894228;
+    const double b5 = 1.330274429;
+    const double p = 0.2316419;
+    const double c = 0.39894228;
 
-    if(x >= 0.0) {
-        double t = 1.0 / ( 1.0 + p * x );
-        return (1.0 - c * exp( -x * x / 2.0 ) * t *
-        (t *(t * (t * (t * b5 + b4 ) + b3 ) + b2 ) + b1 ));
+    if (x >= 0.0) {
+        double t = 1.0 / (1.0 + p * x);
+        return (1.0 - c * exp(-x * x / 2.0) * t * (t * (t * (t * (t * b5 + b4) + b3) + b2) + b1));
     }
     else {
-        double t = 1.0 / ( 1.0 - p * x );
-        return (c * exp( -x * x / 2.0 ) * t *
-        (t *(t * (t * (t * b5 + b4 ) + b3 ) + b2 ) + b1 ));
+        double t = 1.0 / (1.0 - p * x);
+        return (c * exp(-x * x / 2.0) * t * (t * (t * (t * (t * b5 + b4) + b3) + b2) + b1));
     }
 }
 
 static double erf_ref(double x) {
-    return 2.0 * CNDF(1.4142135623730950488016887242097*x) - 1.0;
+    return 2.0 * CNDF(1.4142135623730950488016887242097 * x) - 1.0;
 }
 
 static const auto inv_sqrt2 = 0.7071067811865475727373109293694142252207;
 
-void bs_ref(double r, double sig, std::vector<double>& s0, std::vector<double>& x, std::vector<double>& t,
-            std::vector<double>& vcall, std::vector<double>& vput) {
-
+void bs_ref(double risk_neutral_rate, double volatility, std::vector<double>& initial_stock_price,
+            std::vector<double>& strike_price, std::vector<double>& t, std::vector<double>& vcall,
+            std::vector<double>& vput) {
     double a, b, c, y, z, e, d1, d2, w1, w2;
 
-    for(size_t i = 0; i < s0.size(); i++) {
-        a = log(s0[i] / x[i]);
-        b = t[i] * r;
-        z = t[i]*sig*sig;
-    
+    for (size_t i = 0; i < initial_stock_price.size(); i++) {
+        a = log(initial_stock_price[i] / strike_price[i]);
+        b = t[i] * risk_neutral_rate;
+        z = t[i] * volatility * volatility;
+
         c = 0.5 * z;
         e = exp(-b);
         y = 1.0 / sqrt(z);
-                         
+
         w1 = (a + b + c) * y;
         w2 = (a + b - c) * y;
         d1 = erf_ref(inv_sqrt2 * w1);
@@ -273,8 +278,8 @@ void bs_ref(double r, double sig, std::vector<double>& s0, std::vector<double>& 
         d1 = 0.5 + 0.5 * d1;
         d2 = 0.5 + 0.5 * d2;
 
-        vcall[i] = s0[i] * d1 - x[i] * e * d2;
-        vput[i]  = vcall[i] - s0[i] + x[i] * e;
+        vcall[i] = initial_stock_price[i] * d1 - strike_price[i] * e * d2;
+        vput[i] = vcall[i] - initial_stock_price[i] + strike_price[i] * e;
     }
 }
 
@@ -282,12 +287,12 @@ double estimate_error(std::vector<double>& v_put_ref, std::vector<double>& v_put
     double abs_err = 0.0;
     double abs_err_res = 0.0;
 
-    for(size_t i = 0; i < v_put_ref.size(); ++i) {
+    for (size_t i = 0; i < v_put_ref.size(); ++i) {
         abs_err = (v_put_ref[i] - v_put[i]);
-        if(abs_err < 0) {
+        if (abs_err < 0) {
             abs_err = -abs_err;
         }
-        if(abs_err_res < abs_err) {
+        if (abs_err_res < abs_err) {
             abs_err_res = abs_err;
         }
     }

--- a/Libraries/oneMKL/monte_carlo_pi/mc_pi.cpp
+++ b/Libraries/oneMKL/monte_carlo_pi/mc_pi.cpp
@@ -24,6 +24,13 @@
 namespace oneapi {}
 using namespace oneapi;
 
+// Temporary code for beta08 compatibility. Reduce routine is moved from intel::
+// to ONEAPI:: namespace
+#if __SYCL_COMPILER_VERSION < 20200902L
+using sycl::intel::reduce;
+#else
+using sycl::ONEAPI::reduce;
+#endif
 
 // Value of Pi with many exact digits to compare with estimated value of Pi
 static const auto pi = 3.1415926535897932384626433832795;
@@ -75,7 +82,7 @@ double estimate_pi(sycl::queue& q, size_t n_points) {
                         count += 1;
                     }
                 }
-                count_acc[item.get_group_linear_id()] = sycl::intel::reduce(item.get_group(), count, std::plus<size_t>());
+                count_acc[item.get_group_linear_id()] = reduce(item.get_group(), count, std::plus<size_t>());
             });
         });
     }

--- a/Libraries/oneMKL/monte_carlo_pi/mc_pi_device_api.cpp
+++ b/Libraries/oneMKL/monte_carlo_pi/mc_pi_device_api.cpp
@@ -25,6 +25,14 @@
 namespace oneapi {}
 using namespace oneapi;
 
+// Temporary code for beta08 compatibility. Reduce routine is moved from intel::
+// to ONEAPI:: namespace
+#if __SYCL_COMPILER_VERSION < 20200902L
+using sycl::intel::reduce;
+#else
+using sycl::ONEAPI::reduce;
+#endif
+
 // Value of Pi with many exact digits to compare with estimated value of Pi
 static const auto pi = 3.1415926535897932384626433832795;
 
@@ -69,7 +77,7 @@ double estimate_pi(sycl::queue& q, size_t n_points) {
                         count += 1;
                     }
                 }
-                count_acc[item.get_group_linear_id()] = sycl::intel::reduce(item.get_group(), count, std::plus<size_t>());
+                count_acc[item.get_group_linear_id()] = reduce(item.get_group(), count, std::plus<size_t>());
             });
         });
     }

--- a/Libraries/oneMKL/monte_carlo_pi/mc_pi_usm.cpp
+++ b/Libraries/oneMKL/monte_carlo_pi/mc_pi_usm.cpp
@@ -25,6 +25,14 @@
 namespace oneapi {}
 using namespace oneapi;
 
+// Temporary code for beta08 compatibility. Reduce routine is moved from intel::
+// to ONEAPI:: namespace
+#if __SYCL_COMPILER_VERSION < 20200902L
+using sycl::intel::reduce;
+#else
+using sycl::ONEAPI::reduce;
+#endif
+
 // Value of Pi with many exact digits to compare with estimated value of Pi
 static const auto pi = 3.1415926535897932384626433832795;
 
@@ -73,7 +81,7 @@ double estimate_pi(sycl::queue& q, size_t n_points) {
                     count += 1;
                 }
             }
-            count_ptr[item.get_group_linear_id()] = sycl::intel::reduce(item.get_group(), count, std::plus<size_t>());
+            count_ptr[item.get_group_linear_id()] = reduce(item.get_group(), count, std::plus<size_t>());
         });
     });
 

--- a/Libraries/oneMKL/random_sampling_without_replacement/GNUmakefile
+++ b/Libraries/oneMKL/random_sampling_without_replacement/GNUmakefile
@@ -1,0 +1,24 @@
+# Makefile for GNU Make
+
+default: run_all
+
+run_all: lottery lottery_usm lottery_device_api
+		./lottery
+		./lottery_usm
+		./lottery_device_api
+
+DPCPP_OPTS = -I${MKLROOT}/include -mkl -DMKL_ILP64 -fsycl-device-code-split=per_kernel -fno-sycl-early-optimizations
+
+lottery: lottery.cpp
+		dpcpp $< -o $@ $(DPCPP_OPTS)
+
+lottery_usm: lottery_usm.cpp
+		dpcpp $< -o $@ $(DPCPP_OPTS)
+
+lottery_device_api: lottery_device_api.cpp
+		dpcpp $< -o $@ $(DPCPP_OPTS)
+
+clean:
+		-rm -f lottery lottery_usm lottery_device_api
+
+.PHONY: run_all clean

--- a/Libraries/oneMKL/random_sampling_without_replacement/License.txt
+++ b/Libraries/oneMKL/random_sampling_without_replacement/License.txt
@@ -1,0 +1,7 @@
+Copyright Intel Corporation
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/Libraries/oneMKL/random_sampling_without_replacement/README.md
+++ b/Libraries/oneMKL/random_sampling_without_replacement/README.md
@@ -1,0 +1,86 @@
+# Multiple Simple Random Sampling without replacement
+
+Multiple Simple Random Sampling without replacement shows how to use the oneMKL library's random number generation (RNG) functionality to generate K>>1 simple random length-M samples without replacement from a population of size N (1 ≤ M ≤ N).
+
+For more information on oneMKL, and complete documentation of all oneMKL routines, see https://software.intel.com/content/www/us/en/develop/tools/oneapi/components/onemkl.html.
+
+| Optimized for       | Description
+|:---                 |:---
+| OS                  | Linux* Ubuntu* 18.04; Windows 10
+| Hardware            | Skylake with Gen9 or newer
+| Software            | Intel&reg; oneMKL beta
+| What you will learn | How to use oneMKL's random number generation functionality
+| Time to complete    | 15 minutes
+
+
+## Purpose
+
+The sample demonstrates Partial Fisher-Yates Shuffle algorithm conducts 11 969 664 experiments. Each experiment, which generates a sequence of M unique random natural numbers from 1 to N, is actually a partial length-M random shuffle of the whole population of N elements. Because the main loop of the algorithm works as a real lottery, each experiment is called "lottery M of N" in the program.
+The program uses M=6 and N=49, stores result samples (sequences of length M) in a single array.
+
+This sample uses oneMKL's random number generation functionality to produce the random numbers. oneMKL RNG has APIs that can be called from the host, and APIs that can be called from within a kernel; both kinds of APIs are illustrated.
+
+This sample performs its computations on the default DPC++ device. You can set the `SYCL_DEVICE_TYPE` environment variable to `cpu` or `gpu` to select the device to use.
+
+
+## Key Implementation Details
+
+This sample illustrates how to create an RNG engine object (the source of pseudo-randomness), a distribution object (specifying the desired probability distribution), and finally generate the random numbers themselves. Random number generation can be done from the host, storing the results in a DPC++ buffer or USM pointer, or directly in a DPC++ kernel.
+
+In this sample, a Philox 4x32x10 generator is used, and a uniform distribution is the basis for the algorithm. oneMKL provides many other generators and distributions to suit a range of applications.
+
+
+## License
+
+This code sample is licensed under the MIT license.
+
+
+## Building the Multiple Simple Random Sampling without replacement Sample
+
+### Running Samples In DevCloud
+If running a sample in the Intel DevCloud, remember that you must specify the compute node (CPU, GPU, FPGA) as well whether to run in batch or interactive mode. For more information see the Intel® oneAPI Base Toolkit Get Started Guide (https://devcloud.intel.com/oneapi/get-started/base-toolkit/)
+
+### On a Linux* System
+Run `make` to build and run the sample. Three programs are generated, which illustrate different APIs for random number generation.
+
+You can remove all generated files with `make clean`.
+
+### On a Windows* System
+Run `nmake` to build and run the sample. `nmake clean` removes temporary files.
+
+## Running the Multiple Simple Random Sampling without replacement Sample
+
+### Example of Output
+If everything is working correctly, after building you will see step-by-step output from each of the three example programs, providing the results of lottery.
+```
+./lottery
+
+Multiple Simple Random Sampling without replacement
+Unified Shared Memory Api
+---------------------------------------------------
+M = 6, N = 49, Number of experiments = 11969664
+Sample 11969661 of lottery of 11969664: 19, 5, 17, 27, 44, 34,
+Sample 11969662 of lottery of 11969664: 31, 39, 6, 19, 48, 15,
+Sample 11969663 of lottery of 11969664: 24, 11, 29, 44, 2, 20,
+
+./lottery_usm
+
+Multiple Simple Random Sampling without replacement
+Unified Shared Memory Api
+---------------------------------------------------
+M = 6, N = 49, Number of experiments = 11969664
+Results with Host API:
+Sample 11969661 of lottery of 11969664: 19, 5, 17, 27, 44, 34,
+Sample 11969662 of lottery of 11969664: 31, 39, 6, 19, 48, 15,
+Sample 11969663 of lottery of 11969664: 24, 11, 29, 44, 2, 20,
+
+./lottery_device_api
+
+Multiple Simple Random Sampling without replacement
+Device Api
+---------------------------------------------------
+M = 6, N = 49, Number of experiments = 11969664
+Sample 11969661 of lottery of 11969664: 19, 5, 17, 27, 44, 34,
+Sample 11969662 of lottery of 11969664: 31, 39, 6, 19, 48, 15,
+Sample 11969663 of lottery of 11969664: 24, 11, 29, 44, 2, 20,
+```

--- a/Libraries/oneMKL/random_sampling_without_replacement/lottery.cpp
+++ b/Libraries/oneMKL/random_sampling_without_replacement/lottery.cpp
@@ -1,0 +1,148 @@
+//==============================================================
+// Copyright © 2020 Intel Corporation
+//
+// SPDX-License-Identifier: MIT
+// =============================================================
+
+/*
+*
+*  Content:
+*       This file contains Multiple Simple Random Sampling without replacement
+*       for DPC++ USM-based interface of random number generators
+*
+*******************************************************************************/
+
+#include <iostream>
+
+#include <CL/sycl.hpp>
+
+#include "mkl_rng_sycl.hpp"
+
+// Temporary code for beta08 compatibility. oneMKL routines
+//  move to the oneapi namespace in beta09.
+namespace oneapi {}
+using namespace oneapi;
+
+// Initialization value for random number generator
+static const auto seed = 777;
+
+// Lottery default parameters
+static const auto m_def = 6; // lottery first parameter
+static const auto n_def = 49; // lottery second parameter
+static const auto num_exp_def = 11969664; // number of lottery experiments
+
+void lottery(sycl::queue& q, size_t m, size_t n, size_t num_exp, size_t* result_ptr) {
+
+    // Generate (m * num_exp) random numbers
+    // Generator initialization
+    // Create an object of basic random numer generator (engine)
+    oneapi::mkl::rng::philox4x32x10 engine(q, seed);
+    // Create an object of distribution (by default float, a = 0.0f, b = 1.0f)
+    oneapi::mkl::rng::uniform distr;
+
+    float* rng_buf = sycl::malloc_device<float>(m * num_exp, q);
+
+    // Random number generation
+    auto event = oneapi::mkl::rng::generate(distr, engine, m * num_exp, rng_buf);
+    // Make sure, that generation is finished
+    event.wait_and_throw();
+
+    {
+
+        event = q.submit([&] (sycl::handler& h) {
+            sycl::accessor<size_t, 1, sycl::access::mode::read_write, sycl::access::target::local>
+                local_buf(sycl::range<1>{n}, h);
+            h.parallel_for(sycl::nd_range<1>(num_exp, 1),
+                [=](sycl::nd_item<1> item) {
+                size_t id = item.get_group(0);
+                // Let buf contain natural numbers 1, 2, ..., N
+                for (size_t i = 0; i < n; ++i) {
+                    local_buf[i] = i + 1;
+                }
+                // Shuffle copied buffer
+                for (size_t i = 0; i < m; ++i) {
+                    // Generate random natural number j from {i,...,N-1}
+                    auto j = i + (size_t)(rng_buf[id * m + i] * (float)(n - i));
+                    // Swap local_buf[i] and local_buf[j]
+                    auto tmp = local_buf[i];
+                    local_buf[i] = local_buf[j];
+
+                    local_buf[j] = tmp;
+                }
+                for (size_t i = 0; i < m; ++i) {
+                    // Copy shuffled buffer
+                    result_ptr[id * m + i] = local_buf[i];
+                }
+            });
+        });
+    }
+
+    event.wait_and_throw();
+}
+
+// Prints last 3 lottery samples
+void print_results(size_t* result_ptr, size_t m, size_t num_exp) {
+    for (size_t i = num_exp - 3; i < num_exp; ++i) {
+        std::cout << "Sample " << i << " of lottery of " << num_exp << ": ";
+        for (size_t j = 0; j < m; ++j) {
+            std::cout << result_ptr[i * m + j] << ", ";
+        }
+        std::cout << std::endl;
+    }
+    std::cout << std::endl;
+}
+
+int main(int argc, char ** argv) {
+
+    std::cout << std::endl;
+    std::cout << "Multiple Simple Random Sampling without replacement" << std::endl;
+    std::cout << "Buffer Api" << std::endl;
+    std::cout << "---------------------------------------------------" << std::endl;
+
+    size_t m = m_def;
+    size_t n = n_def;
+    size_t num_exp = num_exp_def;
+    if(argc >= 4) {
+        m = atol(argv[1]);
+        n = atol(argv[2]);
+        num_exp = atol(argv[3]);
+        if(m == 0 || n == 0 || num_exp == 0 || m > n) {
+            m = m_def;
+            n = n_def;
+            num_exp = num_exp_def;
+        }
+    }
+    std::cout << "M = " << m << ", N = " << n << ", Number of experiments = " << num_exp << std::endl;
+    // This exception handler will catch async exceptions
+    auto exception_handler = [&](sycl::exception_list exceptions) {
+        for(std::exception_ptr const& e : exceptions) {
+            try {
+                std::rethrow_exception(e);
+            } catch (sycl::exception const& e) {
+                std::cout << "Caught asynchronous SYCL exception:\n" << e.what() << std::endl;
+                std::terminate();
+            }
+        }
+    };
+
+    // Pointer to result storage
+    size_t* result_ptr;
+
+    try {
+        // Queue constructor passed exception handler
+        sycl::queue q(sycl::default_selector{}, exception_handler);
+        // Allocate memory
+        result_ptr = sycl::malloc_shared<size_t>(m * num_exp, q);
+        // Launch lottery for Host USM API
+        lottery(q, m, n, num_exp, result_ptr);
+    } catch (...) {
+        // Some other exception detected
+        std::cout << "Failure" << std::endl;
+        std::terminate();
+    }
+
+    // Print output
+    print_results(result_ptr, m, num_exp);
+
+    return 0;
+}

--- a/Libraries/oneMKL/random_sampling_without_replacement/lottery_device_api.cpp
+++ b/Libraries/oneMKL/random_sampling_without_replacement/lottery_device_api.cpp
@@ -1,0 +1,137 @@
+//==============================================================
+// Copyright © 2020 Intel Corporation
+//
+// SPDX-License-Identifier: MIT
+// =============================================================
+
+/*
+*
+*  Content:
+*       This file contains Multiple Simple Random Sampling without replacement
+*       for DPC++ device interface of random number generators
+*
+*******************************************************************************/
+
+#include <iostream>
+
+#include <CL/sycl.hpp>
+
+#include "mkl_rng_sycl_device.hpp"
+
+// Temporary code for beta08 compatibility. oneMKL routines
+//  move to the oneapi namespace in beta09.
+namespace oneapi {}
+using namespace oneapi;
+
+// Initialization value for random number generator
+static const auto seed = 777;
+
+// Lottery default parameters
+static const auto m_def = 6; // lottery first parameter
+static const auto n_def = 49; // lottery second parameter
+static const auto num_exp_def = 11969664; // number of lottery experiments
+
+void lottery_device_api(sycl::queue& q, size_t m, size_t n, size_t num_exp, std::vector<size_t>& result_vec) {
+
+    {
+        sycl::buffer<size_t, 1> result_buf(result_vec.data(), result_vec.size());
+
+        q.submit([&](sycl::handler& h) {
+            auto res_acc = result_buf.template get_access<sycl::access::mode::write>(h);
+            sycl::accessor<size_t, 1, sycl::access::mode::read_write, sycl::access::target::local>
+                local_buf(sycl::range<1>{n}, h);
+            h.parallel_for(sycl::nd_range<1>(num_exp, 1),
+                [=](sycl::nd_item<1> item) {
+                size_t id = item.get_group(0);
+                // Let buf contain natural numbers 1, 2, ..., N
+                for (size_t i = 0; i < n; ++i) {
+                    local_buf[i] = i + 1;
+                }
+                // Create an object of basic random numer generator (engine)
+                oneapi::mkl::rng::device::philox4x32x10 engine(seed, id * m);
+                // Create an object of distribution (by default float, a = 0.0f, b = 1.0f)
+                oneapi::mkl::rng::device::uniform distr;
+
+                for (size_t i = 0; i < m; ++i) {
+                    auto res = oneapi::mkl::rng::device::generate(distr, engine);
+                    // Generate random natural number j from {i,...,N-1}
+                    auto j = i + (size_t)(res * (float)(n - i));
+                    // Swap local_buf[i] and local_buf[j]
+                    auto tmp = local_buf[i];
+                    local_buf[i] = local_buf[j];
+
+                    local_buf[j] = tmp;
+                }
+                for (size_t i = 0; i < m; ++i) {
+                    // Copy shuffled buffer
+                    res_acc[id * m + i] = local_buf[i];
+                }
+            });
+        });
+    }
+}
+
+// Prints last 3 lottery samples
+void print_results(std::vector<size_t>& res, size_t m) {
+    for (size_t i = res.size() / m - 3; i < res.size() / m; ++i) {
+        std::cout << "Sample " << i << " of lottery of " << res.size() / m << ": ";
+        for (size_t j = 0; j < m; ++j) {
+            std::cout << res[i * m + j] << ", ";
+        }
+        std::cout << std::endl;
+    }
+    std::cout << std::endl;
+}
+
+int main(int argc, char ** argv) {
+
+    std::cout << std::endl;
+    std::cout << "Multiple Simple Random Sampling without replacement" << std::endl;
+    std::cout << "Device Api" << std::endl;
+    std::cout << "---------------------------------------------------" << std::endl;
+
+    size_t m = m_def;
+    size_t n = n_def;
+    size_t num_exp = num_exp_def;
+    if(argc >= 4) {
+        m = atol(argv[1]);
+        n = atol(argv[2]);
+        num_exp = atol(argv[3]);
+        if(m == 0 || n == 0 || num_exp == 0 || m > n) {
+            m = m_def;
+            n = n_def;
+            num_exp = num_exp_def;
+        }
+    }
+    std::cout << "M = " << m << ", N = " << n << ", Number of experiments = " << num_exp << std::endl;
+    // This exception handler will catch async exceptions
+    auto exception_handler = [&](sycl::exception_list exceptions) {
+        for(std::exception_ptr const& e : exceptions) {
+            try {
+                std::rethrow_exception(e);
+            } catch (sycl::exception const& e) {
+                std::cout << "Caught asynchronous SYCL exception:\n" << e.what() << std::endl;
+                std::terminate();
+            }
+        }
+    };
+
+    // Result storage
+    std::vector<size_t> result_vec(m * num_exp);
+
+    try {
+        // Queue constructor passed exception handler
+        sycl::queue q(sycl::default_selector{}, exception_handler);
+        // Launch lottery for device API
+        lottery_device_api(q, m, n, num_exp, result_vec);
+    } catch (...) {
+        // Some other exception detected
+        std::cout << "Failure" << std::endl;
+        std::terminate();
+    }
+
+    // Print output
+    print_results(result_vec, m);
+
+    return 0;
+}

--- a/Libraries/oneMKL/random_sampling_without_replacement/lottery_usm.cpp
+++ b/Libraries/oneMKL/random_sampling_without_replacement/lottery_usm.cpp
@@ -1,0 +1,149 @@
+//==============================================================
+// Copyright © 2020 Intel Corporation
+//
+// SPDX-License-Identifier: MIT
+// =============================================================
+
+/*
+*
+*  Content:
+*       This file contains Multiple Simple Random Sampling without replacement
+*       for DPC++ USM-based interface of random number generators
+*
+*******************************************************************************/
+
+#include <iostream>
+
+#include <CL/sycl.hpp>
+
+#include "mkl_rng_sycl.hpp"
+
+// Temporary code for beta08 compatibility. oneMKL routines
+//  move to the oneapi namespace in beta09.
+namespace oneapi {}
+using namespace oneapi;
+
+// Initialization value for random number generator
+static const auto seed = 777;
+
+// Lottery default parameters
+static const auto m_def = 6; // lottery first parameter
+static const auto n_def = 49; // lottery second parameter
+static const auto num_exp_def = 11969664; // number of lottery experiments
+
+void lottery(sycl::queue& q, size_t m, size_t n, size_t num_exp, size_t* result_ptr) {
+
+    // Generate (m * num_exp) random numbers
+    // Generator initialization
+    // Create an object of basic random numer generator (engine)
+    oneapi::mkl::rng::philox4x32x10 engine(q, seed);
+    // Create an object of distribution (by default float, a = 0.0f, b = 1.0f)
+    oneapi::mkl::rng::uniform distr;
+
+    float* rng_buf = sycl::malloc_device<float>(m * num_exp, q);
+
+    // Random number generation
+    auto event = oneapi::mkl::rng::generate(distr, engine, m * num_exp, rng_buf);
+    // Make sure, that generation is finished
+    event.wait_and_throw();
+
+    {
+
+        event = q.submit([&] (sycl::handler& h) {
+            sycl::accessor<size_t, 1, sycl::access::mode::read_write, sycl::access::target::local>
+                local_buf(sycl::range<1>{n}, h);
+            h.parallel_for(sycl::nd_range<1>(num_exp, 1),
+                [=](sycl::nd_item<1> item) {
+                size_t id = item.get_group(0);
+                // Let buf contain natural numbers 1, 2, ..., N
+                for (size_t i = 0; i < n; ++i) {
+                    local_buf[i] = i + 1;
+                }
+                // Shuffle copied buffer
+                for (size_t i = 0; i < m; ++i) {
+                    // Generate random natural number j from {i,...,N-1}
+                    auto j = i + (size_t)(rng_buf[id * m + i] * (float)(n - i));
+                    // Swap local_buf[i] and local_buf[j]
+                    auto tmp = local_buf[i];
+                    local_buf[i] = local_buf[j];
+
+                    local_buf[j] = tmp;
+                }
+                for (size_t i = 0; i < m; ++i) {
+                    // Copy shuffled buffer
+                    result_ptr[id * m + i] = local_buf[i];
+                }
+            });
+        });
+    }
+
+    event.wait_and_throw();
+}
+
+// Prints last 3 lottery samples
+void print_results(size_t* result_ptr, size_t m, size_t num_exp) {
+    for (size_t i = num_exp - 3; i < num_exp; ++i) {
+        std::cout << "Sample " << i << " of lottery of " << num_exp << ": ";
+        for (size_t j = 0; j < m; ++j) {
+            std::cout << result_ptr[i * m + j] << ", ";
+        }
+        std::cout << std::endl;
+    }
+    std::cout << std::endl;
+}
+
+int main(int argc, char ** argv) {
+
+    std::cout << std::endl;
+    std::cout << "Multiple Simple Random Sampling without replacement" << std::endl;
+    std::cout << "Unified Shared Memory Api" << std::endl;
+    std::cout << "---------------------------------------------------" << std::endl;
+
+    size_t m = m_def;
+    size_t n = n_def;
+    size_t num_exp = num_exp_def;
+    if(argc >= 4) {
+        m = atol(argv[1]);
+        n = atol(argv[2]);
+        num_exp = atol(argv[3]);
+        if(m == 0 || n == 0 || num_exp == 0 || m > n) {
+            m = m_def;
+            n = n_def;
+            num_exp = num_exp_def;
+        }
+    }
+    std::cout << "M = " << m << ", N = " << n << ", Number of experiments = " << num_exp << std::endl;
+    // This exception handler will catch async exceptions
+    auto exception_handler = [&](sycl::exception_list exceptions) {
+        for(std::exception_ptr const& e : exceptions) {
+            try {
+                std::rethrow_exception(e);
+            } catch (sycl::exception const& e) {
+                std::cout << "Caught asynchronous SYCL exception:\n" << e.what() << std::endl;
+                std::terminate();
+            }
+        }
+    };
+
+    // Pointer to result storage
+    size_t* result_ptr;
+
+    try {
+        // Queue constructor passed exception handler
+        sycl::queue q(sycl::default_selector{}, exception_handler);
+        // Allocate memory
+        result_ptr = sycl::malloc_shared<size_t>(m * num_exp, q);
+        // Launch lottery for Host USM API
+        lottery(q, m, n, num_exp, result_ptr);
+    } catch (...) {
+        // Some other exception detected
+        std::cout << "Failure" << std::endl;
+        std::terminate();
+    }
+
+    // Print output
+    std::cout << "Results with Host API:" << std::endl;
+    print_results(result_ptr, m, num_exp);
+
+    return 0;
+}

--- a/Libraries/oneMKL/random_sampling_without_replacement/makefile
+++ b/Libraries/oneMKL/random_sampling_without_replacement/makefile
@@ -1,0 +1,26 @@
+# Makefile for NMAKE
+
+default: run_all
+
+run_all: lottery.exe lottery_usm.exe lottery_device_api.exe
+	.\lottery
+	.\lottery_usm
+	.\lottery_device_api
+
+DPCPP_OPTS=/I"$(MKLROOT)\include" /Qmkl /DMKL_ILP64 /EHsc -fsycl-device-code-split=per_kernel -fno-sycl-early-optimizations OpenCL.lib
+
+lottery.exe: lottery.cpp
+	dpcpp lottery.cpp /Felottery.exe $(DPCPP_OPTS)
+
+lottery_usm.exe: lottery_usm.cpp
+	dpcpp lottery_usm.cpp /Felottery_usm.exe $(DPCPP_OPTS)
+
+lottery_device_api.exe: lottery_device_api.cpp
+	dpcpp lottery_device_api.cpp /Felottery_device_api.exe $(DPCPP_OPTS)
+
+clean:
+	del /q lottery.exe lottery_usm.exe lottery_device_api.exe
+	del /q lottery.exp lottery_usm.exp lottery_device_api.exp
+	del /q lottery.lib lottery_usm.lib lottery_device_api.lib
+
+pseudo: run_all clean

--- a/Libraries/oneMKL/random_sampling_without_replacement/sample.json
+++ b/Libraries/oneMKL/random_sampling_without_replacement/sample.json
@@ -12,7 +12,6 @@
     "ciTests": {
       "linux": [
         {
-          "id": "random_sampling_without_replacement",
           "steps": [
             "make clean",
             "make"
@@ -21,7 +20,6 @@
       ],
       "windows": [
         {
-          "id": "random_sampling_without_replacement",
           "steps": [
             "nmake clean",
             "nmake"

--- a/Libraries/oneMKL/random_sampling_without_replacement/sample.json
+++ b/Libraries/oneMKL/random_sampling_without_replacement/sample.json
@@ -1,0 +1,32 @@
+{
+    "guid": "7AC408C8-DF59-46AE-B970-178CF257F364",
+    "name": "Multiple Simple Random Sampling without replacement",
+    "categories": [ "Toolkit/Intel® oneAPI Base Toolkit", "Toolkit/Intel® oneAPI HPC Toolkit" ],
+    "toolchain": [ "dpcpp" ],
+    "dependencies": [ "mkl" ],
+    "description": "Multiple simple random sampling without replacement with oneMKL random number generators.",
+    "languages": [ { "cpp": { "properties": { "projectOptions": [ { "projectType": "makefile" } ] } } } ],
+    "targetDevice": [ "CPU", "GPU" ],
+    "os": [ "linux", "windows" ],
+    "builder": [ "make" ],
+    "ciTests": {
+      "linux": [
+        {
+          "id": "random_sampling_without_replacement",
+          "steps": [
+            "make clean",
+            "make"
+          ]
+        }
+      ],
+      "windows": [
+        {
+          "id": "random_sampling_without_replacement",
+          "steps": [
+            "nmake clean",
+            "nmake"
+          ]
+        }
+      ]
+    }
+  }


### PR DESCRIPTION
# Description

- W/a is added for reduce function (namespace changes from sycl::intel to sycl::ONEAPI::)

- European option pricing sample is cleaned and aligned with pi number evaluation sample

- Add new RNG sample: Multiple Simple Random Sampling without replacement

Fixes # (issue) 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?
Manually tests for Linux and Windows CPU and GPU with oneMKL beta08 and oneMKL beta09 functionality

- [x] Command Line