### PR TITLE
Address DB Q9's long build time + small README fixes

### DIFF
--- a/DirectProgramming/DPC++FPGA/ReferenceDesigns/db/README.md
+++ b/DirectProgramming/DPC++FPGA/ReferenceDesigns/db/README.md
@@ -56,7 +56,7 @@ When compiling for FPGA hardware, it is recommended to increase the job timeout 
 
 ### On a Linux* System
 
-1. Install the design into a directory `build` from the design directory by running `cmake`:
+1. Generate the `Makefile` by running `cmake`.
 
    ```
    mkdir build
@@ -71,7 +71,7 @@ When compiling for FPGA hardware, it is recommended to increase the job timeout 
 
    Where `<QUERY_NUMBER>` can be one of `1`, `9`, `11` or `12`.
 
-2. Compile the design through the generated `Makefile`. The following targets are provided and they match the recommended development flow:
+2. Compile the design through the generated `Makefile`. The following targets are provided, matching the recommended development flow:
 
     * Compile for emulation (fast compile time, targets emulated FPGA device).
 
@@ -79,11 +79,12 @@ When compiling for FPGA hardware, it is recommended to increase the job timeout 
        make fpga_emu
        ```
 
-    * Generate the optimization report. Find the report in `db_report.prj/reports/report.html`directory.
+    * Generate the optimization report. Find the report in the `db_report.prj/reports/report.html` directory.
 
        ```
        make report
        ```
+       _Note:_ If you are compiling Query 9 (`-DQUERY=9`), the report generation time is unusually long. Pre-generated reports can be downloaded  <a href="https://iotdk.intel.com/fpga-precompiled-binaries/latest/db.fpga.tar.gz" download>here</a>.
 
     * Compile for FPGA hardware (longer compile time, targets FPGA device).
 
@@ -92,36 +93,43 @@ When compiling for FPGA hardware, it is recommended to increase the job timeout 
        ```
       When building for hardware, the default scale factor is 1. To use the smaller scale factor of 0.01, add the flag `-DSF_SMALL=1` to the original `cmake` command. For example: `cmake .. -DQUERY=9 -DSF_SMALL=1`. See the [Database files](#database-files) for more information.
 
-3. (Optional) As the above hardware compile may take several hours to complete, an Intel® PAC D5005 (with Intel Stratix® 10 SX FPGA) precompiled binary (compatible with Linux* Ubuntu* 18.04) can be downloaded <a href="https://iotdk.intel.com/fpga-precompiled-binaries/latest/db.fpga.tar.gz" download>here</a>.
+3. (Optional) As the hardware compile may take several hours to complete, an Intel® PAC D5005 (with Intel Stratix® 10 SX FPGA) precompiled binary (compatible with Linux* Ubuntu* 18.04) can be downloaded <a href="https://iotdk.intel.com/fpga-precompiled-binaries/latest/db.fpga.tar.gz" download>here</a>.
 
 ### On a Windows* System
-Note: `cmake` is not yet supported on Windows. A `build.ninja` file is provided instead. 
 
-Note: Ensure that Microsoft Visual Studio* (2017, or 2019 Version 16.4 or newer) with "Desktop development with C++" workload is installed on your system.
+1. Generate the `Makefile` by running `cmake`.
 
-1. Enter source file directory.
+   ```
+   mkdir build
+   cd build
+   ```
 
-```
-cd src
-```
+   Run `cmake` using the command:
 
-2. Compile the design. The following targets are provided and they match the recommended development flow:
+   ```
+   cmake -G "NMake Makefiles" .. -DQUERY=<QUERY_NUMBER>
+   ```
+
+   Where `<QUERY_NUMBER>` can be one of `1`, `9`, `11` or `12`.
+
+2. Compile the design through the generated `Makefile`. The following targets are provided, matching the recommended development flow:
 
     * Compile for emulation (fast compile time, targets emulated FPGA device).
 
-      ```
-      ninja fpga_emu_q<QUERY_NUMBER>
-      ```
+       ```
+       nmake fpga_emu
+       ```
 
-    * Generate HTML performance report. Find the report in `../src/db_<QUERY_NUMBER>_report.prj/reports/report.html`directory.
+    * Generate the optimization report. Find the report in the `db_report.prj/reports/report.html` directory.
 
-      ```
-      ninja report_q<QUERY_NUMBER>
-      ```
+       ```
+       nmake report
+       ```
+       _Note:_ If you are compiling Query 9 (`-DQUERY=9`), the report generation time is unusually long. 
 
-    Where `<QUERY_NUMBER>` can be one of `1`, `9`, `11` or `12`.
-
-    * Compiling for FPGA hardware is not yet supported on Windows.
+    * An FPGA hardware target is not provided on Windows*.
+  
+*Note:* The Intel® PAC with Intel Arria® 10 GX FPGA and Intel® PAC D5005 (with Intel Stratix® 10 SX FPGA) do not yet support Windows*. Compiling to FPGA hardware on Windows* requires a third-party or custom Board Support Package (BSP) with Windows* support.
 
 ### In Third-Party Integrated Development Environments (IDEs)
 

--- a/DirectProgramming/DPC++FPGA/ReferenceDesigns/db/README.md
+++ b/DirectProgramming/DPC++FPGA/ReferenceDesigns/db/README.md
@@ -84,7 +84,7 @@ When compiling for FPGA hardware, it is recommended to increase the job timeout 
        ```
        make report
        ```
-       _Note:_ If you are compiling Query 9 (`-DQUERY=9`), the report generation time is unusually long. Pre-generated reports can be downloaded  <a href="https://iotdk.intel.com/fpga-precompiled-binaries/latest/db.fpga.tar.gz" download>here</a>.
+       _Note:_ If you are compiling Query 9 (`-DQUERY=9`), the report generation time is unusually long. Pre-generated reports can be downloaded <a href="https://iotdk.intel.com/fpga-precompiled-binaries/latest/db.fpga.tar.gz" download>here</a>.
 
     * Compile for FPGA hardware (longer compile time, targets FPGA device).
 

--- a/DirectProgramming/DPC++FPGA/ReferenceDesigns/db/sample.json
+++ b/DirectProgramming/DPC++FPGA/ReferenceDesigns/db/sample.json
@@ -60,15 +60,6 @@
         ]
       },
       {
-        "id": "report_q9",
-        "steps": [
-          "mkdir build-q9",
-          "cd build-q9",
-          "cmake .. -DQUERY=9",
-          "make report"
-        ]
-      },
-      {
         "id": "report_q11",
         "steps": [
           "mkdir build-q11",
@@ -125,13 +116,6 @@
         "steps": [
           "cd src",
           "ninja report_q1"
-        ]
-      },
-      {
-        "id": "report_q9",
-        "steps": [
-          "cd src",
-          "ninja report_q9"
         ]
       },
       {

--- a/DirectProgramming/DPC++FPGA/ReferenceDesigns/qrd/src/qrd.hpp
+++ b/DirectProgramming/DPC++FPGA/ReferenceDesigns/qrd/src/qrd.hpp
@@ -27,7 +27,7 @@
 // California and by the laws of the United States of America.
 
 // The values for FIXED_ITERATIONS, ROWS_COMPONENT and COLS_COMPONENT will be
-// supplied by the build system (cmake/build.ninja)
+// supplied by the build system
 
 // Architecture/Design Parameters used to implement the triagular loop
 // structure of the design. See the tutorial on triangular loop optimization

--- a/DirectProgramming/DPC++FPGA/Tutorials/GettingStarted/fast_recompile/README.md
+++ b/DirectProgramming/DPC++FPGA/Tutorials/GettingStarted/fast_recompile/README.md
@@ -94,7 +94,7 @@ The compilation is a 3-step process:
 
 The following graph depicts device link compilation process:
 
-![](fast_recompile.png)
+![](device_link.png)
 
 ### Which method to use?
 Of the two methods described, `-reuse-exe` is easier to use. It also allows you to keep your host and device code as single source, which is preferred for small programs. 

--- a/DirectProgramming/DPC++FPGA/Tutorials/GettingStarted/fpga_compile/README.md
+++ b/DirectProgramming/DPC++FPGA/Tutorials/GettingStarted/fpga_compile/README.md
@@ -49,7 +49,7 @@ There are two important caveats to remember when using the FPGA emulator.
 * **Undefined behavior may differ.** If your code produces different results when compiled for the FPGA emulator versus FPGA hardware, it is likely that your code is exercising undefined behavior. By definition, undefined behavior is not specified by the language specification, and may manifest differently on different targets.
 
 #### Optimization Report
-An full FPGA compilation occurs in two stages:
+A full FPGA compilation occurs in two stages:
 1. **FPGA early image:** The DPC++ device code is optimized and converted into an FPGA design specified in Verilog RTL (a low-level, native entry language for FPGAs). This intermediate compilation result is the FPGA early device image, which is *not* executable. This FPGA early image compilation process takes minutes.
 2. **FPGA hardware image:** The Verilog RTL specifying the design's circuit topology is mapped onto the FPGA's sea of primitive hardware resources by the Intel® Quartus® Prime software.  Intel® Quartus® Prime is included in the Intel® FPGA Add-On, which is required for this compilation stage. The result is an FPGA hardware binary (also referred to as a bitstream). This compilation process takes hours.
 


### PR DESCRIPTION
# Description

DB Q9's report target takes an unexpectedly long time to build, ~2 hours. This leads to timeout failures in the CI test set, and it's a bad user experience too. This should be addressed at a product level, but in the short term I've pulled the tests out of CI and updated DB's README to alert the user.

Some minor typo fixes in other files are also included in this PR.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

