### PR TITLE
ApplicationDebugger/array-transform: use explicit type for parallel_for's index

### DIFF
--- a/Tools/ApplicationDebugger/array-transform/src/array-transform.cpp
+++ b/Tools/ApplicationDebugger/array-transform/src/array-transform.cpp
@@ -20,7 +20,7 @@ using namespace std;
 using namespace sycl;
 
 // A device function, called from inside the kernel.
-static size_t GetDim(item<1> wi, int dim) {
+static size_t GetDim(id<1> wi, int dim) {
   return wi[dim];
 }
 
@@ -51,7 +51,7 @@ int main(int argc, char *argv[]) {
       accessor out(buffer_out, h, write_only);
 
       // kernel-start
-      h.parallel_for(data_range, [=](auto index) {
+      h.parallel_for(data_range, [=](id<1> index) {
         size_t id0 = GetDim(index, 0);
         int element = in[index];  // breakpoint-here
         int result = element + 50;


### PR DESCRIPTION
# Description

Use the explicit type `id` for parallel_for's index parameter.  This
is necessary because the `auto` type is inferred by the compiler as
`item`; however, the `item` type impacts the debugger's Get Started
Guide.  There is a pretty printer defined for `id`, but not `item`.

## Type of change

A fix that improves documentation (Get Started Guide).

# How Has This Been Tested?

- [X] Command Line
- [ ] oneapi-cli
- [ ] Visual Studio
- [ ] Eclipse IDE
- [ ] VSCode

