### PR TITLE
Remove irrelevant known issue from README.md of histogram sample

### DIFF
--- a/DirectProgramming/DPC++/ParallelPatterns/histogram/README.md
+++ b/DirectProgramming/DPC++/ParallelPatterns/histogram/README.md
@@ -57,15 +57,6 @@ Error 'dpc_common.hpp' file not found
 ```
 You need to add the following directory to the list of include folders, that are required by your project, in your project's Visual Studio project property panel. The missing include folder is located at `%ONEAPI_ROOT%\dev-utilities\latest\include` on your development system.
 
-## Known issues
-
-The sample is prone to ``Floating point exception`` and `CL_INVALID_WORK_GROUP_SIZE` errors on GPU with DPC++ L0 backend, which can be avoided
-by setting `_PSTL_COMPILE_KERNEL` macro to `0`. You can do it using the following command before running `cmake`:
-
-```
-export CXXFLAGS=-D_PSTL_COMPILE_KERNEL=0
-```
-
 ## Running the Sample
 
 Application Parameters


### PR DESCRIPTION
Signed-off-by: Sobolev, Dmitriy <dmitriy.sobolev@intel.com>

# Description
This removes the work-around from README.md of histogram sample which irrelevant for oneAPI beta10.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
I downloaded and ran the latest  Intel® oneAPI Base Toolkit docker image following these commands:
```bash
image=intel/oneapi-basekit
docker pull "$image"
docker run --device=/dev/dri -it "$image"
```
then built and ran the histogram sample:
```bash
cd oneAPI-samples/DirectProgramming/DPC++/ParallelPatterns/histogram
mkdir build
cd build
cmake ..
make
export SYCL_DEVICE_TYPE=GPU
export SYLC_BE=PI_LEVEL0
make run
```
No issue noticed during execution.

- [X] Command Line

# Checklist for Moving samples:
Links and Details can be found in the samples WG Teams Files. 

- [ ] Review sample design with domain reviewers https://github.com/oneapi-src/oneAPI-samples/wiki/Reviewers-and-Domain-Experts 
- [ ] Implement coding guidelines and ensure code quality.
- [ ] Adhere to sample.json specification. https://github.com/oneapi-src/oneAPI-samples/wiki/sample-json-specification
- [ ] Run jsonlint on sample.json to verify json syntax. www.jsonlint.com
- [ ] Adhere to readme template 
- [ ] Ensure/create CI test configurations for sample (ciTests field) https://github.com/oneapi-src/oneAPI-samples/wiki/sample-json-ci-test-object
- [ ] Enforce format via clang-format config file
- [ ] Review DPC++ code with Paul Peterseon. (GitHub User: pmpeter1)
- [ ] Review readme with Tom Lenth or Joe Oster. (GitHub User: JoeOster)
- [ ] Tested using Dev Cloud when applicable
- [ ] Implement fixes for ONSAM Jiras
- [ ] If you have new dependencies/binaries, inform Samples Project Manager Swapna R Dontharaju (@srdontha) or @JoeOster

