### PR TITLE
Add "make all" target for better user experience in Eclipse for migration samples.

### DIFF
--- a/Tools/Migration/folder-options-dpct/Makefile
+++ b/Tools/Migration/folder-options-dpct/Makefile
@@ -15,6 +15,8 @@ CPPFLAGS += $(INC_FLAGS)
 %.o: %.cu
 	$(CXX) -c $(CXXFLAGS) $(CPPFLAGS) $< -o $@
 
+all: $(TARGET)
+
 $(TARGET): $(OBJS)
 	$(CXX) $(LDFLAGS) $(OBJS) -o $@ $(LOADLIBES) $(LDLIBS)
 

--- a/Tools/Migration/rodinia-nw-dpct/Makefile
+++ b/Tools/Migration/rodinia-nw-dpct/Makefile
@@ -7,6 +7,8 @@ DEPS = src/needle_kernel.cu src/needle.h
 %.o: %.cu
 	$(CXX) -c $(CXXFLAGS) $(CPPFLAGS) $< -o $@
 
+all: $(TARGET)
+
 $(TARGET): $(SRCS) $(DEPS)
 	$(CXX) $(SRCS) -o $@
 

--- a/Tools/Migration/vector-add-dpct/Makefile
+++ b/Tools/Migration/vector-add-dpct/Makefile
@@ -6,6 +6,8 @@ SRCS = src/vector_add.cu
 %.o: %.cu
 	$(CXX) -c $(CXXFLAGS) $(CPPFLAGS) $< -o $@
 
+all: $(TARGET)
+
 $(TARGET): $(SRCS) $(DEPS)
 	$(CXX) $(SRCS) -o $@
 


### PR DESCRIPTION
# Description

Testing the three migration samples within Eclipse made it apparent that an "all" target was necessary, in order that the end-user can use the default Eclipse build action (make all) when these are imported into Eclipse via the Eclipse samples browser.

This change results in zero changes to the actual sample sources. It simply adds an "all" target in the Makefile that points to what was the previously default target. Thus, the result of a "make" command (without specifying a target) is unchanged. The only functional change is that now a "make all" command will not result in a make error message. The "make all" command is the default action performed in Eclipse when one takes the default "build" action on a Makefile project; these three projects are Makefile projects.

## Type of change

Please delete options that are not relevant. Add a 'X' to the one that is applicable. 

- [X] Usability fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [X] Command Line
- [X] oneapi-cli
- [X] Eclipse IDE
- [X] VSCode

FYI: @srdontha and @JoeOster and @tomlenth 