### PR TITLE
oneMKL sample updates for Gold

### DIFF
--- a/Libraries/oneMKL/block_lu_decomposition/factor.cpp
+++ b/Libraries/oneMKL/block_lu_decomposition/factor.cpp
@@ -77,8 +77,14 @@ int main(){
     sycl::queue queue(device, error_handler);
     sycl::context context = queue.get_context();
 
+    if (device.is_gpu() && device.get_platform().get_backend() != sycl::backend::level_zero) {
+        std::cerr << "This sample requires Level Zero when running on GPUs." << std::endl;
+        std::cerr << "Please check your system configuration." << std::endl;
+        return 0;
+    }
+
     if (device.get_info<sycl::info::device::double_fp_config>().empty()) {
-        std::cerr << "The sample uses double precision, which is not supported" << std::endl;
+        std::cerr << "This sample uses double precision, which is not supported" << std::endl;
         std::cerr << "by the selected device. Quitting." << std::endl;
         return 0;
     }

--- a/Libraries/oneMKL/block_lu_decomposition/solve.cpp
+++ b/Libraries/oneMKL/block_lu_decomposition/solve.cpp
@@ -92,8 +92,14 @@ int main() {
     sycl::queue queue(device, error_handler);
     sycl::context context = queue.get_context();
 
+    if (device.is_gpu() && device.get_platform().get_backend() != sycl::backend::level_zero) {
+        std::cerr << "This sample requires Level Zero when running on GPUs." << std::endl;
+        std::cerr << "Please check your system configuration." << std::endl;
+        return 0;
+    }
+
     if (device.get_info<sycl::info::device::double_fp_config>().empty()) {
-        std::cerr << "The sample uses double precision, which is not supported" << std::endl;
+        std::cerr << "This sample uses double precision, which is not supported" << std::endl;
         std::cerr << "by the selected device. Quitting." << std::endl;
         return 0;
     }
@@ -129,7 +135,7 @@ int main() {
     std::cout << "Testing accuracy of solution of linear equations system" << std::endl;
     std::cout << "with randomly generated block tridiagonal coefficient" << std::endl;
     std::cout << "matrix by calculating ratios of residuals" << std::endl;
-    std::cout << "to RHS vectors norms." << std::endl;
+    std::cout << "to RHS vectors' norms." << std::endl;
 
     // LU factorization of the coefficient matrix      
     info = dgeblttrf(queue, n, nb, d.data(), dl.data(), du1.data(), du2.data(), ipiv.data());

--- a/Libraries/oneMKL/monte_carlo_european_opt/mc_european_usm.cpp
+++ b/Libraries/oneMKL/monte_carlo_european_opt/mc_european_usm.cpp
@@ -68,7 +68,6 @@ static void mc_kernel(sycl::queue& q, EngineType& engine, size_t num_samples,
                       double strike_price, double t, double& vcall, double& vput, double* rng_ptr) {
     double a, nu;
     double sc_dp, sp_dp;
-    double st;
 
     a = (risk_neutral_rate - volatility * volatility * 0.5) * t;
     nu = volatility * sqrt(t);


### PR DESCRIPTION
# Description

* Restricts block_lu_decomposition to L0 when running on GPU (temporary)
* Removes unused variable in mc_european_usm flagged by -Wall.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [X] Command Line
