### PR TITLE
Update header location and namespace for beta10

### DIFF
--- a/DirectProgramming/DPC++/DenseLinearAlgebra/vector-add/src/vector-add-buffers.cpp
+++ b/DirectProgramming/DPC++/DenseLinearAlgebra/vector-add/src/vector-add-buffers.cpp
@@ -32,19 +32,19 @@ using namespace sycl;
 constexpr size_t array_size = 10000;
 typedef std::array<int, array_size> IntArray;
 
-// this exception handler with catch async exceptions
-static auto exception_handler = [](cl::sycl::exception_list eList) {
-	for (std::exception_ptr const &e : eList) {
-		try {
-			std::rethrow_exception(e);
-		}
-		catch (std::exception const &e) {
+// Create an exception handler for asynchronous SYCL exceptions
+static auto exception_handler = [](sycl::exception_list e_list) {
+  for (std::exception_ptr const &e : e_list) {
+    try {
+      std::rethrow_exception(e);
+    }
+    catch (std::exception const &e) {
 #if _DEBUG
-			std::cout << "Failure" << std::endl;
+      std::cout << "Failure" << std::endl;
 #endif
-			std::terminate();
-		}
-	}
+      std::terminate();
+    }
+  }
 };
 
 //************************************

--- a/DirectProgramming/DPC++/DenseLinearAlgebra/vector-add/src/vector-add-buffers.cpp
+++ b/DirectProgramming/DPC++/DenseLinearAlgebra/vector-add/src/vector-add-buffers.cpp
@@ -23,7 +23,7 @@
 #include <array>
 #include <iostream>
 #if FPGA || FPGA_EMULATOR
-#include <CL/sycl/intel/fpga_extensions.hpp>
+#include <CL/sycl/INTEL/fpga_extensions.hpp>
 #endif
 
 using namespace sycl;
@@ -97,10 +97,10 @@ int main() {
   // Create device selector for the device of your interest.
 #if FPGA_EMULATOR
   // DPC++ extension: FPGA emulator selector on systems without FPGA card.
-  intel::fpga_emulator_selector d_selector;
+  INTEL::fpga_emulator_selector d_selector;
 #elif FPGA
   // DPC++ extension: FPGA selector on systems with FPGA card.
-  intel::fpga_selector d_selector;
+  INTEL::fpga_selector d_selector;
 #else
   // The default device selector will select the most performant device.
   default_selector d_selector;

--- a/DirectProgramming/DPC++/DenseLinearAlgebra/vector-add/src/vector-add-usm.cpp
+++ b/DirectProgramming/DPC++/DenseLinearAlgebra/vector-add/src/vector-add-usm.cpp
@@ -23,7 +23,7 @@
 #include <array>
 #include <iostream>
 #if FPGA || FPGA_EMULATOR
-#include <CL/sycl/intel/fpga_extensions.hpp>
+#include <CL/sycl/INTEL/fpga_extensions.hpp>
 #endif
 
 using namespace sycl;
@@ -80,10 +80,10 @@ int main() {
   // Create device selector for the device of your interest.
 #if FPGA_EMULATOR
   // DPC++ extension: FPGA emulator selector on systems without FPGA card.
-  intel::fpga_emulator_selector d_selector;
+  INTEL::fpga_emulator_selector d_selector;
 #elif FPGA
   // DPC++ extension: FPGA selector on systems with FPGA card.
-  intel::fpga_selector d_selector;
+  INTEL::fpga_selector d_selector;
 #else
   // The default device selector will select the most performant device.
   default_selector d_selector;

--- a/DirectProgramming/DPC++/DenseLinearAlgebra/vector-add/src/vector-add-usm.cpp
+++ b/DirectProgramming/DPC++/DenseLinearAlgebra/vector-add/src/vector-add-usm.cpp
@@ -31,19 +31,19 @@ using namespace sycl;
 // Array size for this example.
 constexpr size_t array_size = 10000;
 
-// this exception handler with catch async exceptions
-static auto exception_handler = [](cl::sycl::exception_list eList) {
-	for (std::exception_ptr const &e : eList) {
-		try {
-			std::rethrow_exception(e);
-		}
-		catch (std::exception const &e) {
+// Create an exception handler for asynchronous SYCL exceptions
+static auto exception_handler = [](sycl::exception_list e_list) {
+  for (std::exception_ptr const &e : e_list) {
+    try {
+      std::rethrow_exception(e);
+    }
+    catch (std::exception const &e) {
 #if _DEBUG
-			std::cout << "Failure" << std::endl;
+      std::cout << "Failure" << std::endl;
 #endif
-			std::terminate();
-		}
-	}
+      std::terminate();
+    }
+  }
 };
 
 //************************************


### PR DESCRIPTION
# Description

In beta10, the Intel header locations and the Intel SYCL extension namespace changed from "intel" to "INTEL" following the Khronos SYCL requirements. There is no deprecation period. This minor change updates the vector-add sample for beta10 compatibility.

This will fail on beta09. I consider this acceptable for master, since beta10 release tag is only 2 weeks away.

While in the neighborhood, I also fixed up the formatting of the async handler code.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)


# How Has This Been Tested?

- [X] Command Line