### PR TITLE
Change FPGA samples' intelfpga:: attributes to updated intel:: syntax

### DIFF
--- a/DirectProgramming/DPC++FPGA/ReferenceDesigns/crr/src/main.cpp
+++ b/DirectProgramming/DPC++FPGA/ReferenceDesigns/crr/src/main.cpp
@@ -164,41 +164,41 @@ double CrrSolver(const int n_items, vector<CRRMeta> &in_params,
           int oc = 0;
           do {
             // Metadata of CRR problems
-            [[intelfpga::register]] double u[OUTER_UNROLL];
-            [[intelfpga::register]] double c1[OUTER_UNROLL];
-            [[intelfpga::register]] double c2[OUTER_UNROLL];
-            [[intelfpga::register]] double param_1[OUTER_UNROLL];
-            [[intelfpga::register]] double param_2[OUTER_UNROLL];
-            [[intelfpga::register]] short n_steps[OUTER_UNROLL];
+            [[intel::fpga_register]] double u[OUTER_UNROLL];
+            [[intel::fpga_register]] double c1[OUTER_UNROLL];
+            [[intel::fpga_register]] double c2[OUTER_UNROLL];
+            [[intel::fpga_register]] double param_1[OUTER_UNROLL];
+            [[intel::fpga_register]] double param_2[OUTER_UNROLL];
+            [[intel::fpga_register]] short n_steps[OUTER_UNROLL];
 
             // Current values in binomial tree.  We only need to keep track of
             // one level worth of data, not the entire tree.
-            [[intelfpga::memory, intelfpga::singlepump,
-              intelfpga::bankwidth(sizeof(double)),
-              intelfpga::numbanks(INNER_UNROLL * OUTER_UNROLL_POW2),
-              intelfpga::private_copies(
+            [[intel::fpga_memory, intel::singlepump,
+              intel::bankwidth(sizeof(double)),
+              intel::numbanks(INNER_UNROLL * OUTER_UNROLL_POW2),
+              intel::private_copies(
                   8)]] double optval[kMaxNSteps3][OUTER_UNROLL_POW2];
 
             // Initial values in binomial tree, which correspond to the last
             // level of the binomial tree.
-            [[intelfpga::memory, intelfpga::singlepump,
-              intelfpga::bankwidth(sizeof(double)),
-              intelfpga::numbanks(INNER_UNROLL * OUTER_UNROLL_POW2),
-              intelfpga::private_copies(
+            [[intel::fpga_memory, intel::singlepump,
+              intel::bankwidth(sizeof(double)),
+              intel::numbanks(INNER_UNROLL * OUTER_UNROLL_POW2),
+              intel::private_copies(
                   8)]] double init_optval[kMaxNSteps3][OUTER_UNROLL_POW2];
 
             // u2_array precalculates the power function of u2.
-            [[intelfpga::memory, intelfpga::singlepump,
-              intelfpga::bankwidth(sizeof(double)),
-              intelfpga::numbanks(INNER_UNROLL * OUTER_UNROLL_POW2),
-              intelfpga::private_copies(
+            [[intel::fpga_memory, intel::singlepump,
+              intel::bankwidth(sizeof(double)),
+              intel::numbanks(INNER_UNROLL * OUTER_UNROLL_POW2),
+              intel::private_copies(
                   8)]] double u2_array[kMaxNSteps3][OUTER_UNROLL_POW2];
 
             // p1powu_array precalculates p1 multipy the power of u.
-            [[intelfpga::memory, intelfpga::singlepump,
-              intelfpga::bankwidth(sizeof(double)),
-              intelfpga::numbanks(INNER_UNROLL * OUTER_UNROLL_POW2),
-              intelfpga::private_copies(
+            [[intel::fpga_memory, intel::singlepump,
+              intel::bankwidth(sizeof(double)),
+              intel::numbanks(INNER_UNROLL * OUTER_UNROLL_POW2),
+              intel::private_copies(
                   8)]] double p1powu_array[kMaxNSteps3][OUTER_UNROLL_POW2];
 
             // n0_optval stores the binomial tree value corresponding to node 0
@@ -209,9 +209,9 @@ double CrrSolver(const int n_items, vector<CRRMeta> &in_params,
             // of n0_optval that stores the node 0 value for a specific layer of
             // the tree. pgreek is the array saving values for post-calculating
             // Greeks.
-            [[intelfpga::register]] double n0_optval[OUTER_UNROLL];
-            [[intelfpga::register]] double n0_optval_2[OUTER_UNROLL];
-            [[intelfpga::register]] double pgreek[4][OUTER_UNROLL];
+            [[intel::fpga_register]] double n0_optval[OUTER_UNROLL];
+            [[intel::fpga_register]] double n0_optval_2[OUTER_UNROLL];
+            [[intel::fpga_register]] double pgreek[4][OUTER_UNROLL];
 
             // L1 + L2:
             // Populate init_optval -- calculate the last level of the binomial
@@ -252,9 +252,9 @@ double CrrSolver(const int n_items, vector<CRRMeta> &in_params,
             // Update optval[] -- calculate each level of the binomial tree.
             // reg[] helps to achieve updating INNER_UNROLL elements in optval[]
             // simultaneously.
-            [[intelfpga::disable_loop_pipelining]] for (short t = 0;
+            [[intel::disable_loop_pipelining]] for (short t = 0;
                                                         t <= steps - 1; ++t) {
-              [[intelfpga::register]] double reg[INNER_UNROLL + 1][OUTER_UNROLL];
+              [[intel::fpga_register]] double reg[INNER_UNROLL + 1][OUTER_UNROLL];
 
               double val_1, val_2;
 
@@ -266,7 +266,7 @@ double CrrSolver(const int n_items, vector<CRRMeta> &in_params,
               // L4:
               // Calculate all the elements in optval[] -- all the tree nodes
               // for one level of the tree
-              [[intelfpga::ivdep]] for (int n = 0; n <= steps - 1 - t;
+              [[intel::ivdep]] for (int n = 0; n <= steps - 1 - t;
                                         n += INNER_UNROLL) {
 
                 #pragma unroll

--- a/DirectProgramming/DPC++FPGA/ReferenceDesigns/db/src/db_utils/Accumulator.hpp
+++ b/DirectProgramming/DPC++FPGA/ReferenceDesigns/db/src/db_utils/Accumulator.hpp
@@ -137,10 +137,10 @@ class BRAMAccumulator {
   StorageType mem[size];
 
   // internal cache for hiding write latency
-  [[intelfpga::register]]
+  [[intel::fpga_register]]
   StorageType cache_value[cache_size + 1];
 
-  [[intelfpga::register]]
+  [[intel::fpga_register]]
   IndexType cache_tag[cache_size + 1];
 };
 ///////////////////////////////////////////////////////

--- a/DirectProgramming/DPC++FPGA/ReferenceDesigns/db/src/db_utils/fifo_sort.hpp
+++ b/DirectProgramming/DPC++FPGA/ReferenceDesigns/db/src/db_utils/fifo_sort.hpp
@@ -272,9 +272,9 @@ class Preloader {
   // preloaded_data_: registers for storing the preloaded data
   // data_in_flight_: data in flight
   // valids_in_flight_: load decisions in flight
-  [[intel::register]] T preloaded_data_[sz_preload];
-  [[intel::register]] T data_in_flight_[ld_dist];
-  [[intel::register]] bool valids_in_flight_[ld_dist];
+  [[intel::fpga_register]] T preloaded_data_[sz_preload];
+  [[intel::fpga_register]] T data_in_flight_[ld_dist];
+  [[intel::fpga_register]] bool valids_in_flight_[ld_dist];
 
   // preload_count_ stores the address where to insert the next item in
   // preloaded_data_.
@@ -312,12 +312,12 @@ class Preloader {
 
   // Computation of each index of preloaded_data_ == preload_count_, precomputed
   // in advance of EnqueueFront to remove compare from the critical path
-  [[intel::register]] bool preload_count_equal_indices_[sz_preload];
+  [[intel::fpga_register]] bool preload_count_equal_indices_[sz_preload];
 
   // Computation of each index of preloaded_data_ == preload_count_dec_,
   // precomputed in advance of EnqueueFront to remove compare from the critical
   // path
-  [[intel::register]] bool preload_count_dec_equal_indices_[sz_preload];
+  [[intel::fpga_register]] bool preload_count_dec_equal_indices_[sz_preload];
 
   bool CheckEmpty() { return empty_counter_ < 0; }
 
@@ -327,7 +327,7 @@ class Preloader {
     // Equivalent to preloaded_data_[preload_count_] = data;
     // Implemented this way to convince the compiler to implement
     // preloaded_data_ in registers because it wouldn't cooperate even with the
-    // intel::register attribute.
+    // intel::fpga_register attribute.
     unroller<0, sz_preload>::step([&](auto s) {
       if (preload_count_equal_indices_[s]) preloaded_data_[s] = data;
     });
@@ -731,7 +731,7 @@ void sort(Compare compare) {
   bool is_receiving_b[num_stages];
 
   // The data transfered between the sort stages
-  [[intel::register]] SortType stream_data[num_stages + 1];
+  [[intel::fpga_register]] SortType stream_data[num_stages + 1];
 
   // Used in stage unroller to determine when a stage should begin, and when
   // a stage should start outputting data.
@@ -769,7 +769,6 @@ void sort(Compare compare) {
   constexpr int kTotalIter = kOutputStartLastStage + sort_size;
 
   // Sort
-  //[[intel::ii(1)]]
   for (int i = 0; i < kTotalIter; i++) {
 #ifdef DEBUG
     std::cout << "I: " << i << std::endl;

--- a/DirectProgramming/DPC++FPGA/ReferenceDesigns/db/src/db_utils/fifo_sort.hpp
+++ b/DirectProgramming/DPC++FPGA/ReferenceDesigns/db/src/db_utils/fifo_sort.hpp
@@ -272,9 +272,9 @@ class Preloader {
   // preloaded_data_: registers for storing the preloaded data
   // data_in_flight_: data in flight
   // valids_in_flight_: load decisions in flight
-  [[intelfpga::register]] T preloaded_data_[sz_preload];
-  [[intelfpga::register]] T data_in_flight_[ld_dist];
-  [[intelfpga::register]] bool valids_in_flight_[ld_dist];
+  [[intel::register]] T preloaded_data_[sz_preload];
+  [[intel::register]] T data_in_flight_[ld_dist];
+  [[intel::register]] bool valids_in_flight_[ld_dist];
 
   // preload_count_ stores the address where to insert the next item in
   // preloaded_data_.
@@ -312,12 +312,12 @@ class Preloader {
 
   // Computation of each index of preloaded_data_ == preload_count_, precomputed
   // in advance of EnqueueFront to remove compare from the critical path
-  [[intelfpga::register]] bool preload_count_equal_indices_[sz_preload];
+  [[intel::register]] bool preload_count_equal_indices_[sz_preload];
 
   // Computation of each index of preloaded_data_ == preload_count_dec_,
   // precomputed in advance of EnqueueFront to remove compare from the critical
   // path
-  [[intelfpga::register]] bool preload_count_dec_equal_indices_[sz_preload];
+  [[intel::register]] bool preload_count_dec_equal_indices_[sz_preload];
 
   bool CheckEmpty() { return empty_counter_ < 0; }
 
@@ -327,7 +327,7 @@ class Preloader {
     // Equivalent to preloaded_data_[preload_count_] = data;
     // Implemented this way to convince the compiler to implement
     // preloaded_data_ in registers because it wouldn't cooperate even with the
-    // intelfpga::register attribute.
+    // intel::register attribute.
     unroller<0, sz_preload>::step([&](auto s) {
       if (preload_count_equal_indices_[s]) preloaded_data_[s] = data;
     });
@@ -731,7 +731,7 @@ void sort(Compare compare) {
   bool is_receiving_b[num_stages];
 
   // The data transfered between the sort stages
-  [[intelfpga::register]] SortType stream_data[num_stages + 1];
+  [[intel::register]] SortType stream_data[num_stages + 1];
 
   // Used in stage unroller to determine when a stage should begin, and when
   // a stage should start outputting data.
@@ -769,7 +769,7 @@ void sort(Compare compare) {
   constexpr int kTotalIter = kOutputStartLastStage + sort_size;
 
   // Sort
-  //[[intelfpga::ii(1)]]
+  //[[intel::ii(1)]]
   for (int i = 0; i < kTotalIter; i++) {
 #ifdef DEBUG
     std::cout << "I: " << i << std::endl;

--- a/DirectProgramming/DPC++FPGA/ReferenceDesigns/db/src/query1/query1_kernel.cpp
+++ b/DirectProgramming/DPC++FPGA/ReferenceDesigns/db/src/query1/query1_kernel.cpp
@@ -107,7 +107,7 @@ bool SubmitQuery1(queue& q, Database& dbinfo, DBDate low_date,
       count_local.Init();
 
       // stream each row in the DB (kElementsPerCycle rows at a time)
-      [[intelfpga::ii(1)]]
+      [[intel::ii(1)]]
       for (size_t r = 0; r < rows; r += kElementsPerCycle) {
         // locals
         DBDecimal qty[kElementsPerCycle];

--- a/DirectProgramming/DPC++FPGA/ReferenceDesigns/db/src/query11/query11_kernel.cpp
+++ b/DirectProgramming/DPC++FPGA/ReferenceDesigns/db/src/query11/query11_kernel.cpp
@@ -145,7 +145,7 @@ bool SubmitQuery11(queue& q, Database& dbinfo, std::string& nation,
 
       // populate MapJoiner map
       // why a map? keys may not be sequential
-      [[intelfpga::ivdep]]
+      [[intel::ivdep]]
       for (size_t i = 0; i < s_rows; i++) {
         // read in supplier and nation key
         // NOTE: based on TPCH docs, SUPPKEY is guaranteed to be unique
@@ -179,7 +179,7 @@ bool SubmitQuery11(queue& q, Database& dbinfo, std::string& nation,
       // initialize accumulator
       partkey_values.Init();
 
-      [[intelfpga::ivdep]]
+      [[intel::ivdep]]
       for (size_t i = 0; i < ps_rows; i += kJoinWinSize) {
         SupplierPartSupplierJoinedPipeData pipe_data = 
             PartSupplierPartsPipe::read();

--- a/DirectProgramming/DPC++FPGA/ReferenceDesigns/gzip/src/gzipkernel.cpp
+++ b/DirectProgramming/DPC++FPGA/ReferenceDesigns/gzip/src/gzipkernel.cpp
@@ -2020,13 +2020,13 @@ void SubmitGzipTasksSingleEngine(
       //   Hash Table(s)
       //-------------------------------------
 
-      [[intelfpga::singlepump]] [[intelfpga::numbanks(kVec)]] [
-          [intelfpga::max_replicates(kVec)]] struct {
+      [[intel::singlepump]] [[intel::numbanks(kVec)]] [
+          [intel::max_replicates(kVec)]] struct {
         unsigned char s[kLen];
       } dictionary[kDepth][kVec];
 
-      [[intelfpga::singlepump]] [[intelfpga::numbanks(kVec)]] [
-          [intelfpga::max_replicates(
+      [[intel::singlepump]] [[intel::numbanks(kVec)]] [
+          [intel::max_replicates(
               kVec)]] unsigned int dict_offset[kDepth][kVec];
 
       // Initialize history to empty.

--- a/DirectProgramming/DPC++FPGA/ReferenceDesigns/qrd/src/qrd.cpp
+++ b/DirectProgramming/DPC++FPGA/ReferenceDesigns/qrd/src/qrd.cpp
@@ -125,8 +125,8 @@ void QRDecomposition(vector<float> &in_matrix, vector<float> &out_matrix,
         auto out_matrix2 = out_matrix;
         h.single_task<class QRD>([=]() [[intel::kernel_args_restrict]] {
           for (int l = 0; l < matrices; l++) {
-            [[intelfpga::bankwidth(kBankwidth),
-              intelfpga::numbanks(kNumBanks)]] struct {
+            [[intel::bankwidth(kBankwidth),
+              intel::numbanks(kNumBanks)]] struct {
               MyComplex d[ROWS_COMPONENT];
             } a_matrix[COLS_COMPONENT], ap_matrix[COLS_COMPONENT],
                 aload_matrix[COLS_COMPONENT];
@@ -175,7 +175,7 @@ void QRDecomposition(vector<float> &in_matrix, vector<float> &out_matrix,
                           : 0;
             int qr_idx = l * kOutputMatrixSize / 2;
 
-            [[intelfpga::ii(1)]] [[intelfpga::ivdep(
+            [[intel::ii(1)]] [[intel::ivdep(
                 FIXED_ITERATIONS)]] for (int s = 0; s < ITERATIONS; s++) {
               MyComplex vector_t[ROWS_COMPONENT];
               MyComplex sori[kNumBanks];

--- a/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/onchip_memory_cache/src/onchip_memory_cache.cpp
+++ b/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/onchip_memory_cache/src/onchip_memory_cache.cpp
@@ -61,7 +61,7 @@ void Histogram(std::unique_ptr<queue>& q, buffer<uint32_t>& input_buf,
 
         // Specify that the minimum dependence-distance of
         // loop carried variables is kCacheDepth.
-        [[intelfpga::ivdep(kCacheDepth)]] for (uint32_t n = 0;
+        [[intel::ivdep(kCacheDepth)]] for (uint32_t n = 0;
                                                n < kInitNumInputs; ++n) {
           // Compute the Histogram index to increment
           uint32_t b = input[n] % kNumOutputs;

--- a/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/optimize_inner_loop/src/optimize_inner_loop.cpp
+++ b/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/optimize_inner_loop/src/optimize_inner_loop.cpp
@@ -34,7 +34,7 @@ template <int version> class Producer;
 template <int version> class Consumer;
 
 // Declare the pipe class name globally to reduce name mangling.
-// Templating allows us to instantiate multiple versions of pipes for each 
+// Templating allows us to instantiate multiple versions of pipes for each
 // version of the kernel.
 template <int version> class PipeClass;
 
@@ -100,7 +100,7 @@ void SubmitKernels(const device_selector &selector, std::vector<int> &in,
             // more difficult for the compiler. As a result, the compiler will
             // be conservative and assume this inner loop may have a large trip
             // count and decide to make (or not make) optimizations accordingly.
-            [[intelfpga::speculated_iterations(spec_iters)]]
+            [[intel::speculated_iterations(spec_iters)]]
             for (int j = 0; j < val; j++) {
               Pipe::write(true);
             }
@@ -110,7 +110,7 @@ void SubmitKernels(const device_selector &selector, std::vector<int> &in,
             // 'j<in_element_upper_bound' loop exit condition. This provides the
             // compiler with a constant upperbound on the trip count and allows
             // it to make optimizations accordingly.
-            [[intelfpga::speculated_iterations(spec_iters)]]
+            [[intel::speculated_iterations(spec_iters)]]
             for (int j = 0; j < val && j <= in_element_upper_bound; j++) {
               Pipe::write(true);
             }

--- a/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/shannonization/src/IntersectionKernel.hpp
+++ b/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/shannonization/src/IntersectionKernel.hpp
@@ -56,7 +56,7 @@ struct IntersectionKernel<0, II, APipe, BPipe> {
     int b_count = 1;
     int n = 0;
 
-    [[intelfpga::ii(II)]]
+    [[intel::ii(II)]]
     while (a_count < a_size || b_count < b_size) {
       // increment the intersection counter if the table elements match
       if (a == b) {
@@ -106,7 +106,7 @@ struct IntersectionKernel<1, II, APipe, BPipe> {
     int b_count_next = 2;
     int n = 0;
 
-    [[intelfpga::ii(II)]]
+    [[intel::ii(II)]]
     while (a_count < a_size || b_count < b_size) {
       // increment the intersection counter if the table elements match
       if (a == b) {
@@ -168,7 +168,7 @@ struct IntersectionKernel<2, II, APipe, BPipe> {
     bool b_count_next_inrange = true;
     bool keep_going = true;
 
-    [[intelfpga::ii(II)]]
+    [[intel::ii(II)]]
     while (keep_going) {
       // increment the intersection counter if the table elements match
       if (a == b) {
@@ -260,7 +260,7 @@ struct IntersectionKernel<3, II, APipe, BPipe> {
       b = BPipe::read(b_valid);
     } while (!b_valid);
 
-    [[intelfpga::ii(II)]]
+    [[intel::ii(II)]]
     while (keep_going) {
       if (a == b && a_valid && b_valid) {
         n++;

--- a/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/triangular_loop/src/triangular_loop.cpp
+++ b/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/triangular_loop/src/triangular_loop.cpp
@@ -87,7 +87,7 @@ void TriangularLoop(std::unique_ptr<queue>& q, buffer<uint32_t>& input_buf,
         // Specify that the minimum dependence-distance of loop-carried
         // variables is kM iterations. We ensure this is true by modifying the y
         // index such that a minimum of kM iterations are always executed.
-        [[intelfpga::ivdep(kM)]] for (int i = 0; i < loop_bound; i++) {
+        [[intel::ivdep(kM)]] for (int i = 0; i < loop_bound; i++) {
           // Determine if this iteration is a dummy iteration or a real
           // iteration in which the computation should be performed.
           bool compute = y > x;

--- a/DirectProgramming/DPC++FPGA/Tutorials/Features/fpga_reg/src/fpga_reg.cpp
+++ b/DirectProgramming/DPC++FPGA/Tutorials/Features/fpga_reg/src/fpga_reg.cpp
@@ -85,7 +85,7 @@ void RunKernel(const device_selector &selector,
 
         // Force the compiler to implement the coefficient array in FPGA
         // pipeline registers rather than in on-chip memory.
-        [[intelfpga::register]] std::array coeff = kCoeff;
+        [[intel::fpga_register]] std::array coeff = kCoeff;
 
         // The compiler will pipeline the outer loop.
         for (size_t i = 0; i < input_size; ++i) {
@@ -120,7 +120,7 @@ void RunKernel(const device_selector &selector,
           }
 
           // Rotate the values of the coefficient array.
-          // The loop is fully unrolled. This is a cannonical code structure;
+          // The loop is fully unrolled. This is a canonical code structure;
           // the DPC++ compiler's FPGA backend infers a shift register here.
           int tmp = coeff[0];
           #pragma unroll

--- a/DirectProgramming/DPC++FPGA/Tutorials/Features/loop_coalesce/src/loop_coalesce.cpp
+++ b/DirectProgramming/DPC++FPGA/Tutorials/Features/loop_coalesce/src/loop_coalesce.cpp
@@ -62,7 +62,7 @@ void MatrixMultiply(const device_selector &selector,
         // The loop_coalesce instructs the compiler to attempt to "merge"
         // coalesce_factor loop levels of this nested loop together.
         // For example, a coalesce_factor of 2 turns this into a single loop.
-        [[intelfpga::loop_coalesce(coalesce_factor)]]
+        [[intel::loop_coalesce(coalesce_factor)]]
         for (size_t i = 0; i < kNumRows; ++i) {
           for (size_t j = 0; j < kNumCols; ++j) {
             a[i][j] = accessor_matrix_a[idx];
@@ -76,7 +76,7 @@ void MatrixMultiply(const device_selector &selector,
         // loop results coalescing from the outside in.
         // For example, a coalesce_factor of 2 coalesces the "i" and "j" loops,
         // making a doubly nested loop.
-        [[intelfpga::loop_coalesce(coalesce_factor)]]
+        [[intel::loop_coalesce(coalesce_factor)]]
         for (size_t i = 0; i < kNumRows; ++i) {
           for (size_t j = 0; j < kNumCols; ++j) {
             float sum = 0.0f;
@@ -88,7 +88,7 @@ void MatrixMultiply(const device_selector &selector,
         }
 
         idx = 0;
-        [[intelfpga::loop_coalesce(coalesce_factor)]]
+        [[intel::loop_coalesce(coalesce_factor)]]
         for (size_t i = 0; i < kNumRows; ++i) {
           for (size_t j = 0; j < kNumCols; ++j) {
             accessor_res[idx] = tmp[i][j];

--- a/DirectProgramming/DPC++FPGA/Tutorials/Features/loop_ivdep/src/loop_ivdep.cpp
+++ b/DirectProgramming/DPC++FPGA/Tutorials/Features/loop_ivdep/src/loop_ivdep.cpp
@@ -52,7 +52,7 @@ void TransposeAndFold(const device_selector &selector,
         // location that are less than kRowLength iterations apart.
         // The ivdep here instructs the compiler that it can safely assume no
         // loop-carried dependencies over safe_len consecutive iterations.
-        [[intelfpga::ivdep(safe_len)]]
+        [[intel::ivdep(safe_len)]]
         for (size_t j = 0; j < kMatrixSize * kRowLength; j++) {
           #pragma unroll
           for (size_t i = 0; i < kRowLength; i++) {

--- a/DirectProgramming/DPC++FPGA/Tutorials/Features/max_concurrency/src/max_concurrency.cpp
+++ b/DirectProgramming/DPC++FPGA/Tutorials/Features/max_concurrency/src/max_concurrency.cpp
@@ -54,7 +54,7 @@ void PartialSumWithShift(const device_selector &selector,
         // active at one time.
         // This limits memory usage, since each iteration of the outer
         // loop requires its own copy of a1.
-        [[intelfpga::max_concurrency(concurrency)]]
+        [[intel::max_concurrency(concurrency)]]
         for (size_t i = 0; i < kMaxIter; i++) {
           float a1[kSize];
           for (size_t j = 0; j < kSize; j++)

--- a/DirectProgramming/DPC++FPGA/Tutorials/Features/max_interleaving/src/max_interleaving.cpp
+++ b/DirectProgramming/DPC++FPGA/Tutorials/Features/max_interleaving/src/max_interleaving.cpp
@@ -70,7 +70,7 @@ void Transform(const device_selector &selector, const TwoDimFloatArray &array_a,
           // inner loop at a time so that accesses to temp_r occur
           // in the correct order -- use max_interleaving to simplify
           // the datapath and reduce hardware resource usage
-          [[intelfpga::max_interleaving(interleaving)]] 
+          [[intel::max_interleaving(interleaving)]] 
           for (size_t j = 0; j < kSize; j++) {
             temp_r[j] = SomethingComplicated(temp_a[i*kSize+j], temp_r[j]);
           }

--- a/DirectProgramming/DPC++FPGA/Tutorials/Features/memory_attributes/src/memory_attributes.cpp
+++ b/DirectProgramming/DPC++FPGA/Tutorials/Features/memory_attributes/src/memory_attributes.cpp
@@ -109,10 +109,10 @@ event submitKernel<1>(queue& q, unsigned init, buffer<unsigned, 1>& d_buf,
 
     h.single_task<Kernel<1>>([=]() [[intel::kernel_args_restrict]] {
       // Declare 'dict_offset' whose attributes are applied based on AttrType
-      [[intelfpga::singlepump,
-        intelfpga::memory("MLAB"),
-        intelfpga::numbanks(kVec),
-        intelfpga::max_replicates(kVec)]]
+      [[intel::singlepump,
+        intel::fpga_memory("MLAB"),
+        intel::numbanks(kVec),
+        intel::max_replicates(kVec)]]
       unsigned dict_offset[kRows][kVec];
 
       // Initialize 'dict_offset' with values from global memory.
@@ -142,10 +142,10 @@ event submitKernel<2>(queue& q, unsigned init, buffer<unsigned, 1>& d_buf,
 
     h.single_task<Kernel<2>>([=]() [[intel::kernel_args_restrict]] {
       // Declare 'dict_offset' whose attributes are applied based on AttrType
-      [[intelfpga::doublepump,
-        intelfpga::memory("MLAB"),
-        intelfpga::numbanks(kVec),
-        intelfpga::max_replicates(kVec)]]
+      [[intel::doublepump,
+        intel::fpga_memory("MLAB"),
+        intel::numbanks(kVec),
+        intel::max_replicates(kVec)]]
       unsigned dict_offset[kRows][kVec];
 
       // Initialize 'dict_offset' with values from global memory.

--- a/DirectProgramming/DPC++FPGA/Tutorials/Features/speculated_iterations/src/speculated_iterations.cpp
+++ b/DirectProgramming/DPC++FPGA/Tutorials/Features/speculated_iterations/src/speculated_iterations.cpp
@@ -53,7 +53,7 @@ void ComplexExit(const device_selector &selector, float bound, int &res) {
         // Since the value of var is not known at compile time, the loop
         // trip count is variable and the exit condition must be evaluated at
         // each iteration.
-        [[intelfpga::speculated_iterations(spec_iter)]]
+        [[intel::speculated_iterations(spec_iter)]]
         while (sycl::log10((float)(x)) < bound) {
           x++;
         }


### PR DESCRIPTION
Signed-off-by: Audrey Kertesz <audrey.kertesz@intel.com>

# Description

The intelfpga:: attributes are deprecated in the 2021.1 production release in favor of a more universal syntax under the intel:: namespace. This change updates all FPGA samples that use these attributes to the new syntax. As a result, these attributes will be ignored if compiled against beta10.

## Type of change

- [X] Syntax update in response to a product change

# How Has This Been Tested?

- [X] Command Line
