### PR TITLE
Apply CMAKE_CXX_FLAGS warnings fix to FPGA cmake template

### DIFF
--- a/DirectProgramming/DPC++/ProjectTemplates/cmake-fpga/src/CMakeLists.txt
+++ b/DirectProgramming/DPC++/ProjectTemplates/cmake-fpga/src/CMakeLists.txt
@@ -12,6 +12,7 @@ if (DEFINED FPGA_BOARD)
     set(FPGA_DEVICE_NAME ${FPGA_BOARD})
 endif()
 # use: cmake -D FPGA_BOARD=<board> to override the default FPGA card
+#      (third party or custom FPGA cards can also be used)
 
 
 # Compile flags
@@ -34,8 +35,9 @@ set(DEVICE_OBJ_FILE ${TARGET_NAME}_report.a)
 add_custom_target(report DEPENDS ${DEVICE_OBJ_FILE})
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/${SOURCE_FILE} ${SOURCE_FILE} COPYONLY)
 separate_arguments(HARDWARE_LINK_FLAGS_LIST UNIX_COMMAND "${HARDWARE_LINK_FLAGS}")
+separate_arguments(CMAKE_CXX_FLAGS_LIST UNIX_COMMAND "${CMAKE_CXX_FLAGS}")
 add_custom_command(OUTPUT ${DEVICE_OBJ_FILE}
-                   COMMAND ${CMAKE_CXX_COMPILER} ${CMAKE_CXX_FLAGS} ${HARDWARE_LINK_FLAGS_LIST} -fsycl-link ${SOURCE_FILE} -o ${CMAKE_BINARY_DIR}/${DEVICE_OBJ_FILE}
+                   COMMAND ${CMAKE_CXX_COMPILER} ${CMAKE_CXX_FLAGS_LIST} ${HARDWARE_LINK_FLAGS_LIST} -fsycl-link ${SOURCE_FILE} -o ${CMAKE_BINARY_DIR}/${DEVICE_OBJ_FILE}
                    DEPENDS ${SOURCE_FILE})
 
 


### PR DESCRIPTION
Signed-off-by: Audrey Kertesz <audrey.kertesz@intel.com>

# Description

Apply the same fix from PR 287 to the FPGA CMake project template.
https://github.com/oneapi-src/oneAPI-samples/pull/287

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Sample Migration (Moving sample from old repository after completing checklist established)

# How Has This Been Tested?

- [X] Command Line
