### PR TITLE
oneMKL sample updates for beta10

### DIFF
--- a/Libraries/oneMKL/black_scholes/black_scholes.cpp
+++ b/Libraries/oneMKL/black_scholes/black_scholes.cpp
@@ -21,12 +21,14 @@
 
 #include <CL/sycl.hpp>
 
+#if __has_include("oneapi/mkl.hpp")
+#include "oneapi/mkl.hpp"
+#include "oneapi/mkl/rng/device.hpp"
+#else
+// Beta09 compatibility -- not needed for new code.
 #include "mkl_sycl.hpp"
 #include "mkl_rng_sycl_device.hpp"
-
-namespace oneapi {
-
-} // namespace oneapi
+#endif
 
 using namespace oneapi;
 

--- a/Libraries/oneMKL/block_cholesky_decomposition/dpbltrf.cpp
+++ b/Libraries/oneMKL/block_cholesky_decomposition/dpbltrf.cpp
@@ -13,11 +13,14 @@
 #include <CL/sycl.hpp>
 #include <cstdint>
 #include "mkl.h"
-#include "mkl_sycl.hpp"
 
-// Temporary code for beta08 compatibility. oneMKL routines
-//  move to the oneapi namespace in beta09.
-namespace oneapi {}
+#if __has_include("oneapi/mkl.hpp")
+#include "oneapi/mkl.hpp"
+#else
+// Beta09 compatibility -- not needed for new code.
+#include "mkl_sycl.hpp"
+#endif
+
 using namespace oneapi;
 
 /************************************************************************
@@ -131,7 +134,7 @@ int64_t dpbltrf(cl::sycl::queue queue, int64_t n, int64_t nb, double* d, int64_t
         sycl::free(scratchpad, context);
     } catch(mkl::lapack::exception const& e) {
         // Handle LAPACK related exceptions happened during synchronous call
-        std::cout << "Unexpected exception caught during synchronous call to LAPACK API:\nreason: " << e.reason() << "\ninfo: " << e.info() << std::endl;
+        std::cout << "Unexpected exception caught during synchronous call to LAPACK API:\ninfo: " << e.info() << std::endl;
         if (e.info() > 0) {
         // INFO is equal to the 'global' index of the element u_ii of the factor
         // U which is equal to zero
@@ -160,7 +163,7 @@ int64_t dpbltrf(cl::sycl::queue queue, int64_t n, int64_t nb, double* d, int64_t
             sycl::free(scratchpad, context);
         } catch(mkl::lapack::exception const& e) {
             // Handle LAPACK related exceptions happened during synchronous call
-            std::cout << "Unexpected exception caught during synchronous call to LAPACK API:\nreason: " << e.reason() << "\ninfo: " << e.info() << std::endl;
+            std::cout << "Unexpected exception caught during synchronous call to LAPACK API:\ninfo: " << e.info() << std::endl;
             if (e.info() > 0) {
             // INFO is equal to the 'global' index of the element u_ii of the factor
             // U which is equal to zero

--- a/Libraries/oneMKL/block_cholesky_decomposition/dpbltrs.cpp
+++ b/Libraries/oneMKL/block_cholesky_decomposition/dpbltrs.cpp
@@ -14,11 +14,14 @@
 #include <CL/sycl.hpp>
 #include <cstdint>
 #include "mkl.h"
-#include "mkl_sycl.hpp"
 
-// Temporary code for beta08 compatibility. oneMKL routines
-//  move to the oneapi namespace in beta09.
-namespace oneapi {}
+#if __has_include("oneapi/mkl.hpp")
+#include "oneapi/mkl.hpp"
+#else
+// Beta09 compatibility -- not needed for new code.
+#include "mkl_sycl.hpp"
+#endif
+
 using namespace oneapi;
 
 /************************************************************************

--- a/Libraries/oneMKL/block_cholesky_decomposition/factor.cpp
+++ b/Libraries/oneMKL/block_cholesky_decomposition/factor.cpp
@@ -36,11 +36,14 @@
 #include <iostream>
 #include <vector>
 #include "mkl.h"
-#include "mkl_sycl.hpp"
 
-// Temporary code for beta08 compatibility. oneMKL routines
-//  move to the oneapi namespace in beta09.
-namespace oneapi {}
+#if __has_include("oneapi/mkl.hpp")
+#include "oneapi/mkl.hpp"
+#else
+// Beta09 compatibility -- not needed for new code.
+#include "mkl_sycl.hpp"
+#endif
+
 using namespace oneapi;
 
 int64_t dpbltrf(sycl::queue queue, int64_t n, int64_t nb, double* d, int64_t ldd, double* b, int64_t ldb);
@@ -67,7 +70,7 @@ int main() {
             } catch(mkl::lapack::exception const& e) {
                 // Handle LAPACK related exceptions happened during asynchronous call
                 info = e.info();
-                std::cout << "Unexpected exception caught during asynchronous LAPACK operation:\n" << e.reason() << "\ninfo: " << e.info() << std::endl;
+                std::cout << "Unexpected exception caught during asynchronous LAPACK operation:\ninfo: " << e.info() << std::endl;
             } catch(sycl::exception const& e) {
                 // Handle not LAPACK related exceptions happened during asynchronous call
                 std::cout << "Unexpected exception caught during asynchronous operation:\n" << e.what() << std::endl;

--- a/Libraries/oneMKL/block_cholesky_decomposition/solve.cpp
+++ b/Libraries/oneMKL/block_cholesky_decomposition/solve.cpp
@@ -37,11 +37,14 @@
 #include <iostream>
 #include <vector>
 #include "mkl.h"
-#include "mkl_sycl.hpp"
 
-// Temporary code for beta08 compatibility. oneMKL routines
-//  move to the oneapi namespace in beta09.
-namespace oneapi {}
+#if __has_include("oneapi/mkl.hpp")
+#include "oneapi/mkl.hpp"
+#else
+// Beta09 compatibility -- not needed for new code.
+#include "mkl_sycl.hpp"
+#endif
+
 using namespace oneapi;
 
 template<typename T>
@@ -69,7 +72,7 @@ int main() {
             } catch(mkl::lapack::exception const& e) {
                 // Handle LAPACK related exceptions happened during asynchronous call
                 info = e.info();
-                std::cout << "Unexpected exception caught during asynchronous LAPACK operation:\n" << e.reason() << "\ninfo: " << e.info() << std::endl;
+                std::cout << "Unexpected exception caught during asynchronous LAPACK operation:\ninfo: " << e.info() << std::endl;
             } catch(cl::sycl::exception const& e) {
                 // Handle not LAPACK related exceptions happened during asynchronous call
                 std::cout << "Unexpected exception caught during asynchronous operation:\n" << e.what() << std::endl;

--- a/Libraries/oneMKL/block_lu_decomposition/dgeblttrf.cpp
+++ b/Libraries/oneMKL/block_lu_decomposition/dgeblttrf.cpp
@@ -15,11 +15,14 @@
 #include <cstdint>
 #include <CL/sycl.hpp>
 #include "mkl.h"
-#include "mkl_sycl.hpp"
 
-// Temporary code for beta08 compatibility. oneMKL routines
-//  move to the oneapi namespace in beta09.
-namespace oneapi {}
+#if __has_include("oneapi/mkl.hpp")
+#include "oneapi/mkl.hpp"
+#else
+// Beta09 compatibility -- not needed for new code.
+#include "mkl_sycl.hpp"
+#endif
+
 using namespace oneapi;
 
 int64_t ptldgetrf(sycl::queue queue, int64_t m, int64_t n, int64_t k, double* a, int64_t lda, int64_t* ipiv);
@@ -226,7 +229,7 @@ int64_t dgeblttrf(sycl::queue queue, int64_t n, int64_t nb, double* d, double* d
         sycl::free(scratchpad, context);
     } catch(mkl::lapack::exception const& e) {
         // Handle LAPACK related exceptions happened during synchronous call
-        std::cout << "Unexpected exception caught during synchronous call to LAPACK API:\nreason: " << e.reason() << "\ninfo: " << e.info() << std::endl;
+        std::cout << "Unexpected exception caught during synchronous call to LAPACK API:\ninfo: " << e.info() << std::endl;
         if (e.info() > 0) {
         // INFO is equal to the 'global' index of the element u_ii of the factor  
         // U which is equal to zero
@@ -349,7 +352,7 @@ int64_t ptldgetrf(sycl::queue queue, int64_t m, int64_t n, int64_t k, double* a,
                 sycl::free(scratchpad, context);
             } catch(mkl::lapack::exception const& e) {
                 // Handle LAPACK related exceptions happened during synchronous call
-                std::cout << "Unexpected exception caught during synchronous call to LAPACK API:\nreason: " << e.reason() << "\ninfo: " << e.info() << std::endl;
+                std::cout << "Unexpected exception caught during synchronous call to LAPACK API:\ninfo: " << e.info() << std::endl;
                 if (e.info() > 0) {
                     info = e.info();
                 }

--- a/Libraries/oneMKL/block_lu_decomposition/dgeblttrs.cpp
+++ b/Libraries/oneMKL/block_lu_decomposition/dgeblttrs.cpp
@@ -82,12 +82,15 @@
 ***********************************************************************/
 #include <cstdint>
 #include <CL/sycl.hpp>
-#include "mkl_sycl.hpp"
 #include "mkl.h"
 
-// Temporary code for beta08 compatibility. oneMKL routines
-//  move to the oneapi namespace in beta09.
-namespace oneapi {}
+#if __has_include("oneapi/mkl.hpp")
+#include "oneapi/mkl.hpp"
+#else
+// Beta09 compatibility -- not needed for new code.
+#include "mkl_sycl.hpp"
+#endif
+
 using namespace oneapi;
 
 int64_t dgeblttrs(sycl::queue queue, int64_t n, int64_t nb, int64_t nrhs, double* d, double* dl, double* du1, double* du2, int64_t* ipiv, double* f, int64_t ldf) {

--- a/Libraries/oneMKL/block_lu_decomposition/factor.cpp
+++ b/Libraries/oneMKL/block_lu_decomposition/factor.cpp
@@ -29,11 +29,13 @@
 #include <iostream>
 #include <vector>
 #include "mkl.h"
+#if __has_include("oneapi/mkl.hpp")
+#include "oneapi/mkl.hpp"
+#else
+// Beta09 compatibility -- not needed for new code.
 #include "mkl_sycl.hpp"
+#endif
 
-// Temporary code for beta08 compatibility. oneMKL routines
-//  move to the oneapi namespace in beta09.
-namespace oneapi {}
 using namespace oneapi;
 
 int64_t dgeblttrf(sycl::queue queue, int64_t n, int64_t nb, double* d, double* dl, double* du1, double* du2, int64_t* ipiv);
@@ -62,7 +64,7 @@ int main(){
             } catch(mkl::lapack::exception const& e) {
                 // Handle LAPACK related exceptions happened during asynchronous call
                 info = e.info();
-                std::cout << "Unexpected exception caught during asynchronous LAPACK operation:\n" << e.reason() << "\ninfo: " << e.info() << std::endl;
+                std::cout << "Unexpected exception caught during asynchronous LAPACK operation:\ninfo: " << e.info() << std::endl;
             } catch(sycl::exception const& e) {
                 // Handle not LAPACK related exceptions happened during asynchronous call
                 std::cout << "Unexpected exception caught during asynchronous operation:\n" << e.what() << std::endl;

--- a/Libraries/oneMKL/block_lu_decomposition/solve.cpp
+++ b/Libraries/oneMKL/block_lu_decomposition/solve.cpp
@@ -42,11 +42,13 @@
 #include <iostream>
 #include <vector>
 #include "mkl.h"
+#if __has_include("oneapi/mkl.hpp")
+#include "oneapi/mkl.hpp"
+#else
+// Beta09 compatibility -- not needed for new code.
 #include "mkl_sycl.hpp"
+#endif
 
-// Temporary code for beta08 compatibility. oneMKL routines
-//  move to the oneapi namespace in beta09.
-namespace oneapi {}
 using namespace oneapi;
 
 int64_t dgeblttrf(sycl::queue, int64_t n, int64_t nb, double* d, double* dl, double* du1, double* du2, int64_t* ipiv);
@@ -77,7 +79,7 @@ int main() {
             } catch(mkl::lapack::exception const& e) {
                 // Handle LAPACK related exceptions happened during asynchronous call
                 info = e.info();
-                std::cout << "Unexpected exception caught during asynchronous LAPACK operation:\n" << e.reason() << "\ninfo: " << e.info() << std::endl;
+                std::cout << "Unexpected exception caught during asynchronous LAPACK operation:\ninfo: " << e.info() << std::endl;
             } catch(sycl::exception const& e) {
                 // Handle not LAPACK related exceptions happened during asynchronous call
                 std::cout << "Unexpected exception caught during asynchronous operation:\n" << e.what() << std::endl;

--- a/Libraries/oneMKL/matrix_mul_mkl/matrix_mul_mkl.cpp
+++ b/Libraries/oneMKL/matrix_mul_mkl/matrix_mul_mkl.cpp
@@ -12,7 +12,13 @@
 #include <CL/sycl.hpp>
 #include <iostream>
 #include <limits>
+
+#if __has_include("oneapi/mkl.hpp")
+#include "oneapi/mkl.hpp"
+#else
+// Beta09 compatibility -- not needed for new code.
 #include "mkl_sycl.hpp"
+#endif
 
 double rand_uniform();
 bool verify_result(int m, int n, int k, int ldc, double *C, double *C_reference);

--- a/Libraries/oneMKL/monte_carlo_european_opt/mc_european.cpp
+++ b/Libraries/oneMKL/monte_carlo_european_opt/mc_european.cpp
@@ -17,11 +17,13 @@
 
 #include <CL/sycl.hpp>
 
+#if __has_include("oneapi/mkl.hpp")
+#include "oneapi/mkl.hpp"
+#else
+// Beta09 compatibility -- not needed for new code.
 #include "mkl_rng_sycl.hpp"
+#endif
 
-// Temporary code for compatibility with beta08.
-// oneMKL moves to the oneapi namespace in beta09.
-namespace oneapi {}
 using namespace oneapi;
 
 // Temporary code for beta08 compatibility. Reduce routine is moved from intel::

--- a/Libraries/oneMKL/monte_carlo_european_opt/mc_european_usm.cpp
+++ b/Libraries/oneMKL/monte_carlo_european_opt/mc_european_usm.cpp
@@ -17,11 +17,13 @@
 
 #include <CL/sycl.hpp>
 
+#if __has_include("oneapi/mkl.hpp")
+#include "oneapi/mkl.hpp"
+#else
+// Beta09 compatibility -- not needed for new code.
 #include "mkl_rng_sycl.hpp"
+#endif
 
-// Temporary code for compatibility with beta08.
-// oneMKL moves to the oneapi namespace in beta09.
-namespace oneapi {}
 using namespace oneapi;
 
 // Temporary code for beta08 compatibility. Reduce routine is moved from intel::

--- a/Libraries/oneMKL/monte_carlo_pi/mc_pi.cpp
+++ b/Libraries/oneMKL/monte_carlo_pi/mc_pi.cpp
@@ -17,11 +17,13 @@
 
 #include <CL/sycl.hpp>
 
+#if __has_include("oneapi/mkl.hpp")
+#include "oneapi/mkl.hpp"
+#else
+// Beta09 compatibility -- not needed for new code.
 #include "mkl_rng_sycl.hpp"
+#endif
 
-// Temporary code for beta08 compatibility. oneMKL routines
-//  move to the oneapi namespace in beta09.
-namespace oneapi {}
 using namespace oneapi;
 
 // Temporary code for beta08 compatibility. Reduce routine is moved from intel::

--- a/Libraries/oneMKL/monte_carlo_pi/mc_pi_device_api.cpp
+++ b/Libraries/oneMKL/monte_carlo_pi/mc_pi_device_api.cpp
@@ -17,12 +17,13 @@
 
 #include <CL/sycl.hpp>
 
+#if __has_include("oneapi/mkl/rng/device.hpp")
+#include "oneapi/mkl/rng/device.hpp"
+#else
+// Beta09 compatibility -- not needed for new code.
 #include "mkl_rng_sycl_device.hpp"
+#endif
 
-
-// Temporary code for beta08 compatibility. oneMKL routines
-//  move to the oneapi namespace in beta09.
-namespace oneapi {}
 using namespace oneapi;
 
 // Temporary code for beta08 compatibility. Reduce routine is moved from intel::

--- a/Libraries/oneMKL/monte_carlo_pi/mc_pi_usm.cpp
+++ b/Libraries/oneMKL/monte_carlo_pi/mc_pi_usm.cpp
@@ -17,12 +17,13 @@
 
 #include <CL/sycl.hpp>
 
+#if __has_include("oneapi/mkl.hpp")
+#include "oneapi/mkl.hpp"
+#else
+// Beta09 compatibility -- not needed for new code.
 #include "mkl_rng_sycl.hpp"
+#endif
 
-
-// Temporary code for beta08 compatibility. oneMKL routines
-//  move to the oneapi namespace in beta09.
-namespace oneapi {}
 using namespace oneapi;
 
 // Temporary code for beta08 compatibility. Reduce routine is moved from intel::

--- a/Libraries/oneMKL/random_sampling_without_replacement/lottery.cpp
+++ b/Libraries/oneMKL/random_sampling_without_replacement/lottery.cpp
@@ -16,11 +16,13 @@
 
 #include <CL/sycl.hpp>
 
+#if __has_include("oneapi/mkl.hpp")
+#include "oneapi/mkl.hpp"
+#else
+// Beta09 compatibility -- not needed for new code.
 #include "mkl_rng_sycl.hpp"
+#endif
 
-// Temporary code for beta08 compatibility. oneMKL routines
-//  move to the oneapi namespace in beta09.
-namespace oneapi {}
 using namespace oneapi;
 
 // Initialization value for random number generator

--- a/Libraries/oneMKL/random_sampling_without_replacement/lottery_device_api.cpp
+++ b/Libraries/oneMKL/random_sampling_without_replacement/lottery_device_api.cpp
@@ -16,11 +16,13 @@
 
 #include <CL/sycl.hpp>
 
+#if __has_include("oneapi/mkl/rng/device.hpp")
+#include "oneapi/mkl/rng/device.hpp"
+#else
+// Beta09 compatibility -- not needed for new code.
 #include "mkl_rng_sycl_device.hpp"
+#endif
 
-// Temporary code for beta08 compatibility. oneMKL routines
-//  move to the oneapi namespace in beta09.
-namespace oneapi {}
 using namespace oneapi;
 
 // Initialization value for random number generator

--- a/Libraries/oneMKL/random_sampling_without_replacement/lottery_usm.cpp
+++ b/Libraries/oneMKL/random_sampling_without_replacement/lottery_usm.cpp
@@ -16,11 +16,13 @@
 
 #include <CL/sycl.hpp>
 
+#if __has_include("oneapi/mkl.hpp")
+#include "oneapi/mkl.hpp"
+#else
+// Beta09 compatibility -- not needed for new code.
 #include "mkl_rng_sycl.hpp"
+#endif
 
-// Temporary code for beta08 compatibility. oneMKL routines
-//  move to the oneapi namespace in beta09.
-namespace oneapi {}
 using namespace oneapi;
 
 // Initialization value for random number generator

--- a/Libraries/oneMKL/sparse_conjugate_gradient/sparse_cg.cpp
+++ b/Libraries/oneMKL/sparse_conjugate_gradient/sparse_cg.cpp
@@ -43,14 +43,17 @@
 #include <list>
 #include <vector>
 
+#if __has_include("oneapi/mkl.hpp")
+#include "oneapi/mkl.hpp"
+#else
+// Beta09 compatibility -- not needed for new code.
 #include "mkl_sycl.hpp"
+#endif
+
 #include <CL/sycl.hpp>
 
 #include "utils.hpp"
 
-// Temporary code for beta08 compatibility. oneMKL routines
-//  move to the oneapi namespace in beta09.
-namespace oneapi {}
 using namespace oneapi;
 
 


### PR DESCRIPTION
# Description

Updates existing oneMKL samples for compatibility with beta10:
- [X] updated header locations
- [X] LAPACK exception changes

Changes retain beta09 compatibility. At the same time, old beta08 compatibility code has been dropped.


## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [X] Command Line

