### PR TITLE
Remove Windows as a supported platform for the "hello iot" sample

### DIFF
--- a/Tools/IoTConnectionTools/hello-iot-world/README.md
+++ b/Tools/IoTConnectionTools/hello-iot-world/README.md
@@ -1,24 +1,35 @@
 # Hello IoT World
 
 ## Introduction
+
 This is a simple sample you could use for a quick compiler test.
 
 ## What it is
-This project outputs a "Hello World" message and lets users know if the Intel® C++ Compiler Classic was used
-to compile the code sample.
+
+This project outputs a "Hello World" message and lets users know if the Intel®
+C++ Compiler Classic was used to compile the code sample.
 
 ## Hardware requirements
+
 Any Intel® CPU
 
 ## Software requirements
+
 Intel® C++ Compiler Classic
 
-## How to build and run
+## Build and Run
+
 ### Linux CLI
-Use the `oneapi-cli` utility from a terminal to download and create the sample at a location of your choice.
-Source the `setvars.sh` script distributed with oneAPI to configure the compiler. By default this can be found under
-`/opt/intel/inteloneapi`.
+
+Source the `setvars.sh` environment setup script distributed with oneAPI to
+configure the oneAPI development environment. By default this script can be
+found in the `/opt/intel/oneapi` directory.
+
+After sourcing `setvars.sh`, type `oneapi-cli` at the command line to download
+and create the sample at a location of your choice.
+
 Use the following commands to build and run the sample:
+
 ```
 mkdir build
 cd build
@@ -26,30 +37,29 @@ cmake ..
 make
 make run
 ```
-### Windows CLI
-Use the `oneapi-cli.exe` utility from a `Developer Command Prompt for VS` to download and create the sample at a location of your choice.
 
-*Note:* On Windows systems you will need "MSBuild Tools", "Windows 10 SDK" and "C++ CMake tools for Windows" as part of your installed Visual Studio components.
+### Eclipse on Linux
 
-Source the `setvars.bat` script distributed with oneAPI to configure the compiler. By default this can be found under
-`"C:\Program Files (x86)\Intel\oneAPI"`.
-Use the following commands to build and run the sample:
-```
-mkdir build
-cd build
-cmake -G "NMake Makefiles" ..
-nmake
-nmake run
-```
-### IDE
-Use the Samples Plugin for Eclipse or Visual Studio to create and run the sample.
+Use the Intel Samples Plugin in Eclipse to create and run the sample.
 
-You may need to source the `setvars` script distributed with oneAPI before launching the IDE to use the Intel® C++ Compiler Classic or make it available as a toolchain in the IDE.
+You may need to source the `setvars.sh` script distributed with oneAPI before
+launching Eclipse, so that Eclipse can locate and use the Intel® C++ Compiler
+Classic.
 
-### Additional Links
+## Additional Links
+
 Access the Getting Started Guides with the following links:
+
  * [Linux\*](https://software.intel.com/en-us/get-started-with-intel-oneapi-linux-get-started-with-the-intel-oneapi-iot-toolkit)
  * [Windows\*](https://software.intel.com/en-us/get-started-with-intel-oneapi-windows-get-started-with-the-intel-oneapi-iot-toolkit)
 
 ## Disclaimer
-IMPORTANT NOTICE: This software is sample software. It is not designed or intended for use in any medical, life-saving or life-sustaining systems, transportation systems, nuclear systems, or for any other mission-critical application in which the failure of the system could lead to critical injury or death. The software may not be fully tested and may contain bugs or errors; it may not be intended or suitable for commercial release. No regulatory approvals for the software have been obtained, and therefore software may not be certified for use in certain countries or environments.
+
+IMPORTANT NOTICE: This software is sample software. It is not designed or
+intended for use in any medical, life-saving or life-sustaining systems,
+transportation systems, nuclear systems, or for any other mission-critical
+application in which the failure of the system could lead to critical injury
+or death. The software may not be fully tested and may contain bugs or errors;
+it may not be intended or suitable for commercial release. No regulatory
+approvals for the software have been obtained, and therefore software may not
+be certified for use in certain countries or environments.

--- a/Tools/IoTConnectionTools/hello-iot-world/sample.json
+++ b/Tools/IoTConnectionTools/hello-iot-world/sample.json
@@ -3,7 +3,7 @@
   "name": "Hello IoT World",
   "categories": ["Toolkit/oneAPI Tools/IoT Connection Tools"],
   "description": "This is a basic sample that outputs the classic 'Hello World' message along with the compiler identification string",
-  "os": ["linux", "windows"],
+  "os": ["linux"],
   "builder": ["cmake"],
   "toolchain": ["icc", "gcc"],
   "languages": [{"cpp":{}}],
@@ -17,18 +17,6 @@
             "cmake ..",
             "make",
             "make run"
-            ]
-        }
-    ],
-    "windows": [
-        { "id": "hello-iot-world",
-          "env": [],
-          "steps": [
-            "mkdir build",
-            "cd build",
-            "cmake -G \"NMake Makefiles\" ..",
-            "nmake",
-            "nmake run"
             ]
         }
     ]


### PR DESCRIPTION
# Description

Removing this sample from the Windows sample feed. It will remain in the Linux sample feed. This will make it consistent with the other IoT Toolkit samples. No changes to the actual sample sources are required, only to the sample.json and README.md files.

Signed-off-by: Paul A. Fischer <paul.a.fischer@intel.com>

Addresses Teams and email thread regarding usability issues regarding this sample in the context of Visual Studio.

## Type of change

Please delete options that are not relevant. Add a 'X' to the one that is applicable. 

- [X] Sample feed change (Win/Lin > Lin only)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Command Line
- [X] oneapi-cli
- [ ] Visual Studio
- [ ] Eclipse IDE
- [ ] VSCode

# Additional Supporting Notes

As part of any _possible_ future efforts to support oneAPI CMake samples in Visual Studio, we will need to:

* Insure CMake on Windows works well with _all_ Intel C/C++ compilers.

* Document the Visual Studio modules that are needed in a user's Visual Studio installation to support CMake projects on Windows.

* Update README.md files for CMake on Windows samples (which have unique handling requirements).

* Create online documentation to help end-users understand the differences between a traditional VS project and a VS CMake project.

* Implement automated testing for CMake on Windows samples.

FYI: @srdontha) or @JoeOster