### PR TITLE
Update crr's sample.json

### DIFF
--- a/DirectProgramming/DPC++FPGA/ReferenceDesigns/crr/sample.json
+++ b/DirectProgramming/DPC++FPGA/ReferenceDesigns/crr/sample.json
@@ -38,7 +38,7 @@
           "cd build",
           "cmake -G \"NMake Makefiles\" ..",
           "nmake fpga_emu",
-          "crr.fpga_emu.exe ./data/ordered_inputs.csv -o=./data/ordered_outputs.csv"
+          "crr.fpga_emu.exe ../src/data/ordered_inputs.csv -o=../src/data/ordered_outputs.csv"
         ]
       },
       {


### PR DESCRIPTION
Signed-off-by: Audrey Kertesz <audrey.kertesz@intel.com>

# Description

The Windows sample.json target has a slight error in the path of the input file, causing a CI failure on Windows. This fixes it.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
