### PR TITLE
Fix MSVC build/runtime issues in oneVPL samples

### DIFF
--- a/Libraries/oneVPL/dpcpp-blur/CMakeLists.txt
+++ b/Libraries/oneVPL/dpcpp-blur/CMakeLists.txt
@@ -27,7 +27,6 @@ project(dpcpp-blur LANGUAGES CXX)
 set(TARGET dpcpp-blur)
 set(SOURCES src/dpcpp-blur.cpp)
 set(VPL_NAME mfx)
-set(CMAKE_MSVCIDE_RUN_PATH $ENV{PATH})
 set(RUNARGS ${CMAKE_CURRENT_SOURCE_DIR}/content/cars_128x96.i420 128 96)
 
 set(CMAKE_CXX_STANDARD 17)
@@ -36,6 +35,9 @@ add_executable(${TARGET} ${SOURCES})
 
 if(MSVC)
   add_definitions(-D_CRT_SECURE_NO_WARNINGS)
+  if(NOT DEFINED ENV{VSCMD_VER})
+    set(CMAKE_MSVCIDE_RUN_PATH $ENV{PATH})
+  endif()
 endif()
 
 if(DPCPP_COMPILER)

--- a/Libraries/oneVPL/dpcpp-blur/README.md
+++ b/Libraries/oneVPL/dpcpp-blur/README.md
@@ -1,13 +1,13 @@
 # `dpcpp-blur` Sample
 
-This sample shows how to use a DPC++ kernel together with oneAPI Video
-Processing Library (oneVPL) to perform a simple video content blur.
+This sample shows how to use a DPC++ kernel together with
+oneAPI Video Processing Library to perform a simple video content blur.
 
 | Optimized for   | Description
 |---------------- | ----------------------------------------
 | OS              | Ubuntu* 18.04; Windows* 10
 | Hardware        | Intel® Processor Graphics GEN9 or newer
-| Software        | Intel® oneAPI Video Processing Library(oneVPL)
+| Software        | Intel® oneAPI Video Processing Library (oneVPL)
 | What You Will Learn | How to use oneVPL and DPC++ to convert I420 raw video file in to RGB32 and blur each frame.
 | Time to Complete | 5 minutes
 
@@ -19,7 +19,7 @@ I420 format video elementary stream as an argument, converts it to RGB32 with
 oneVPL and blurs each frame with DPC++ by using SYCL kernel, and writes the
 decoded output to `out.rgba` in RGB32 format.
 
-If a DPC++ compiler is not found the blur operation will be disabled
+If the oneAPI DPC++ Compiler is not found the blur operation will be disabled.
 
 
 
@@ -52,7 +52,7 @@ Perform the following steps:
 
 2. Set up your environment using the following command.
    ```
-   $ source <oneapi_install_dir>/setvars.sh
+   source <oneapi_install_dir>/setvars.sh
    ```
    Here `<oneapi_install_dir>` represents the root folder of your oneAPI
    installation, which is `/opt/intel/oneapi/` when installed as root, and
@@ -61,15 +61,15 @@ Perform the following steps:
 
 3. Build the program using the following commands:
    ```
-   $ mkdir build
-   $ cd build
-   $ cmake ..
-   $ cmake --build .
+   mkdir build
+   cd build
+   cmake ..
+   cmake --build .
    ```
 
 4. Run the program using the following command:
    ```
-   $ cmake --build . --target run
+   cmake --build . --target run
    ```
 
 
@@ -85,7 +85,7 @@ Perform the following steps:
 
 2. Set up your environment using the following command.
    ```
-   > <oneapi_install_dir>\setvars.bat
+   <oneapi_install_dir>\setvars.bat
    ```
    Here `<oneapi_install_dir>` represents the root folder of your oneAPI
    installation, which is which is `C:\Program Files (x86)\Intel\oneAPI\`
@@ -96,15 +96,15 @@ Perform the following steps:
 
 3. Build the program using the following commands:
    ```
-   $ mkdir build
-   $ cd build
-   $ cmake ..
-   $ cmake --build .
+   mkdir build
+   cd build
+   cmake .. -T "Intel(R) oneAPI DPC++ Compiler"
+   cmake --build .
    ```
 
 4. Run the program using the following command:
    ```
-   $ cmake --build . --target run
+   cmake --build . --target run
    ```
 
 
@@ -127,7 +127,6 @@ The instructions given above run the sample executable with the argument
 ### Example of Output
 
 ```
-Running on Intel(R) Core(TM) i7-6770HQ CPU @ 2.60GHz
 Processing dpcpp-blur/content/cars_128x96.i420 -> out.rgba
 Processed 60 frames
 ```

--- a/Libraries/oneVPL/dpcpp-blur/dpcpp-blur.vcxproj.user
+++ b/Libraries/oneVPL/dpcpp-blur/dpcpp-blur.vcxproj.user
@@ -3,13 +3,13 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <LocalDebuggerCommandArguments>"content\cars_128x96.i420" 128 96</LocalDebuggerCommandArguments>
     <DebuggerFlavor>WindowsLocalDebugger</DebuggerFlavor>
-    <LocalDebuggerEnvironment>PATH=$(ONEAPI_ROOT)\vpl\latest\bin;%PATH%
+    <LocalDebuggerEnvironment>PATH=$(ONEAPI_ROOT)\vpl\latest\bin;$(ONEAPI_ROOT)\compiler\latest\windows\lib\oclfpga\windows64\bin;$(ONEAPI_ROOT)\compiler\latest\windows\bin;$(ONEAPI_ROOT)\compiler\latest\windows\redist\intel64_win\compiler;$(ONEAPI_ROOT)\compiler\latest\windows\lib\oclfpga\bin;$(ONEAPI_ROOT)\compiler\latest\windows\lib\oclfpga\windows64\bin;$(ONEAPI_ROOT)\compiler\latest\windows\lib\oclfpga\host\windows64\bin;$(ONEAPI_ROOT)\compiler\latest\windows\lib\oclfpga\board\intel_a10gx_pac\windows64\bin;$(ONEAPI_ROOT)\compiler\latest\windows..\lib\oclgpu;$(ONEAPI_ROOT)\compiler\latest\windows..\windows\bin\intel64;$(ONEAPI_ROOT)\compiler\latest\windows..\windows\redist\intel64_win\compiler;$(ONEAPI_ROOT)\compiler\latest\windows..\windows\bin;$(ONEAPI_ROOT)\compiler\latest\windows..\windows\lib;$(ONEAPI_ROOT)\compiler\latest\windows..\windows\ioc\bin;$(ONEAPI_ROOT)\compiler\latest\windows..\windows\lib\ocloc;$(ONEAPI_ROOT)\compiler\latest\windows......\tbb\latest\redist\intel64\vc_mt;%PATH%
 </LocalDebuggerEnvironment>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <LocalDebuggerCommandArguments>"content\cars_128x96.i420" 128 96</LocalDebuggerCommandArguments>
     <DebuggerFlavor>WindowsLocalDebugger</DebuggerFlavor>
-    <LocalDebuggerEnvironment>PATH=$(ONEAPI_ROOT)\vpl\latest\bin;%PATH%
+    <LocalDebuggerEnvironment>PATH=$(ONEAPI_ROOT)\vpl\latest\bin;$(ONEAPI_ROOT)\compiler\latest\windows\lib\oclfpga\windows64\bin;$(ONEAPI_ROOT)\compiler\latest\windows\bin;$(ONEAPI_ROOT)\compiler\latest\windows\redist\intel64_win\compiler;$(ONEAPI_ROOT)\compiler\latest\windows\lib\oclfpga\bin;$(ONEAPI_ROOT)\compiler\latest\windows\lib\oclfpga\windows64\bin;$(ONEAPI_ROOT)\compiler\latest\windows\lib\oclfpga\host\windows64\bin;$(ONEAPI_ROOT)\compiler\latest\windows\lib\oclfpga\board\intel_a10gx_pac\windows64\bin;$(ONEAPI_ROOT)\compiler\latest\windows..\lib\oclgpu;$(ONEAPI_ROOT)\compiler\latest\windows..\windows\bin\intel64;$(ONEAPI_ROOT)\compiler\latest\windows..\windows\redist\intel64_win\compiler;$(ONEAPI_ROOT)\compiler\latest\windows..\windows\bin;$(ONEAPI_ROOT)\compiler\latest\windows..\windows\lib;$(ONEAPI_ROOT)\compiler\latest\windows..\windows\ioc\bin;$(ONEAPI_ROOT)\compiler\latest\windows..\windows\lib\ocloc;$(ONEAPI_ROOT)\compiler\latest\windows......\tbb\latest\redist\intel64\vc_mt;%PATH%
 </LocalDebuggerEnvironment>
   </PropertyGroup>
 </Project>

--- a/Libraries/oneVPL/dpcpp-blur/sample.json
+++ b/Libraries/oneVPL/dpcpp-blur/sample.json
@@ -27,7 +27,7 @@
         "steps": [
           "mkdir build",
           "cd build",
-          "cmake ..",
+          "cmake .. -T \"Intel(R) oneAPI DPC++ Compiler\"",
           "cmake --build .",
           "cmake --build . --target run"
         ] }

--- a/Libraries/oneVPL/dpcpp-blur/src/dpcpp-blur.cpp
+++ b/Libraries/oneVPL/dpcpp-blur/src/dpcpp-blur.cpp
@@ -147,7 +147,7 @@ int main(int argc, char *argv[]) {
     mfxI32 input_height = isize;
 
     // initialize  session
-    mfxInitParam init_params   = { 0 };
+    mfxInitParam init_params   = {};
     init_params.Version.Major  = 2;
     init_params.Version.Minor  = 0;
     init_params.Implementation = MFX_IMPL_SOFTWARE;
@@ -294,7 +294,7 @@ int main(int argc, char *argv[]) {
     }
 
     // Prepare bit stream buffer
-    mfxBitstream bitstream = { 0 };
+    mfxBitstream bitstream = {};
     bitstream.MaxLength    = 2000000;
     std::vector<mfxU8> bitstream_data(bitstream.MaxLength);
     bitstream.Data = bitstream_data.data();

--- a/Libraries/oneVPL/hello-decode/CMakeLists.txt
+++ b/Libraries/oneVPL/hello-decode/CMakeLists.txt
@@ -4,7 +4,6 @@ project(hello-decode)
 set(TARGET hello-decode)
 set(SOURCES src/hello-decode.cpp)
 set(VPL_NAME mfx)
-set(CMAKE_MSVCIDE_RUN_PATH $ENV{PATH})
 set(RUNARGS ${CMAKE_CURRENT_SOURCE_DIR}/content/cars_128x96.h265)
 
 # Set default build type to RelWithDebInfo if not specified
@@ -29,6 +28,9 @@ endif()
 
 if(MSVC)
   add_definitions(-D_CRT_SECURE_NO_WARNINGS)
+  if(NOT DEFINED ENV{VSCMD_VER})
+    set(CMAKE_MSVCIDE_RUN_PATH $ENV{PATH})
+  endif()
 endif()
 
 if(TARGET mfx)

--- a/Libraries/oneVPL/hello-decode/README.md
+++ b/Libraries/oneVPL/hello-decode/README.md
@@ -48,7 +48,7 @@ Perform the following steps:
 
 2. Set up your environment using the following command.
    ```
-   $ source <oneapi_install_dir>/setvars.sh
+   source <oneapi_install_dir>/setvars.sh
    ```
    Here `<oneapi_install_dir>` represents the root folder of your oneAPI
    installation, which is `/opt/intel/oneapi/` when installed as root, and
@@ -57,15 +57,15 @@ Perform the following steps:
 
 3. Build the program using the following commands:
    ```
-   $ mkdir build
-   $ cd build
-   $ cmake ..
-   $ cmake --build .
+   mkdir build
+   cd build
+   cmake ..
+   cmake --build .
    ```
 
 4. Run the program using the following command:
    ```
-   $ cmake --build . --target run
+   cmake --build . --target run
    ```
 
 
@@ -81,7 +81,7 @@ Perform the following steps:
 
 2. Set up your environment using the following command.
    ```
-   > <oneapi_install_dir>\setvars.bat
+   <oneapi_install_dir>\setvars.bat
    ```
    Here `<oneapi_install_dir>` represents the root folder of your oneAPI
    installation, which is which is `C:\Program Files (x86)\Intel\oneAPI\`
@@ -92,15 +92,15 @@ Perform the following steps:
 
 3. Build the program using the following commands:
    ```
-   $ mkdir build
-   $ cd build
-   $ cmake ..
-   $ cmake --build .
+   mkdir build
+   cd build
+   cmake ..
+   cmake --build .
    ```
 
 4. Run the program using the following command:
    ```
-   $ cmake --build . --target run
+   cmake --build . --target run
    ```
 
 

--- a/Libraries/oneVPL/hello-encode/CMakeLists.txt
+++ b/Libraries/oneVPL/hello-encode/CMakeLists.txt
@@ -4,7 +4,6 @@ project(hello-encode)
 set(TARGET hello-encode)
 set(SOURCES src/hello-encode.cpp)
 set(VPL_NAME mfx)
-set(CMAKE_MSVCIDE_RUN_PATH $ENV{PATH})
 set(RUNARGS ${CMAKE_CURRENT_SOURCE_DIR}/content/cars_128x96.i420 128 96)
 
 # Set default build type to RelWithDebInfo if not specified
@@ -29,6 +28,9 @@ endif()
 
 if(MSVC)
   add_definitions(-D_CRT_SECURE_NO_WARNINGS)
+  if(NOT DEFINED ENV{VSCMD_VER})
+    set(CMAKE_MSVCIDE_RUN_PATH $ENV{PATH})
+  endif()
 endif()
 
 if(TARGET mfx)

--- a/Libraries/oneVPL/hello-encode/README.md
+++ b/Libraries/oneVPL/hello-encode/README.md
@@ -48,7 +48,7 @@ Perform the following steps:
 
 2. Set up your environment using the following command.
    ```
-   $ source <oneapi_install_dir>/setvars.sh
+   source <oneapi_install_dir>/setvars.sh
    ```
    Here `<oneapi_install_dir>` represents the root folder of your oneAPI
    installation, which is `/opt/intel/oneapi/` when installed as root, and
@@ -57,15 +57,15 @@ Perform the following steps:
 
 3. Build the program using the following commands:
    ```
-   $ mkdir build
-   $ cd build
-   $ cmake ..
-   $ cmake --build .
+   mkdir build
+   cd build
+   cmake ..
+   cmake --build .
    ```
 
 4. Run the program using the following command:
    ```
-   $ cmake --build . --target run
+   cmake --build . --target run
    ```
 
 
@@ -81,7 +81,7 @@ Perform the following steps:
 
 2. Set up your environment using the following command.
    ```
-   > <oneapi_install_dir>\setvars.bat
+   <oneapi_install_dir>\setvars.bat
    ```
    Here `<oneapi_install_dir>` represents the root folder of your oneAPI
    installation, which is which is `C:\Program Files (x86)\Intel\oneAPI\`
@@ -92,15 +92,15 @@ Perform the following steps:
 
 3. Build the program using the following commands:
    ```
-   $ mkdir build
-   $ cd build
-   $ cmake ..
-   $ cmake --build .
+   mkdir build
+   cd build
+   cmake ..
+   cmake --build .
    ```
 
 4. Run the program using the following command:
    ```
-   $ cmake --build . --target run
+   cmake --build . --target run
    ```
 
 

--- a/Libraries/oneVPL/hello-vpp/CMakeLists.txt
+++ b/Libraries/oneVPL/hello-vpp/CMakeLists.txt
@@ -4,7 +4,6 @@ project(hello-vpp)
 set(TARGET hello-vpp)
 set(SOURCES src/hello-vpp.cpp)
 set(VPL_NAME mfx)
-set(CMAKE_MSVCIDE_RUN_PATH $ENV{PATH})
 set(RUNARGS ${CMAKE_CURRENT_SOURCE_DIR}/content/cars_128x96.i420 128 96)
 
 # Set default build type to RelWithDebInfo if not specified
@@ -29,6 +28,9 @@ endif()
 
 if(MSVC)
   add_definitions(-D_CRT_SECURE_NO_WARNINGS)
+  if(NOT DEFINED ENV{VSCMD_VER})
+    set(CMAKE_MSVCIDE_RUN_PATH $ENV{PATH})
+  endif()
 endif()
 
 if(TARGET mfx)

--- a/Libraries/oneVPL/hello-vpp/README.md
+++ b/Libraries/oneVPL/hello-vpp/README.md
@@ -44,7 +44,7 @@ Perform the following steps:
 
 2. Set up your environment using the following command.
    ```
-   $ source <oneapi_install_dir>/setvars.sh
+   source <oneapi_install_dir>/setvars.sh
    ```
    Here `<oneapi_install_dir>` represents the root folder of your oneAPI
    installation, which is `/opt/intel/oneapi/` when installed as root, and
@@ -53,15 +53,15 @@ Perform the following steps:
 
 3. Build the program using the following commands:
    ```
-   $ mkdir build
-   $ cd build
-   $ cmake ..
-   $ cmake --build .
+   mkdir build
+   cd build
+   cmake ..
+   cmake --build .
    ```
 
 4. Run the program using the following command:
    ```
-   $ cmake --build . --target run
+   cmake --build . --target run
    ```
 
 
@@ -77,7 +77,7 @@ Perform the following steps:
 
 2. Set up your environment using the following command.
    ```
-   > <oneapi_install_dir>\setvars.bat
+   <oneapi_install_dir>\setvars.bat
    ```
    Here `<oneapi_install_dir>` represents the root folder of your oneAPI
    installation, which is which is `C:\Program Files (x86)\Intel\oneAPI\`
@@ -88,15 +88,15 @@ Perform the following steps:
 
 3. Build the program using the following commands:
    ```
-   $ mkdir build
-   $ cd build
-   $ cmake ..
-   $ cmake --build .
+   mkdir build
+   cd build
+   cmake ..
+   cmake --build .
    ```
 
 4. Run the program using the following command:
    ```
-   $ cmake --build . --target run
+   cmake --build . --target run
    ```
 
 


### PR DESCRIPTION
# Description

Fix MSVC build/runtime issues in oneVPL samples

Fixes VPL7-290, VPL7-291, VPL7-292, VPL7-293, VPL7-294

## Type of change

Please delete options that are not relevant. Add a 'X' to the one that is applicable. 

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Sample Migration (Moving sample from old repository after completing checklist established)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [X] Command Line
- [ ] oneapi-cli
- [X] Visual Studio
- [ ] Eclipse IDE
- [ ] VSCode

# Checklist for Moving samples:
Links and Details can be found in the samples WG Teams Files. 

- [ ] Review sample design with domain reviewers https://github.com/oneapi-src/oneAPI-samples/wiki/Reviewers-and-Domain-Experts 
- [ ] Implement coding guidelines and ensure code quality.
- [ ] Adhere to sample.json specification. https://github.com/oneapi-src/oneAPI-samples/wiki/sample-json-specification
- [ ] Run jsonlint on sample.json to verify json syntax. www.jsonlint.com
- [ ] Adhere to readme template 
- [ ] Ensure/create CI test configurations for sample (ciTests field) https://github.com/oneapi-src/oneAPI-samples/wiki/sample-json-ci-test-object
- [ ] Enforce format via clang-format config file
- [ ] Review DPC++ code with Paul Peterseon. (GitHub User: pmpeter1)
- [ ] Review readme with Tom Lenth or Joe Oster. (GitHub User: JoeOster)
- [ ] Tested using Dev Cloud when applicable
- [ ] Implement fixes for ONSAM Jiras
- [ ] If you have new dependencies/binaries, inform Samples Project Manager Swapna R Dontharaju (@srdontha) or @JoeOster

