### PR TITLE
Improve clarity of two key FPGA tutorials in response to user feedback

### DIFF
--- a/DirectProgramming/DPC++FPGA/Tutorials/Features/pipes/README.md
+++ b/DirectProgramming/DPC++FPGA/Tutorials/Features/pipes/README.md
@@ -247,9 +247,47 @@ Navigate to the "System Viewer" to visualize the structure of the kernel system.
      ```
 
 ### Example of Output
-```
-Input Array Size:  1024
-Enqueuing producer...
-Enqueuing consumer...
-PASSED: The results are correct
-```
+You should see the following output in the console:
+
+1. When running on the FPGA emulator
+    ```
+    Input Array Size: 8192
+    Enqueuing producer...
+    Enqueuing consumer...
+
+    Profiling Info
+      Producer:
+        Start time: 0 ms
+        End time: +8.18174 ms
+        Kernel Duration: 8.18174 ms
+      Consumer:
+        Start time: +7.05307 ms
+        End time: +8.18231 ms
+        Kernel Duration: 1.12924 ms
+      Design Duration: 8.18231 ms
+      Design Throughput: 4.00474 MB/s
+
+    PASSED: The results are correct
+    ```
+    NOTE: The FPGA emulator does not accurately represent the performance nor the relative timing of the kernels (i.e. the start and end times).
+
+2. When running on the FPGA device
+    ```
+    Input Array Size: 1048576
+    Enqueuing producer...
+    Enqueuing consumer...
+
+    Profiling Info
+      Producer:
+        Start time: 0 ms
+        End time: +4.481 ms
+        Kernel Duration: 4.481 ms
+      Consumer:
+        Start time: +0.917 ms
+        End time: +4.484 ms
+        Kernel Duration: 3.568 ms
+      Design Duration: 4.484 ms
+      Design Throughput: 935.348 MB/s
+
+    PASSED: The results are correct
+    ```

--- a/DirectProgramming/DPC++FPGA/Tutorials/Features/pipes/src/pipes.cpp
+++ b/DirectProgramming/DPC++FPGA/Tutorials/Features/pipes/src/pipes.cpp
@@ -21,15 +21,14 @@ using ProducerToConsumerPipe = INTEL::pipe<  // Defined in the SYCL headers.
     int,                                     // The type of data in the pipe.
     4>;                                      // The capacity of the pipe.
 
-// Forward declare the kernel names
-// (This prevents unwanted name mangling in the optimization report.)
+// Forward declare the kernel names to reduce name mangling
 class ProducerTutorial;
 class ConsumerTutorial;
 
 // The Producer kernel reads data from a SYCL buffer and writes it to
 // a pipe. This transfers the input data from the host to the Consumer kernel
 // that is running concurrently.
-void Producer(queue &q, buffer<int, 1> &input_buffer) {
+event Producer(queue &q, buffer<int, 1> &input_buffer) {
   std::cout << "Enqueuing producer...\n";
 
   auto e = q.submit([&](handler &h) {
@@ -42,6 +41,8 @@ void Producer(queue &q, buffer<int, 1> &input_buffer) {
       }
     });
   });
+
+  return e;
 }
 
 
@@ -51,7 +52,7 @@ int ConsumerWork(int i) { return i * i; }
 
 // The Consumer kernel reads data from the pipe, performs some work
 // on the data, and writes the results to an output buffer
-void Consumer(queue &q, buffer<int, 1> &out_buf) {
+event Consumer(queue &q, buffer<int, 1> &out_buf) {
   std::cout << "Enqueuing consumer...\n";
 
   auto e = q.submit([&](handler &h) {
@@ -60,35 +61,48 @@ void Consumer(queue &q, buffer<int, 1> &out_buf) {
 
     h.single_task<ConsumerTutorial>([=]() {
       for (size_t i = 0; i < num_elements; ++i) {
+        // read the input from the pipe
         int input = ProducerToConsumerPipe::read();
+
+        // do work on the input
         int answer = ConsumerWork(input);
+
+        // write the result to the output buffer
         out_accessor[i] = answer;
       }
     });
   });
+
+  return e;
 }
 
 int main(int argc, char *argv[]) {
-  size_t array_size = (1 << 10);
-
+  // Default values for the buffer size is based on whether the target is the
+  // FPGA emulator or actual FPGA hardware
+#if defined(FPGA_EMULATOR)
+  size_t array_size = 1 << 12;
+#else
+  size_t array_size = 1 << 20;
+#endif
+  
+  // allow the user to change the buffer size at the command line
   if (argc > 1) {
     std::string option(argv[1]);
     if (option == "-h" || option == "--help") {
-      std::cout << "Usage: \n<executable> <data size>\n\nFAILED\n";
+      std::cout << "Usage: \n./pipes <data size>\n\nFAILED\n";
       return 1;
     } else {
-      array_size = std::stoi(option);
+      array_size = atoi(argv[1]);
     }
   }
 
-  std::cout << "Input Array Size:  " << array_size << "\n";
+  std::cout << "Input Array Size: " << array_size << "\n";
 
   std::vector<int> producer_input(array_size, -1);
   std::vector<int> consumer_output(array_size, -1);
 
-  // Initialize the input data
-  for (size_t i = 0; i < array_size; i++)
-    producer_input[i] = i;
+  // Initialize the input data with numbers from 0, 1, 2, ..., array_size-1
+  std::iota(producer_input.begin(), producer_input.begin(), 0);
 
 #if defined(FPGA_EMULATOR)
   INTEL::fpga_emulator_selector device_selector;
@@ -96,18 +110,25 @@ int main(int argc, char *argv[]) {
   INTEL::fpga_selector device_selector;
 #endif
 
-  try {
-    queue q(device_selector, dpc_common::exception_handler);
+  event producer_event, consumer_event;
 
+  try {
+    // property list to enable SYCL profiling for the device queue
+    auto props = property_list{property::queue::enable_profiling()};
+
+    // create the device queue with SYCL profiling enabled
+    queue q(device_selector, dpc_common::exception_handler, props);
+
+    // create the 
     buffer producer_buffer(producer_input);
     buffer consumer_buffer(consumer_output);
 
     // Run the two kernels concurrently. The Producer kernel sends
     // data via a pipe to the Consumer kernel.
-    Producer(q, producer_buffer);
-    Consumer(q, consumer_buffer);
+    producer_event = Producer(q, producer_buffer);
+    consumer_event = Consumer(q, consumer_buffer);
 
-  } catch (sycl::exception const &e) {
+  } catch (exception const &e) {
     // Catches exceptions in the host code
     std::cerr << "Caught a SYCL host exception:\n" << e.what() << "\n";
 
@@ -122,7 +143,52 @@ int main(int argc, char *argv[]) {
     std::terminate();
   }
 
-  // Verify result
+  // At this point, the producer_buffer and consumer_buffer have gone out 
+  // of scope. This will cause their destructors to be called, which will in 
+  // turn block until the Producer and Consumer kernels are finished and the
+  // output data is copied back to the host. Therefore, at this point it is
+  // safe and correct to access the contents of the consumer_output vector.
+
+  // print profiling information
+  // alias the 'info::event_profiling' namespace to save column space
+  using syclprof = info::event_profiling;
+
+  // start and end time of the Producer kernel
+  double p_start = producer_event.get_profiling_info<syclprof::command_start>();
+  double p_end = producer_event.get_profiling_info<syclprof::command_end>();
+
+  // start and end time of the Consumer kernel
+  double c_start = consumer_event.get_profiling_info<syclprof::command_start>();
+  double c_end = consumer_event.get_profiling_info<syclprof::command_end>();
+
+  // the total application time
+  double total_time_ms = (c_end - p_start) * 1e-6;
+
+  // the input size in MBs
+  double input_size_mb = array_size * sizeof(int) * 1e-6;
+
+  // the total application throughput
+  double throughput_mbs = input_size_mb / (total_time_ms * 1e-3);
+
+  // Print the start times normalized to the start time of the producer.
+  // i.e. the producer starts at 0ms and the other start/end times are
+  // reported as differences to that number (+X ms).
+  std::cout << std::fixed << std::setprecision(3);
+  std::cout << "\n";
+  std::cout << "Profiling Info\n";
+  std::cout << "\tProducer:\n";
+  std::cout << "\t\tStart time: " << 0 << " ms\n";
+  std::cout << "\t\tEnd time: +" << (p_end-p_start)*1e-6 << " ms\n";
+  std::cout << "\t\tKernel Duration: " << (p_end-p_start)*1e-6 << " ms\n";
+  std::cout << "\tConsumer:\n";
+  std::cout << "\t\tStart time: +" << (c_start-p_start)*1e-6 << " ms\n";
+  std::cout << "\t\tEnd time: +" << (c_end-p_start)*1e-6 << " ms\n";
+  std::cout << "\t\tKernel Duration: " << (c_end-c_start)*1e-6 << " ms\n";
+  std::cout << "\tDesign Duration: " << total_time_ms << " ms\n";
+  std::cout << "\tDesign Throughput: " << throughput_mbs << " MB/s\n";
+  std::cout << "\n";
+
+  // Verify the result
   for (size_t i = 0; i < array_size; i++) {
     if (consumer_output[i] != ConsumerWork(producer_input[i])) {
       std::cout << "input = " << producer_input[i]

--- a/DirectProgramming/DPC++FPGA/Tutorials/GettingStarted/fast_recompile/README.md
+++ b/DirectProgramming/DPC++FPGA/Tutorials/GettingStarted/fast_recompile/README.md
@@ -21,7 +21,7 @@ The Intel® oneAPI DPC++ Compiler provides two different mechanisms to separate 
 * Passing `-reuse-exe=<exe_name>` flag to `dpcpp` instructs the compiler to attempt to reuse the existing FPGA device image.
 * The more explicit "device link" method requires you to separate the host and device code into separate files. When a code change only applies to host-only files, an FPGA device image is not regenerated. 
 
-This tutorial explains both mechanisms and the pros and cons of each. The included code sample demonstrates the device link method.
+This tutorial explains both mechanisms and the pros and cons of each. The included code sample demonstrates the device link method but does **not** demonstrate the use of the `-reuse-exe` flag.
 
 ### Using the `-reuse-exe` flag
 
@@ -40,17 +40,19 @@ dpcpp <files.cpp> -o out.fpga -reuse-exe=out.fpga -Xshardware -fintelfpga
 ```
 If `out.fpga` does not exist, `-reuse-exe` is ignored and the FPGA device image is regenerated. This will always be the case the first time a project is compiled.
 
-If `out.fpga` is found, the compiler verifies that no changes that affect the FPGA device code have been made since the last compilation. If so, the compiler reuses the existing FPGA binary and only the host code is recompiled. The recompilation process takes a few minutes. Note that the device code is *partially* re-compiled (the equivalent of a report flow compile) in order to check that the FPGA binary can safely be reused.
+If `out.fpga` is found, the compiler checks whether any changes affecting the FPGA device code have been made since the last compilation. If no such changes are detected, the compiler reuses the existing FPGA binary and only the host code is recompiled. The recompilation process takes a few minutes. Note that the device code is partially re-compiled (similar to a report flow compile) in order to check that the FPGA binary can safely be reused.
+
+If `out.fpga` is found but the compiler is unable to prove that the FPGA device code will yield a result identical to the last compilation, a warning is printed and the FPGA device code is fully recompiled. Since the compiler checks must be conservative, spurious recompilations can sometimes occur when using `-reuse-exe`.
 
 ### Using the device link method
 
-The program accompanying this tutorial is separated into two files, `main.cpp` and `kernel.cpp`. Only the `kernel.cpp` file contains device code. 
+The program accompanying this tutorial is separated into two files, `host.cpp` and `kernel.cpp`. Only the `kernel.cpp` file contains device code. 
 
-In the normal compilation process, FPGA device image generation happens at link time. As a result, any change to either `main.cpp` or `kernel.cpp` will trigger the regeneration of an FPGA device image. 
+In the normal compilation process, FPGA device image generation happens at link time. As a result, any change to either `host.cpp` or `kernel.cpp` will trigger the regeneration of an FPGA device image. 
 
 ```
 # normal compile command
-dpcpp -fintelfpga main.cpp kernel.cpp -Xshardware -o link.fpga
+dpcpp -fintelfpga host.cpp kernel.cpp -Xshardware -o link.fpga
 ```
 
 The following graph depicts this compilation process:
@@ -78,7 +80,7 @@ The compilation is a 3-step process:
 2. Compile the host code:
    
    ``` 
-   dpcpp -fintelfpga main.cpp -c -o host.o
+   dpcpp -fintelfpga host.cpp -c -o host.o
    ```
    Input files should include all source files that only contain host code. This takes seconds.
 
@@ -201,4 +203,4 @@ You can compile and run this tutorial in the Eclipse* IDE (in Linux*) and the Vi
 PASSED: results are correct
 ```
 ### Discussion of Results
-Try modifying `main.cpp` to produce a different output message. Then, perform a host-only recompile via the device link method to see how quickly the design is recompiled.
+Try modifying `host.cpp` to produce a different output message. Then, perform a host-only recompile via the device link method to see how quickly the design is recompiled.

--- a/DirectProgramming/DPC++FPGA/Tutorials/GettingStarted/fast_recompile/fast_recompile.vcxproj
+++ b/DirectProgramming/DPC++FPGA/Tutorials/GettingStarted/fast_recompile/fast_recompile.vcxproj
@@ -152,10 +152,10 @@
   </ItemDefinitionGroup>
   <ItemGroup>
     <ClCompile Include="src\kernel.cpp" />
-    <ClCompile Include="src\main.cpp" />
+    <ClCompile Include="src\host.cpp" />
   </ItemGroup>
   <ItemGroup>
-    <ClInclude Include="src\kernel.h" />
+    <ClInclude Include="src\kernel.hpp" />
   </ItemGroup>
   <ItemGroup>
     <None Include="README.md" />

--- a/DirectProgramming/DPC++FPGA/Tutorials/GettingStarted/fast_recompile/src/CMakeLists.txt
+++ b/DirectProgramming/DPC++FPGA/Tutorials/GettingStarted/fast_recompile/src/CMakeLists.txt
@@ -1,6 +1,6 @@
 set(DEVICE_SOURCE_FILE kernel.cpp)
 set(KERNEL_HEADER_FILE kernel.hpp)
-set(HOST_SOURCE_FILE main.cpp)
+set(HOST_SOURCE_FILE host.cpp)
 set(TARGET_NAME fast_recompile)
 set(EMULATOR_TARGET ${TARGET_NAME}.fpga_emu)
 set(FPGA_TARGET ${TARGET_NAME}.fpga)

--- a/DirectProgramming/DPC++FPGA/Tutorials/GettingStarted/fast_recompile/src/host.cpp
+++ b/DirectProgramming/DPC++FPGA/Tutorials/GettingStarted/fast_recompile/src/host.cpp
@@ -1,0 +1,103 @@
+//==============================================================
+// Copyright Intel Corporation
+//
+// SPDX-License-Identifier: MIT
+// =============================================================
+
+#include <iostream>
+#include <vector>
+
+#include <CL/sycl.hpp>
+#include <CL/sycl/INTEL/fpga_extensions.hpp>
+
+// dpc_common.hpp can be found in the dev-utilities include folder.
+// e.g., $ONEAPI_ROOT/dev-utilities//include/dpc_common.hpp
+#include "dpc_common.hpp"
+
+// This code sample demonstrates how to split the host and FPGA kernel code into
+// separate compilation units so that they can be separately recompiled.
+// Consult the README for a detailed discussion.
+//  - host.cpp (this file) contains exclusively code that executes on the host.
+//  - kernel.cpp contains almost exclusively code that executes on the device.
+//  - kernel.hpp contains only the forward declaration of a function containing
+//    the device code.
+#include "kernel.hpp"
+
+using namespace sycl;
+
+// the tolerance used in floating point comparisons
+constexpr float kTol = 0.001;
+
+// the array size of vectors a, b and c
+constexpr size_t kArraySize = 32;
+
+int main() {
+  std::vector<float> vec_a(kArraySize);
+  std::vector<float> vec_b(kArraySize);
+  std::vector<float> vec_r(kArraySize);
+
+  // Fill vectors a and b with random float values
+  for (size_t i = 0; i < kArraySize; i++) {
+    vec_a[i] = rand() / (float)RAND_MAX;
+    vec_b[i] = rand() / (float)RAND_MAX;
+  }
+
+  // Select either the FPGA emulator or FPGA device
+#if defined(FPGA_EMULATOR)
+  INTEL::fpga_emulator_selector device_selector;
+#else
+  INTEL::fpga_selector device_selector;
+#endif
+
+  try {
+
+    // Create a queue bound to the chosen device.
+    // If the device is unavailable, a SYCL runtime exception is thrown.
+    queue q(device_selector, dpc_common::exception_handler);
+
+    // create the device buffers
+    buffer device_a(vec_a);
+    buffer device_b(vec_b);
+    buffer device_r(vec_r);
+
+    // The definition of this function is in a different compilation unit,
+    // so host and device code can be separately compiled.
+    RunKernel(q, device_a, device_b, device_r, kArraySize);
+
+  } catch (exception const &e) {
+    // Catches exceptions in the host code
+    std::cerr << "Caught a SYCL host exception:\n" << e.what() << "\n";
+
+    // Most likely the runtime couldn't find FPGA hardware!
+    if (e.get_cl_code() == CL_DEVICE_NOT_FOUND) {
+      std::cerr << "If you are targeting an FPGA, please ensure that your "
+                   "system has a correctly configured FPGA board.\n";
+      std::cerr << "Run sys_check in the oneAPI root directory to verify.\n";
+      std::cerr << "If you are targeting the FPGA emulator, compile with "
+                   "-DFPGA_EMULATOR.\n";
+    }
+    std::terminate();
+  }
+
+  // At this point, the device buffers have gone out of scope and the kernel
+  // has been synchronized. Therefore, the output data (vec_r) has been updated
+  // with the results of the kernel and is safely accesible by the host CPU.
+
+  // Test the results
+  size_t correct = 0;
+  for (size_t i = 0; i < kArraySize; i++) {
+    float tmp = vec_a[i] + vec_b[i] - vec_r[i];
+    if (tmp * tmp < kTol * kTol) {
+      correct++;
+    }
+  }
+
+  // Summarize results
+  if (correct == kArraySize) {
+    std::cout << "PASSED: results are correct\n";
+  } else {
+    std::cout << "FAILED: results are incorrect\n";
+  }
+
+  return !(correct == kArraySize);
+}

--- a/DirectProgramming/DPC++FPGA/Tutorials/GettingStarted/fast_recompile/src/kernel.cpp
+++ b/DirectProgramming/DPC++FPGA/Tutorials/GettingStarted/fast_recompile/src/kernel.cpp
@@ -5,68 +5,34 @@
 // =============================================================
 #include <CL/sycl/INTEL/fpga_extensions.hpp>
 
-// dpc_common.hpp can be found in the dev-utilities include folder.
-// e.g., $ONEAPI_ROOT/dev-utilities//include/dpc_common.hpp
-#include "dpc_common.hpp"
-
 #include "kernel.hpp"
 
-// Forward declaration of the kernel name
-// (This will become unnecessary in a future compiler version.)
+// Forward declaration of the kernel name reduces name mangling
 class VectorAdd;
 
-void RunKernel(std::vector<float> &vec_a, std::vector<float> &vec_b,
-               std::vector<float> &vec_r) {
-
-  // Select either the FPGA emulator or FPGA device
-#if defined(FPGA_EMULATOR)
-  INTEL::fpga_emulator_selector device_selector;
-#else
-  INTEL::fpga_selector device_selector;
-#endif
-
-  try {
-
-    // Create a queue bound to the chosen device.
-    // If the device is unavailable, a SYCL runtime exception is thrown.
-    queue q(device_selector, dpc_common::exception_handler);
-
-    // Print out the device information.
-    std::cout << "Running on device: "
-              << q.get_device().get_info<info::device::name>() << "\n";
-
-    // Device buffers
-    buffer device_a(vec_a);
-    buffer device_b(vec_b);
-    buffer device_r(vec_r);
-
+// This file contains 'almost' exclusively device code. The single-source SYCL
+// code has been refactored between host.cpp and kernel.cpp to separate host and
+// device code to the extent that the language permits.
+// Note that ANY change in either this file or kernel.hpp will be detected
+// by the build system as a difference in the dependencies of device.o,
+// triggering the full recompilation of the device code. This is true even of
+// a trivial change, e.g. tweaking the function definition or the names of
+// variables like 'q' or 'h', EVEN THOUGH these are not truly "device code".
+void RunKernel(queue& q, buffer<float,1>& buf_a, buffer<float,1>& buf_b,
+               buffer<float,1>& buf_r, size_t size){
+    // submit the kernel
     q.submit([&](handler &h) {
       // Data accessors
-      accessor a(device_a, h, read_only);
-      accessor b(device_b, h, read_only);
-      accessor r(device_r, h, write_only, noinit);
+      accessor a(buf_a, h, read_only);
+      accessor b(buf_b, h, read_only);
+      accessor r(buf_r, h, write_only, noinit);
 
       // Kernel executes with pipeline parallelism on the FPGA.
       // Use kernel_args_restrict to specify that a, b, and r do not alias.
       h.single_task<VectorAdd>([=]() [[intel::kernel_args_restrict]] {
-        for (size_t i = 0; i < kArraySize; ++i) {
+        for (size_t i = 0; i < size; ++i) {
           r[i] = a[i] + b[i];
         }
       });
     });
-
-  } catch (sycl::exception const &e) {
-    // Catches exceptions in the host code
-    std::cerr << "Caught a SYCL host exception:\n" << e.what() << "\n";
-
-    // Most likely the runtime couldn't find FPGA hardware!
-    if (e.get_cl_code() == CL_DEVICE_NOT_FOUND) {
-      std::cerr << "If you are targeting an FPGA, please ensure that your "
-                   "system has a correctly configured FPGA board.\n";
-      std::cerr << "Run sys_check in the oneAPI root directory to verify.\n";
-      std::cerr << "If you are targeting the FPGA emulator, compile with "
-                   "-DFPGA_EMULATOR.\n";
-    }
-    std::terminate();
-  }
 }

--- a/DirectProgramming/DPC++FPGA/Tutorials/GettingStarted/fast_recompile/src/kernel.hpp
+++ b/DirectProgramming/DPC++FPGA/Tutorials/GettingStarted/fast_recompile/src/kernel.hpp
@@ -4,13 +4,8 @@
 // SPDX-License-Identifier: MIT
 // =============================================================
 #include <CL/sycl.hpp>
+
 using namespace sycl;
 
-// tolerance used in floating point comparisons
-constexpr float kTol = 0.001;
-
-// array size of vectors a, b and c
-constexpr size_t kArraySize = 32;
-
-void RunKernel(std::vector<float> &vec_a, std::vector<float> &vec_b,
-               std::vector<float> &vec_r);
+void RunKernel(queue& q, buffer<float,1>& buf_a, buffer<float,1>& buf_b,
+               buffer<float,1>& buf_r, size_t size);


### PR DESCRIPTION

# Description

**DPC++FPGA/GettingStarted/fast-recompile**
Internal user gave feedback that code sample was unclear about the fast recompile method demonstrated. Also, that the kernel and host code were insufficiently well separated. Minor changes to the README and cpp files were made to increase clarity, and to make a better template for splitting host/kernel code.

**DPC++FPGA/Features/pipes**
The filer of issue https://github.com/oneapi-src/oneAPI-samples/issues/360 perceived a "bug" which proved to be simply a point of confusion about the significance of timing results in the FPGA emulator vs. HW. The code sample is improved to a) dump timing information during execution, b) explain the results observed in emulation and hardware runs, and c) increase the amount of data transfer to better show the kernel execution overlap.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [X] Command Line
- [X] Visual Studio

