### PR TITLE
Fix warnings in oneMKL samples

### DIFF
--- a/Libraries/oneMKL/black_scholes/black_scholes.cpp
+++ b/Libraries/oneMKL/black_scholes/black_scholes.cpp
@@ -59,16 +59,6 @@ enum class dev_select : int {
     gpu = 2
 };
 
-double uniform(double a, double b, std::mt19937_64 & rng) {
-    union {
-        double d;
-        uint64_t w;
-    } arg;
-
-    arg.w = (UINT64_C(0x3FF) << 52) | (rng() >> 12);
-    return (arg.d - 1.0) * (b - a) + a;
-}
-
 constexpr uint64_t seed = UINT64_C(0x1234'5678'09ab'cdef);
 
 constexpr double s0_low  = 10.0;
@@ -102,17 +92,6 @@ void async_sycl_error(sycl::exception_list el) {
         } catch(const sycl::exception & e) {
             std::cerr << "SYCL exception occured with code " << e.get_cl_code() << " with " << e.what() << std::endl;
         }
-    }
-}
-
-template <typename T>
-void generate_inputs_ref(int64_t nopt, T * s0, T * x, T * t) {
-    std::mt19937_64 rng { seed };
-
-    for (int64_t i = 0; i < nopt; ++i) {
-        s0[i] = uniform(s0_low, s0_high, rng);
-        x[i]  = uniform(x_low, x_high, rng);
-        t[i]  = uniform(t_low, t_high, rng);
     }
 }
 

--- a/Libraries/oneMKL/computed_tomography/computed_tomography.cpp
+++ b/Libraries/oneMKL/computed_tomography/computed_tomography.cpp
@@ -71,9 +71,9 @@ typedef oneapi::mkl::dft::descriptor<oneapi::mkl::dft::precision::DOUBLE,
 // A simple transparent matrix class, row-major layout
 template <typename T>
 struct matrix {
+    sycl::queue q;
     T *data;
     int h, w, ldw;
-    sycl::queue q;
     matrix(sycl::queue &main_queue) : q{main_queue}, data{NULL} {}
     matrix(const matrix &);
     matrix &operator=(const matrix &);

--- a/Libraries/oneMKL/monte_carlo_european_opt/mc_european.cpp
+++ b/Libraries/oneMKL/monte_carlo_european_opt/mc_european.cpp
@@ -69,7 +69,6 @@ static void mc_kernel(sycl::queue& q, EngineType& engine, size_t num_samples,
                       sycl::buffer<double>& rng_buf) {
     double a, nu;
     double sc_dp, sp_dp;
-    double st;
 
     a = (risk_neutral_rate - volatility * volatility * 0.5) * t;
     nu = volatility * sqrt(t);


### PR DESCRIPTION
# Description

Fixes some warnings that appear when compiling some oneMKL samples with `-Wall`.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [X] Command Line

