### PR TITLE
Add 'Running on DevCloud' README section to simple-add and vector-add

### DIFF
--- a/DirectProgramming/DPC++/DenseLinearAlgebra/simple-add/README.md
+++ b/DirectProgramming/DPC++/DenseLinearAlgebra/simple-add/README.md
@@ -27,8 +27,11 @@ This code sample is licensed under MIT license.
 
 ## Building the `simple add DPC++` Program for CPU and GPU 
 
-## Include Files
+### Include Files
 The include folder is located at "%ONEAPI_ROOT%\dev-utilities\latest\include" on your development system.
+
+### Running Samples in DevCloud
+If running a sample in the Intel DevCloud, remember that you must specify the compute node (cpu, gpu, fpga_compile, or fpga_runtime) as well as whether to run in batch or interactive mode. For more information see the Intel® oneAPI Base Toolkit Get Started Guide ([https://devcloud.intel.com/oneapi/get-started/base-toolkit/](https://devcloud.intel.com/oneapi/get-started/base-toolkit/)).
 
 ### On a Linux* System
 Perform the following steps:

--- a/DirectProgramming/DPC++/DenseLinearAlgebra/vector-add/README.md
+++ b/DirectProgramming/DPC++/DenseLinearAlgebra/vector-add/README.md
@@ -27,6 +27,9 @@ This code sample is licensed under MIT license.
 
 ## Building the `vector-add` Program for CPU and GPU 
 
+### Running Samples in DevCloud
+If running a sample in the Intel DevCloud, remember that you must specify the compute node (cpu, gpu, fpga_compile, or fpga_runtime) as well as whether to run in batch or interactive mode. For more information see the Intel® oneAPI Base Toolkit Get Started Guide ([https://devcloud.intel.com/oneapi/get-started/base-toolkit/](https://devcloud.intel.com/oneapi/get-started/base-toolkit/)).
+
 ### On a Linux* System
 Perform the following steps:
 1. Build the program using the following `make` commands (default uses buffers):


### PR DESCRIPTION
Signed-off-by: Audrey Kertesz <audrey.kertesz@intel.com>

# Description

The 'Running on DevCloud' README section is missing from these key introductory samples. An issue was filed recently by a user who ran into trouble because he failed to specify a DevCloud node.

## Type of change

Please delete options that are not relevant. Add a 'X' to the one that is applicable. 

- [X] Bug fix (non-breaking change which fixes an issue)
