### PR TITLE
Add compute_units DPC++ FPGA tutorial

### DIFF
--- a/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/compute_units/CMakeLists.txt
+++ b/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/compute_units/CMakeLists.txt
@@ -1,0 +1,11 @@
+set(CMAKE_CXX_COMPILER "dpcpp")
+
+cmake_minimum_required (VERSION 2.8)
+
+project(ComputeUnits)
+
+set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})
+set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})
+
+add_subdirectory (src)

--- a/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/compute_units/License.txt
+++ b/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/compute_units/License.txt
@@ -1,0 +1,7 @@
+Copyright Intel Corporation
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/compute_units/README.md
+++ b/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/compute_units/README.md
@@ -1,0 +1,151 @@
+
+# Using Compute Units To Duplicate Kernels
+This FPGA tutorial showcases a design pattern that allows you to make multiple copies of a kernel, called compute units.
+
+***Documentation***: The [oneAPI DPC++ FPGA Optimization Guide](https://software.intel.com/content/www/us/en/develop/documentation/oneapi-fpga-optimization-guide)  provides comprehensive instructions for targeting FPGAs through DPC++. The [oneAPI Programming Guide](https://software.intel.com/en-us/oneapi-programming-guide) is a general resource for target-independent DPC++ programming. 
+
+| Optimized for                     | Description
+---                                 |---
+| OS                                | Linux* Ubuntu* 18.04; Windows* 10
+| Hardware                          | Intel® Programmable Acceleration Card (PAC) with Intel Arria® 10 GX FPGA; <br> Intel® Programmable Acceleration Card (PAC) with Intel Stratix® 10 SX FPGA
+| Software                          | Intel® oneAPI DPC++ Compiler (Beta) <br> Intel® FPGA Add-On for oneAPI Base Toolkit 
+| What you will learn               | A design pattern to generate multiple compute units in DPC++ using template metaprogramming
+| Time to complete                  | 15 minutes
+
+_Notice: Limited support in Windows*; compiling for FPGA hardware is not supported in Windows*_
+
+## Purpose
+The performance of a design can sometimes by increased by making multiple copies of kernels, to make full use of the FPGA resources. Each kernel copy is called a compute unit.  
+
+This tutorial provides a header file that defines an abstraction for making multiple copies of a single-task kernel. This header can be used in any DPC++ design and can be extended as necessary.
+
+### Compute units example 
+
+This code sample builds on the pipe_array tutorial. It includes the header files `pipe_array.hpp`, `pipe_array_internal.hpp`, and `unroller.hpp` from the pipe_array tutorial, and provides the `compute_units.hpp` header as well.
+
+This code sample defines a `Source` kernel, and a `Sink` kernel. Data is read from host memory by the `Source` kernel, and sent to the `Sink` kernel via a chain of compute units. The number of compute units in the chain between `Source` and `Sink` is determined by the following parameter:
+
+``` c++
+constexpr size_t kEngines = 5;
+```
+
+Data is passed between kernels using pipes. The number of pipes needed is equal to the length of the chain, i.e., the number of compute units, plus one.
+This array of pipes is declared as follows:
+
+``` c++
+using Pipes = PipeArray<class MyPipe, float, 1, kEngines + 1>;
+```
+
+The `Source` kernel reads data from host memory and writes it to the first pipe:
+
+``` c++
+void SourceKernel(queue &q, float data) {
+
+  q.submit([&](handler &h) {
+    h.single_task<Source>([=]() { Pipes::PipeAt<0>::write(data); });
+  });
+}
+```
+
+At the end of the chain, the `Sink` kernel reads data from the last pipe and returns it to the host:
+
+``` c++
+void SinkKernel(queue &q, std::array<float, 1> &out_data) {
+
+  buffer<float, 1> out_buf(out_data.data(), 1);
+
+  q.submit([&](handler &h) {
+    auto out_accessor = out_buf.get_access<access::mode::write>(h);
+    h.single_task<Sink>(
+        [=]() { out_accessor[0] = Pipes::PipeAt<kEngines>::read(); });
+  });
+}
+```
+
+ The following line defines the functionality of each compute unit, and submits each compute unit to the given queue `q`. The number of copies to submit is provided by the first template parameter of `submit_compute_units`, while the second template parameter allows you to give the compute units a shared base name, e.g., `ChainComputeUnit`. The functionality of each compute unit must be specified by a generic lambda expression, that takes a single argument (with type `auto`) that provides an ID for each compute unit:
+
+``` c++
+intelfpga::submit_compute_units<kEngines, ChainComputeUnit>(q, [=](auto ID) {
+    float f = Pipes::PipeAt<ID>::read();
+    Pipes::PipeAt<ID + 1>::write(f);
+  });
+```
+
+Each compute unit in the chain from `Source` to `Sink` must read from a unique pipe, and write to the next pipe. As seen above, each compute unit knows its own ID and therefore its behavior can depend on this ID. Each compute unit in the chain will read from pipe `ID` and write to pipe `ID + 1`.
+
+## Key Concepts
+* A design pattern to generate multiple compute units in DPC++ using template metaprogramming
+
+## License  
+This code sample is licensed under MIT license.
+
+
+## Building the `compute_units` Tutorial
+
+### Include Files
+The included header `dpc_common.hpp` is located at `%ONEAPI_ROOT%\dev-utilities\latest\include` on your development system.
+
+### Running Samples in DevCloud
+If running a sample in the Intel DevCloud, remember that you must specify the compute node (fpga_compile or fpga_runtime) as well as whether to run in batch or interactive mode. For more information see the Intel® oneAPI Base Toolkit Get Started Guide ([https://devcloud.intel.com/oneapi/get-started/base-toolkit/](https://devcloud.intel.com/oneapi/get-started/base-toolkit/)).
+
+When compiling for FPGA hardware, it is recommended to increase the job timeout to 12h.
+
+### On a Linux* System
+
+1. Generate the `Makefile` by running `cmake`.
+     ```
+   mkdir build
+   cd build
+   ```
+   To compile for the Intel® PAC with Intel Arria® 10 GX FPGA, run `cmake` using the command:  
+    ```
+    cmake ..
+   ```
+   Alternatively, to compile for the Intel® PAC with Intel Stratix® 10 SX FPGA, run `cmake` using the command:
+
+   ```
+   cmake .. -DFPGA_BOARD=intel_s10sx_pac:pac_s10
+   ```
+
+2. Compile the design through the generated `Makefile`. The following build targets are provided, matching the recommended development flow:
+
+   * Compile for emulation (fast compile time, targets emulated FPGA device): 
+      ```
+      make fpga_emu
+      ```
+   * Generate the optimization report: 
+     ```
+     make report
+     ``` 
+   * Compile for FPGA hardware (longer compile time, targets FPGA device): 
+     ```
+     make fpga
+     ``` 
+3. (Optional) As the above hardware compile may take several hours to complete, an Intel® PAC with Intel Arria® 10 GX FPGA precompiled binary can be downloaded <a href="https://software.intel.com/content/dam/develop/external/us/en/documents/compute_units.fpga.tar.gz" download>here</a>.
+
+ ### In Third-Party Integrated Development Environments (IDEs)
+
+You can compile and run this tutorial in the Eclipse* IDE (in Linux*). For instructions, refer to the following link: [Intel® oneAPI DPC++ FPGA Workflows on Third-Party IDEs](https://software.intel.com/en-us/articles/intel-oneapi-dpcpp-fpga-workflow-on-ide)
+
+
+## Examining the Reports
+Locate `report.html` in the `compute_units_report.prj/reports/` or `compute_units_s10_pac_report.prj/reports/` directory. Open the report in any of Chrome*, Firefox*, Edge*, or Internet Explorer*.
+
+You can visualize the kernels and pipes generated by looking at the "System Viewer" section of the report. Note that each compute unit is shown as a unique kernel in the reports, with names `ChainComputeUnit<0>`, `ChainComputeUnit<1>`, etc.
+
+## Running the Sample
+
+ 1. Run the sample on the FPGA emulator (the kernels execute on the CPU):
+     ```
+     ./compute_units.fpga_emu     (Linux)
+     compute_units.fpga_emu.exe   (Windows)
+     ```
+2. Run the sample on the FPGA device:
+     ```
+     ./compute_units.fpga         (Linux)
+     ```
+
+### Example of Output
+```
+PASSED: The results are correct
+```

--- a/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/compute_units/compute_units.sln
+++ b/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/compute_units/compute_units.sln
@@ -1,0 +1,25 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 15
+VisualStudioVersion = 15.0.28307.705
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "compute_units", "compute_units.vcxproj", "{FA3FB2D1-BA98-4B4E-A8FA-A9BE6F8CA204}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|x64 = Debug|x64
+		Release|x64 = Release|x64
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{FA3FB2D1-BA98-4B4E-A8FA-A9BE6F8CA204}.Debug|x64.ActiveCfg = Debug|x64
+		{FA3FB2D1-BA98-4B4E-A8FA-A9BE6F8CA204}.Debug|x64.Build.0 = Debug|x64
+		{FA3FB2D1-BA98-4B4E-A8FA-A9BE6F8CA204}.Release|x64.ActiveCfg = Release|x64
+		{FA3FB2D1-BA98-4B4E-A8FA-A9BE6F8CA204}.Release|x64.Build.0 = Release|x64
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {936BD366-28EA-4A45-B5CF-EE6630694F28}
+	EndGlobalSection
+EndGlobal

--- a/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/compute_units/compute_units.vcxproj
+++ b/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/compute_units/compute_units.vcxproj
@@ -1,0 +1,166 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="src\compute_units.cpp" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="src\compute_units.h" />
+    <ClInclude Include="src\pipe_array.h" />
+    <ClInclude Include="src\pipe_array_internal.h" />
+    <ClInclude Include="src\unroller.h" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="README.md" />
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <VCProjectVersion>15.0</VCProjectVersion>
+    <ProjectGuid>{fa3fb2d1-ba98-4b4e-a8fa-a9be6f8ca204}</ProjectGuid>
+    <Keyword>Win32Proj</Keyword>
+    <RootNamespace>compute_units</RootNamespace>
+    <WindowsTargetPlatformVersion>$(WindowsSDKVersion.Replace("\",""))</WindowsTargetPlatformVersion>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>Intel(R) oneAPI DPC++ Compiler</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>Intel(R) oneAPI DPC++ Compiler</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>Intel(R) oneAPI DPC++ Compiler</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>Intel(R) oneAPI DPC++ Compiler</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="Shared">
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <LinkIncremental>true</LinkIncremental>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <LinkIncremental>true</LinkIncremental>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <LinkIncremental>false</LinkIncremental>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <LinkIncremental>false</LinkIncremental>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <ClCompile>
+      <PrecompiledHeader>Use</PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>Disabled</Optimization>
+      <SDLCheck>true</SDLCheck>
+      <ConformanceMode>true</ConformanceMode>
+      <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
+      <AdditionalIncludeDirectories>$(ONEAPI_ROOT)dev-utilities\latest\include</AdditionalIncludeDirectories>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <ClCompile>
+      <PrecompiledHeader>Use</PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>Disabled</Optimization>
+      <SDLCheck>true</SDLCheck>
+      <ConformanceMode>true</ConformanceMode>
+      <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
+      <EnableFPGACompilationAhead>true</EnableFPGACompilationAhead>
+      <AdditionalOptions>-DFPGA_EMULATOR %(AdditionalOptions)</AdditionalOptions>
+      <ObjectFileName>$(IntDir)compute_units.obj</ObjectFileName>
+      <AdditionalIncludeDirectories>$(ONEAPI_ROOT)dev-utilities\latest\include</AdditionalIncludeDirectories>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <ClCompile>
+      <PrecompiledHeader>Use</PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <SDLCheck>true</SDLCheck>
+      <ConformanceMode>true</ConformanceMode>
+      <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
+      <AdditionalIncludeDirectories>$(ONEAPI_ROOT)dev-utilities\latest\include</AdditionalIncludeDirectories>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile>
+      <PrecompiledHeader>Use</PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <SDLCheck>true</SDLCheck>
+      <ConformanceMode>true</ConformanceMode>
+      <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
+      <EnableFPGACompilationAhead>true</EnableFPGACompilationAhead>
+      <AdditionalOptions>-DFPGA_EMULATOR %(AdditionalOptions)</AdditionalOptions>
+      <ObjectFileName>$(IntDir)compute_units.obj</ObjectFileName>
+      <AdditionalIncludeDirectories>$(ONEAPI_ROOT)dev-utilities\latest\include</AdditionalIncludeDirectories>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+  </ItemDefinitionGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/compute_units/sample.json
+++ b/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/compute_units/sample.json
@@ -1,0 +1,51 @@
+{
+  "guid": "5E7932C9-B208-4A50-8700-D4970927D39D",
+  "name": "Using Compute Units To Duplicate Kernels",
+  "categories": ["Toolkit/Intel® oneAPI Base Toolkit/FPGA/Tutorials"],
+  "description": "FPGA tutorial showcasing a design pattern to enable the creation of compute units.",
+  "toolchain": ["dpcpp"],
+  "os": ["linux", "windows"],
+  "targetDevice": ["FPGA"],
+  "builder": ["ide", "cmake"],
+  "languages": [{"cpp":{}}],
+  "ciTests": {
+    "linux": [
+      {
+        "id": "fpga_emu",
+        "steps": [
+          "mkdir build",
+          "cd build",
+          "cmake ..",
+          "make fpga_emu",
+          "./compute_units.fpga_emu"
+        ]
+      },
+      {
+        "id": "report",
+        "steps": [
+          "mkdir build",
+          "cd build",
+          "cmake ..",
+          "make report"
+        ]
+      }
+    ],
+    "windows": [
+      {
+        "id": "fpga_emu",
+        "steps": [
+          "cd src",
+          "ninja fpga_emu",
+          "compute_units.fpga_emu.exe"
+        ]
+      },
+      {
+        "id": "report",
+        "steps": [
+          "cd src",
+          "ninja report"
+        ]
+      }
+    ]
+  }
+}

--- a/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/compute_units/src/CMakeLists.txt
+++ b/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/compute_units/src/CMakeLists.txt
@@ -1,0 +1,92 @@
+set(SOURCE_FILE compute_units.cpp)
+set(TARGET_NAME compute_units)
+set(EMULATOR_TARGET ${TARGET_NAME}.fpga_emu)
+set(FPGA_TARGET ${TARGET_NAME}.fpga)
+
+# Intel supported FPGA Boards and their names
+set(A10_PAC_BOARD_NAME "intel_a10gx_pac:pac_a10")
+set(S10_PAC_BOARD_NAME "intel_s10sx_pac:pac_s10")
+
+# Assume target is the Intel(R) PAC with Intel Arria(R) 10 GX FPGA 
+SET(_FPGA_BOARD ${A10_PAC_BOARD_NAME})
+
+# Check if target is the Intel(R) PAC with Intel Stratix(R) 10 SX FPGA
+IF (NOT DEFINED FPGA_BOARD)
+    MESSAGE(STATUS "\tFPGA_BOARD was not specified. Configuring the design to run on the Intel(R) Programmable Acceleration Card (PAC) with Intel Arria(R) 10 GX FPGA. Please refer to the README for more information on how to run the design on the Intel(R) PAC with Intel Stratix(R) 10 SX FPGA.")
+
+ELSEIF(FPGA_BOARD STREQUAL ${A10_PAC_BOARD_NAME})
+    MESSAGE(STATUS "\tConfiguring the design to run on the Intel(R) Programmable Acceleration Card (PAC) with Intel Arria(R) 10 GX FPGA.")
+
+ELSEIF(FPGA_BOARD STREQUAL ${S10_PAC_BOARD_NAME})
+    MESSAGE(STATUS "\tConfiguring the design to run on the Intel(R) Programmable Acceleration Card (PAC) with Intel Stratix(R) 10 SX FPGA.")
+    SET(_FPGA_BOARD ${S10_PAC_BOARD_NAME})
+
+ELSE()
+    MESSAGE(STATUS "\tAn invalid board name was passed in using the FPGA_BOARD flag. Configuring the design to run on the Intel(R) Programmable Acceleration Card (PAC) with Intel Arria(R) 10 GX FPGA. Please refer to the README for the list of valid board names.")
+ENDIF()
+
+set(HARDWARE_COMPILE_FLAGS "-fintelfpga")
+
+# use cmake -D USER_HARDWARE_FLAGS=<flags> to set extra flags for FPGA backend compilation
+set(HARDWARE_LINK_FLAGS "-fintelfpga -Xshardware -Xsboard=${_FPGA_BOARD} ${USER_HARDWARE_FLAGS}")
+
+set(EMULATOR_COMPILE_FLAGS "-fintelfpga -DFPGA_EMULATOR")
+set(EMULATOR_LINK_FLAGS "-fintelfpga")
+
+# fpga emulator
+if(WIN32)
+      set(WIN_EMULATOR_TARGET ${EMULATOR_TARGET}.exe)
+      add_custom_target(fpga_emu DEPENDS ${WIN_EMULATOR_TARGET})
+      separate_arguments(WIN_EMULATOR_COMPILE_FLAGS WINDOWS_COMMAND "${EMULATOR_COMPILE_FLAGS}")
+      add_custom_command(OUTPUT ${WIN_EMULATOR_TARGET} 
+                   COMMAND ${CMAKE_CXX_COMPILER} ${WIN_EMULATOR_COMPILE_FLAGS} /GX ${CMAKE_CURRENT_SOURCE_DIR}/${SOURCE_FILE} -o ${CMAKE_BINARY_DIR}/${WIN_EMULATOR_TARGET}
+                   DEPENDS ${SOURCE_FILE})
+
+else()
+      add_executable(${EMULATOR_TARGET} ${SOURCE_FILE})
+      add_custom_target(fpga_emu DEPENDS ${EMULATOR_TARGET})
+      set_target_properties(${EMULATOR_TARGET} PROPERTIES COMPILE_FLAGS ${EMULATOR_COMPILE_FLAGS})
+      set_target_properties(${EMULATOR_TARGET} PROPERTIES LINK_FLAGS ${EMULATOR_LINK_FLAGS})
+endif()
+
+# fpga
+if(WIN32)
+     add_custom_target(fpga
+                  COMMAND echo "FPGA hardware flow is not supported in Windows")
+else()
+    add_executable(${FPGA_TARGET} EXCLUDE_FROM_ALL ${SOURCE_FILE})
+    add_custom_target(fpga DEPENDS ${FPGA_TARGET})
+    set_target_properties(${FPGA_TARGET} PROPERTIES COMPILE_FLAGS ${HARDWARE_COMPILE_FLAGS})
+    set_target_properties(${FPGA_TARGET} PROPERTIES LINK_FLAGS ${HARDWARE_LINK_FLAGS})
+endif()
+
+# report
+if(WIN32)
+    set(DEVICE_OBJ_FILE ${TARGET_NAME}_report.a)
+    add_custom_target(report DEPENDS ${DEVICE_OBJ_FILE})
+
+    separate_arguments(HARDWARE_LINK_FLAGS_LIST WINDOWS_COMMAND "${HARDWARE_LINK_FLAGS}")
+    add_custom_command(OUTPUT ${DEVICE_OBJ_FILE} 
+        COMMAND ${CMAKE_CXX_COMPILER} /EHsc ${CMAKE_CXX_FLAGS} ${HARDWARE_LINK_FLAGS_LIST} -fsycl-link ${CMAKE_CURRENT_SOURCE_DIR}/${SOURCE_FILE} -o ${CMAKE_BINARY_DIR}/${DEVICE_OBJ_FILE}
+                       DEPENDS ${SOURCE_FILE})
+
+else()
+    set(DEVICE_OBJ_FILE ${TARGET_NAME}_report.a)
+    add_custom_target(report DEPENDS ${DEVICE_OBJ_FILE})
+
+    configure_file(${CMAKE_CURRENT_SOURCE_DIR}/${SOURCE_FILE} ${SOURCE_FILE} COPYONLY)
+    configure_file(${CMAKE_CURRENT_SOURCE_DIR}/compute_units.hpp compute_units.hpp COPYONLY)
+    configure_file(${CMAKE_CURRENT_SOURCE_DIR}/pipe_array.hpp pipe_array.hpp COPYONLY)
+    configure_file(${CMAKE_CURRENT_SOURCE_DIR}/unroller.hpp unroller.hpp COPYONLY)
+    configure_file(${CMAKE_CURRENT_SOURCE_DIR}/pipe_array_internal.hpp pipe_array_internal.hpp COPYONLY)
+
+    separate_arguments(HARDWARE_LINK_FLAGS_LIST UNIX_COMMAND "${HARDWARE_LINK_FLAGS}")
+    add_custom_command(OUTPUT ${DEVICE_OBJ_FILE} 
+                       COMMAND ${CMAKE_CXX_COMPILER} ${CMAKE_CXX_FLAGS} ${HARDWARE_LINK_FLAGS_LIST} -fsycl-link ${SOURCE_FILE} -o ${CMAKE_BINARY_DIR}/${DEVICE_OBJ_FILE}
+                       DEPENDS ${SOURCE_FILE} compute_units.hpp pipe_array.hpp unroller.hpp pipe_array_internal.hpp)
+endif()
+
+# run
+add_custom_target(run
+                  COMMAND ../${TARGET_NAME}.fpga_emu
+                  DEPENDS ${TARGET_NAME}.fpga_emu)

--- a/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/compute_units/src/build.ninja
+++ b/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/compute_units/src/build.ninja
@@ -5,8 +5,8 @@ emulator_target = ${target_name}.fpga_emu.exe
 report_target = ${target_name}_report.a
 report_target_s10_pac = ${target_name}_s10_pac_report.a
 
-hardware_flags = -fintelfpga -Xshardware -std=c++14
-emulator_flags = -fintelfpga -DFPGA_EMULATOR -std=c++14
+hardware_flags = -fintelfpga -Xshardware
+emulator_flags = -fintelfpga -DFPGA_EMULATOR
 
 rule build_fpga_emu
   command = dpcpp /GX ${emulator_flags} $in -o $out

--- a/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/compute_units/src/build.ninja
+++ b/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/compute_units/src/build.ninja
@@ -1,0 +1,30 @@
+source_file = compute_units.cpp
+target_name = compute_units
+
+emulator_target = ${target_name}.fpga_emu.exe
+report_target = ${target_name}_report.a
+report_target_s10_pac = ${target_name}_s10_pac_report.a
+
+hardware_flags = -fintelfpga -Xshardware -std=c++14
+emulator_flags = -fintelfpga -DFPGA_EMULATOR -std=c++14
+
+rule build_fpga_emu
+  command = dpcpp /GX ${emulator_flags} $in -o $out
+
+rule gen_report
+  command = dpcpp /GX ${hardware_flags} -Xsboard=intel_a10gx_pac:pac_a10 -fsycl-link $in -o $out
+
+rule gen_report_s10_pac
+  command = dpcpp /GX ${hardware_flags} -Xsboard=intel_s10sx_pac:pac_s10 -fsycl-link $in -o $out
+
+# FPGA emulator
+build fpga_emu: phony ${emulator_target}
+build ${emulator_target}: build_fpga_emu ${source_file}
+
+# report
+build report: phony ${report_target}
+build ${report_target}: gen_report ${source_file}
+
+# report (S10 PAC)
+build report_s10_pac: phony ${report_target_s10_pac}
+build ${report_target_s10_pac}: gen_report_s10_pac ${source_file}

--- a/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/compute_units/src/compute_units.cpp
+++ b/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/compute_units/src/compute_units.cpp
@@ -5,6 +5,7 @@
 // =============================================================
 #include <CL/sycl.hpp>
 #include <iostream>
+
 // dpc_common.hpp can be found in the dev-utilities include folder,
 // e.g., $ONEAPI_ROOT/dev-utilities/latest/include/dpc_common.hpp
 #include "dpc_common.hpp"

--- a/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/compute_units/src/compute_units.cpp
+++ b/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/compute_units/src/compute_units.cpp
@@ -1,0 +1,109 @@
+//==============================================================
+// Copyright Intel Corporation
+//
+// SPDX-License-Identifier: MIT
+// =============================================================
+#include <CL/sycl.hpp>
+#include <iostream>
+// dpc_common.hpp can be found in the dev-utilities include folder,
+// e.g., $ONEAPI_ROOT/dev-utilities/latest/include/dpc_common.hpp
+#include "dpc_common.hpp"
+#include "compute_units.hpp"
+#include "pipe_array.hpp"
+
+// Header locations and some DPC++ extensions changed between beta09 and beta10
+// Temporarily modify the code sample to accept either version
+#define BETA09 20200827
+#if __SYCL_COMPILER_VERSION <= BETA09
+  #include <CL/sycl/intel/fpga_extensions.hpp>
+  namespace INTEL = sycl::intel;  // Namespace alias for backward compatibility
+#else
+  #include <CL/sycl/INTEL/fpga_extensions.hpp>
+#endif
+
+
+using namespace sycl;
+
+constexpr float kTestData = 555;
+constexpr size_t kEngines = 5;
+
+using Pipes = PipeArray<class MyPipe, float, 1, kEngines + 1>;
+
+// Forward declaration of the kernel name
+// (This will become unnecessary in a future compiler version.)
+class Source;
+class Sink;
+template <std::size_t ID> class ChainComputeUnit;
+
+// Write the data into the chain
+void SourceKernel(queue &q, float data) {
+
+  q.submit([&](handler &h) {
+    h.single_task<Source>([=] { Pipes::PipeAt<0>::write(data); });
+  });
+}
+
+// Get the data out of the chain and return it to the host
+void SinkKernel(queue &q, std::array<float, 1> &out_data) {
+
+  // Use verbose SYCL 1.2 syntax for the output buffer.
+  // (This will become unnecessary in a future compiler version.)
+  buffer<float, 1> out_buf(out_data.data(), 1);
+
+  q.submit([&](handler &h) {
+    auto out_accessor = out_buf.get_access<access::mode::write>(h);
+    h.single_task<Sink>(
+        [=] { out_accessor[0] = Pipes::PipeAt<kEngines>::read(); });
+  });
+}
+
+int main() {
+
+#if defined(FPGA_EMULATOR)
+  INTEL::fpga_emulator_selector device_selector;
+#else
+  INTEL::fpga_selector device_selector;
+#endif
+
+  std::array<float, 1> out_data = {0};
+
+  try {
+    queue q(device_selector, dpc_common::exception_handler);
+
+    // Enqueue the Source kernel
+    SourceKernel(q, kTestData);
+
+    // Enqueue the chain of kEngines compute units
+    // Compute unit must take a single argument, its ID
+    submit_compute_units<kEngines, ChainComputeUnit>(q, [=](auto ID) {
+      float f = Pipes::PipeAt<ID>::read();
+      Pipes::PipeAt<ID + 1>::write(f);
+    });
+
+    // Enqueue the Sink kernel
+    SinkKernel(q, out_data);
+
+  } catch (sycl::exception const &e) {
+    // Catches exceptions in the host code
+    std::cout << "Caught a SYCL host exception:\n" << e.what() << "\n";
+
+    // Most likely the runtime couldn't find FPGA hardware!
+    if (e.get_cl_code() == CL_DEVICE_NOT_FOUND) {
+      std::cout << "If you are targeting an FPGA, please ensure that your "
+                   "system has a correctly configured FPGA board.\n";
+      std::cout << "If you are targeting the FPGA emulator, compile with "
+                   "-DFPGA_EMULATOR.\n";
+    }
+    std::terminate();
+  }
+
+  // Verify result
+  if (out_data[0] != kTestData) {
+    std::cout << "FAILED: The results are incorrect\n";
+    std::cout << "Expected: " << kTestData << " Got: " << out_data[0] << "\n";
+    return 1;
+  }
+
+  std::cout << "PASSED: The results are correct\n";
+  return 0;
+}

--- a/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/compute_units/src/compute_units.hpp
+++ b/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/compute_units/src/compute_units.hpp
@@ -1,0 +1,37 @@
+//==============================================================
+// Copyright Intel Corporation
+//
+// SPDX-License-Identifier: MIT
+// =============================================================
+#include <CL/sycl.hpp>
+#include <utility>
+
+namespace {
+template <class Func, template <std::size_t> class Name, std::size_t index>
+class SubmitOneComputeUnit {
+public:
+  SubmitOneComputeUnit(Func &&f, sycl::queue &q) {
+
+    q.submit([&](sycl::handler &h) {
+      h.single_task<Name<index>>([=] {
+        // verifies that f only takes a single argument
+        f(std::integral_constant<std::size_t, index>());
+      });
+    });
+  }
+};
+
+template <template <std::size_t> class Name, class Func, std::size_t... index>
+inline constexpr void ComputeUnitUnroller(sycl::queue &q, Func &&f,
+                                          std::index_sequence<index...>) {
+  (SubmitOneComputeUnit<Func, Name, index>(f, q), ...); // fold expression
+}
+} // namespace
+
+// N is the number of compute units
+// Name is the kernel's name
+template <std::size_t N, template <std::size_t ID> class Name, class Func>
+constexpr void submit_compute_units(sycl::queue &q, Func &&f) {
+  std::make_index_sequence<N> indices;
+  ComputeUnitUnroller<Name>(q, f, indices);
+}

--- a/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/compute_units/src/pipe_array.hpp
+++ b/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/compute_units/src/pipe_array.hpp
@@ -1,0 +1,43 @@
+//==============================================================
+// Copyright Intel Corporation
+//
+// SPDX-License-Identifier: MIT
+// =============================================================
+#include <CL/sycl.hpp>
+#include <utility>
+
+// Header locations and some DPC++ extensions changed between beta09 and beta10
+// Temporarily modify the code sample to accept either version
+#define BETA09 20200827
+#if __SYCL_COMPILER_VERSION <= BETA09
+  #include <CL/sycl/intel/fpga_extensions.hpp>
+  namespace INTEL = sycl::intel;  // Namespace alias for backward compatibility
+#else
+  #include <CL/sycl/INTEL/fpga_extensions.hpp>
+#endif
+
+
+#include "pipe_array_internal.hpp"
+
+template <class Id, typename BaseTy, size_t depth, size_t... dims>
+struct PipeArray {
+  PipeArray() = delete;
+
+  template <size_t... idxs>
+  struct StructId;
+
+  template <size_t... idxs>
+  struct VerifyIndices {
+    static_assert(sizeof...(idxs) == sizeof...(dims),
+                  "Indexing into a PipeArray requires as many indices as "
+                  "dimensions of the PipeArray.");
+    static_assert(VerifierDimLayer<dims...>::template VerifierIdxLayer<
+                      idxs...>::IsValid(),
+                  "Index out of bounds");
+    using VerifiedPipe =
+        cl::sycl::INTEL::pipe<StructId<idxs...>, BaseTy, depth>;
+  };
+
+  template <size_t... idxs>
+  using PipeAt = typename VerifyIndices<idxs...>::VerifiedPipe;
+};

--- a/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/compute_units/src/pipe_array.hpp
+++ b/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/compute_units/src/pipe_array.hpp
@@ -14,6 +14,7 @@
   namespace INTEL = sycl::intel;  // Namespace alias for backward compatibility
 #else
   #include <CL/sycl/INTEL/fpga_extensions.hpp>
+  using namespace sycl;
 #endif
 
 

--- a/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/compute_units/src/pipe_array.hpp
+++ b/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/compute_units/src/pipe_array.hpp
@@ -35,7 +35,7 @@ struct PipeArray {
                       idxs...>::IsValid(),
                   "Index out of bounds");
     using VerifiedPipe =
-        cl::sycl::INTEL::pipe<StructId<idxs...>, BaseTy, depth>;
+        INTEL::pipe<StructId<idxs...>, BaseTy, depth>;
   };
 
   template <size_t... idxs>

--- a/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/compute_units/src/pipe_array_internal.hpp
+++ b/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/compute_units/src/pipe_array_internal.hpp
@@ -1,0 +1,26 @@
+//==============================================================
+// Copyright Intel Corporation
+//
+// SPDX-License-Identifier: MIT
+// =============================================================
+
+namespace {
+template <size_t dim1, size_t... dims>
+struct VerifierDimLayer {
+  template <size_t idx1, size_t... idxs>
+  struct VerifierIdxLayer {
+    static constexpr bool IsValid() {
+      return idx1 < dim1 &&
+             (VerifierDimLayer<dims...>::template VerifierIdxLayer<
+                 idxs...>::IsValid());
+    }
+  };
+};
+template <size_t dim>
+struct VerifierDimLayer<dim> {
+  template <size_t idx>
+  struct VerifierIdxLayer {
+    static constexpr bool IsValid() { return idx < dim; }
+  };
+};
+}  // namespace

--- a/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/compute_units/src/unroller.hpp
+++ b/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/compute_units/src/unroller.hpp
@@ -1,0 +1,15 @@
+//==============================================================
+// Copyright Intel Corporation
+//
+// SPDX-License-Identifier: MIT
+// =============================================================
+template <size_t it, size_t end> struct Unroller {
+  template <typename Action> static void Step(const Action &action) {
+    action(std::integral_constant<size_t, it>());
+    Unroller<it + 1, end>::Step(action);
+  }
+};
+
+template <size_t end> struct Unroller<end, end> {
+  template <typename Action> static void Step(const Action &) {}
+};


### PR DESCRIPTION
#  Description

This tutorial shows how to make multiple copies of kernels, called compute_units.

# Type of Change

- [X] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- [X] Command Line

