### PR TITLE
Remove unused references to <sys/time.h> and gettimeofday()

### DIFF
--- a/Tools/Migration/rodinia-nw-dpct/src/needle.cu
+++ b/Tools/Migration/rodinia-nw-dpct/src/needle.cu
@@ -5,7 +5,6 @@
 #include <math.h>
 #include "needle.h"
 #include <cuda.h>
-#include <sys/time.h>
 
 // includes, kernels
 #include "needle_kernel.cu"
@@ -41,12 +40,6 @@ int blosum62[24][24] = {
 { 0, -1, -1, -1, -2, -1, -1, -1, -1, -1, -1, -1, -1, -1, -2,  0,  0, -2, -1, -1, -1, -1, -1, -4},
 {-4, -4, -4, -4, -4, -4, -4, -4, -4, -4, -4, -4, -4, -4, -4, -4, -4, -4, -4, -4, -4, -4, -4,  1}
 };
-
-double gettime() {
-    struct timeval t;
-    gettimeofday(&t,NULL);
-    return t.tv_sec+t.tv_usec*1e-6;
-}
 
 ////////////////////////////////////////////////////////////////////////////////
 // Program main


### PR DESCRIPTION
# Description

The `<sys/time.h>` header file and `gettimeofday()` function were unused bits of code that was picked up with the migration of this sample from its original source. They were creating a confusing nuisance error on Windows systems, since Windows does not support the `<sys/time.h>` header file.

Fixes # ONSAM-1356 

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [X] Command Line
- [ ] oneapi-cli
- [ ] Visual Studio
- [ ] Eclipse IDE
- [ ] VSCode

Testing the issue is described in ONSAM-1356. Testing was performed on a Linux system and a Windows system.

FYI: @JoeOster and @srdontha 