### PR TITLE
Add empty ciTest object so testing does not fail.

### DIFF
--- a/Tools/Migration/folder-options-dpct/sample.json
+++ b/Tools/Migration/folder-options-dpct/sample.json
@@ -5,5 +5,6 @@
   "description": "Multi-folder project that illustrates migration of a CUDA project that has files located in multiple folders in a directory tree. Uses the `--in-root` and `--out-root` options to tell the Intel® DPC++ Compatibility Tool where to locate source code to be migrated.",
   "languages": [ { "cpp": {} } ],
   "os": [ "linux", "windows" ],
-  "builder": [ "cli" ]
+  "builder": [ "cli" ],
+  "ciTests": { "linux": [], "windows": [] }
 }

--- a/Tools/Migration/rodinia-nw-dpct/sample.json
+++ b/Tools/Migration/rodinia-nw-dpct/sample.json
@@ -5,5 +5,6 @@
   "description": "Migrate a CUDA project using the DPCT intercept-build feature to create a compilation database. The compilation database provides compilation options, settings, macro definitions and include paths that the Intel® DPC++ Compatibility Tool will use during migration of the project.",
   "languages": [ { "cpp": {} } ],
   "os": [ "linux", "windows" ],
-  "builder": [ "ide", "make" ]
+  "builder": [ "ide", "make" ],
+  "ciTests": { "linux": [], "windows": [] }
 }

--- a/Tools/Migration/vector-add-dpct/sample.json
+++ b/Tools/Migration/vector-add-dpct/sample.json
@@ -5,5 +5,6 @@
   "description": "Simple project to illustrate the basic migration of CUDA code. Use this sample to ensure your environment is configured correctly and to understand the basics of migrating existing CUDA projects to Data Parallel C++.",
   "languages": [ { "cpp": {} } ],
   "os": [ "linux", "windows" ],
-  "builder": [ "ide", "make" ]
+  "builder": [ "ide", "make" ],
+  "ciTests": { "linux": [], "windows": [] }
 }


### PR DESCRIPTION
Signed-off-by: xmnboy <xmnboy@yahoo.com>

# Description

Adding a temporary empty `ciTests` object so the sample tests can proceed without error. Additional software support is needed on the sample CI test system before we can support actual testing of the `dpct` tutorial samples.

Fixes email issue: _Re: Broken samples.json file merged to Sample Open Source repo_ 

> Today’s run of pre-production Samples CI failed with the following error:
> [01:46:39][Step 3/4] _______________________ ERROR collecting test_samples.py _______________________
> [01:46:39][Step 3/4] /usr/local/lib/python3.8/dist-packages/pluggy/hooks.py:286: in __call__
> [01:46:39][Step 3/4] return self._hookexec(self, self.get_hookimpls(), kwargs)
> [01:46:39][Step 3/4] /usr/local/lib/python3.8/dist-packages/pluggy/manager.py:93: in _hookexec
> [01:46:39][Step 3/4] return self._inner_hookexec(hook, methods, kwargs)
> [01:46:39][Step 3/4] /usr/local/lib/python3.8/dist-packages/pluggy/manager.py:84: in <lambda>
> [01:46:39][Step 3/4] self._inner_hookexec = lambda hook, methods, kwargs: hook.multicall(
> [01:46:39][Step 3/4] /usr/local/lib/python3.8/dist-packages/_pytest/python.py:252: in pytest_pycollect_makeitem
> [01:46:39][Step 3/4] res = list(collector._genfunctions(name, obj))
> [01:46:39][Step 3/4] /usr/local/lib/python3.8/dist-packages/_pytest/python.py:473: in _genfunctions
> [01:46:39][Step 3/4] self.ihook.pytest_generate_tests.call_extra(methods, dict(metafunc=metafunc))
> [01:46:39][Step 3/4] /usr/local/lib/python3.8/dist-packages/pluggy/hooks.py:324: in call_extra
> [01:46:39][Step 3/4] return self(**kwargs)
> [01:46:39][Step 3/4] /usr/local/lib/python3.8/dist-packages/pluggy/hooks.py:286: in __call__
> [01:46:39][Step 3/4] return self._hookexec(self, self.get_hookimpls(), kwargs)
> [01:46:39][Step 3/4] /usr/local/lib/python3.8/dist-packages/pluggy/manager.py:93: in _hookexec
> [01:46:39][Step 3/4] return self._inner_hookexec(hook, methods, kwargs)
> [01:46:39][Step 3/4] /usr/local/lib/python3.8/dist-packages/pluggy/manager.py:84: in <lambda>
> [01:46:39][Step 3/4] self._inner_hookexec = lambda hook, methods, kwargs: hook.multicall(
> [01:46:39][Step 3/4] conftest.py:46: in pytest_generate_tests
> [01:46:39][Step 3/4] sample_configurations = generate_configurations(samples_dir, samples_list)
> [01:46:39][Step 3/4] utils.py:47: in generate_configurations
> [01:46:39][Step 3/4] ci_configurations[sample_path] = sample_json['ciTests'][current_os]
> [01:46:39][Step 3/4] E KeyError: 'ciTests'
>  
> Victor found the PR, which is the root cause of this failure - https://github.com/oneapi-src/oneAPI-samples/pull/233

## Type of change

Please delete options that are not relevant. Add a 'X' to the one that is applicable. 

- [X] Bug fix (non-breaking change which fixes an issue)

FYI: @JoeOster and @srdontha 
