### PR TITLE
ApplicationDebugger/array-transform: change the type of GetDim's parameter

### DIFF
--- a/Tools/ApplicationDebugger/array-transform/src/array-transform.cpp
+++ b/Tools/ApplicationDebugger/array-transform/src/array-transform.cpp
@@ -20,7 +20,7 @@ using namespace std;
 using namespace sycl;
 
 // A device function, called from inside the kernel.
-static size_t GetDim(id<1> wi, int dim) {
+static size_t GetDim(item<1> wi, int dim) {
   return wi[dim];
 }
 


### PR DESCRIPTION
Set the type of GetDim's parameter to 'item', because when the
parameter of the kernel is declared as 'auto', the inferred type is
'item'.
