### PR TITLE
Add max_interleaving DPC++ FPGA tutorial

### DIFF
--- a/DirectProgramming/DPC++FPGA/Tutorials/Features/max_interleaving/CMakeLists.txt
+++ b/DirectProgramming/DPC++FPGA/Tutorials/Features/max_interleaving/CMakeLists.txt
@@ -1,0 +1,10 @@
+set(CMAKE_CXX_COMPILER "dpcpp")
+cmake_minimum_required (VERSION 2.8)
+
+project(MaxConcurrency)
+
+set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})
+set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})
+
+add_subdirectory (src)

--- a/DirectProgramming/DPC++FPGA/Tutorials/Features/max_interleaving/License.txt
+++ b/DirectProgramming/DPC++FPGA/Tutorials/Features/max_interleaving/License.txt
@@ -1,0 +1,7 @@
+Copyright Intel Corporation
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/DirectProgramming/DPC++FPGA/Tutorials/Features/max_interleaving/README.md
+++ b/DirectProgramming/DPC++FPGA/Tutorials/Features/max_interleaving/README.md
@@ -1,0 +1,166 @@
+# Maximum Interleaving of a Loop
+This FPGA tutorial explains how to use the `max_interleaving` attribute for loops.
+
+***Documentation***: The [oneAPI DPC++ FPGA Optimization Guide](https://software.intel.com/content/www/us/en/develop/documentation/oneapi-fpga-optimization-guide)  provides comprehensive instructions for targeting FPGAs through DPC++. The [oneAPI Programming Guide](https://software.intel.com/en-us/oneapi-programming-guide) is a general resource for target-independent DPC++ programming.
+
+| Optimized for                     | Description
+---                                 |---
+| OS                                | Linux* Ubuntu* 18.04; Windows* 10
+| Hardware                          | Intel® Programmable Acceleration Card (PAC) with Intel Arria® 10 GX FPGA <br> Intel® Programmable Acceleration Card (PAC) with Intel Stratix® 10 SX FPGA
+| Software                          | Intel® oneAPI DPC++ Compiler (Beta)
+| What you will learn               | The basic usage of the `max_interleaving` attribute <br> How the `max_interleaving` attribute affects loop resource use <br> How to apply the `max_interleaving` attribute to loops in your program 
+| Time to complete                  | 15 minutes
+
+_Notice: Limited support in Windows*, Compiling for FPGA hardware is not supported in Windows*_
+
+## Purpose
+This tutorial demonstrates a method to reduce the area usage of inner loops that cannot realize throughput increases through interleaved execution. By default, the compiler will generate loop datapaths that enable multiple invocations of the same loop to execute simultaneously, called interleaving, in order to maximize throughput when II is greater than 1. In cases where interleaving is dynamically prohibited, e.g., due to data dependency preservation, the hardware resources used to enable interleaving are wasted. The `max_interleaving` attribute can be used to instruct the compiler to limit allocation of these hardware resources in these cases.
+
+### Description of the `max_interleaving` Attribute
+Consider a pipelined inner loop `i` with an II > 1 contained inside a pipelined outer loop `j`. If the trip count of the `i` loop does not vary with respect to the iterations of the `j` loop, the compiler will automatically generate hardware that allows the `i` loop to interleave iterations from different invocations of itself. That is, each iteration of the outer `j` loop will contain a different invocation of the inner `i` loop. Each of these invocations of the `i` loop will issue iterations every II cycles, leaving II-1 cycles in between these iterations empty. These empty cycles can be used to issus iterations of a different invocation of `i` (corresponding to a different iteration of the `j` loop), which we called interleaving. Interleaving allows the generated design to have a high occupancy despite a high II, which improves throughput.
+
+Although interleaving will generally improve throughput, there may be some scenarios in which users may not wish to incur the hardware cost of generating a pipelined datapath that allows interleaving. For example, in a nest of pipelined loops, pipelined iterations of an outer loop may be serialized by the compiler across an inner loop if the inner loop imposes a data dependency on the containing loop. For such scenarios, the generation of a loop datapath that supports interleaving iterations of the containing pipelined loop yields little to no benefit in throughput, because the serialization to preserve the data dependency will prevent interleaving from occuring. Manually restricting or disabling the amount of interleaving on the inner loop reduces the area overhead imposed by a datapath generated to handle interleaved invocations. Users can mark a loop with the `max_interleaving` pragma to limit the number of interleaved invocations supported by the generated loop datapath.
+
+### Example: 
+
+```
+L1: for (size_t i = 0; i < kSize; i++) {
+  L2: for (size_t j = 0; j < kSize; j++) {
+        temp_r[j] = SomethingComplicated(temp_a[i][j], temp_r[j]);
+  }
+  temp_r[i] += temp_b[i];
+}
+```
+
+In this loop nest, pipelined iterations of L1 are serialized across L2 in order to preserve the data dependency on the array variable 'temp_r'. This means that only one invocation of the `j` loop can be executing at any time, and therefore no dynamic interleaving of iterations from different invocations of the `j` loop can occur. By default, the compiler will generate a datapath that includes capacity to run multiple interleaved iterations simultaneously. Since the data dependency prevents dynamic interleaving, the resources spent on an interleaving-capable datapath are wasted. Applying the `max_interleaving` attribute with a argument of `1` will instruct the compiler generate a datapath that restricts the interleaving capacity to a single `j` loop invocation.
+
+## Key Concepts
+* The basic usage of the `max_interleaving` attribute
+* How the `max_interleaving` attribute affects loop throughput and resource use
+* How to apply the `max_interleaving` attribute to loops in your program
+
+## License
+This code sample is licensed under MIT license.
+
+## Building the `max_interleaving` Tutorial
+
+### Include Files
+The included header `dpc_common.hpp` is located at `%ONEAPI_ROOT%\dev-utilities\latest\include` on your development system.
+
+### Running Samples in DevCloud
+If running a sample in the Intel DevCloud, remember that you must specify the compute node (fpga_compile or fpga_runtime) as well whether to run in batch or interactive mode. For more information see the Intel® oneAPI Base Toolkit Get Started Guide ([https://devcloud.intel.com/oneapi/get-started//
+base-toolkit/](https://devcloud.intel.com/oneapi/get-started/base-toolkit/)).
+
+When compiling for FPGA hardware, it is recommended to increase the job timeout to 12h.
+
+### On a Linux* System
+
+1. Generate the `Makefile` by running `cmake`.
+     ```
+   mkdir build
+   cd build
+   ```
+   To compile for the Intel® PAC with Intel Arria® 10 GX FPGA, run `cmake` using the command:
+    ```
+    cmake ..
+   ```
+   Alternatively, to compile for the Intel® PAC with Intel Stratix® 10 SX FPGA, run `cmake` using the command:
+
+   ```
+   cmake .. -DFPGA_BOARD=intel_s10sx_pac:pac_s10
+   ```
+
+2. Compile the design through the generated `Makefile`. The following build targets are provided, matching the recommended development flow:
+
+   * Compile for emulation (fast compile time, targets emulated FPGA device):
+      ```
+      make fpga_emu
+      ```
+   * Generate the optimization report:
+     ```
+     make report
+     ```
+   * Compile for FPGA hardware (longer compile time, targets FPGA device):
+     ```
+     make fpga
+     ```
+
+3. (Optional) As the FPGA hardware compile may take several hours to complete, an Intel® PAC with Intel Arria® 10 GX FPGA precompiled binary can bee
+ downloaded <a href="https://software.intel.com/content/dam/develop/external/us/en/documents/max_interleaving.fpga.tar.gz" download>here</a>.
+
+### On a Windows* System
+Note: `cmake` is not yet supported on Windows. A build.ninja file is provided instead.
+
+1. Enter the source file directory.
+   ```
+   cd src
+   ```
+
+2. Compile the design. The following build targets are provided, matching the recommended development flow:
+
+   * Compile for emulation (fast compile time, targets emulated FPGA device):
+      ```
+      ninja fpga_emu
+      ```
+
+   * Generate the optimization report:
+
+     ```
+     ninja report
+     ```
+     If you are targeting Intel® PAC with Intel Stratix® 10 SX FPGA, instead use:
+     ```
+     ninja report_s10_pac
+     ```
+   * Compiling for FPGA hardware is not yet supported on Windows.
+
+ ### In Third-Party Integrated Development Environments (IDEs)
+
+You can compile and run this tutorial in the Eclipse* IDE (in Linux*) and the Visual Studio* IDE (in Windows*). For instructions, refer to the following link: [Intel® oneAPI DPC++ FPGA Workflows on Third-Party IDEs](https://software.intel.com/en-us/articles/intel-oneapi-dpcpp-fpga-workflow-on-idee
+)
+
+## Examining the Reports
+Locate `report.html` in the `max_interleaving_report.prj/reports/` or `max_interleaving_s10_pac_report.prj/reports/report.html` directory. Open the report in any of Chrome*, Firefox*, Edge*, or Internet Explorer*.
+
+In the "Loops analysis" view from the "Throughput Analysis" drop-down menu, in the Details pane for loop L1 (choose either Compute<0>.B6 or Compute<1>.B6 from the "Loop List" pane, then the click the "Source Location" link in the "Loop Analysis" pane):
+
+Iteration executed serially across KernelCompute<0>.B8. Only a single loop iteration will execute inside this region due to data dependency on variable(s):
+
+    temp_r (max_interleaving.cpp: 56)
+
+As described in the Example section above, generating a loop datapath that supports interleaving iterations of the containing pipelined loop in this scenario yields little to no benefit in throughput because preservation of the data dependency on `temp_r` requires that only one invocation of the inner loop be executed at a time. Adding the `max_interleaving(1)` attribute informs the compiler to not allocated hardware resources for interleaving on the inner loop, reducing the area overhead. 
+
+Referring to the generated report again, choose the "Summary" view, expand the "System Resource Utilization Summary" section in the Summary pane, and select the "Compile Estimated Kernel Resource Utilization Summary" subsection. In this subsection, you will see resource utilization estimates for two kernels: Compute<0> and Compute<1>. These correspond to two nearly-identical kernels, with the only difference being the `max_interleaving` attribute applied to the inner loop at line 58 taking either a 0 or 1 as its argument (`max_interleaving(0)` specifies unlimited interleaving, which is the same as the default `max_interleaving` limit when no attribute is set). Note that Compute<1>, which has restricted interleaving, uses fewer ALUTs, REGs, and MLABs than Compute<0>.
+
+The area usage information can also be accessed on the main report page in the Summary pane. Scroll down to the section titled "System Resource Utilization Summary". Each kernel name ends in the `max_interleaving` attribute argument used for that kernel, e.g., `KernelCompute<1>` uses a `max_interleaving` attribute value of 1. You can verify that the number of ALUTs, REGs, and MLABs used for each kernel decreases when `max_interleaving` is limited to 1 compared to unlimited interleaving when `max_interleaving` is set to 0.
+
+## Running the Sample
+
+ 1. Run the sample on the FPGA emulator (the kernel executes on the CPU):
+     ```
+     ./max_interleaving.fpga_emu     (Linux)
+     max_interleaving.fpga_emu.exe   (Windows)
+     ```
+2. Run the sample on the FPGA device:
+     ```
+     ./max_interleaving.fpga         (Linux)
+     ```
+
+
+### Example of Output
+```
+Max interleaving 0 kernel time : 0.019088 ms
+Throughput for kernel with max_interleaving 0: 0.007 GFlops
+Max interleaving 1 kernel time : 0.015 ms
+Throughput for kernel with max_interleaving 1: 0.009 GFlops
+PASSED: The results are correct
+```
+
+### Discussion of Results
+
+The stdout output shows the giga-floating point operations per second (GFlops) for each kernel.
+
+When run on the Intel® PAC with Intel Arria10® 10 GX FPGA hardware board, we see that the throughput remains unchanged when using `max_interleaving(0)` or `max_interleaving(1)`. However, the kernel using `max_interleaving(1)` uses fewer hardware resources as shown in the reports.
+
+When run on the FPGA emulator, the `max_interleaving` attribute has no effect on runtime. You may notice that the emulator achieved higher throughput than the FPGA in this example. This is because this trivial example uses only a tiny fraction of the spacial compute resources available on the FPGA.
+

--- a/DirectProgramming/DPC++FPGA/Tutorials/Features/max_interleaving/max_interleaving.sln
+++ b/DirectProgramming/DPC++FPGA/Tutorials/Features/max_interleaving/max_interleaving.sln
@@ -1,0 +1,25 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 15
+VisualStudioVersion = 15.0.28307.705
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "max_interleaving", "max_interleaving.vcxproj", "{F0CE4972-62AF-4B9F-996F-1D1DB14D76B7}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|x64 = Debug|x64
+		Release|x64 = Release|x64
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{F0CE4972-62AF-4B9F-996F-1D1DB14D76B7}.Debug|x64.ActiveCfg = Debug|x64
+		{F0CE4972-62AF-4B9F-996F-1D1DB14D76B7}.Debug|x64.Build.0 = Debug|x64
+		{F0CE4972-62AF-4B9F-996F-1D1DB14D76B7}.Release|x64.ActiveCfg = Release|x64
+		{F0CE4972-62AF-4B9F-996F-1D1DB14D76B7}.Release|x64.Build.0 = Release|x64
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {3247AB7C-282F-4907-B1F4-E944349A8835}
+	EndGlobalSection
+EndGlobal

--- a/DirectProgramming/DPC++FPGA/Tutorials/Features/max_interleaving/max_interleaving.vcxproj
+++ b/DirectProgramming/DPC++FPGA/Tutorials/Features/max_interleaving/max_interleaving.vcxproj
@@ -1,0 +1,160 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="src\max_interleaving.cpp" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="README.md" />
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <VCProjectVersion>15.0</VCProjectVersion>
+    <ProjectGuid>{f0ce4972-62af-4b9f-996f-1d1db14d76b7}</ProjectGuid>
+    <Keyword>Win32Proj</Keyword>
+    <RootNamespace>max_interleaving</RootNamespace>
+    <WindowsTargetPlatformVersion>$(WindowsSDKVersion.Replace("\",""))</WindowsTargetPlatformVersion>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>Intel(R) oneAPI DPC++ Compiler</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>Intel(R) oneAPI DPC++ Compiler</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>Intel(R) oneAPI DPC++ Compiler</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>Intel(R) oneAPI DPC++ Compiler</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="Shared">
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <LinkIncremental>true</LinkIncremental>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <LinkIncremental>true</LinkIncremental>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <LinkIncremental>false</LinkIncremental>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <LinkIncremental>false</LinkIncremental>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <ClCompile>
+      <PrecompiledHeader>Use</PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>Disabled</Optimization>
+      <SDLCheck>true</SDLCheck>
+      <ConformanceMode>true</ConformanceMode>
+      <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
+      <AdditionalIncludeDirectories>$(ONEAPI_ROOT)dev-utilities\latest\include</AdditionalIncludeDirectories>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <ClCompile>
+      <PrecompiledHeader>Use</PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>Disabled</Optimization>
+      <SDLCheck>true</SDLCheck>
+      <ConformanceMode>true</ConformanceMode>
+      <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
+      <EnableFPGACompilationAhead>true</EnableFPGACompilationAhead>
+      <AdditionalOptions>-DFPGA_EMULATOR %(AdditionalOptions)</AdditionalOptions>
+      <ObjectFileName>$(IntDir)max_interleaving.obj</ObjectFileName>
+      <AdditionalIncludeDirectories>$(ONEAPI_ROOT)dev-utilities\latest\include</AdditionalIncludeDirectories>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <ClCompile>
+      <PrecompiledHeader>Use</PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <SDLCheck>true</SDLCheck>
+      <ConformanceMode>true</ConformanceMode>
+      <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
+      <AdditionalIncludeDirectories>$(ONEAPI_ROOT)dev-utilities\latest\include</AdditionalIncludeDirectories>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile>
+      <PrecompiledHeader>Use</PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <SDLCheck>true</SDLCheck>
+      <ConformanceMode>true</ConformanceMode>
+      <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
+      <EnableFPGACompilationAhead>true</EnableFPGACompilationAhead>
+      <AdditionalOptions>-DFPGA_EMULATOR %(AdditionalOptions)</AdditionalOptions>
+      <ObjectFileName>$(IntDir)max_interleaving.obj</ObjectFileName>
+      <AdditionalIncludeDirectories>$(ONEAPI_ROOT)dev-utilities\latest\include</AdditionalIncludeDirectories>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+  </ItemDefinitionGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/DirectProgramming/DPC++FPGA/Tutorials/Features/max_interleaving/sample.json
+++ b/DirectProgramming/DPC++FPGA/Tutorials/Features/max_interleaving/sample.json
@@ -1,0 +1,51 @@
+{
+  "guid": "2013EC16-5BB7-4EBF-9F55-E224A1C8CB73",
+  "name": "Loop Max Interleaving Attribute",
+  "categories": ["Toolkit/Intel® oneAPI Base Toolkit/FPGA/Tutorials"],
+  "description": "FPGA tutorial demonstrating the usage of the loop max_interleaving attribute",
+  "toolchain": ["dpcpp"],
+  "os": ["linux", "windows"],
+  "targetDevice": ["FPGA"],
+  "builder": ["ide", "cmake"],
+  "languages": [{"cpp":{}}],
+  "ciTests": {
+    "linux": [
+      {
+        "id": "fpga_emu",
+        "steps": [
+          "mkdir build",
+          "cd build",
+          "cmake ..",
+          "make fpga_emu",
+          "./max_interleaving.fpga_emu"
+        ]
+      },
+      {
+        "id": "report",
+        "steps": [
+          "mkdir build",
+          "cd build",
+          "cmake ..",
+          "make report"
+        ]
+      }
+    ],
+    "windows": [
+      {
+        "id": "fpga_emu",
+        "steps": [
+          "cd src",
+          "ninja fpga_emu",
+          "max_interleaving.fpga_emu.exe"
+        ]
+      },
+      {
+        "id": "report",
+        "steps": [
+          "cd src",
+          "ninja report"
+        ]
+      }
+    ]
+  }
+}

--- a/DirectProgramming/DPC++FPGA/Tutorials/Features/max_interleaving/src/CMakeLists.txt
+++ b/DirectProgramming/DPC++FPGA/Tutorials/Features/max_interleaving/src/CMakeLists.txt
@@ -1,0 +1,107 @@
+set(SOURCE_FILE max_interleaving.cpp)
+set(TARGET_NAME max_interleaving)
+
+set(EMULATOR_TARGET ${TARGET_NAME}.fpga_emu)
+set(CPU_HOST_TARGET ${TARGET_NAME}.cpu_host)
+set(FPGA_TARGET ${TARGET_NAME}.fpga)
+
+set(HARDWARE_COMPILE_FLAGS "-fintelfpga")
+
+# Intel supported FPGA Boards and their names
+set(A10_PAC_BOARD_NAME "intel_a10gx_pac:pac_a10")
+set(S10_PAC_BOARD_NAME "intel_s10sx_pac:pac_s10")
+
+# Assume target is the Intel(R) PAC with Intel Arria(R) 10 GX FPGA 
+SET(_FPGA_BOARD ${A10_PAC_BOARD_NAME})
+
+# Check if target is the Intel(R) PAC with Intel Stratix(R) 10 SX FPGA
+IF (NOT DEFINED FPGA_BOARD)
+    MESSAGE(STATUS "\tFPGA_BOARD was not specified. Configuring the design to run on the Intel(R) Programmable Acceleration Card (PAC) with Intel Arria(R) 10 GX FPGA. Please refer to the README for more information on how to run the design on the Intel(R) PAC with Intel Stratix(R) 10 SX FPGA.")
+
+ELSEIF(FPGA_BOARD STREQUAL ${A10_PAC_BOARD_NAME})
+    MESSAGE(STATUS "\tConfiguring the design to run on the Intel(R) Programmable Acceleration Card (PAC) with Intel Arria(R) 10 GX FPGA.")
+
+ELSEIF(FPGA_BOARD STREQUAL ${S10_PAC_BOARD_NAME})
+    MESSAGE(STATUS "\tConfiguring the design to run on the Intel(R) Programmable Acceleration Card (PAC) with Intel Stratix(R) 10 SX FPGA.")
+    SET(_FPGA_BOARD ${S10_PAC_BOARD_NAME})
+
+ELSE()
+    MESSAGE(STATUS "\tAn invalid board name was passed in using the FPGA_BOARD flag. Configuring the design to run on the Intel(R) Programmable Acceleration Card (PAC) with Intel Arria(R) 10 GX FPGA. Please refer to the README for the list of valid board names.")
+ENDIF()
+
+# use cmake -D USER_HARDWARE_FLAGS=<flags> to set extra flags for FPGA backend compilation
+set(HARDWARE_LINK_FLAGS "-fintelfpga -Xshardware -Xsboard=${_FPGA_BOARD} ${AOC_SEED_FLAG} ${USER_HARDWARE_FLAGS}")
+
+set(EMULATOR_COMPILE_FLAGS "-fintelfpga -DFPGA_EMULATOR")
+set(EMULATOR_LINK_FLAGS "-fintelfpga")
+
+set(CPU_HOST_COMPILE_FLAGS "-DCPU_HOST")
+
+# fpga emulator
+if(WIN32)
+    set(WIN_EMULATOR_TARGET ${EMULATOR_TARGET}.exe)
+    add_custom_target(fpga_emu DEPENDS ${WIN_EMULATOR_TARGET})
+    separate_arguments(WIN_EMULATOR_COMPILE_FLAGS WINDOWS_COMMAND "${EMULATOR_COMPILE_FLAGS}")
+    add_custom_command(OUTPUT ${WIN_EMULATOR_TARGET} 
+                   COMMAND ${CMAKE_CXX_COMPILER} ${WIN_EMULATOR_COMPILE_FLAGS} /GX ${CMAKE_CURRENT_SOURCE_DIR}/${SOURCE_FILE} -o ${CMAKE_BINARY_DIR}/${WIN_EMULATOR_TARGET}
+                   DEPENDS ${SOURCE_FILE})
+else()
+    add_executable(${EMULATOR_TARGET} ${SOURCE_FILE})
+    add_custom_target(fpga_emu DEPENDS ${EMULATOR_TARGET})
+    set_target_properties(${EMULATOR_TARGET} PROPERTIES COMPILE_FLAGS ${EMULATOR_COMPILE_FLAGS})
+    set_target_properties(${EMULATOR_TARGET} PROPERTIES LINK_FLAGS ${EMULATOR_LINK_FLAGS})
+endif()
+
+
+# cpu host
+if(WIN32)
+    set(WIN_HOST_TARGET ${CPU_HOST_TARGET}.exe)
+    add_custom_target(cpu_host DEPENDS ${WIN_HOST_TARGET})
+    separate_arguments(WIN_HOST_COMPILE_FLAGS WINDOWS_COMMAND "${CPU_HOST_COMPILE_FLAGS}")
+    add_custom_command(OUTPUT ${WIN_HOST_TARGET} 
+                   COMMAND ${CMAKE_CXX_COMPILER} ${WIN_HOST_COMPILE_FLAGS} /GX ${CMAKE_CURRENT_SOURCE_DIR}/${SOURCE_FILE} -o ${CMAKE_BINARY_DIR}/${WIN_HOST_TARGET}
+                   DEPENDS ${SOURCE_FILE})  
+
+else()
+    add_executable(${CPU_HOST_TARGET} EXCLUDE_FROM_ALL ${SOURCE_FILE})
+    add_custom_target(cpu_host DEPENDS ${CPU_HOST_TARGET})
+    set_target_properties(${CPU_HOST_TARGET} PROPERTIES COMPILE_FLAGS ${CPU_HOST_COMPILE_FLAGS})
+endif()
+
+# fpga
+if(WIN32)
+    add_custom_target(fpga
+                  COMMAND echo "FPGA hardware flow is not supported in Windows")
+else()
+    add_executable(${FPGA_TARGET} EXCLUDE_FROM_ALL ${SOURCE_FILE})
+    add_custom_target(fpga DEPENDS ${FPGA_TARGET})
+    set_target_properties(${FPGA_TARGET} PROPERTIES COMPILE_FLAGS ${HARDWARE_COMPILE_FLAGS})
+    set_target_properties(${FPGA_TARGET} PROPERTIES LINK_FLAGS ${HARDWARE_LINK_FLAGS})
+endif()
+
+# generate report
+if(WIN32)
+    set(DEVICE_OBJ_FILE ${TARGET_NAME}_report.a)
+    add_custom_target(report DEPENDS ${DEVICE_OBJ_FILE})
+
+    separate_arguments(HARDWARE_LINK_FLAGS_LIST WINDOWS_COMMAND "${HARDWARE_LINK_FLAGS}")
+    add_custom_command(OUTPUT ${DEVICE_OBJ_FILE} 
+        COMMAND ${CMAKE_CXX_COMPILER} /EHsc ${CMAKE_CXX_FLAGS} ${HARDWARE_LINK_FLAGS_LIST} -fsycl-link ${CMAKE_CURRENT_SOURCE_DIR}/${SOURCE_FILE} -o ${CMAKE_BINARY_DIR}/${DEVICE_OBJ_FILE}
+                   DEPENDS ${SOURCE_FILE})
+
+else()
+    set(DEVICE_OBJ_FILE ${TARGET_NAME}_report.a)
+    add_custom_target(report DEPENDS ${DEVICE_OBJ_FILE})
+
+    configure_file(${CMAKE_CURRENT_SOURCE_DIR}/${SOURCE_FILE} ${SOURCE_FILE} COPYONLY)
+
+    separate_arguments(HARDWARE_LINK_FLAGS_LIST UNIX_COMMAND "${HARDWARE_LINK_FLAGS}")
+    add_custom_command(OUTPUT ${DEVICE_OBJ_FILE} 
+                       COMMAND ${CMAKE_CXX_COMPILER} ${CMAKE_CXX_FLAGS} ${HARDWARE_LINK_FLAGS_LIST} -Xsv -Xsv -Xssave-temps -fsycl-link ${SOURCE_FILE} -o ${CMAKE_BINARY_DIR}/${DEVICE_OBJ_FILE}
+                   DEPENDS ${SOURCE_FILE})
+endif()
+
+# run
+add_custom_target(run
+                  COMMAND ../${TARGET_NAME}.fpga_emu
+                  DEPENDS ${TARGET_NAME}.fpga_emu)

--- a/DirectProgramming/DPC++FPGA/Tutorials/Features/max_interleaving/src/build.ninja
+++ b/DirectProgramming/DPC++FPGA/Tutorials/Features/max_interleaving/src/build.ninja
@@ -1,5 +1,5 @@
-source_file = max_concurrency.cpp
-target_name = max_concurrency
+source_file = max_interleaving.cpp
+target_name = max_interleaving
 
 emulator_target = ${target_name}.fpga_emu.exe
 cpu_host_target = ${target_name}.cpu_host.exe

--- a/DirectProgramming/DPC++FPGA/Tutorials/Features/max_interleaving/src/build.ninja
+++ b/DirectProgramming/DPC++FPGA/Tutorials/Features/max_interleaving/src/build.ninja
@@ -1,0 +1,39 @@
+source_file = max_concurrency.cpp
+target_name = max_concurrency
+
+emulator_target = ${target_name}.fpga_emu.exe
+cpu_host_target = ${target_name}.cpu_host.exe
+report_target = ${target_name}_report.a
+report_target_s10_pac = ${target_name}_s10_pac_report.a
+
+hardware_flags = -fintelfpga -Xshardware -Xsseed=3
+emulator_flags = -fintelfpga -DFPGA_EMULATOR
+cpu_host_flags = -DCPU_HOST
+
+rule build_fpga_emu
+  command = dpcpp /GX ${emulator_flags} $in -o $out
+
+rule build_cpu_host
+  command = dpcpp /GX ${cpu_host_flags} $in -o $out
+
+rule gen_report
+  command = dpcpp /GX ${hardware_flags} -Xsboard=intel_a10gx_pac:pac_a10 -fsycl-link $in -o $out
+
+rule gen_report_s10_pac
+  command = dpcpp /GX ${hardware_flags} -Xsboard=intel_s10sx_pac:pac_s10 -fsycl-link $in -o $out
+
+# FPGA emulator
+build fpga_emu: phony ${emulator_target}
+build ${emulator_target}: build_fpga_emu ${source_file}
+
+# cpu host
+build cpu_host: phony ${cpu_host_target}
+build ${cpu_host_target}: build_cpu_host ${source_file}
+
+# report
+build report: phony ${report_target}
+build ${report_target}: gen_report ${source_file}
+
+# report (S10 PAC)
+build report_s10_pac: phony ${report_target_s10_pac}
+build ${report_target_s10_pac}: gen_report_s10_pac ${source_file}

--- a/DirectProgramming/DPC++FPGA/Tutorials/Features/max_interleaving/src/max_interleaving.cpp
+++ b/DirectProgramming/DPC++FPGA/Tutorials/Features/max_interleaving/src/max_interleaving.cpp
@@ -34,7 +34,7 @@ using FloatScalar = std::array<float, 1>;
 
 // an example complicated operation that creates a long critical path of
 // combinational logic from the use of the parameter values to the result
-float SomethingComplicated(float x, float y) { return sqrt(x) * sqrt(y); }
+float SomethingComplicated(float x, float y) { return sycl::sqrt(x) * sycl::sqrt(y); }
 
 template <int interleaving>
 class KernelCompute;

--- a/DirectProgramming/DPC++FPGA/Tutorials/Features/max_interleaving/src/max_interleaving.cpp
+++ b/DirectProgramming/DPC++FPGA/Tutorials/Features/max_interleaving/src/max_interleaving.cpp
@@ -1,0 +1,193 @@
+//==============================================================
+// Copyright Intel Corporation
+//
+// SPDX-License-Identifier: MIT
+// =============================================================
+#include <CL/sycl.hpp>
+#include <CL/sycl/INTEL/fpga_extensions.hpp>
+#include <array>
+#include <iomanip>
+#include <iostream>
+
+#include "dpc_common.hpp"
+
+using namespace sycl;
+
+constexpr size_t kSize = 8;
+constexpr float kErrorThreshold = 0.001;
+constexpr int kTotalOps = kSize * (2 * kSize + 1);
+
+using FloatArray = std::array<float, kSize>;
+using TwoDimFloatArray = std::array<float, kSize*kSize>;
+using FloatScalar = std::array<float, 1>;
+
+// an example complicated operation that creates a long critical path of
+// combinational logic from the use of the parameter values to the result
+float SomethingComplicated(float x, float y) { return sqrt(x) * sqrt(y); }
+
+template <int interleaving>
+class KernelCompute;
+
+// Launch a kernel on the device specified by selector.
+// The kernel's functionality is designed to show the
+// performance impact of the max_interleaving attribute.
+template <int interleaving>
+void Transform(const device_selector &selector, const TwoDimFloatArray &array_a,
+               const FloatArray &array_b, FloatArray &array_r) {
+  double kernel_time = 0.0;
+
+  try {
+    queue q(selector, dpc_common::exception_handler,
+            property::queue::enable_profiling{});
+
+    buffer array_a_buffer(array_a);
+    buffer array_b_buffer(array_b);
+    buffer array_r_buffer(array_r);
+
+    event e = q.submit([&](handler &h) {
+      auto array_a_accessor = accessor(array_a_buffer, h, read_only);
+      auto array_b_accessor = accessor(array_b_buffer, h, read_only);
+      auto accessor_array_r = accessor(array_r_buffer, h, write_only, noinit);
+
+      h.single_task<KernelCompute<interleaving>>([=]() 
+                                                 [[intel::kernel_args_restrict]] {
+        float temp_a[kSize*kSize];
+        float temp_b[kSize];
+        float temp_r[kSize];
+
+        for (size_t i = 0; i < kSize; i++) {
+          for (size_t j = 0; j < kSize; j++) {
+            temp_a[i*kSize+j] = array_a_accessor[i*kSize+j];
+          }
+          temp_b[i] = array_b_accessor[i];
+          temp_r[i] = 1.0;
+        }
+
+        for (size_t i = 0; i < kSize; i++) {
+          // only one iteration of the outer loop can be executing the
+          // inner loop at a time so that accesses to temp_r occur
+          // in the correct order -- use max_interleaving to simplify
+          // the datapath and reduce hardware resource usage
+          [[intelfpga::max_interleaving(interleaving)]] 
+          for (size_t j = 0; j < kSize; j++) {
+            temp_r[j] = SomethingComplicated(temp_a[i*kSize+j], temp_r[j]);
+          }
+          temp_r[i] += temp_b[i];
+        }
+
+        for (size_t i = 0; i < kSize; i++) {
+          accessor_array_r[i] = temp_r[i];
+        }
+      });
+    });
+
+    // SYCL event profiling allows the kernel execution to be timed
+    double start = e.get_profiling_info<info::event_profiling::command_start>();
+    double end = e.get_profiling_info<info::event_profiling::command_end>();
+    kernel_time = (double)(end - start) * 1e-6f;
+
+  } catch (cl::sycl::exception const &e) {
+    // Catches exceptions in the host code
+    std::cout << "Caught a SYCL host exception:" << '\n' << e.what() << '\n';
+
+    // Most likely the runtime couldn't find FPGA hardware!
+    if (e.get_cl_code() == CL_DEVICE_NOT_FOUND) {
+      std::cout << "If you are targeting an FPGA, please ensure that your "
+                   "system has a correctly configured FPGA board.\n";
+      std::cout << "If you are targeting the FPGA emulator, compile with "
+                   "-DFPGA_EMULATOR.\n";
+    }
+    std::terminate();
+  }
+
+  // The performance of the kernel is measured in GFlops, based on:
+  // 1) the number of floating-point operations performed by the kernel.
+  //    This can be calculated easily for the simple example kernel.
+  // 2) the kernel execution time reported by SYCL event profiling.
+  std::cout << "Max interleaving " << interleaving << " "
+            << "kernel time : " << kernel_time << " ms\n";
+  std::cout << "Throughput for kernel with max_interleaving " << interleaving
+            << ": ";
+  std::cout << std::fixed << std::setprecision(3)
+            << ((double)(kTotalOps) / kernel_time) / 1e6f << " GFlops\n";
+}
+
+// Calculates the expected results. Used to verify that the kernel
+// is functionally correct.
+void GoldenResult(const TwoDimFloatArray &A, const FloatArray &B,
+                  FloatArray &R) {
+  for (size_t i = 0; i < kSize; i++) {
+    for (size_t j = 0; j < kSize; j++) {
+      R[j] = SomethingComplicated(A[i*kSize+j], R[j]);
+    }
+    R[i] += B[i];
+  }
+}
+
+int main() {
+  bool success = true;
+
+  TwoDimFloatArray indata_A;
+  FloatArray indata_B;
+  FloatArray outdata_R_compute_0;
+  FloatArray outdata_R_compute_1;
+  FloatArray outdata_R_golden;
+
+  // initialize the input data
+  srand(7);
+  for (size_t i = 0; i < kSize; i++) {
+    indata_B[i] = (float)(rand() % 256);
+    for (size_t j = 0; j < kSize; j++) {
+      indata_A[i*kSize+j] = (float)(rand() % 256);
+    }
+    outdata_R_golden[i] = 1.0;
+  }
+
+#if defined(FPGA_EMULATOR)
+  INTEL::fpga_emulator_selector selector;
+#else
+  INTEL::fpga_selector selector;
+#endif
+
+  // Run the kernel with two different values of the max_interleaving
+  // attribute. In this case, unlimited interleaving (max_interleaving
+  // set to 0) gives no improvement in runtime performance over
+  // restricted interleaving (max_interleaving set to 1), despite
+  // requiring more hardware resources (see README.md for details
+  // on confirming this difference in hardware resource usage in
+  // the reports).
+  Transform<0>(selector, indata_A, indata_B, outdata_R_compute_0);
+  Transform<1>(selector, indata_A, indata_B, outdata_R_compute_1);
+
+  // compute the actual result here
+  GoldenResult(indata_A, indata_B, outdata_R_golden);
+
+  // error check for Transform<0>
+  bool failed = false;
+  for (unsigned i = 0; i < kSize; i++) {
+    if (std::abs(outdata_R_compute_0[i] - outdata_R_golden[i]) >
+        kErrorThreshold) {
+      std::cout << "error at [" << i << "]: " << outdata_R_compute_0[i]
+                << " != " << outdata_R_golden[i] << '\n';
+      failed = true;
+    }
+  }
+
+  // error check for Transform<1>
+  for (unsigned i = 0; i < kSize; i++) {
+    if (std::abs(outdata_R_compute_1[i] - outdata_R_golden[i]) >
+        kErrorThreshold) {
+      std::cout << "error at [" << i << "]: " << outdata_R_compute_1[i]
+                << " != " << outdata_R_golden[i] << '\n';
+      failed = true;
+    }
+  }
+
+  if (failed) {
+    std::cout << "FAILED: The results are incorrect\n";
+    return 1;
+  } else {
+    std::cout << "PASSED: The results are correct\n";
+    return 0;
+  }
+}

--- a/DirectProgramming/DPC++FPGA/Tutorials/Features/max_interleaving/src/max_interleaving.cpp
+++ b/DirectProgramming/DPC++FPGA/Tutorials/Features/max_interleaving/src/max_interleaving.cpp
@@ -14,7 +14,6 @@
 
 // Header locations and some DPC++ extensions changed between beta09 and beta10
 // Temporarily modify the code sample to accept either version
-#include <CL/sycl.hpp>
 #define BETA09 20200827
 #if __SYCL_COMPILER_VERSION <= BETA09
   #include <CL/sycl/intel/fpga_extensions.hpp>

--- a/DirectProgramming/DPC++FPGA/Tutorials/Features/max_interleaving/src/max_interleaving.cpp
+++ b/DirectProgramming/DPC++FPGA/Tutorials/Features/max_interleaving/src/max_interleaving.cpp
@@ -4,12 +4,21 @@
 // SPDX-License-Identifier: MIT
 // =============================================================
 #include <CL/sycl.hpp>
-#include <CL/sycl/INTEL/fpga_extensions.hpp>
 #include <array>
 #include <iomanip>
 #include <iostream>
-
 #include "dpc_common.hpp"
+
+// Header locations and some DPC++ extensions changed between beta09 and beta10
+// Temporarily modify the code sample to accept either version
+#include <CL/sycl.hpp>
+#define BETA09 20200827
+#if __SYCL_COMPILER_VERSION <= BETA09
+  #include <CL/sycl/intel/fpga_extensions.hpp>
+  namespace INTEL = sycl::intel;  // Namespace alias for backward compatibility
+#else
+  #include <CL/sycl/INTEL/fpga_extensions.hpp>
+#endif
 
 using namespace sycl;
 

--- a/DirectProgramming/DPC++FPGA/Tutorials/Features/max_interleaving/src/max_interleaving.cpp
+++ b/DirectProgramming/DPC++FPGA/Tutorials/Features/max_interleaving/src/max_interleaving.cpp
@@ -3,10 +3,13 @@
 //
 // SPDX-License-Identifier: MIT
 // =============================================================
-#include <CL/sycl.hpp>
 #include <array>
+#include <CL/sycl.hpp>
 #include <iomanip>
 #include <iostream>
+
+// dpc_common.hpp can be found in the dev-utilities include folder.
+// e.g., $ONEAPI_ROOT/dev-utilities//include/dpc_common.hpp
 #include "dpc_common.hpp"
 
 // Header locations and some DPC++ extensions changed between beta09 and beta10


### PR DESCRIPTION
Add max_interleaving DPC++FPGA tutorial

# Description

This tutorial demonstrates how to apply the max_interleaving attribute to loops and how it affects loop resource use.

Fixes # (issue) 

## Type of change

Please delete options that are not relevant. Add a 'X' to the one that is applicable. 
- [X] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
- [X] Command Line



