### PR TITLE
Revert "DEV1A-1215: fix include paths (#259)"

### DIFF
--- a/DirectProgramming/DPC++/ProjectTemplates/cmake-fpga/src/main.cpp
+++ b/DirectProgramming/DPC++/ProjectTemplates/cmake-fpga/src/main.cpp
@@ -6,7 +6,7 @@
 
 // located in $ONEAPI_ROOT/compiler/latest/linux/include/sycl/
 #include <CL/sycl.hpp>
-#include <CL/sycl/INTEL/fpga_extensions.hpp>
+#include <CL/sycl/intel/fpga_extensions.hpp>
 #include <cstdlib>
 #include <iostream>
 

--- a/DirectProgramming/DPC++/ProjectTemplates/makefile-fpga/src/main.cpp
+++ b/DirectProgramming/DPC++/ProjectTemplates/makefile-fpga/src/main.cpp
@@ -6,7 +6,7 @@
 
 // located in $ONEAPI_ROOT/compiler/latest/linux/include/sycl/
 #include <CL/sycl.hpp>
-#include <CL/sycl/INTEL/fpga_extensions.hpp>
+#include <CL/sycl/intel/fpga_extensions.hpp>
 #include <cstdlib>
 #include <iostream>
 


### PR DESCRIPTION
# Description

This reverts commit a145f40ac146cdae396c233fdd0c9cd836049a1f.
According to DEV-1215, the change request was made in error and this change should be reverted.
FYI @anjgola @xmnboy 

Fixes DEV1A-1215

## Type of change

Please delete options that are not relevant. Add a 'X' to the one that is applicable. 

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Not tested.
