### PR TITLE
Adding FPGA tutorial 'zero_copy_data_transfer' (after beta10)

### DIFF
--- a/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/zero_copy_data_transfer/CMakeLists.txt
+++ b/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/zero_copy_data_transfer/CMakeLists.txt
@@ -1,0 +1,11 @@
+set(CMAKE_CXX_COMPILER "dpcpp")
+
+cmake_minimum_required (VERSION 2.8)
+
+project(ZeroCopyDataTransfer)
+
+set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})
+set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})
+
+add_subdirectory (src)

--- a/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/zero_copy_data_transfer/License.txt
+++ b/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/zero_copy_data_transfer/License.txt
@@ -1,0 +1,7 @@
+Copyright Intel Corporation
+ 
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ 
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+ 
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/zero_copy_data_transfer/README.md
+++ b/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/zero_copy_data_transfer/README.md
@@ -1,0 +1,150 @@
+# Zero-copy Data Transfer
+This tutorial demonstrates how to use zero-copy host memory via the SYCL restricted Unified Shared Memory (USM) to improve the performance of your FPGA design.
+
+***Documentation***: The [oneAPI DPC++ FPGA Optimization Guide](https://software.intel.com/content/www/us/en/develop/documentation/oneapi-fpga-optimization-guide)  provides comprehensive instructions for targeting FPGAs through DPC++. The [oneAPI Programming Guide](https://software.intel.com/en-us/oneapi-programming-guide) is a general resource for target-independent DPC++ programming.
+
+| Optimized for                     | Description
+---                                 |---
+| OS                                | Linux* Ubuntu* 18.04; Windows* 10
+| Hardware                          | Intel® Programmable Acceleration Card (PAC) with Intel Stratix® 10 SX FPGA
+| Software                          | Intel&reg; oneAPI DPC++ Compiler (Beta)
+| What you will learn               | How to use Restricted USM for the FPGA
+| Time to complete                  | 15 minutes
+
+_Notice: Limited support in Windows*, Compiling for FPGA hardware is not supported in Windows*_</br>
+_Notice: Restricted USM (and therefore this tutorial) is only supported for the Intel® Programmable Acceleration Card (PAC) with Intel Stratix 10 SX FPGA_
+
+## Purpose
+The purpose of this tutorial is to show you how to take advantage of zero-copy host memory for the FPGA to improve the performance of your design. On an FPGA, all host and shared allocations are implemented as *zero-copy* data in host memory. This means that the FPGA will access the data directly over PCIe, which can improve performance in cases where there is little or no temporal reuse of data in the FPGA kernel. This tutorial includes two different kernels: one using traditional SYCL buffers (`src/buffer_kernel.hpp`) and one using restricted USM (`src/restricted_usm_kernel.hpp`) that takes advantage of zero-copy host memory. Before completing this tutorial, it is suggested you review the **Explicit USM** (explicit_usm) tutorial.
+
+### Restricted USM
+Restricted USM allows the host and device to share their respective memories. A typical SYCL design, which transfers data using either SYCL buffers/accessors or explicit USM, copies its input data from the Host Memory to the FPGA's Device Memory. To do this, the data is sent to the FPGA board over PCIe. Once all the data is copied to the FPGA's Device Memory, the FPGA kernel is run and produces output that is also stored in Device Memory. Finally, the output data is transferred from the FPGA's Device Memory back to the CPU's Host Memory over PCIe. This model is shown in the figure below.
+
+```
+|-------------|                                   |---------------|
+|             |   |-------|   PCIe   |--------|   |               |
+| Host Memory |<=>|  CPU  |<========>|  FPGA  |<=>| Device Memory |
+|             |   |-------|          |--------|   |               |
+|-------------|                                   |---------------|
+```
+
+Consider a kernel that simply performs computation for each entry in a buffer independently. Using SYCL buffers or explicit USM, we would bulk transfer the data from the Host Memory to the FPGA's Device Memory, run the kernel that performs the computation on each entry in the buffer, and then bulk transfer the buffer back to the host.
+
+However, a better approach would simply stream the data from the host memory to the FPGA over PCIe, perform the computation on each piece of data, and then stream it back to host memory over PCIe. The desired structure is illustrated below. This would enable us to eliminate the overhead of copying the data to and from the Host Memory and the FPGA's Device Memory. This is done by using zero-copy host memory via the SYCL restricted USM model. This technique is demonstrated in `src/restricted_usm_kernel.hpp`.
+
+```
+|---------------|
+|               |    |-------|  PCIe   |--------|
+|               |    |       |========>|        |
+|  Host Memory  |<==>|  CPU  |         |  FPGA  |
+|               |    |       |<========|        |
+|               |    |-------|  PCIe   |--------|
+|---------------|
+```
+
+This approach is not considered host streaming, since the CPU and FPGA cannot (reliably) access the input/output data simultaneously. In other words, the host must wait until all the FPGA kernels have finished before (reliably) accessing the output data. However, we did avoid copying the data to and from the FPGA's Device Memory and therefore we get an overall savings in total latency. This savings can be seen by running the sample on FPGA hardware, or by the example output later in the [Example of Output](#example-of-output) section. In the future, we plan to create a tutorial that describes how to achieve true host streaming using restricted USM.
+
+## Key Concepts
+* How to use restricted USM for the FPGA
+* The performance benefits of using restricted USM over traditional SYCL buffers or explicit USM
+ 
+## License
+This code sample is licensed under MIT license.
+ 
+## Building the `zero_copy_data_transfer` Tutorial
+### Include Files
+The included header `dpc_common.hpp` is located at `%ONEAPI_ROOT%\dev-utilities\latest\include` on your development system.
+ 
+### Running Samples in DevCloud
+If running a sample in the Intel DevCloud, remember that you must specify the compute node (fpga_compile or fpga_runtime) as well whether to run in batch or interactive mode. For more information see the Intel® oneAPI Base Toolkit Get Started Guide ([https://devcloud.intel.com/oneapi/get-started/base-toolkit/](https://devcloud.intel.com/oneapi/get-started/base-toolkit/)).
+ 
+When compiling for FPGA hardware, it is recommended to increase the job timeout to 12h.
+ 
+### On a Linux* System
+ 
+1. Generate the `Makefile` by running `cmake`.
+     ```
+   mkdir build
+   cd build
+   ```
+   To compile for the Intel® PAC with Intel Stratix® 10 SX FPGA, run `cmake` using the command:  
+    ```
+    cmake ..
+   ```
+
+2. Compile the design through the generated `Makefile`. The following build targets are provided, matching the recommended development flow:
+ 
+   * Compile for emulation (fast compile time, targets emulated FPGA device): 
+     ```
+     make fpga_emu
+     ```
+   * Generate the optimization report: 
+     ```
+     make report
+     ```
+   * Compile for FPGA hardware (longer compile time, targets FPGA device): 
+     ```
+     make fpga
+     ```
+3. (Optional) As the above hardware compile may take several hours to complete, an Intel® PAC with Intel Stratix® 10 SX FPGA precompiled binary can be downloaded <a href="https://iotdk.intel.com/fpga-precompiled-binaries/latest/zero_copy_data_transfer.fpga.tar.gz" download>here</a>.
+ 
+### On a Windows* System
+Note: `cmake` is not yet supported on Windows. A build.ninja file is provided instead. 
+ 
+1. Enter the source file directory.
+   ```
+   cd src
+   ```
+ 
+2. Compile the design. The following build targets are provided, matching the recommended development flow:
+ 
+   * Compile for emulation (fast compile time, targets emulated FPGA device): 
+      ```
+      ninja fpga_emu
+      ```
+ 
+   * Generate the optimization report:
+ 
+     ```
+     ninja report
+     ```
+
+   * Compiling for FPGA hardware is not yet supported on Windows.
+ 
+### In Third-Party Integrated Development Environments (IDEs)
+
+You can compile and run this tutorial in the Eclipse* IDE (in Linux*) and the Visual Studio* IDE (in Windows*). For instructions, refer to the following link: [Intel® oneAPI DPC++ FPGA Workflows on Third-Party IDEs](https://software.intel.com/en-us/articles/intel-oneapi-dpcpp-fpga-workflow-on-ide).
+
+## Examining the Reports
+Locate `report.html` in the `zero_copy_data_transfer_report.prj/reports/` directory. Open the report in any of Chrome*, Firefox*, Edge*, or Internet Explorer*.
+
+## Running the Sample
+ 
+ 1. Run the sample on the FPGA emulator (the kernel executes on the CPU):
+     ```
+     ./zero_copy_data_transfer.fpga_emu     (Linux)
+     zero_copy_data_transfer.fpga_emu.exe   (Windows)
+     ```
+2. Run the sample on the FPGA device:
+     ```
+     ./zero_copy_data_transfer.fpga         (Linux)
+     ```
+ 
+### Example of Output
+You should see the following output in the console:
+
+1. When running on the FPGA emulator
+    ```
+    Running the buffer kernel version with size=10000
+    Running the restricted USM kernel version with size=10000
+    PASSED
+    ```
+
+2. When running on the FPGA device
+    ```
+    Running the buffer kernel with size=100000000
+    Running the restricted USM kernel with size=100000000
+    Average latency for the buffer kernel: 479.713 ms
+    Average latency for the restricted USM kernel: 310.734 ms
+    PASSED
+    ```

--- a/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/zero_copy_data_transfer/sample.json
+++ b/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/zero_copy_data_transfer/sample.json
@@ -1,0 +1,52 @@
+{
+  "guid": "EEF0B7DA-BB7A-482D-AACB-0F5E45CDCB0D",
+  "name": "Zero-copy Data Transfer",
+  "categories": ["Toolkit/Intel® oneAPI Base Toolkit/FPGA/Tutorials"],
+  "description": "An FPGA tutorial demonstrating zero-copy host memory using the SYCL restricted Unified Shared Memory (USM) model",
+  "toolchain": ["dpcpp"],
+  "os": ["linux", "windows"],
+  "targetDevice": ["FPGA"],
+  "builder": ["ide", "cmake"],
+  "languages": [{"cpp":{}}],
+  "ciTests": {
+    "linux": [
+      {
+        "id": "fpga_emu",
+        "steps": [
+          "mkdir build",
+          "cd build",
+          "cmake ..",
+          "make fpga_emu",
+          "./zero_copy_data_transfer.fpga_emu"
+        ]
+      },
+      {
+        "id": "report",
+        "steps": [
+          "mkdir build",
+          "cd build",
+          "cmake ..",
+          "make report"
+        ]
+      }
+    ],
+    "windows": [
+      {
+        "id": "fpga_emu",
+        "steps": [
+          "cd src",
+          "ninja fpga_emu",
+          "zero_copy_data_transfer.fpga_emu.exe"
+        ]
+      },
+      {
+        "id": "report",
+        "steps": [
+          "cd src",
+          "ninja report"
+        ]
+      }
+    ]
+  }
+}
+

--- a/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/zero_copy_data_transfer/src/CMakeLists.txt
+++ b/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/zero_copy_data_transfer/src/CMakeLists.txt
@@ -1,0 +1,54 @@
+set(SOURCE_FILE zero_copy_data_transfer.cpp)
+set(TARGET_NAME zero_copy_data_transfer)
+
+set(EMULATOR_TARGET ${TARGET_NAME}.fpga_emu)
+set(FPGA_TARGET ${TARGET_NAME}.fpga)
+set(REPORTS_TARGET ${TARGET_NAME}_report)
+
+# USM is only supported on the PACS10 board
+set(S10_PAC_USM_BOARD_NAME "intel_s10sx_pac:pac_s10_usm")
+
+set(HARDWARE_COMPILE_FLAGS "-fintelfpga -c")
+
+# use cmake -D USER_HARDWARE_FLAGS=<flags> to set extra flags for FPGA backend compilation
+set(HARDWARE_LINK_FLAGS "-fintelfpga -Wall -Xshardware -Xsboard=${S10_PAC_USM_BOARD_NAME} ${USER_HARDWARE_FLAGS}")
+
+set(EMULATOR_COMPILE_FLAGS "-fintelfpga -Wall -DFPGA_EMULATOR")
+set(EMULATOR_LINK_FLAGS "-fintelfpga")
+
+# fpga emulator
+if(WIN32)
+    message(FATAL_ERROR "No CMake support for Windows, yet")
+else()
+add_executable(${EMULATOR_TARGET} ${SOURCE_FILE})
+add_custom_target(fpga_emu DEPENDS ${EMULATOR_TARGET})
+set_target_properties(${EMULATOR_TARGET} PROPERTIES COMPILE_FLAGS ${EMULATOR_COMPILE_FLAGS})
+set_target_properties(${EMULATOR_TARGET} PROPERTIES LINK_FLAGS ${EMULATOR_LINK_FLAGS})
+endif()
+
+# fpga
+if(WIN32)
+    message(FATAL_ERROR "No CMake support for Windows, yet")
+else()
+add_executable(${FPGA_TARGET} EXCLUDE_FROM_ALL ${SOURCE_FILE})
+add_custom_target(fpga DEPENDS ${FPGA_TARGET})
+set_target_properties(${FPGA_TARGET} PROPERTIES COMPILE_FLAGS ${HARDWARE_COMPILE_FLAGS})
+set_target_properties(${FPGA_TARGET} PROPERTIES LINK_FLAGS ${HARDWARE_LINK_FLAGS})
+endif()
+
+# fpga report
+if(WIN32)
+    message(FATAL_ERROR "No CMake support for Windows, yet")
+else()
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/${SOURCE_FILE} ${SOURCE_FILE} COPYONLY)
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/buffer_kernel.hpp buffer_kernel.hpp COPYONLY)
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/restricted_usm_kernel.hpp restricted_usm_kernel.hpp COPYONLY)
+
+separate_arguments(HARDWARE_LINK_FLAGS_LIST UNIX_COMMAND "${HARDWARE_LINK_FLAGS}")
+
+add_custom_command(OUTPUT ${REPORTS_TARGET}
+             COMMAND ${CMAKE_CXX_COMPILER} ${CMAKE_CXX_FLAGS} ${HARDWARE_LINK_FLAGS_LIST} -fsycl-link ${SOURCE_FILE} -o ${CMAKE_BINARY_DIR}/${REPORTS_TARGET}
+             DEPENDS ${SOURCE_FILE})
+add_custom_target(report DEPENDS ${REPORTS_TARGET})
+endif()
+

--- a/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/zero_copy_data_transfer/src/buffer_kernel.hpp
+++ b/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/zero_copy_data_transfer/src/buffer_kernel.hpp
@@ -1,0 +1,55 @@
+#ifndef __BUFFER_KERNEL_HPP__
+#define __BUFFER_KERNEL_HPP__
+#pragma once
+
+#include <vector>
+
+#include <CL/sycl.hpp>
+#include <CL/sycl/INTEL/fpga_extensions.hpp>
+
+using namespace sycl;
+using namespace std::chrono;
+
+// Declare the kernel class name globally to avoid name mangling.
+class BufferWorker;
+
+// kernel using buffers to transfer data
+template <typename T>
+double BufferKernel(queue& q, std::vector<T>& in, std::vector<T>& out,
+                    const unsigned int size) {
+  // start timer
+  auto start = high_resolution_clock::now();
+
+  {
+    // set up the input/output buffers
+    buffer in_buf(in);
+    buffer out_buf(out);
+
+    // launch the computation kernel
+    auto kernel_event = q.submit([&](handler& h) {
+      accessor in_accessor { in_buf, h, read_only };
+      accessor out_accessor { out_buf, h, write_only, noinit };
+
+      h.single_task<BufferWorker>([=]() [[intel::kernel_args_restrict]] {
+        for (size_t i = 0; i < size; i++) {
+          out_accessor[i] = in_accessor[i] * i;
+        }
+      });
+    });
+  }
+
+  // We use the scope above to synchronize the FPGA kernels.
+  // Exiting the scope will cause the buffer destructors to be called
+  // which will wait until the kernels finish and copy the data back to the
+  // host (if the buffer was written to).
+  // Therefore, at this point in the code, we know the kernels have finished
+  // and the data has been transferred back to the host.
+
+  // stop the timer
+  auto end = high_resolution_clock::now();
+  duration<double, std::milli> diff = end - start;
+
+  return diff.count();
+}
+
+#endif /* __BUFFER_KERNEL_HPP__ */

--- a/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/zero_copy_data_transfer/src/buffer_kernel.hpp
+++ b/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/zero_copy_data_transfer/src/buffer_kernel.hpp
@@ -27,12 +27,12 @@ double BufferKernel(queue& q, std::vector<T>& in, std::vector<T>& out,
 
     // launch the computation kernel
     auto kernel_event = q.submit([&](handler& h) {
-      accessor in_accessor { in_buf, h, read_only };
-      accessor out_accessor { out_buf, h, write_only, noinit };
+      accessor in_a(in_buf, h, read_only);
+      accessor out_a(out_buf, h, write_only, noinit);
 
       h.single_task<BufferWorker>([=]() [[intel::kernel_args_restrict]] {
         for (size_t i = 0; i < size; i++) {
-          out_accessor[i] = in_accessor[i] * i;
+          out_a[i] = in_a[i] * i;
         }
       });
     });

--- a/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/zero_copy_data_transfer/src/build.ninja
+++ b/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/zero_copy_data_transfer/src/build.ninja
@@ -21,5 +21,4 @@ build ${emulator_target}: build_fpga_emu ${source_file}
 build report: phony ${report_target}
 build ${report_target}: gen_report ${source_file}
 
-build report_s10: phony ${report_target}
-build ${report_target}: gen_report ${source_file}
+build report_s10_pac: phony report

--- a/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/zero_copy_data_transfer/src/build.ninja
+++ b/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/zero_copy_data_transfer/src/build.ninja
@@ -1,0 +1,22 @@
+source_file = zero_copy_data_transfer.cpp
+target_name = zero_copy_data_transfer
+
+emulator_target = ${target_name}.fpga_emu.exe
+report_target = ${target_name}_report.a
+
+hardware_flags = -fintelfpga -Xshardware -fsycl-enable-usm-address-space
+emulator_flags = -fintelfpga -fsycl-enable-usm-address-space -DFPGA_EMULATOR
+
+rule build_fpga_emu
+  command = dpcpp /GX ${emulator_flags} $in -o $out
+
+rule gen_report
+  command = dpcpp /GX ${hardware_flags} -Xsboard=intel_s10sx_pac:pac_s10_usm -fsycl-link $in -o $out
+
+# FPGA emulator 
+build fpga_emu: phony ${emulator_target}
+build ${emulator_target}: build_fpga_emu ${source_file}
+
+# report
+build report: phony ${report_target}
+build ${report_target}: gen_report ${source_file}

--- a/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/zero_copy_data_transfer/src/build.ninja
+++ b/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/zero_copy_data_transfer/src/build.ninja
@@ -20,3 +20,6 @@ build ${emulator_target}: build_fpga_emu ${source_file}
 # report
 build report: phony ${report_target}
 build ${report_target}: gen_report ${source_file}
+
+build report_s10: phony ${report_target}
+build ${report_target}: gen_report ${source_file}

--- a/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/zero_copy_data_transfer/src/build.ninja
+++ b/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/zero_copy_data_transfer/src/build.ninja
@@ -4,8 +4,8 @@ target_name = zero_copy_data_transfer
 emulator_target = ${target_name}.fpga_emu.exe
 report_target = ${target_name}_report.a
 
-hardware_flags = -fintelfpga -Xshardware -fsycl-enable-usm-address-space
-emulator_flags = -fintelfpga -fsycl-enable-usm-address-space -DFPGA_EMULATOR
+hardware_flags = -fintelfpga -Xshardware
+emulator_flags = -fintelfpga -DFPGA_EMULATOR
 
 rule build_fpga_emu
   command = dpcpp /GX ${emulator_flags} $in -o $out

--- a/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/zero_copy_data_transfer/src/restricted_usm_kernel.hpp
+++ b/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/zero_copy_data_transfer/src/restricted_usm_kernel.hpp
@@ -67,7 +67,7 @@ event SubmitProducer(queue& q, T* in_data, size_t size) {
       host_ptr<T> h_in_data(in_data);
 
       for (size_t i = 0; i < size; i++) {
-        const T data_from_host_memory = *(h_in_data + i);
+        T data_from_host_memory = *(h_in_data + i);
         ProducePipe<T>::write(data_from_host_memory);
       }
     });
@@ -87,8 +87,8 @@ event SubmitWorker(queue& q, size_t size) {
   auto e = q.submit([&](handler& h) {
     h.single_task<RestrictedUSM>([=]() [[intel::kernel_args_restrict]] {
       for (size_t i = 0; i < size; i++) {
-        const T data = ProducePipe<T>::read();
-        const T value = data * i; // perform computation
+        T data = ProducePipe<T>::read();
+        T value = data * i; // perform computation
         ConsumePipe<T>::write(value);
       }
     });
@@ -110,7 +110,7 @@ event SubmitConsumer(queue& q, T* out_data, size_t size) {
 
     h.single_task<Consumer>([=]() [[intel::kernel_args_restrict]] {
       for (size_t i = 0; i < size; i++) {
-        const T data_to_host_memory = ConsumePipe<T>::read();
+        T data_to_host_memory = ConsumePipe<T>::read();
         *(h_out_data + i) = data_to_host_memory;
       }
     });

--- a/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/zero_copy_data_transfer/src/restricted_usm_kernel.hpp
+++ b/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/zero_copy_data_transfer/src/restricted_usm_kernel.hpp
@@ -1,0 +1,142 @@
+#ifndef __RESTRICTED_USM_KERNEL_HPP__
+#define __RESTRICTED_USM_KERNEL_HPP__
+#pragma once
+
+#include <vector>
+
+#include <CL/sycl.hpp>
+#include <CL/sycl/INTEL/fpga_extensions.hpp>
+
+using namespace sycl;
+using namespace std::chrono;
+
+//
+// The structure of the kernels in this design is shown in the diagram below.
+// The Producer kernel reads the data from CPU memory (via PCIe), producing it
+// for the RestrictedUSM via a pipe. The Worker does the computation on the
+// input data and writes it to the ConsumePipe. The consumer reads the data
+// from this pipe and writes the output back to the CPU memory (via PCIe).
+//
+//                                |----------------------------------|
+//                                |              FPGA                |
+//               |-------------|  |                                  |
+//               |             |  | |- --------|   |---------------| |
+//  |-------|    |             |--->| Producer |==>|               | |
+//  |       |    |             |  | |----------|   |               | |
+//  |  CPU  |<-->| Host Memory |  |                | RestrictedUSM | |
+//  |       |    |             |  | |----------|   |               | |
+//  |-------|    |             |<---| Consumer |<==|               | |
+//               |             |  | |----------|   |---------------| |
+//               |-------------|  |                                  |
+//                                |----------------------------------|
+//
+//
+// As shown in the image above and the code below, we have split this design
+// into three kernels:
+//    1) Producer
+//    2) RestrictedUSM
+//    3) Consumer
+// We do this to decouple the reads/writes from/to the Host Memory over PCIe.
+// Decoupling the memory accesses and using SYCL pipes with a substantial
+// depth ('kPipeDepth' below) allows the kernel to be more resilient against
+// stalls while reading/writing from/to the Host Memory over PCIe. 
+//
+
+// Declare the kernel class names globally to avoid name mangling.
+class RestrictedUSM;
+class Producer;
+class Consumer;
+
+// pipes
+constexpr size_t kPipeDepth = 64;
+template <typename T>
+using ProducePipe = pipe<class ProducePipeClass, T, kPipeDepth>;
+template <typename T>
+using ConsumePipe = pipe<class ConsumePipeClass, T, kPipeDepth>;
+
+//
+// reads the input data from the hosts memory
+// and writes it to the ProducePipe
+//
+template <typename T>
+event SubmitProducer(queue& q, T* in_data, size_t size) {
+  auto e = q.submit([&](handler& h) {
+    h.single_task<Producer>([=]() [[intel::kernel_args_restrict]] {
+      // using a host_ptr tells the compiler that this pointer lives in the
+      // hosts address space
+      host_ptr<T> h_in_data(in_data);
+
+      for (size_t i = 0; i < size; i++) {
+        const T data_from_host_memory = *(h_in_data + i);
+        ProducePipe<T>::write(data_from_host_memory);
+      }
+    });
+  });
+
+  return e;
+}
+
+//
+// The worker kernel in the device:
+//  1) read input data from the ProducePipe
+//  2) perform computation
+//  3) write the output data to the ConsumePipe
+//
+template <typename T>
+event SubmitWorker(queue& q, size_t size) {
+  auto e = q.submit([&](handler& h) {
+    h.single_task<RestrictedUSM>([=]() [[intel::kernel_args_restrict]] {
+      for (size_t i = 0; i < size; i++) {
+        const T data = ProducePipe<T>::read();
+        const T value = data * i; // perform computation
+        ConsumePipe<T>::write(value);
+      }
+    });
+  });
+
+  return e;
+}
+
+//
+// reads output data from the device via ConsumePipe
+// and writes it to the hosts memory
+//
+template <typename T>
+event SubmitConsumer(queue& q, T* out_data, size_t size) {
+  auto e = q.submit([&](handler& h) {
+    // using a host_ptr tells the compiler that this pointer lives in the
+    // hosts address space
+    host_ptr<T> h_out_data(out_data);
+
+    h.single_task<Consumer>([=]() [[intel::kernel_args_restrict]] {
+      for (size_t i = 0; i < size; i++) {
+        const T data_to_host_memory = ConsumePipe<T>::read();
+        *(h_out_data + i) = data_to_host_memory;
+      }
+    });
+  });
+
+  return e;
+}
+
+template <typename T>
+double RestrictedUSMKernel(queue& q, T* in, T* out, size_t size) {
+  // start the timer
+  auto start = high_resolution_clock::now();
+
+  // start the kernels
+  auto worker_event = SubmitWorker<T>(q, size);
+  auto producer_event = SubmitProducer<T>(q, in, size);
+  auto consumer_event = SubmitConsumer<T>(q, out, size);
+
+  // wait for all the kernels to finish
+  q.wait();
+
+  // stop the timer
+  auto end = high_resolution_clock::now();
+  duration<double, std::milli> diff = end - start;
+
+  return diff.count();
+}
+
+#endif /* __RESTRICTED_USM_KERNEL_HPP__ */

--- a/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/zero_copy_data_transfer/src/zero_copy_data_transfer.cpp
+++ b/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/zero_copy_data_transfer/src/zero_copy_data_transfer.cpp
@@ -160,9 +160,10 @@ int main(int argc, char* argv[]) {
               << restricted_usm_avg_lat << " ms\n";
 #endif
 
-    // free the manually allocated USM memory
-    sycl::free(in_restricted_usm, q.get_context());
-    sycl::free(out_restricted_usm, q.get_context());
+    // free the allocated host usm memory
+    // note that these are calls to sycl::free()
+    free(in_restricted_usm, q);
+    free(out_restricted_usm, q);
 
   } catch (exception const& e) {
     // Catches exceptions in the host code

--- a/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/zero_copy_data_transfer/src/zero_copy_data_transfer.cpp
+++ b/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/zero_copy_data_transfer/src/zero_copy_data_transfer.cpp
@@ -1,0 +1,184 @@
+#include <assert.h>
+#include <algorithm>
+#include <chrono>
+#include <iomanip>
+#include <random>
+#include <type_traits>
+
+#include <CL/sycl.hpp>
+#include <CL/sycl/INTEL/fpga_extensions.hpp>
+
+// dpc_common.hpp can be found in the dev-utilities include folder.
+// e.g., $ONEAPI_ROOT/dev-utilities//include/dpc_common.hpp
+#include "dpc_common.hpp"
+
+#include "buffer_kernel.hpp"
+#include "restricted_usm_kernel.hpp"
+
+using namespace sycl;
+
+// the data type - assert that it is arithmetic
+// this allows the design to easily switch between types by changing
+// the line below
+using Type = int;
+static_assert(std::is_arithmetic<Type>::value);
+
+int main(int argc, char* argv[]) {
+  // parse command line arguments
+#if defined(FPGA_EMULATOR)
+  size_t size = 10000;
+  size_t iterations = 1;
+#else
+  size_t size = 100000000;
+  size_t iterations = 5;
+#endif
+
+  // Allow the size to be changed by a command line argument
+  if (argc > 1) {
+    size = std::stoi(std::string(argv[1]));
+  }
+
+  // check the size
+  if (size <= 0) {
+    std::cerr << "ERROR: size must be greater than 0\n";
+    return 1;
+  }
+
+  try {
+    // device selector
+#if defined(FPGA_EMULATOR)
+    INTEL::fpga_emulator_selector selector;
+#else
+    INTEL::fpga_selector selector;
+#endif
+
+    // queue properties to enable profiling
+    auto prop_list = property_list{ property::queue::enable_profiling() };
+
+    // create the device queue
+    queue q(selector, dpc_common::exception_handler, prop_list);
+
+    // make sure the device supports USM host allocations
+    device d = q.get_device();
+    if (!d.get_info<info::device::usm_host_allocations>()) {
+      std::cerr << "ERROR: The selected device does not support USM host"
+                << " allocations\n";
+      return 1;
+    }
+
+    // the golden output
+    std::vector<Type> out_gold(size);
+
+    // input and output data for the buffer version
+    std::vector<Type> in_buffer(size), out_buffer(size);
+
+    // input and output data for the restricted USM version
+    // malloc_host allocates memory specifically in the host's address space
+    Type* in_restricted_usm = malloc_host<Type>(size, q.get_context());
+    Type* out_restricted_usm = malloc_host<Type>(size, q.get_context());
+    
+    // ensure that we could allocate space for both the input and output
+    if (in_restricted_usm == NULL) {
+      std::cerr << "ERROR: failed to allocate space for 'in_restricted_usm'\n";
+      return 1;
+    }
+    if (out_restricted_usm == NULL) {
+      std::cerr << "ERROR: failed to allocate space for 'out_restricted_usm'\n";
+      return 1;
+    }
+
+    // generate some random input data and compute the golden result
+    for (int i = 0; i < size; i++) {
+      // generate a random value
+      Type n = Type(rand() % 100);
+
+      // populate the inputs
+      in_buffer[i] = in_restricted_usm[i] = n;
+
+      // compute the golden result
+      out_gold[i] = n * i;
+    }
+
+    // run the buffer version kernel
+    std::cout << "Running the buffer kernel version with size=" << size << "\n";
+    std::vector<double> buffer_kernel_latency(iterations);
+    for (size_t i = 0; i < iterations; i++) {
+      buffer_kernel_latency[i] = BufferKernel<Type>(q, in_buffer,
+                                                    out_buffer, size);
+    }
+
+    // run the restricted USM version kernel
+    std::cout << "Running the restricted USM kernel version with size=" << size
+              << "\n";
+    std::vector<double> restricted_usm_latency(iterations);
+    for (size_t i = 0; i < iterations; i++) {
+      restricted_usm_latency[i] = RestrictedUSMKernel<Type>(q,
+                                                            in_restricted_usm,
+                                                            out_restricted_usm,
+                                                            size);
+    }
+
+    // validate the outputs
+    // validate the buffer version
+    for (int i = 0; i < size; i++) {
+      if (out_gold[i] != out_buffer[i]) {
+        std::cerr << "ERROR: mismatch at entry " << i
+                  << " of 'Buffer' kernel output "
+                  << "(" << out_gold[i] << "," << out_buffer[i] << ")"
+                  << "\n";
+        return 1;
+      }
+    }
+    // validate the restricted USM version
+    for (int i = 0; i < size; i++) {
+      if (out_gold[i] != out_restricted_usm[i]) {
+        std::cerr << "ERROR: mismatch at entry " << i
+                  << " of 'RestrictedUSM' kernel output "
+                  << "(" << out_gold[i] << "," << out_restricted_usm[i] << ")"
+                  << "\n";
+        return 1;
+      }
+    }
+
+    // The FPGA emulator does not accurately represent the hardware performance
+    // so we don't print performance results when running with the emulator
+#ifndef FPGA_EMULATOR
+    // Compute the average latency across all iterations.
+    // We use the first iteration as a 'warmup' for the FPGA,
+    // so we ignore its results.
+    double buffer_avg_lat = std::accumulate(buffer_kernel_latency.begin() + 1,
+                                            buffer_kernel_latency.end(), 0.0) /
+                            (double)(iterations - 1);
+    double restricted_usm_avg_lat =
+        std::accumulate(restricted_usm_latency.begin() + 1,
+                        restricted_usm_latency.end(), 0.0) /
+        (double)(iterations - 1);
+
+    std::cout << "Average latency for the buffer kernel: " << buffer_avg_lat
+              << " ms\n";
+    std::cout << "Average latency for the restricted USM kernel: "
+              << restricted_usm_avg_lat << " ms\n";
+#endif
+
+    // free the manually allocated USM memory
+    sycl::free(in_restricted_usm, q.get_context());
+    sycl::free(out_restricted_usm, q.get_context());
+
+  } catch (exception const& e) {
+    // Catches exceptions in the host code
+    std::cerr << "Caught a SYCL host exception:\n" << e.what() << "\n";
+    // Most likely the runtime couldn't find FPGA hardware!
+    if (e.get_cl_code() == CL_DEVICE_NOT_FOUND) {
+      std::cerr << "If you are targeting an FPGA, please ensure that your "
+                   "system has a correctly configured FPGA board.\n";
+      std::cerr << "Run sys_check in the oneAPI root directory to verify.\n";
+      std::cerr << "If you are targeting the FPGA emulator, compile with "
+                   "-DFPGA_EMULATOR.\n";
+    }
+    std::terminate();
+  }
+
+  std::cout << "PASSED\n";
+
+  return 0;
+}

--- a/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/zero_copy_data_transfer/src/zero_copy_data_transfer.cpp
+++ b/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/zero_copy_data_transfer/src/zero_copy_data_transfer.cpp
@@ -35,7 +35,7 @@ int main(int argc, char* argv[]) {
 
   // Allow the size to be changed by a command line argument
   if (argc > 1) {
-    size = std::stoi(std::string(argv[1]));
+    size = atoi(argv[1]);
   }
 
   // check the size
@@ -148,11 +148,11 @@ int main(int argc, char* argv[]) {
     // so we ignore its results.
     double buffer_avg_lat = std::accumulate(buffer_kernel_latency.begin() + 1,
                                             buffer_kernel_latency.end(), 0.0) /
-                            (double)(iterations - 1);
+                                        (iterations - 1);
     double restricted_usm_avg_lat =
         std::accumulate(restricted_usm_latency.begin() + 1,
                         restricted_usm_latency.end(), 0.0) /
-        (double)(iterations - 1);
+                    (iterations - 1);
 
     std::cout << "Average latency for the buffer kernel: " << buffer_avg_lat
               << " ms\n";

--- a/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/zero_copy_data_transfer/zero_copy_data_transfer.sln
+++ b/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/zero_copy_data_transfer/zero_copy_data_transfer.sln
@@ -1,0 +1,25 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 15
+VisualStudioVersion = 15.0.28307.705
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "zero_copy_data_transfer", "zero_copy_data_transfer.vcxproj", "{D6A634E7-9F2B-46C2-A21C-2402F631A55A}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|x64 = Debug|x64
+		Release|x64 = Release|x64
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{D6A634E7-9F2B-46C2-A21C-2402F631A55A}.Debug|x64.ActiveCfg = Debug|x64
+		{D6A634E7-9F2B-46C2-A21C-2402F631A55A}.Debug|x64.Build.0 = Debug|x64
+		{D6A634E7-9F2B-46C2-A21C-2402F631A55A}.Release|x64.ActiveCfg = Release|x64
+		{D6A634E7-9F2B-46C2-A21C-2402F631A55A}.Release|x64.Build.0 = Release|x64
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {4AC13DD2-5B0F-4051-93BF-85AEAF6E50C9}
+	EndGlobalSection
+EndGlobal

--- a/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/zero_copy_data_transfer/zero_copy_data_transfer.vcxproj
+++ b/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/zero_copy_data_transfer/zero_copy_data_transfer.vcxproj
@@ -98,6 +98,7 @@
     <Link>
       <SubSystem>Console</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
+      <SpecifyDevCmplAdditionalOptions>-Xsboard=intel_s10sx_pac:pac_s10_usm</SpecifyDevCmplAdditionalOptions>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
@@ -115,6 +116,7 @@
     <Link>
       <SubSystem>Console</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
+      <SpecifyDevCmplAdditionalOptions>-Xsboard=intel_s10sx_pac:pac_s10_usm</SpecifyDevCmplAdditionalOptions>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
@@ -134,6 +136,7 @@
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
       <GenerateDebugInformation>true</GenerateDebugInformation>
+      <SpecifyDevCmplAdditionalOptions>-Xsboard=intel_s10sx_pac:pac_s10_usm</SpecifyDevCmplAdditionalOptions>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
@@ -155,6 +158,7 @@
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
       <GenerateDebugInformation>true</GenerateDebugInformation>
+      <SpecifyDevCmplAdditionalOptions>-Xsboard=intel_s10sx_pac:pac_s10_usm</SpecifyDevCmplAdditionalOptions>
     </Link>
   </ItemDefinitionGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />

--- a/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/zero_copy_data_transfer/zero_copy_data_transfer.vcxproj
+++ b/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/zero_copy_data_transfer/zero_copy_data_transfer.vcxproj
@@ -1,0 +1,163 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="src\zero_copy_data_transfer.cpp" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="src\buffer_kernel.hpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
+    </ClInclude>
+    <ClInclude Include="src\restricted_usm_kernel.hpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
+    </ClInclude>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <VCProjectVersion>15.0</VCProjectVersion>
+    <ProjectGuid>{d6a634e7-9f2b-46c2-a21c-2402f631a55a}</ProjectGuid>
+    <Keyword>Win32Proj</Keyword>
+    <RootNamespace>zero_copy_data_transfer</RootNamespace>
+    <WindowsTargetPlatformVersion>10.0.17763.0</WindowsTargetPlatformVersion>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>Intel(R) oneAPI DPC++ Compiler</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>Intel(R) oneAPI DPC++ Compiler</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>Intel(R) oneAPI DPC++ Compiler</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>Intel(R) oneAPI DPC++ Compiler</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="Shared">
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <LinkIncremental>true</LinkIncremental>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <LinkIncremental>true</LinkIncremental>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <LinkIncremental>false</LinkIncremental>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <LinkIncremental>false</LinkIncremental>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <ClCompile>
+      <PrecompiledHeader>Use</PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>Disabled</Optimization>
+      <SDLCheck>true</SDLCheck>
+      <ConformanceMode>true</ConformanceMode>
+      <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
+      <AdditionalIncludeDirectories>$(ONEAPI_ROOT)dev-utilities\latest\include</AdditionalIncludeDirectories>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <ClCompile>
+      <PrecompiledHeader>Use</PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>Disabled</Optimization>
+      <SDLCheck>true</SDLCheck>
+      <ConformanceMode>true</ConformanceMode>
+      <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
+      <EnableFPGACompilationAhead>true</EnableFPGACompilationAhead>
+      <AdditionalIncludeDirectories>$(ONEAPI_ROOT)dev-utilities\latest\include</AdditionalIncludeDirectories>
+      <AdditionalOptions>-DFPGA_EMULATOR %(AdditionalOptions)</AdditionalOptions>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <ClCompile>
+      <PrecompiledHeader>Use</PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <SDLCheck>true</SDLCheck>
+      <ConformanceMode>true</ConformanceMode>
+      <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
+      <AdditionalIncludeDirectories>$(ONEAPI_ROOT)dev-utilities\latest\include</AdditionalIncludeDirectories>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile>
+      <PrecompiledHeader>Use</PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <SDLCheck>true</SDLCheck>
+      <ConformanceMode>true</ConformanceMode>
+      <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
+      <EnableFPGACompilationAhead>true</EnableFPGACompilationAhead>
+      <AdditionalOptions>-DFPGA_EMULATOR %(AdditionalOptions)</AdditionalOptions>
+      <AdditionalIncludeDirectories>$(ONEAPI_ROOT)dev-utilities\latest\include</AdditionalIncludeDirectories>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+  </ItemDefinitionGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>


### PR DESCRIPTION
Signed-off-by: tyoungsc <tanner.young-schultz@intel.com>

# Description
Adding new FPGA tutorial on how to use restricted USM to do zero-copy data transfer between the CPU and FPGA.

## Type of change
- [X] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?
- [X] Command Line
- [X] Visual Studio

# Testing pipeline
Expected to fail:
1) INTEL/intel namespace/filename incompatibility of beta09/beta10
2) Linux OS support - Ubuntu 20.4 not yet supported for FPGA
