### PR TITLE
Add environment variable setting info in README for FPGA Reference Design QRD

### DIFF
--- a/DirectProgramming/DPC++FPGA/ReferenceDesigns/qrd/README.md
+++ b/DirectProgramming/DPC++FPGA/ReferenceDesigns/qrd/README.md
@@ -162,10 +162,11 @@ NOTE: The design is optimized to perform best when run on a large number of matr
 
 
  1. Run the sample on the FPGA emulator (the kernel executes on the CPU).
+ Increase the amount of memory that the emulator runtime is permitted to allocate by setting the CL_CONFIG_CPU_FORCE_PRIVATE_MEM_SIZE environment variable before running the executable.
      ```
+     export CL_CONFIG_CPU_FORCE_PRIVATE_MEM_SIZE=32MB
      ./qrd.fpga_emu           (Linux)
 
-     # On Windows, set the CL_CONFIG_CPU_FORCE_PRIVATE_MEM_SIZE environment variable before running the executable
      set CL_CONFIG_CPU_FORCE_PRIVATE_MEM_SIZE=32MB
      qrd.fpga_emu.exe         (Windows)
      ```


### PR DESCRIPTION
Signed-off-by: Abhishek Tiwari <abhishek2.tiwari@intel.com>

# Description
Update the README to guide users to set the CL_CONFIG_CPU_FORCE_PRIVATE_MEM_SIZE environment variable on Linux before running the emulator executable. This increases the memory allocation limit for the emulator runtime and is needed to prevent CL_OUT_OF_RESOURCES error.

## Type of change

No code change is being made, this is purely a documentation update.

# How Has This Been Tested?

Setting of the environment variable has been tested on:
- [ X ] Command Line
- [ X ] Visual Studio

