### PR TITLE
DEV1A-1215: fix namespace casing

### DIFF
--- a/DirectProgramming/DPC++/ProjectTemplates/cmake-fpga/src/main.cpp
+++ b/DirectProgramming/DPC++/ProjectTemplates/cmake-fpga/src/main.cpp
@@ -17,10 +17,10 @@ int main() {
   // FPGA_EMULATOR defined in cmake-fpga/src/CMakeLists.txt
 #if defined(FPGA_EMULATOR)
   // DPC++ extension: FPGA emulator selector on systems without FPGA card
-  intel::fpga_emulator_selector device_selector;
+  INTEL::fpga_emulator_selector device_selector;
 #else
   // DPC++ extension: FPGA selector on systems with FPGA card
-  intel::fpga_selector device_selector;
+  INTEL::fpga_selector device_selector;
 #endif
 
   // create a buffer

--- a/DirectProgramming/DPC++/ProjectTemplates/makefile-fpga/src/main.cpp
+++ b/DirectProgramming/DPC++/ProjectTemplates/makefile-fpga/src/main.cpp
@@ -17,10 +17,10 @@ int main() {
   // FPGA_EMULATOR defined in makefile-fpga/Makefile
 #if defined(FPGA_EMULATOR)
   // DPC++ extension: FPGA emulator selector on systems without FPGA card
-  intel::fpga_emulator_selector device_selector;
+  INTEL::fpga_emulator_selector device_selector;
 #else
   // DPC++ extension: FPGA selector on systems with FPGA card
-  intel::fpga_selector device_selector;
+  INTEL::fpga_selector device_selector;
 #endif
 
   // create a buffer


### PR DESCRIPTION
As discussed with @akertesz, update the casing of intel namespace to INTEL.
Fixes DEV1A-1215.
FYI @akertesz please review and merge.

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
Not tested.