### PR TITLE
Fix FPGA issues in vector-add and simple-add

### DIFF
--- a/DirectProgramming/DPC++/DenseLinearAlgebra/simple-add/Makefile.fpga
+++ b/DirectProgramming/DPC++/DenseLinearAlgebra/simple-add/Makefile.fpga
@@ -18,49 +18,42 @@ report_usm: simple-add-usm_report.a_usm
 simple-add-buffers.fpga_emu: $(SRC)
 	$(CXX) $(CXXFLAGS) -fintelfpga $^ -o $@ -DFPGA_EMULATOR=1	
 simple-add-usm.fpga_emu_usm: $(USM_SRC)
-	@#$(CXX) $(CXXFLAGS) -fintelfpga $^ -o $@ -DFPGA_EMULATOR=1
-	@echo USM is not supported for FPGAs, yet
+	$(CXX) $(CXXFLAGS) -fintelfpga $^ -o $@ -DFPGA_EMULATOR=1
 
 
 a_buffers.o: $(SRC)
 	$(CXX) $(CXXFLAGS) -fintelfpga -c $^ -o $@ -DFPGA=1
 a_usm.o: $(USM_SRC)
-	@#$(CXX) $(CXXFLAGS) -fintelfpga -c $^ -o $@ -DFPGA=1
-	@echo USM is not supported for FPGAs, yet
+	$(CXX) $(CXXFLAGS) -fintelfpga -c $^ -o $@ -DFPGA=1
 
 
 simple-add-buffers.fpga: a_buffers.o
 	$(CXX) $(CXXFLAGS) -fintelfpga $^ -o $@ -Xshardware
 simple-add-usm.fpga: a_usm.o
-	@#$(CXX) $(CXXFLAGS) -fintelfpga $^ -o $@ -Xshardware
-	@echo USM is not supported for FPGAs, yet
+	$(CXX) $(CXXFLAGS) -fintelfpga $^ -o $@ -Xshardware
 
 run_emu: simple-add-buffers.fpga_emu
 	./simple-add-buffers.fpga_emu
 run_emu_usm: simple-add-usm.fpga_emu_usm
-	@#./simple-add-usm.fpga_emu_usm
-	@echo USM is not supported for FPGAs, yet
+	./simple-add-usm.fpga_emu_usm
 
 		
 run_hw: simple-add-buffers.fpga
 	./simple-add-buffers.fpga
 run_hw_usm: simple-add-usm.fpga
-	@#./simple-add-usm.fpga
-	@echo USM is not supported for FPGAs, yet
+	./simple-add-usm.fpga
 
 
 dev_buffers.o: $(SRC)
 	$(CXX) $(CXXFLAGS) -fintelfpga -c $^ -o $@ -DFPGA=1
 dev_usm.o: $(USM_SRC)
-	@#$(CXX) $(CXXFLAGS) -fintelfpga -c $^ -o $@ -DFPGA=1
-	@echo USM is not supported for FPGAs, yet
+	$(CXX) $(CXXFLAGS) -fintelfpga -c $^ -o $@ -DFPGA=1
 
 
 simple-add-buffers_report.a_buffers: dev_buffers.o
 	$(CXX) $(CXXFLAGS) -fintelfpga -fsycl-link $^ -o $@ -Xshardware
 simple-add-usm_report.a_usm: dev_usm.o
-	@#$(CXX) $(CXXFLAGS) -fintelfpga -fsycl-link $^ -o $@ -Xshardware
-	@echo USM is not supported for FPGAs, yet
+	$(CXX) $(CXXFLAGS) -fintelfpga -fsycl-link $^ -o $@ -Xshardware
 
 
 clean:

--- a/DirectProgramming/DPC++/DenseLinearAlgebra/simple-add/Makefile.win.fpga
+++ b/DirectProgramming/DPC++/DenseLinearAlgebra/simple-add/Makefile.win.fpga
@@ -13,14 +13,14 @@ all: fpga_emu
 fpga_emu: $(SRC)
 	$(CXX) $(CXXFLAGS) -fintelfpga $(SRC) -o $(EXE) -DFPGA_EMULATOR=1
 
-fpga_emu_usm: $(SRC)
-	@echo USM is not supported for FPGAs, yet
+fpga_emu_usm: $(USM_SRC)
+	$(CXX) $(CXXFLAGS) -fintelfpga $(USM_SRC) -o $(USM_EXE) -DFPGA_EMULATOR=1
 
 run: 
 	$(EXE)
 
 run_usm:
-	@echo USM is not supported for FPGAs, yet
+	$(USM_EXE)
 
 clean: 
 	del /f *.o *.d *.out *.mon *.emu *.aocr *.aoco *.prj *.fpga_emu *.fpga_emu_usm *.a $(EXE) $(USM_EXE)

--- a/DirectProgramming/DPC++/DenseLinearAlgebra/simple-add/sample.json
+++ b/DirectProgramming/DPC++/DenseLinearAlgebra/simple-add/sample.json
@@ -35,10 +35,25 @@
         ]
       },
       {
+        "id": "fpga_emu_usm",
+        "steps": [
+          "make clean -f Makefile.fpga",
+          "make fpga_emu_usm -f Makefile.fpga",
+          "make run_emu_usm -f Makefile.fpga"
+        ]
+      },
+      {
         "id": "fpga_report_buffers",
         "steps": [
           "make clean -f Makefile.fpga",
           "make report -f Makefile.fpga"
+        ]
+      },
+      {
+        "id": "fpga_report_usm",
+        "steps": [
+          "make clean -f Makefile.fpga",
+          "make report_usm -f Makefile.fpga"
         ]
       }
     ],
@@ -64,6 +79,14 @@
         "steps": [
           "nmake -f Makefile.win.fpga",
           "nmake -f Makefile.win.fpga run",
+          "nmake -f Makefile.win.fpga clean"
+        ]
+      },
+      {
+        "id": "fpga_emu_usm",
+        "steps": [
+          "nmake -f Makefile.win.fpga fpga_emu_usm",
+          "nmake -f Makefile.win.fpga run_usm",
           "nmake -f Makefile.win.fpga clean"
         ]
       }

--- a/DirectProgramming/DPC++/DenseLinearAlgebra/simple-add/src/simple-add-buffers.cpp
+++ b/DirectProgramming/DPC++/DenseLinearAlgebra/simple-add/src/simple-add-buffers.cpp
@@ -26,17 +26,8 @@
 // dpc_common.hpp can be found in the dev-utilities include folder.
 // e.g., $ONEAPI_ROOT/dev-utilities/<version>/include/dpc_common.hpp
 #include "dpc_common.hpp"
-
 #if FPGA || FPGA_EMULATOR
-// Header locations and some DPC++ extensions changed between beta09 and beta10
-// Temporarily modify the code sample to accept either version
-#define BETA09 20200827
-#if __SYCL_COMPILER_VERSION <= BETA09
-  #include <CL/sycl/intel/fpga_extensions.hpp>
-  namespace INTEL = sycl::intel;  // Namespace alias for backward compatibility
-#else
   #include <CL/sycl/INTEL/fpga_extensions.hpp>
-#endif
 #endif
 
 using namespace sycl;
@@ -62,7 +53,7 @@ void IotaParallel(queue &q, IntArray &a_array, int value) {
   // data access permission and device computation (kernel).
   q.submit([&](auto &h) {
     // Create an accessor with write permission.
-    accessor a(a_buf, h, write_only);
+    accessor a(a_buf, h, write_only, noinit);
 
     // Use parallel_for to populate consecutive numbers starting with a
     // specified value in parallel on device. This executes the kernel.

--- a/DirectProgramming/DPC++/DenseLinearAlgebra/simple-add/src/simple-add-usm.cpp
+++ b/DirectProgramming/DPC++/DenseLinearAlgebra/simple-add/src/simple-add-usm.cpp
@@ -26,17 +26,8 @@
 // dpc_common.hpp can be found in the dev-utilities include folder.
 // e.g., $ONEAPI_ROOT/dev-utilities/<version>/include/dpc_common.hpp
 #include "dpc_common.hpp"
-
 #if FPGA || FPGA_EMULATOR
-// Header locations and some DPC++ extensions changed between beta09 and beta10
-// Temporarily modify the code sample to accept either version
-#define BETA09 20200827
-#if __SYCL_COMPILER_VERSION <= BETA09
-  #include <CL/sycl/intel/fpga_extensions.hpp>
-  namespace INTEL = sycl::intel;  // Namespace alias for backward compatibility
-#else
   #include <CL/sycl/INTEL/fpga_extensions.hpp>
-#endif
 #endif
 
 using namespace sycl;

--- a/DirectProgramming/DPC++/DenseLinearAlgebra/vector-add/Makefile.fpga
+++ b/DirectProgramming/DPC++/DenseLinearAlgebra/vector-add/Makefile.fpga
@@ -18,48 +18,41 @@ report_usm: vector-add-usm_report.a_usm
 vector-add-buffers.fpga_emu: $(SRC)
 	$(CXX) $(CXXFLAGS) -fintelfpga $^ -o $@ -DFPGA_EMULATOR=1
 vector-add-usm.fpga_emu_usm: $(USM_SRC)
-	@#$(CXX) $(CXXFLAGS) -fintelfpga $^ -o $@ -DFPGA_EMULATOR=1
-	@echo USM is not supported for FPGAs, yet
+	$(CXX) $(CXXFLAGS) -fintelfpga $^ -o $@ -DFPGA_EMULATOR=1
 
 
 a.o: $(SRC)
 	$(CXX) $(CXXFLAGS) -fintelfpga -c $^ -o $@ -DFPGA=1
 a_usm.o: $(USM_SRC)
-	@#$(CXX) $(CXXFLAGS) -fintelfpga -c $^ -o $@ -DFPGA=1
-	@echo USM is not supported for FPGAs, yet	
+	$(CXX) $(CXXFLAGS) -fintelfpga -c $^ -o $@ -DFPGA=1	
 
 vector-add-buffers.fpga: a.o
 	$(CXX) $(CXXFLAGS) -fintelfpga $^ -o $@ -Xshardware
 vector-add-usm.fpga: a_usm.o
-	@#$(CXX) $(CXXFLAGS) -fintelfpga $^ -o $@ -Xshardware
-	@echo USM is not supported for FPGAs, yet
+	$(CXX) $(CXXFLAGS) -fintelfpga $^ -o $@ -Xshardware
 
 run_emu: vector-add-buffers.fpga_emu
 	./vector-add-buffers.fpga_emu
 run_emu_usm: vector-add-usm.fpga_emu_usm
-	@#./vector-add-usm.fpga_emu_usm
-	@echo USM is not supported for FPGAs, yet
+	./vector-add-usm.fpga_emu_usm
 
 
 run_hw: vector-add-buffers.fpga
 	./vector-add-buffers.fpga
 run_hw_usm: vector-add-usm.fpga
-	@#./vector-add-usm.fpga
-	@echo USM is not supported for FPGAs, yet	
+	./vector-add-usm.fpga	
 
 dev.o: $(SRC)
 	$(CXX) $(CXXFLAGS) -fintelfpga -c $^ -o $@ -DFPGA=1
 dev_usm.o: $(USM_SRC)
-	@#$(CXX) $(CXXFLAGS) -fintelfpga -c $^ -o $@ -DFPGA=1
-	@echo USM is not supported for FPGAs, yet
+	$(CXX) $(CXXFLAGS) -fintelfpga -c $^ -o $@ -DFPGA=1
 
 
 
 vector-add-buffers_report.a: dev.o
 	$(CXX) $(CXXFLAGS) -fintelfpga -fsycl-link $^ -o $@ -Xshardware
 vector-add-usm_report.a_usm: dev_usm.o
-	@#$(CXX) $(CXXFLAGS) -fintelfpga -fsycl-link $^ -o $@ -Xshardware
-	@echo USM is not supported for FPGAs, yet
+	$(CXX) $(CXXFLAGS) -fintelfpga -fsycl-link $^ -o $@ -Xshardware
 
 
 clean:

--- a/DirectProgramming/DPC++/DenseLinearAlgebra/vector-add/Makefile.win.fpga
+++ b/DirectProgramming/DPC++/DenseLinearAlgebra/vector-add/Makefile.win.fpga
@@ -13,14 +13,14 @@ all: fpga_emu
 fpga_emu: $(SRC)
 	$(CXX) $(CXXFLAGS) -fintelfpga $(SRC) -o $(EXE) -DFPGA_EMULATOR=1
 
-fpga_emu_usm: $(SRC)
-	@echo USM is not supported for FPGAs, yet
+fpga_emu_usm: $(USM_SRC)
+	$(CXX) $(CXXFLAGS) -fintelfpga $(USM_SRC) -o $(USM_EXE) -DFPGA_EMULATOR=1
 
 run: 
 	$(EXE)
 
 run_usm:
-	@echo USM is not supported for FPGAs, yet
+	$(USM_EXE)
 
 clean: 
 	del /F /S /Q *.ilk *.pdb *.o *.d *.out *.mon *.emu *.aocr *.aoco *.prj *.fpga_emu *.fpga_emu_buffers *.a $(EXE) $(USM_EXE)

--- a/DirectProgramming/DPC++/DenseLinearAlgebra/vector-add/sample.json
+++ b/DirectProgramming/DPC++/DenseLinearAlgebra/vector-add/sample.json
@@ -101,9 +101,24 @@
         ]
       },
       {
+        "id": "fpga_emu_usm",
+        "steps": [
+          "make fpga_emu_usm -f Makefile.fpga",
+          "make run_emu_usm -f Makefile.fpga",
+          "make clean -f Makefile.fpga"
+        ]
+      },
+      {
         "id": "fpga_report_buffers",
         "steps": [
           "make report -f Makefile.fpga",
+          "make clean -f Makefile.fpga"
+        ]
+      },
+      {
+        "id": "fpga_report_usm",
+        "steps": [
+          "make report_usm -f Makefile.fpga",
           "make clean -f Makefile.fpga"
         ]
       }
@@ -196,6 +211,14 @@
         "steps": [
           "nmake -f Makefile.win.fpga",
           "nmake -f Makefile.win.fpga run",
+          "nmake -f Makefile.win.fpga clean"
+        ]
+      },
+      {
+        "id": "fpga_emu_usm",
+        "steps": [
+          "nmake -f Makefile.win.fpga fpga_emu_usm",
+          "nmake -f Makefile.win.fpga run_usm",
           "nmake -f Makefile.win.fpga clean"
         ]
       }

--- a/DirectProgramming/DPC++/DenseLinearAlgebra/vector-add/src/vector-add-buffers.cpp
+++ b/DirectProgramming/DPC++/DenseLinearAlgebra/vector-add/src/vector-add-buffers.cpp
@@ -71,7 +71,7 @@ void VectorAdd(queue &q, const IntArray &a_array, const IntArray &b_array,
     accessor b(b_buf, h, read_only);
 
     // The sum_accessor is used to store (with write permission) the sum data.
-    accessor sum(sum_buf, h, write_only);
+    accessor sum(sum_buf, h, write_only, noinit);
 
     // Use parallel_for to run vector addition in parallel on device. This
     // executes the kernel.


### PR DESCRIPTION
# Description
Updating FPGA portion of simple-add and vector-add

1. Enabling USM targets in Makefile.fpga and Makefile.win.fpga
2. Updating samples.json to run the FPGA USM targets
3. Removing Beta09/Beta10 include hack
4. Adding noinit flag to output buffer accessor

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
- [X] Command Line

