### PR TITLE
move oneDPL headers before standard headers

### DIFF
--- a/Libraries/oneDPL/gamma-correction/src/main.cpp
+++ b/Libraries/oneDPL/gamma-correction/src/main.cpp
@@ -4,14 +4,16 @@
 // SPDX-License-Identifier: MIT
 // =============================================================
 
+
+// oneDPL headers should be included before standard headers
+#include <oneapi/dpl/algorithm>
+#include <oneapi/dpl/execution>
+#include <oneapi/dpl/iterator>
+
 #include <iomanip>
 #include <iostream>
 
 #include <CL/sycl.hpp>
-
-#include <oneapi/dpl/algorithm>
-#include <oneapi/dpl/execution>
-#include <oneapi/dpl/iterator>
 
 #include "utils.hpp"
 

--- a/Libraries/oneDPL/stable_sort_by_key/src/main.cpp
+++ b/Libraries/oneDPL/stable_sort_by_key/src/main.cpp
@@ -4,12 +4,13 @@
 // SPDX-License-Identifier: MIT
 // =============================================================
 
-#include <CL/sycl.hpp>
-#include <iostream>
-
+// oneDPL headers should be included before standard headers
 #include <oneapi/dpl/algorithm>
 #include <oneapi/dpl/execution>
 #include <oneapi/dpl/iterator>
+
+#include <CL/sycl.hpp>
+#include <iostream>
 
 using namespace sycl;
 using namespace std;


### PR DESCRIPTION
# Description

oneDPL headers shall be placed before C++ standard library headers especially when libstdc++9 or newer is installed on the system.

## Type of change

Please delete options that are not relevant. Add a 'X' to the one that is applicable. 

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Sample Migration (Moving sample from old repository after completing checklist established)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [X] Command Line
- [ ] oneapi-cli
- [ ] Visual Studio
- [ ] Eclipse IDE
- [ ] VSCode

# Checklist for Moving samples:
Links and Details can be found in the samples WG Teams Files. 

- [ ] Review sample design with domain reviewers https://github.com/oneapi-src/oneAPI-samples/wiki/Reviewers-and-Domain-Experts 
- [ ] Implement coding guidelines and ensure code quality.
- [ ] Adhere to sample.json specification. https://github.com/oneapi-src/oneAPI-samples/wiki/sample-json-specification
- [ ] Run jsonlint on sample.json to verify json syntax. www.jsonlint.com
- [ ] Adhere to readme template 
- [ ] Ensure/create CI test configurations for sample (ciTests field) https://github.com/oneapi-src/oneAPI-samples/wiki/sample-json-ci-test-object
- [ ] Enforce format via clang-format config file
- [ ] Review DPC++ code with Paul Peterseon. (GitHub User: pmpeter1)
- [ ] Review readme with Tom Lenth or Joe Oster. (GitHub User: JoeOster)
- [ ] Tested using Dev Cloud when applicable
- [ ] Implement fixes for ONSAM Jiras
- [ ] If you have new dependencies/binaries, inform Samples Project Manager Swapna R Dontharaju (@srdontha) or @JoeOster

