### PR TITLE
Warn about long oneMKL link times on Windows

### DIFF
--- a/Libraries/oneMKL/black_scholes/README.md
+++ b/Libraries/oneMKL/black_scholes/README.md
@@ -53,6 +53,7 @@ You can remove all generated files with `make clean`.
 ### On a Windows* System
 Run `nmake` to build and run the sample. `nmake clean` removes temporary files.
 
+*Warning*: On Windows, static linking with oneMKL currently takes a very long time, due to a known compiler issue. This will be addressed in an upcoming release.
 
 ## Running the Black-Scholes Sample
 If everything is working correctly, the program will exercise different combinations of APIs for both single and double precision (if available), and print a summary of its computations.

--- a/Libraries/oneMKL/block_cholesky_decomposition/README.md
+++ b/Libraries/oneMKL/block_cholesky_decomposition/README.md
@@ -41,6 +41,8 @@ Run `make` to build and run the factor and solve programs. You can remove all ge
 ### On a Windows* System
 Run `nmake` to build and run the sample. `nmake clean` removes temporary files.
 
+*Warning*: On Windows, static linking with oneMKL currently takes a very long time, due to a known compiler issue. This will be addressed in an upcoming release.
+
 ## Running the Block Cholesky Decomposition Sample
 
 ### Example of Output

--- a/Libraries/oneMKL/block_lu_decomposition/README.md
+++ b/Libraries/oneMKL/block_lu_decomposition/README.md
@@ -41,6 +41,8 @@ Run `make` to build and run the factor and solve programs. You can remove all ge
 ### On a Windows* System
 Run `nmake` to build and run the sample. `nmake clean` removes temporary files.
 
+*Warning*: On Windows, static linking with oneMKL currently takes a very long time, due to a known compiler issue. This will be addressed in an upcoming release.
+
 ## Running the Block LU Decomposition Sample
 
 ### Example of Output

--- a/Libraries/oneMKL/computed_tomography/README.md
+++ b/Libraries/oneMKL/computed_tomography/README.md
@@ -41,6 +41,8 @@ You can remove all generated files with `make clean`.
 ### On a Windows* System
 Run `nmake` to build and run the sample. `nmake clean` removes temporary files.
 
+*Warning*: On Windows, static linking with oneMKL currently takes a very long time, due to a known compiler issue. This will be addressed in an upcoming release.
+
 ## Running the Computed Tomography Reconstruction Sample
 
 ### Example of Output

--- a/Libraries/oneMKL/matrix_mul_mkl/README.md
+++ b/Libraries/oneMKL/matrix_mul_mkl/README.md
@@ -42,6 +42,8 @@ You can remove all generated files with `make clean`.
 ### On a Windows* System
 Run `nmake` to build and run the sample. `nmake clean` removes temporary files.
 
+*Warning*: On Windows, static linking with oneMKL currently takes a very long time, due to a known compiler issue. This will be addressed in an upcoming release.
+
 ## Running the Matrix Multiplication with oneMKL Sample
 
 ### Example of Output

--- a/Libraries/oneMKL/monte_carlo_european_opt/README.md
+++ b/Libraries/oneMKL/monte_carlo_european_opt/README.md
@@ -46,6 +46,7 @@ You can remove all generated files with `make clean`.
 ### On a Windows* System
 Run `nmake` to build and run the sample programs. `nmake clean` removes temporary files.
 
+*Warning*: On Windows, static linking with oneMKL currently takes a very long time, due to a known compiler issue. This will be addressed in an upcoming release.
 
 ## Running the Monte Carlo European Options Sample
 If everything is working correctly, both buffer and USM versions of the program will run the Monte Carlo simulation. After simulation, results will be checked against the known true values given by the Black-Scholes formula, and the absolute error is output.

--- a/Libraries/oneMKL/monte_carlo_pi/README.md
+++ b/Libraries/oneMKL/monte_carlo_pi/README.md
@@ -47,6 +47,7 @@ You can remove all generated files with `make clean`.
 ### On a Windows* System
 Run `nmake` to build and run the sample. `nmake clean` removes temporary files.
 
+*Warning*: On Windows, static linking with oneMKL currently takes a very long time, due to a known compiler issue. This will be addressed in an upcoming release.
 ## Running the Monte Carlo Pi Estimation Sample
 
 ### Example of Output

--- a/Libraries/oneMKL/random_sampling_without_replacement/README.md
+++ b/Libraries/oneMKL/random_sampling_without_replacement/README.md
@@ -48,6 +48,8 @@ You can remove all generated files with `make clean`.
 ### On a Windows* System
 Run `nmake` to build and run the sample. `nmake clean` removes temporary files.
 
+*Warning*: On Windows, static linking with oneMKL currently takes a very long time, due to a known compiler issue. This will be addressed in an upcoming release.
+
 ## Running the Multiple Simple Random Sampling without replacement Sample
 
 ### Example of Output

--- a/Libraries/oneMKL/sparse_conjugate_gradient/README.md
+++ b/Libraries/oneMKL/sparse_conjugate_gradient/README.md
@@ -43,6 +43,8 @@ You can remove all generated files with `make clean`.
 ### On a Windows* System
 Run `nmake` to build and run the sample. `nmake clean` removes temporary files.
 
+*Warning*: On Windows, static linking with oneMKL currently takes a very long time, due to a known compiler issue. This will be addressed in an upcoming release.
+
 ## Running the Sparse Conjugate Gradient Sample
 
 ### Example of Output


### PR DESCRIPTION
# Description

This PR adds warning text to the READMEs about long link times on Windows.


FYI: @JoeOster 