### PR TITLE
black_scholes: update for beta10

### DIFF
--- a/Libraries/oneMKL/black_scholes/black_scholes.cpp
+++ b/Libraries/oneMKL/black_scholes/black_scholes.cpp
@@ -45,13 +45,13 @@ using std::size_t;
 
 
 #if (defined (ACC_ep))
-uint64_t vml_accuracy = mkl::vm::mode::ep;
+auto vml_accuracy = mkl::vm::mode::ep;
 #elif (defined (ACC_la))
-uint64_t vml_accuracy = mkl::vm::mode::la;
+auto vml_accuracy = mkl::vm::mode::la;
 #elif(defined (ACC_ha))
-uint64_t vml_accuracy = mkl::vm::mode::ha;
+auto vml_accuracy = mkl::vm::mode::ha;
 #else
-uint64_t vml_accuracy = mkl::vm::mode::not_defined;
+auto vml_accuracy = mkl::vm::mode::not_defined;
 #endif
 
 enum class dev_select : int {

--- a/Libraries/oneMKL/black_scholes/black_scholes.hpp
+++ b/Libraries/oneMKL/black_scholes/black_scholes.hpp
@@ -33,7 +33,7 @@ void run(
         T * t,
         T * opt_call,
         T * opt_put,
-        uint64_t vml_accuracy,
+        mkl::vm::mode vml_accuracy,
         sycl::queue & q
     ) {
 

--- a/Libraries/oneMKL/black_scholes/black_scholes_buffer_vml.hpp
+++ b/Libraries/oneMKL/black_scholes/black_scholes_buffer_vml.hpp
@@ -30,7 +30,7 @@ void run(
         T * t,
         T * opt_call,
         T * opt_put,
-        uint64_t vml_accuracy,
+        mkl::vm::mode vml_accuracy,
         sycl::queue & q
     ) {
 

--- a/Libraries/oneMKL/black_scholes/black_scholes_usm_vml.hpp
+++ b/Libraries/oneMKL/black_scholes/black_scholes_usm_vml.hpp
@@ -46,7 +46,7 @@ void run(
         T * t,
         T * opt_call,
         T * opt_put,
-        uint64_t vml_accuracy,
+        mkl::vm::mode vml_accuracy,
         sycl::queue & q 
     ) {
 // allocate memory on device


### PR DESCRIPTION
# Description

Updates the Black-Scholes example to use the new `oneapi::mkl::vm::mode` enum introduced in beta10.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [X] Command Line