### PR TITLE
Add 'all' target to oneMKL samples for Eclipse

### DIFF
--- a/Libraries/oneMKL/computed_tomography/GNUmakefile
+++ b/Libraries/oneMKL/computed_tomography/GNUmakefile
@@ -2,6 +2,8 @@
 
 default: run
 
+all: run
+
 run: computed_tomography
 	./computed_tomography 400 400 input.bmp radon.bmp restored.bmp
 
@@ -13,4 +15,4 @@ computed_tomography: computed_tomography.cpp
 clean:
 	-rm -f computed_tomography radon.bmp restored.bmp
 
-.PHONY: clean run
+.PHONY: clean run all

--- a/Libraries/oneMKL/computed_tomography/makefile
+++ b/Libraries/oneMKL/computed_tomography/makefile
@@ -2,6 +2,8 @@
 
 default: run
 
+all: run
+
 run: computed_tomography.exe
 	.\computed_tomography.exe 400 400 input.bmp radon.bmp restored.bmp
 
@@ -13,4 +15,4 @@ computed_tomography.exe: computed_tomography.cpp
 clean:
 	del /q computed_tomography.exe computed_tomography.exp computed_tomography.lib
 
-pseudo: clean run
+pseudo: clean run all

--- a/Libraries/oneMKL/matrix_mul_mkl/GNUmakefile
+++ b/Libraries/oneMKL/matrix_mul_mkl/GNUmakefile
@@ -2,6 +2,8 @@
 
 default: run
 
+all: run
+
 run: matrix_mul_mkl
 	./matrix_mul_mkl
 
@@ -13,4 +15,4 @@ matrix_mul_mkl: matrix_mul_mkl.cpp
 clean:
 	-rm -f matrix_mul_mkl
 
-.PHONY: clean run
+.PHONY: clean run all

--- a/Libraries/oneMKL/matrix_mul_mkl/makefile
+++ b/Libraries/oneMKL/matrix_mul_mkl/makefile
@@ -2,6 +2,8 @@
 
 default: run
 
+all: run
+
 run: matrix_mul_mkl.exe
 	.\matrix_mul_mkl.exe
 
@@ -13,4 +15,4 @@ matrix_mul_mkl.exe: matrix_mul_mkl.cpp
 clean:
 	del /q matrix_mul_mkl.exe matrix_mul_mkl.exp matrix_mul_mkl.lib
 
-pseudo: clean run
+pseudo: clean run all

--- a/Libraries/oneMKL/monte_carlo_european_opt/GNUmakefile
+++ b/Libraries/oneMKL/monte_carlo_european_opt/GNUmakefile
@@ -1,5 +1,7 @@
 default: run_all
 
+all: run_all
+
 run_all: mc_european mc_european_usm
 	./mc_european
 	@echo
@@ -16,4 +18,4 @@ mc_european_usm: mc_european_usm.cpp
 clean:
 	-rm -f mc_european mc_european_usm
 
-.PHONY: run_all clean
+.PHONY: run_all clean all

--- a/Libraries/oneMKL/monte_carlo_european_opt/makefile
+++ b/Libraries/oneMKL/monte_carlo_european_opt/makefile
@@ -1,5 +1,7 @@
 default: run_all
 
+all: run_all
+
 run_all: mc_european.exe mc_european_usm.exe
 	.\mc_european
 	.\mc_european_usm
@@ -17,5 +19,4 @@ clean:
 	del /q mc_european.exp mc_european_usm.exp
 	del /q mc_european.lib mc_european_usm.lib
 
-pseudo: run_all clean
-
+pseudo: run_all clean all

--- a/Libraries/oneMKL/monte_carlo_pi/GNUmakefile
+++ b/Libraries/oneMKL/monte_carlo_pi/GNUmakefile
@@ -2,6 +2,8 @@
 
 default: run_all
 
+all: run_all
+
 run_all: mc_pi mc_pi_usm mc_pi_device_api
 	./mc_pi
 	./mc_pi_usm
@@ -21,4 +23,4 @@ mc_pi_device_api: mc_pi_device_api.cpp
 clean:
 	-rm -f mc_pi mc_pi_usm mc_pi_device_api
 
-.PHONY: run_all clean
+.PHONY: run_all clean all

--- a/Libraries/oneMKL/monte_carlo_pi/makefile
+++ b/Libraries/oneMKL/monte_carlo_pi/makefile
@@ -2,6 +2,8 @@
 
 default: run_all
 
+all: run_all
+
 run_all: mc_pi.exe mc_pi_usm.exe mc_pi_device_api.exe
 	.\mc_pi
 	.\mc_pi_usm
@@ -23,5 +25,5 @@ clean:
 	del /q mc_pi.exp mc_pi_usm.exp mc_pi_device_api.exp
 	del /q mc_pi.lib mc_pi_usm.lib mc_pi_device_api.lib
 
-pseudo: run_all clean
+pseudo: run_all clean all
 

--- a/Libraries/oneMKL/random_sampling_without_replacement/GNUmakefile
+++ b/Libraries/oneMKL/random_sampling_without_replacement/GNUmakefile
@@ -2,6 +2,8 @@
 
 default: run_all
 
+all: run_all
+
 run_all: lottery lottery_usm lottery_device_api
 		./lottery
 		./lottery_usm
@@ -21,4 +23,4 @@ lottery_device_api: lottery_device_api.cpp
 clean:
 		-rm -f lottery lottery_usm lottery_device_api
 
-.PHONY: run_all clean
+.PHONY: run_all clean all

--- a/Libraries/oneMKL/random_sampling_without_replacement/makefile
+++ b/Libraries/oneMKL/random_sampling_without_replacement/makefile
@@ -2,6 +2,8 @@
 
 default: run_all
 
+all: run_all
+
 run_all: lottery.exe lottery_usm.exe lottery_device_api.exe
 	.\lottery
 	.\lottery_usm
@@ -23,4 +25,4 @@ clean:
 	del /q lottery.exp lottery_usm.exp lottery_device_api.exp
 	del /q lottery.lib lottery_usm.lib lottery_device_api.lib
 
-pseudo: run_all clean
+pseudo: run_all clean all

--- a/Libraries/oneMKL/sparse_conjugate_gradient/GNUmakefile
+++ b/Libraries/oneMKL/sparse_conjugate_gradient/GNUmakefile
@@ -2,6 +2,8 @@
 
 default: run
 
+all: run
+
 run: sparse_cg
 	./sparse_cg
 
@@ -13,4 +15,4 @@ sparse_cg: sparse_cg.cpp
 clean:
 	-rm -f sparse_cg
 
-.PHONY: clean run
+.PHONY: clean run all

--- a/Libraries/oneMKL/sparse_conjugate_gradient/makefile
+++ b/Libraries/oneMKL/sparse_conjugate_gradient/makefile
@@ -2,6 +2,8 @@
 
 default: run
 
+all: run
+
 run: sparse_cg.exe
 	.\sparse_cg
 
@@ -13,4 +15,4 @@ sparse_cg.exe: sparse_cg.cpp
 clean:
 	del /q sparse_cg.exe sparse_cg.exp sparse_cg.lib
 
-pseudo: clean run
+pseudo: clean run all


### PR DESCRIPTION
# Description

Adds "all" targets for oneMKL sample makefiles which do not have them. This is the default target for Eclipse.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

