### PR TITLE
Add tbb-resumable-tasks-sycl sample for oneTBB library

### DIFF
--- a/Libraries/oneTBB/README.md
+++ b/Libraries/oneTBB/README.md
@@ -2,8 +2,9 @@
 
 | Code sample name                          | Supported Intel(r) Architecture(s) | Description
 |:---                                       |:---                                |:---
-| tbb-async-sycl             | GPU, CPU  | The calculations are split between TBB Flow Graph asynchronous node that calls SYCL kernel on GPU while TBB functional node does CPU part of calculations. 
-| tbb-task-sycl              | GPU, CPU  | One TBB task executes SYCL code on GPU while another TBB task performs calculations using TBB parallel_for. 
+| tbb-async-sycl             | GPU, CPU  | The calculations are split between TBB Flow Graph asynchronous node that calls SYCL kernel on GPU while TBB functional node does CPU part of calculations.
+| tbb-task-sycl              | GPU, CPU  | One TBB task executes SYCL code on GPU while another TBB task performs calculations using TBB parallel_for.
+| tbb-resumable-tasks-sycl   | GPU, CPU  | The calculations are split between TBB resumable task that calls SYCL kernel on GPU while TBB parallel_for does CPU part of calculations.
 
-## License  
-The code samples are licensed under MIT license 
+## License
+The code samples are licensed under MIT license

--- a/Libraries/oneTBB/tbb-resumable-tasks-sycl/CMakeLists.txt
+++ b/Libraries/oneTBB/tbb-resumable-tasks-sycl/CMakeLists.txt
@@ -1,0 +1,5 @@
+set(CMAKE_C_COMPILER "clang")
+set(CMAKE_CXX_COMPILER "dpcpp")
+cmake_minimum_required (VERSION 3.0)
+project (TBB-RESUMABLE-TASKS-SYCL)
+add_subdirectory (src)

--- a/Libraries/oneTBB/tbb-resumable-tasks-sycl/License.txt
+++ b/Libraries/oneTBB/tbb-resumable-tasks-sycl/License.txt
@@ -1,0 +1,8 @@
+Copyright 2020 Intel Corporation
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+

--- a/Libraries/oneTBB/tbb-resumable-tasks-sycl/License.txt
+++ b/Libraries/oneTBB/tbb-resumable-tasks-sycl/License.txt
@@ -1,4 +1,4 @@
-Copyright 2020 Intel Corporation
+Copyright Intel Corporation
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 

--- a/Libraries/oneTBB/tbb-resumable-tasks-sycl/README.md
+++ b/Libraries/oneTBB/tbb-resumable-tasks-sycl/README.md
@@ -1,23 +1,23 @@
-# tbb-async-sycl sample
+# `tbb-resumable-tasks-sycl` sample
+
 This sample illustrates how computational kernel can be split for execution between CPU and GPU using TBB resumable task and parallel_for. The TBB resumable task uses SYCL to implement calculations on GPU while the parallel_for algorithm does CPU part of calculations. This tbb-resumable-tasks-sycl sample code is implemented using C++ and SYCL language for CPU and GPU.
 | Optimized for                     | Description
 |:---                               |:---
 | OS                                | Linux* Ubuntu* 18.04; Windows 10
 | Hardware                          | Skylake with GEN9 or newer
-| Software                          | Intel&reg; oneAPI DPC++ Compiler (beta) 
+| Software                          | Intel&reg; oneAPI DPC++ Compiler (beta)
 | What you will learn               | How to offload the computation to GPU using Intel DPC++ compiler
 | Time to complete                  | 15 minutes
 
-  
-## Key implementation details 
-TBB resumable tasks and DPC++ implementation explained. 
+## Purpose
+The purpose of this sample is to show how during execution, a computational kernel can be split between CPU and GPU using TBB resumable tasks and TBB parallel_for.
 
-## License  
-This code sample is licensed under MIT license
+## Key implementation details
+TBB resumable tasks and DPC++ implementation explained.
 
-## How to Build
+## Building the tbb-resumable-tasks-sycl Program
 
-### On Linux
+### On a Linux System
     * Build tbb-resumable-tasks-sycl program
       cd tbb-resumable-tasks-sycl &&
       mkdir build &&
@@ -31,13 +31,27 @@ This code sample is licensed under MIT license
     * Clean the program
       make clean
 
-### On Windows
+### On a Windows System
 
 #### Command line using MSBuild
-     * MSBuild tbb-resumable-tasks-sycl.sln /t:Rebuild /p:Configuration="debug"
+    * MSBuild tbb-resumable-tasks-sycl.sln /t:Rebuild /      p:Configuration="debug"
 
 #### Visual Studio IDE
-     * Open Visual Studio 2017
-     * Select Menu "File > Open > Project/Solution", find "tbb-resumable-tasks-sycl" folder and select "tbb-resumable-tasks-sycl.sln"
-     * Select Menu "Project > Build" to build the selected configuration
-     * Select Menu "Debug > Start Without Debugging" to run the program
+    * Open Visual Studio 2017
+    * Select Menu "File > Open > Project/Solution", find "tbb-resumable-tasks-sycl" folder and select "tbb-resumable-tasks-sycl.sln"
+    * Select Menu "Project > Build" to build the selected configuration
+    * Select Menu "Debug > Start Without Debugging" to run the program
+
+## Running the Sample
+
+### Application Parameters
+None
+
+### Example of Output
+
+    start index for GPU = 0; end index for GPU = 8
+    start index for CPU = 8; end index for CPU = 16
+    Heterogenous triad correct.
+    c_array: 0 1.5 3 4.5 6 7.5 9 10.5 12 13.5 15 16.5 18 19.5 21 22.5
+    c_gold : 0 1.5 3 4.5 6 7.5 9 10.5 12 13.5 15 16.5 18 19.5 21 22.5
+    Built target run

--- a/Libraries/oneTBB/tbb-resumable-tasks-sycl/README.md
+++ b/Libraries/oneTBB/tbb-resumable-tasks-sycl/README.md
@@ -1,0 +1,43 @@
+# tbb-async-sycl sample
+This sample illustrates how computational kernel can be split for execution between CPU and GPU using TBB resumable task and parallel_for. The TBB resumable task uses SYCL to implement calculations on GPU while the parallel_for algorithm does CPU part of calculations. This tbb-resumable-tasks-sycl sample code is implemented using C++ and SYCL language for CPU and GPU.
+| Optimized for                     | Description
+|:---                               |:---
+| OS                                | Linux* Ubuntu* 18.04; Windows 10
+| Hardware                          | Skylake with GEN9 or newer
+| Software                          | Intel&reg; oneAPI DPC++ Compiler (beta) 
+| What you will learn               | How to offload the computation to GPU using Intel DPC++ compiler
+| Time to complete                  | 15 minutes
+
+  
+## Key implementation details 
+TBB resumable tasks and DPC++ implementation explained. 
+
+## License  
+This code sample is licensed under MIT license
+
+## How to Build
+
+### On Linux
+    * Build tbb-resumable-tasks-sycl program
+      cd tbb-resumable-tasks-sycl &&
+      mkdir build &&
+      cd build &&
+      cmake ../. &&
+      make VERBOSE=1
+
+    * Run the program
+      make run
+
+    * Clean the program
+      make clean
+
+### On Windows
+
+#### Command line using MSBuild
+     * MSBuild tbb-resumable-tasks-sycl.sln /t:Rebuild /p:Configuration="debug"
+
+#### Visual Studio IDE
+     * Open Visual Studio 2017
+     * Select Menu "File > Open > Project/Solution", find "tbb-resumable-tasks-sycl" folder and select "tbb-resumable-tasks-sycl.sln"
+     * Select Menu "Project > Build" to build the selected configuration
+     * Select Menu "Debug > Start Without Debugging" to run the program

--- a/Libraries/oneTBB/tbb-resumable-tasks-sycl/README.md
+++ b/Libraries/oneTBB/tbb-resumable-tasks-sycl/README.md
@@ -22,8 +22,7 @@ TBB resumable tasks and DPC++ implementation explained.
       cd tbb-resumable-tasks-sycl &&
       mkdir build &&
       cd build &&
-      cmake ../. &&
-      make VERBOSE=1
+      cmake .. && make VERBOSE=1
 
     * Run the program
       make run

--- a/Libraries/oneTBB/tbb-resumable-tasks-sycl/sample.json
+++ b/Libraries/oneTBB/tbb-resumable-tasks-sycl/sample.json
@@ -1,0 +1,11 @@
+{
+  "name": "tbb-resumable-tasks-sycl",
+  "categories": ["Toolkit/Intel® oneAPI Base Toolkit/oneTBB"],
+  "toolchain": ["dpcpp"],
+  "description": "This sample illustrates how computational kernel can be split for execution between CPU and GPU using TBB resumable task and parallel_for. The TBB resumable task uses SYCL to implement calculations on GPU while the parallel_for algorithm does CPU part of calculations. This tbb-resumable-tasks-sycl sample code is implemented using C++ and SYCL language for CPU and GPU.",
+  "languages": [{"cpp":{}}],
+  "targetDevice": ["CPU", "GPU"],
+  "os":["linux", "windows"],
+  "builder": ["ide", "cmake"]
+}
+

--- a/Libraries/oneTBB/tbb-resumable-tasks-sycl/sample.json
+++ b/Libraries/oneTBB/tbb-resumable-tasks-sycl/sample.json
@@ -1,4 +1,5 @@
 {
+  "guid": "17B9CB18-EAC1-4D08-8BBE-96F5D777C303",
   "name": "tbb-resumable-tasks-sycl",
   "categories": ["Toolkit/Intel® oneAPI Base Toolkit/oneTBB"],
   "toolchain": ["dpcpp"],
@@ -6,6 +7,24 @@
   "languages": [{"cpp":{}}],
   "targetDevice": ["CPU", "GPU"],
   "os":["linux", "windows"],
-  "builder": ["ide", "cmake"]
+  "builder": ["ide", "cmake"],
+  "ciTests": {
+      "linux": [{
+          "steps": [
+              "mkdir build",
+              "cd build",
+              "cmake ..",
+              "make VERBOSE=1",
+              "make run"
+          ]
+      }],
+      "windows": [{
+          "steps": [
+              "MSBuild tbb-resumable-tasks-sycl.sln /t:Rebuild /p:Configuration=\"debug\"",
+              "cd x64/Debug",
+              "tbb-resumable-tasks-sycl.exe"
+          ]
+      }]
+  }
 }
 

--- a/Libraries/oneTBB/tbb-resumable-tasks-sycl/src/CMakeLists.txt
+++ b/Libraries/oneTBB/tbb-resumable-tasks-sycl/src/CMakeLists.txt
@@ -12,4 +12,7 @@ endif()
 
 add_executable (tbb-resumable-tasks-sycl tbb-resumable-tasks-sycl.cpp)
 
+find_package(Threads REQUIRED)
+target_link_libraries(tbb-resumable-tasks-sycl Threads::Threads)
+
 add_custom_target (run ./tbb-resumable-tasks-sycl)

--- a/Libraries/oneTBB/tbb-resumable-tasks-sycl/src/CMakeLists.txt
+++ b/Libraries/oneTBB/tbb-resumable-tasks-sycl/src/CMakeLists.txt
@@ -1,0 +1,15 @@
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
+set(CMAKE_C_COMPILER "${CMAKE_C_COMPILER}")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -g -std=c++11 -cl-opt-disable")
+set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -g -ltbb")
+# Set default build type to RelWithDebInfo if not specified
+if (NOT CMAKE_BUILD_TYPE)
+    message (STATUS "Default CMAKE_BUILD_TYPE not set using Release with Debug Info")
+    set (CMAKE_BUILD_TYPE "RelWithDebInfo" CACHE
+        STRING "Choose the type of build, options are: None Debug Release RelWithDebInfo MinSizeRel"
+        FORCE)
+endif()
+
+add_executable (tbb-resumable-tasks-sycl tbb-resumable-tasks-sycl.cpp)
+
+add_custom_target (run ./tbb-resumable-tasks-sycl)

--- a/Libraries/oneTBB/tbb-resumable-tasks-sycl/src/tbb-resumable-tasks-sycl.cpp
+++ b/Libraries/oneTBB/tbb-resumable-tasks-sycl/src/tbb-resumable-tasks-sycl.cpp
@@ -1,17 +1,19 @@
 //==============================================================
-// Copyright © 2020 Intel Corporation
+// Copyright © 2019 Intel Corporation
 //
 // SPDX-License-Identifier: MIT
 // =============================================================
 
-#include <cmath> // for std::ceil
+#include <cmath>
 #include <array>
 #include <thread>
 #include <iostream>
+#include <atomic>
 #include <sstream>
 
 #include <CL/sycl.hpp>
 
+#include <tbb/blocked_range.h>
 #include <tbb/global_control.h>
 #include <tbb/task.h>
 #include <tbb/task_group.h>
@@ -34,35 +36,56 @@ void print_array( const char* text, const std::array<float, array_size>& array )
     std::cout << std::endl;
 }
 
-void run_sycl_activity( float offload_ratio ) {
-    std::size_t array_size_sycl = std::ceil(array_size * offload_ratio);
-    std::stringstream sstream;
-    sstream << "start index for GPU = 0; end index for GPU = "
-            << array_size_sycl << std::endl;
-    std::cout << sstream.str();
-    const float coeff = alpha; // coeff is a local variable
+class AsyncActivity {
+    float offload_ratio;
+    std::atomic<bool> submit_flag;
+    tbb::task::suspend_point suspend_point;
+    std::thread service_thread;
 
-    { // starting SYCL code
-        cl::sycl::range<1> n_items{array_size_sycl};
-        cl::sycl::buffer<cl_float, 1> a_buffer(a_array.data(), n_items);
-        cl::sycl::buffer<cl_float, 1> b_buffer(b_array.data(), n_items);
-        cl::sycl::buffer<cl_float, 1> c_buffer(c_array.data(), n_items);
+public:
+    AsyncActivity() : offload_ratio(0), submit_flag(false),
+        service_thread([this] {
+            while(!submit_flag) {
+                std::this_thread::yield();
+            }
+            std::size_t array_size_sycl = std::ceil(array_size * offload_ratio);
+            std::stringstream sstream;
+            sstream << "start index for GPU = 0; end index for GPU = "
+                    << array_size_sycl << std::endl;
+            std::cout << sstream.str();
+            const float coeff = alpha; // coeff is a local variable
 
-        cl::sycl::queue q;
-        tbb::task::suspend([&](tbb::task::suspend_point sus_point) {
-            q.submit([&](cl::sycl::handler& h) {
-                auto a_accessor = a_buffer.get_access<sycl_read>(h);
-                auto b_accessor = b_buffer.get_access<sycl_read>(h);
-                auto c_accessor = c_buffer.get_access<sycl_write>(h);
+            { // starting SYCL code
+                cl::sycl::range<1> n_items{array_size_sycl};
+                cl::sycl::buffer<cl_float, 1> a_buffer(a_array.data(), n_items);
+                cl::sycl::buffer<cl_float, 1> b_buffer(b_array.data(), n_items);
+                cl::sycl::buffer<cl_float, 1> c_buffer(c_array.data(), n_items);
 
-                h.parallel_for(n_items, [=](cl::sycl::id<1> index) {
-                    c_accessor[index] = a_accessor[index] + coeff * b_accessor[index];
-                }); // end of the kernel
-                tbb::task::resume(sus_point);
-            });
-        });
-    } // end of SYCL code
-}
+                cl::sycl::queue q;
+                q.submit([&](cl::sycl::handler& h) {
+                    auto a_accessor = a_buffer.get_access<sycl_read>(h);
+                    auto b_accessor = b_buffer.get_access<sycl_read>(h);
+                    auto c_accessor = c_buffer.get_access<sycl_write>(h);
+
+                    h.parallel_for(n_items, [=](cl::sycl::id<1> index) {
+                        c_accessor[index] = a_accessor[index] + coeff * b_accessor[index];
+                    }); // end of the kernel
+                }).wait();
+            }
+
+            tbb::task::resume(suspend_point);
+        }) {}
+
+    ~AsyncActivity() {
+        service_thread.join();
+    }
+
+    void submit( float ratio, tbb::task::suspend_point sus_point ) {
+        offload_ratio = ratio;
+        suspend_point = sus_point;
+        submit_flag = true;
+    }
+}; // class AsyncActivity
 
 int main() {
     // init input arrays
@@ -74,6 +97,7 @@ int main() {
     std::size_t n_threads = 4;
     tbb::global_control gc(tbb::global_control::max_allowed_parallelism, n_threads + 1); // One more thread, but sleeping
     tbb::task_group tg;
+    AsyncActivity activity;
 
     // Run CPU part
     tg.run([&]{
@@ -89,7 +113,9 @@ int main() {
     });
 
     // Run GPU part
-    run_sycl_activity(ratio);
+    tbb::task::suspend([&]( tbb::task::suspend_point suspend_point ) {
+        activity.submit(ratio, suspend_point);
+    });
 
     tg.wait();
 

--- a/Libraries/oneTBB/tbb-resumable-tasks-sycl/src/tbb-resumable-tasks-sycl.cpp
+++ b/Libraries/oneTBB/tbb-resumable-tasks-sycl/src/tbb-resumable-tasks-sycl.cpp
@@ -1,0 +1,111 @@
+//==============================================================
+// Copyright © 2020 Intel Corporation
+//
+// SPDX-License-Identifier: MIT
+// =============================================================
+
+#include <cmath> // for std::ceil
+#include <array>
+#include <thread>
+#include <iostream>
+#include <sstream>
+
+#include <CL/sycl.hpp>
+
+#include <tbb/global_control.h>
+#include <tbb/task.h>
+#include <tbb/task_group.h>
+#include <tbb/parallel_for.h>
+
+constexpr cl::sycl::access::mode sycl_read = cl::sycl::access::mode::read;
+constexpr cl::sycl::access::mode sycl_write = cl::sycl::access::mode::write;
+
+const float ratio = 0.5; // CPU or GPU offload ratio
+const float alpha = 0.5; // coeff for triad calculation
+
+constexpr std::size_t array_size = 16;
+std::array<float, array_size> a_array; // input array
+std::array<float, array_size> b_array; // input array
+std::array<float, array_size> c_array; // output array
+
+void print_array( const char* text, const std::array<float, array_size>& array ) {
+    std::cout << text;
+    for (const auto& s: array) std::cout << s << ' ';
+    std::cout << std::endl;
+}
+
+void run_sycl_activity( float offload_ratio ) {
+    std::size_t array_size_sycl = std::ceil(array_size * offload_ratio);
+    std::stringstream sstream;
+    sstream << "start index for GPU = 0; end index for GPU = "
+            << array_size_sycl << std::endl;
+    std::cout << sstream.str();
+    const float coeff = alpha; // coeff is a local variable
+
+    { // starting SYCL code
+        cl::sycl::range<1> n_items{array_size_sycl};
+        cl::sycl::buffer<cl_float, 1> a_buffer(a_array.data(), n_items);
+        cl::sycl::buffer<cl_float, 1> b_buffer(b_array.data(), n_items);
+        cl::sycl::buffer<cl_float, 1> c_buffer(c_array.data(), n_items);
+
+        cl::sycl::queue q;
+        tbb::task::suspend([&](tbb::task::suspend_point sus_point) {
+            q.submit([&](cl::sycl::handler& h) {
+                auto a_accessor = a_buffer.get_access<sycl_read>(h);
+                auto b_accessor = b_buffer.get_access<sycl_read>(h);
+                auto c_accessor = c_buffer.get_access<sycl_write>(h);
+
+                h.parallel_for(n_items, [=](cl::sycl::id<1> index) {
+                    c_accessor[index] = a_accessor[index] + coeff * b_accessor[index];
+                }); // end of the kernel
+                tbb::task::resume(sus_point);
+            });
+        });
+    } // end of SYCL code
+}
+
+int main() {
+    // init input arrays
+    for (std::size_t i = 0; i < array_size; ++i) {
+        a_array[i] = i;
+        b_array[i] = i;
+    }
+
+    std::size_t n_threads = 4;
+    tbb::global_control gc(tbb::global_control::max_allowed_parallelism, n_threads + 1); // One more thread, but sleeping
+    tbb::task_group tg;
+
+    // Run CPU part
+    tg.run([&]{
+        std::size_t i_start = static_cast<std::size_t>(std::ceil(array_size * ratio));
+        std::size_t i_end = array_size;
+        std::stringstream sstream;
+        sstream << "start index for CPU = " << i_start
+                << "; end index for CPU = " << i_end << std::endl;
+        std::cout << sstream.str();
+        tbb::parallel_for(i_start, i_end, []( std::size_t index ) {
+            c_array[index] = a_array[index] + alpha * b_array[index];
+        });
+    });
+
+    // Run GPU part
+    run_sycl_activity(ratio);
+
+    tg.wait();
+
+    // Serial execution
+    std::array<float, array_size> c_gold;
+    for (std::size_t i = 0; i < array_size; ++i) {
+        c_gold[i] = a_array[i] + alpha * b_array[i];
+    }
+
+    // Compare golden triad with heterogeneous triad
+    if (!std::equal(c_array.begin(), c_array.end(), c_gold.begin())) {
+        std::cout << "Heterogeneous triad error." << std::endl;
+    } else {
+        std::cout << "Heterogeneous triad correct." << std::endl;
+    }
+
+    print_array("c_array: ", c_array);
+    print_array("c_gold: ", c_gold);
+}

--- a/Libraries/oneTBB/tbb-resumable-tasks-sycl/tbb-resumable-tasks-sycl.sln
+++ b/Libraries/oneTBB/tbb-resumable-tasks-sycl/tbb-resumable-tasks-sycl.sln
@@ -1,0 +1,25 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 15
+VisualStudioVersion = 15.0.28307.136
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "tbb-resumable-tasks-sycl", "tbb-resumable-tasks-sycl.vcxproj", "{D3EBB191-6681-404F-AD76-0EA7A0EC975D}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|x64 = Debug|x64
+		Release|x64 = Release|x64
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{D3EBB191-6681-404F-AD76-0EA7A0EC975D}.Debug|x64.ActiveCfg = Debug|x64
+		{D3EBB191-6681-404F-AD76-0EA7A0EC975D}.Debug|x64.Build.0 = Debug|x64
+		{D3EBB191-6681-404F-AD76-0EA7A0EC975D}.Release|x64.ActiveCfg = Release|x64
+		{D3EBB191-6681-404F-AD76-0EA7A0EC975D}.Release|x64.Build.0 = Release|x64
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {BF8AF209-D72B-435D-B4A1-5E233A07D72C}
+	EndGlobalSection
+EndGlobal

--- a/Libraries/oneTBB/tbb-resumable-tasks-sycl/tbb-resumable-tasks-sycl.vcxproj
+++ b/Libraries/oneTBB/tbb-resumable-tasks-sycl/tbb-resumable-tasks-sycl.vcxproj
@@ -1,0 +1,169 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <VCProjectVersion>15.0</VCProjectVersion>
+    <ProjectGuid>{d3ebb191-6681-404f-ad76-0ea7a0ec975d}</ProjectGuid>
+    <Keyword>Win32Proj</Keyword>
+    <RootNamespace>tbb_resumable_tasks_sycl</RootNamespace>
+    <WindowsTargetPlatformVersion>$(WindowsSDKVersion.Replace("\",""))</WindowsTargetPlatformVersion>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>oneAPI Data Parallel C++ Compiler</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>oneAPI Data Parallel C++ Compiler</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>Intel(R) oneAPI DPC++ Compiler</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>Intel(R) oneAPI DPC++ Compiler</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="Shared">
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <LinkIncremental>true</LinkIncremental>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <LinkIncremental>true</LinkIncremental>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <LinkIncremental>false</LinkIncremental>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <LinkIncremental>false</LinkIncremental>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <ClCompile>
+      <PrecompiledHeader>Use</PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>Disabled</Optimization>
+      <SDLCheck>true</SDLCheck>
+      <ConformanceMode>true</ConformanceMode>
+      <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <ClCompile>
+      <PrecompiledHeader>Use</PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>Disabled</Optimization>
+      <SDLCheck>true</SDLCheck>
+      <ConformanceMode>true</ConformanceMode>
+      <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
+      <SYCLShowVerboseInformation>false</SYCLShowVerboseInformation>
+      <AdditionalOptions>/I"$(ONEAPI_ROOT)/tbb/latest/include" %(AdditionalOptions)</AdditionalOptions>
+      <SYCLWarningLevel>DisableAllWarnings</SYCLWarningLevel>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <SYCLShowVerboseInformation>false</SYCLShowVerboseInformation>
+      <AdditionalOptions>/link /libpath:"$(ONEAPI_ROOT)/tbb/latest/lib/intel64/vc14" %(AdditionalOptions)</AdditionalOptions>
+    </Link>
+    <PostBuildEvent>
+      <Command>copy /y "$(ONEAPI_ROOT)\tbb\latest\redist\intel64\vc14\tbb.dll" "$(SolutionDir)$(Platform)\$(Configuration)\"</Command>
+    </PostBuildEvent>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <ClCompile>
+      <PrecompiledHeader>Use</PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <SDLCheck>true</SDLCheck>
+      <ConformanceMode>true</ConformanceMode>
+      <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile>
+      <PrecompiledHeader>Use</PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <SDLCheck>true</SDLCheck>
+      <ConformanceMode>true</ConformanceMode>
+      <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
+      <SYCLShowVerboseInformation>false</SYCLShowVerboseInformation>
+      <AdditionalOptions>/I"$(ONEAPI_ROOT)/tbb/latest/include" %(AdditionalOptions)</AdditionalOptions>
+      <SYCLWarningLevel>DisableAllWarnings</SYCLWarningLevel>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <SYCLShowVerboseInformation>false</SYCLShowVerboseInformation>
+      <AdditionalOptions>/link /libpath:"$(ONEAPI_ROOT)/tbb/latest/lib/intel64/vc14" %(AdditionalOptions)</AdditionalOptions>
+    </Link>
+    <PostBuildEvent>
+      <Command>copy /y "$(ONEAPI_ROOT)\tbb\latest\redist\intel64\vc14\tbb.dll" "$(SolutionDir)$(Platform)\$(Configuration)\"</Command>
+    </PostBuildEvent>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClCompile Include="src\tbb-resumable-tasks-sycl.cpp" />
+  </ItemGroup>
+  <ItemGroup>
+    <Text Include="License.txt" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="readme.md" />
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/Libraries/oneTBB/tbb-resumable-tasks-sycl/tbb-resumable-tasks-sycl.vcxproj.filters
+++ b/Libraries/oneTBB/tbb-resumable-tasks-sycl/tbb-resumable-tasks-sycl.vcxproj.filters
@@ -1,0 +1,28 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <Filter Include="Source Files">
+      <UniqueIdentifier>{4FC737F1-C7A5-4376-A066-2A32D752A2FF}</UniqueIdentifier>
+      <Extensions>cpp;c;cc;cxx;def;odl;idl;hpj;bat;asm;asmx</Extensions>
+    </Filter>
+    <Filter Include="Header Files">
+      <UniqueIdentifier>{93995380-89BD-4b04-88EB-625FBE52EBFB}</UniqueIdentifier>
+      <Extensions>h;hh;hpp;hxx;hm;inl;inc;ipp;xsd</Extensions>
+    </Filter>
+    <Filter Include="Resource Files">
+      <UniqueIdentifier>{67DA6AB6-F800-4c08-8B7A-83BB121AAD01}</UniqueIdentifier>
+      <Extensions>rc;ico;cur;bmp;dlg;rc2;rct;bin;rgs;gif;jpg;jpeg;jpe;resx;tiff;tif;png;wav;mfcribbon-ms</Extensions>
+    </Filter>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="src\tbb-resumable-tasks-sycl.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+  </ItemGroup>
+  <ItemGroup>
+    <Text Include="License.txt" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="readme.md" />
+  </ItemGroup>
+</Project>

--- a/Libraries/oneTBB/tbb-resumable-tasks-sycl/tbb-resumable-tasks-sycl.vcxproj.user
+++ b/Libraries/oneTBB/tbb-resumable-tasks-sycl/tbb-resumable-tasks-sycl.vcxproj.user
@@ -1,0 +1,9 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <DebuggerFlavor>WindowsLocalDebugger</DebuggerFlavor>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <DebuggerFlavor>WindowsLocalDebugger</DebuggerFlavor>
+  </PropertyGroup>
+</Project>


### PR DESCRIPTION
# Description

Adding new sample for oneTBB library - tbb-resumable-tasks-sycl, which shows how computation can be splitted between CPU and GPU (GPU part is execute inside the tbb::task::suspend function)

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Tested manually on Linux and Windows (Visual Studio). Instructions can be found in the README.MD file.

- [x] Command Line
- [ ] oneapi-cli
- [x] Visual Studio
- [ ] Eclipse IDE
- [ ] VSCode

# Checklist for Moving samples:
Links and Details can be found in the samples WG Teams Files. 

- [x] Review sample design with domain reviewers https://github.com/oneapi-src/oneAPI-samples/wiki/Reviewers-and-Domain-Experts 
- [x] Implement coding guidelines and ensure code quality.
- [x] Adhere to sample.json specification. https://github.com/oneapi-src/oneAPI-samples/wiki/sample-json-specification
- [ ] Run jsonlint on sample.json to verify json syntax. www.jsonlint.com
- [x] Adhere to readme template 
- [x] Ensure/create CI test configurations for sample (ciTests field) https://github.com/oneapi-src/oneAPI-samples/wiki/sample-json-ci-test-object
- [ ] Enforce format via clang-format config file
- [ ] Review DPC++ code with Paul Peterseon. (GitHub User: pmpeter1)
- [ ] Review readme with Tom Lenth or Joe Oster. (GitHub User: JoeOster)
- [ ] Tested using Dev Cloud when applicable
- [ ] Implement fixes for ONSAM Jiras
- [x] If you have new dependencies/binaries, inform Samples Project Manager Swapna R Dontharaju (@srdontha) or @JoeOster

