### PR TITLE
add builder attribute to IoTConnectionTools sample.json files

### DIFF
--- a/Tools/IoTConnectionTools/analog-in/sample.json
+++ b/Tools/IoTConnectionTools/analog-in/sample.json
@@ -6,6 +6,7 @@
   "dependencies": ["pkg|mraa|https://mraa.io"],
   "languages": [{"cpp":{}}],
   "os": ["linux"],
+  "builder": ["cmake"],
   "ciTests": {
     "linux": [
         { "id": "analog-in",

--- a/Tools/IoTConnectionTools/aws-pub-sub/sample.json
+++ b/Tools/IoTConnectionTools/aws-pub-sub/sample.json
@@ -6,6 +6,7 @@
   "dependencies": ["aws-iot-device-sdk-cpp-v2|https://github.com/aws/aws-iot-device-sdk-cpp-v2"],
   "languages": [{"cpp":{}}],
   "os": ["linux"],
+  "builder": ["cmake"],
   "ciTests": {
     "linux": [
         { "id": "aws-pub-sub",

--- a/Tools/IoTConnectionTools/azure-iothub-telemetry/sample.json
+++ b/Tools/IoTConnectionTools/azure-iothub-telemetry/sample.json
@@ -6,6 +6,7 @@
   "dependencies": ["azure-iot-sdk-c|https://github.com/Azure/azure-iot-sdk-c"],
   "languages": [{"cpp":{}}],
   "os": ["linux"],
+  "builder": ["cmake"],
   "ciTests": {
     "linux": [
         { "id": "azure-iothub-telemetry",

--- a/Tools/IoTConnectionTools/digital-in/sample.json
+++ b/Tools/IoTConnectionTools/digital-in/sample.json
@@ -6,6 +6,7 @@
   "dependencies": ["pkg|mraa|https://mraa.io"],
   "languages": [{"cpp":{}}],
   "os": ["linux"],
+  "builder": ["cmake"],
   "ciTests": {
     "linux": [
         { "id": "digital-in",

--- a/Tools/IoTConnectionTools/digital-out/sample.json
+++ b/Tools/IoTConnectionTools/digital-out/sample.json
@@ -6,6 +6,7 @@
   "dependencies": ["pkg|mraa|https://mraa.io"],
   "languages": [{"cpp":{}}],
   "os": ["linux"],
+  "builder": ["cmake"],
   "ciTests": {
     "linux": [
         { "id": "digital-out",

--- a/Tools/IoTConnectionTools/hello-iot-world/sample.json
+++ b/Tools/IoTConnectionTools/hello-iot-world/sample.json
@@ -4,6 +4,7 @@
   "categories": ["Toolkit/Intel® oneAPI IoT Toolkit/Intel® C++ Compiler Classic"],
   "description": "This is a basic sample that outputs the classic 'Hello World' message along with the compiler identification string.",
   "os": ["linux", "windows"],
+  "builder": ["cmake"],
   "toolchain": ["icc", "gcc"],
   "languages": [{"cpp":{}}],
   "ciTests": {

--- a/Tools/IoTConnectionTools/ibm-device/sample.json
+++ b/Tools/IoTConnectionTools/ibm-device/sample.json
@@ -6,6 +6,7 @@
   "dependencies": ["iot-c|https://github.com/ibm-watson-iot/iot-c"],
   "languages": [{"cpp":{}}],
   "os": ["linux"],
+  "builder": ["cmake"],
   "ciTests": {
     "linux": [
         { "id": "ibm-device",

--- a/Tools/IoTConnectionTools/interrupt/sample.json
+++ b/Tools/IoTConnectionTools/interrupt/sample.json
@@ -6,6 +6,7 @@
   "dependencies": ["pkg|mraa|https://mraa.io"],
   "languages": [{"cpp":{}}],
   "os": ["linux"],
+  "builder": ["cmake"],
   "ciTests": {
     "linux": [
         { "id": "interrupt",

--- a/Tools/IoTConnectionTools/onboard-blink/sample.json
+++ b/Tools/IoTConnectionTools/onboard-blink/sample.json
@@ -6,6 +6,7 @@
   "dependencies": ["pkg|mraa|https://mraa.io"],
   "languages": [{"cpp":{}}],
   "os": ["linux"],
+  "builder": ["cmake"],
   "ciTests": {
     "linux": [
         { "id": "onboard-blink",

--- a/Tools/IoTConnectionTools/pwm/sample.json
+++ b/Tools/IoTConnectionTools/pwm/sample.json
@@ -6,6 +6,7 @@
   "dependencies": ["pkg|mraa|https://mraa.io"],
   "languages": [{"cpp":{}}],
   "os": ["linux"],
+  "builder": ["cmake"],
   "ciTests": {
     "linux": [
         { "id": "pwm",

--- a/Tools/IoTConnectionTools/up2-leds/sample.json
+++ b/Tools/IoTConnectionTools/up2-leds/sample.json
@@ -6,6 +6,7 @@
   "dependencies": ["pkg|mraa|https://mraa.io"],
   "languages": [{"cpp":{}}],
   "os": ["linux"],
+  "builder": ["cmake"],
   "ciTests": {
     "linux": [
         { "id": "up2-leds",


### PR DESCRIPTION
Signed-off-by: Mihai Tudor Panu <mihai.tudor.panu@intel.com>

# Description

Fixes CI warning for missing builder attribute from IoT Connection Tools code samples

## Type of change

Please delete options that are not relevant. Add a 'X' to the one that is applicable. 

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Sample Migration (Moving sample from old repository after completing checklist established)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Command Line
- [ ] oneapi-cli
- [ ] Visual Studio
- [ ] Eclipse IDE
- [ ] VSCode

