### PR TITLE
Fix iso3dfd_omp_offload issue

### DIFF
--- a/DirectProgramming/C++/StructuredGrids/iso3dfd_omp_offload/include/iso3dfd.h
+++ b/DirectProgramming/C++/StructuredGrids/iso3dfd_omp_offload/include/iso3dfd.h
@@ -16,8 +16,8 @@
 
 constexpr float dt = 0.002f;
 constexpr float dxyz = 50.0f;
-constexpr unsigned int kHalfLength = 8;
-constexpr unsigned int kMaxTeamSizeLimit = 256;
+constexpr size_t kHalfLength = 8;
+constexpr size_t kMaxTeamSizeLimit = 256;
 
 #define STENCIL_LOOKUP(ir)                                          \
   (coeff[ir] * ((ptr_prev[ix + ir] + ptr_prev[ix - ir]) +           \
@@ -31,22 +31,22 @@ constexpr unsigned int kMaxTeamSizeLimit = 256;
 
 void Usage(const std::string& programName);
 
-void PrintStats(double time, unsigned int n1, unsigned int n2, unsigned int n3,
-                unsigned int num_iterations);
+void PrintStats(double time, size_t n1, size_t n2, size_t n3,
+                size_t num_iterations);
 
-bool WithinEpsilon(float* output, float* reference, unsigned int dim_x,
-                   unsigned int dim_y, unsigned int dim_z, unsigned int radius,
+bool WithinEpsilon(float* output, float* reference, size_t dim_x,
+                   size_t dim_y, size_t dim_z, size_t radius,
                    const int zadjust, const float delta);
 
 void Initialize(float* ptr_prev, float* ptr_next, float* ptr_vel,
-                unsigned int n1, unsigned int n2, unsigned int n3);
+                size_t n1, size_t n2, size_t n3);
 
 bool VerifyResults(float* next_base, float* prev_base, float* vel_base,
-                   float* coeff, unsigned int n1, unsigned int n2,
-                   unsigned int n3, unsigned int num_iterations,
-                   unsigned int n1_block, unsigned int n2_block,
-                   unsigned int n3_block);
+                   float* coeff, size_t n1, size_t n2,
+                   size_t n3, size_t num_iterations,
+                   size_t n1_block, size_t n2_block,
+                   size_t n3_block);
 
-bool ValidateInput(unsigned int n1, unsigned int n2, unsigned int n3,
-                   unsigned int n1_block, unsigned int n2_block,
-                   unsigned int n3_block, unsigned int num_iterations);
+bool ValidateInput(size_t n1, size_t n2, size_t n3,
+                   size_t n1_block, size_t n2_block,
+                   size_t n3_block, size_t num_iterations);

--- a/DirectProgramming/C++/StructuredGrids/iso3dfd_omp_offload/src/iso3dfd.cpp
+++ b/DirectProgramming/C++/StructuredGrids/iso3dfd_omp_offload/src/iso3dfd.cpp
@@ -11,7 +11,7 @@
  * Inline device function to find minimum
  */
 #pragma omp declare target
-inline unsigned int GetMin(unsigned int first, unsigned int second) {
+inline size_t GetMin(size_t first, size_t second) {
   return ((first < second) ? first : second);
 }
 #pragma omp end declare target
@@ -27,10 +27,10 @@ inline unsigned int GetMin(unsigned int first, unsigned int second) {
  */
 void inline Iso3dfdIteration(float *ptr_next_base, float *ptr_prev_base,
                              float *ptr_vel_base, float *coeff,
-                             const unsigned int n1, const unsigned int n2,
-                             const unsigned int n3, const unsigned int n1_block,
-                             const unsigned int n2_block,
-                             const unsigned int n3_block) {
+                             const size_t n1, const size_t n2,
+                             const size_t n3, const size_t n1_block,
+                             const size_t n2_block,
+                             const size_t n3_block) {
   auto dimn1n2 = n1 * n2;
 
   auto n3_end = n3 - kHalfLength;
@@ -88,10 +88,10 @@ void inline Iso3dfdIteration(float *ptr_next_base, float *ptr_prev_base,
  */
 void inline Iso3dfdIteration(float *ptr_next_base, float *ptr_prev_base,
                              float *ptr_vel_base, float *coeff,
-                             const unsigned int n1, const unsigned int n2,
-                             const unsigned int n3, const unsigned int n1_block,
-                             const unsigned int n2_block,
-                             const unsigned int n3_block) {
+                             const size_t n1, const size_t n2,
+                             const size_t n3, const size_t n1_block,
+                             const size_t n2_block,
+                             const size_t n3_block) {
   auto dimn1n2 = n1 * n2;
 
   auto n3_end = n3 - kHalfLength;
@@ -153,10 +153,10 @@ void inline Iso3dfdIteration(float *ptr_next_base, float *ptr_prev_base,
  */
 void inline Iso3dfdIteration(float *ptr_next_base, float *ptr_prev_base,
                              float *ptr_vel_base, float *coeff,
-                             const unsigned int n1, const unsigned int n2,
-                             const unsigned int n3, const unsigned int n1_block,
-                             const unsigned int n2_block,
-                             const unsigned int n3_block) {
+                             const size_t n1, const size_t n2,
+                             const size_t n3, const size_t n1_block,
+                             const size_t n2_block,
+                             const size_t n3_block) {
   auto dimn1n2 = n1 * n2;
 
   auto n3_end = n3 - kHalfLength;
@@ -241,10 +241,10 @@ void inline Iso3dfdIteration(float *ptr_next_base, float *ptr_prev_base,
  */
 void inline Iso3dfdIteration(float *ptr_next_base, float *ptr_prev_base,
                              float *ptr_vel_base, float *coeff,
-                             const unsigned int n1, const unsigned int n2,
-                             const unsigned int n3, const unsigned int n1_block,
-                             const unsigned int n2_block,
-                             const unsigned int n3_block) {
+                             const size_t n1, const size_t n2,
+                             const size_t n3, const size_t n1_block,
+                             const size_t n2_block,
+                             const size_t n3_block) {
   auto dimn1n2 = n1 * n2;
 
   auto n3_end = n3 - kHalfLength;
@@ -320,10 +320,10 @@ void inline Iso3dfdIteration(float *ptr_next_base, float *ptr_prev_base,
  * time steps
  */
 void Iso3dfd(float *ptr_next, float *ptr_prev, float *ptr_vel, float *coeff,
-             const unsigned int n1, const unsigned int n2,
-             const unsigned int n3, const unsigned int nreps,
-             const unsigned int n1_block, const unsigned int n2_block,
-             const unsigned int n3_block) {
+             const size_t n1, const size_t n2,
+             const size_t n3, const size_t nreps,
+             const size_t n1_block, const size_t n2_block,
+             const size_t n3_block) {
   auto dimn1n2 = n1 * n2;
   auto size = n3 * dimn1n2;
 
@@ -355,9 +355,9 @@ int main(int argc, char *argv[]) {
 
   bool error = false;
 
-  unsigned int n1, n2, n3;
-  unsigned int n1_block, n2_block, n3_block;
-  unsigned int num_iterations;
+  size_t n1, n2, n3;
+  size_t n1_block, n2_block, n3_block;
+  size_t num_iterations;
 
   try {
     n1 = std::stoi(argv[1]) + (2 * kHalfLength);
@@ -381,7 +381,7 @@ int main(int argc, char *argv[]) {
   }
 
   // Check for available omp offload capable device
-  unsigned int num_devices = omp_get_num_devices();
+  int num_devices = omp_get_num_devices();
   if (num_devices <= 0) {
     std::cout << "--------------------------------------\n";
     std::cout << " No OpenMP Offload device found\n";

--- a/DirectProgramming/C++/StructuredGrids/iso3dfd_omp_offload/src/iso3dfd_verify.cpp
+++ b/DirectProgramming/C++/StructuredGrids/iso3dfd_omp_offload/src/iso3dfd_verify.cpp
@@ -14,8 +14,8 @@
  */
 void Iso3dfdVerifyIteration(float *ptr_next_base, float *ptr_prev_base,
                             float *ptr_vel_base, float *coeff, int n1, int n2,
-                            int n3, unsigned int n1_block,
-                            unsigned int n2_block, unsigned int n3_block) {
+                            int n3, size_t n1_block,
+                            size_t n2_block, size_t n3_block) {
   auto dimn1n2 = n1 * n2;
 
   auto n3_end = n3 - kHalfLength;
@@ -64,9 +64,9 @@ void Iso3dfdVerifyIteration(float *ptr_next_base, float *ptr_prev_base,
  * accelerated wave propogation
  */
 void Iso3dfdVerify(float *ptr_next, float *ptr_prev, float *ptr_vel,
-                   float *coeff, unsigned int n1, unsigned int n2,
-                   unsigned int n3, unsigned int nreps, unsigned int n1_block,
-                   unsigned int n2_block, unsigned int n3_block) {
+                   float *coeff, size_t n1, size_t n2,
+                   size_t n3, size_t nreps, size_t n1_block,
+                   size_t n2_block, size_t n3_block) {
   for (auto it = 0; it < nreps; it += 1) {
     Iso3dfdVerifyIteration(ptr_next, ptr_prev, ptr_vel, coeff, n1, n2, n3,
                            n1_block, n2_block, n3_block);
@@ -82,10 +82,10 @@ void Iso3dfdVerify(float *ptr_next, float *ptr_prev, float *ptr_vel,
 }
 
 bool VerifyResults(float *next_base, float *prev_base, float *vel_base,
-                   float *coeff, unsigned int n1, unsigned int n2,
-                   unsigned int n3, unsigned int num_iterations,
-                   unsigned int n1_block, unsigned int n2_block,
-                   unsigned int n3_block) {
+                   float *coeff, size_t n1, size_t n2,
+                   size_t n3, size_t num_iterations,
+                   size_t n1_block, size_t n2_block,
+                   size_t n3_block) {
   std::cout << "Checking Results ...\n";
   size_t nsize = n1 * n2 * n3;
   bool error = false;

--- a/DirectProgramming/C++/StructuredGrids/iso3dfd_omp_offload/src/utils.cpp
+++ b/DirectProgramming/C++/StructuredGrids/iso3dfd_omp_offload/src/utils.cpp
@@ -29,7 +29,7 @@ void Usage(const std::string& programName) {
  * Function used for initialization
  */
 void Initialize(float* ptr_prev, float* ptr_next, float* ptr_vel,
-                unsigned int n1, unsigned int n2, unsigned int n3) {
+                size_t n1, size_t n2, size_t n3) {
   auto dim2 = n2 * n1;
 
   for (auto i = 0; i < n3; i++) {
@@ -63,8 +63,8 @@ void Initialize(float* ptr_prev, float* ptr_next, float* ptr_vel,
  * Host-Code
  * Utility function to print stats
  */
-void PrintStats(double time, unsigned int n1, unsigned int n2, unsigned int n3,
-                unsigned int num_iterations) {
+void PrintStats(double time, size_t n1, size_t n2, size_t n3,
+                size_t num_iterations) {
   float throughput_mpoints = 0.0f, mflops = 0.0f, normalized_time = 0.0f;
   double mbytes = 0.0f;
 
@@ -89,8 +89,8 @@ void PrintStats(double time, unsigned int n1, unsigned int n2, unsigned int n3,
  * Utility function to calculate L2-norm between resulting buffer and reference
  * buffer
  */
-bool WithinEpsilon(float* output, float* reference, unsigned int dim_x,
-                   unsigned int dim_y, unsigned int dim_z, unsigned int radius,
+bool WithinEpsilon(float* output, float* reference, size_t dim_x,
+                   size_t dim_y, size_t dim_z, size_t radius,
                    const int zadjust = 0, const float delta = 0.01f) {
   std::ofstream error_file;
   error_file.open("error_diff.txt");
@@ -128,9 +128,9 @@ bool WithinEpsilon(float* output, float* reference, unsigned int dim_x,
  * Host-code
  * Validate input arguments
  */
-bool ValidateInput(unsigned int n1, unsigned int n2, unsigned int n3,
-                   unsigned int n1_block, unsigned int n2_block,
-                   unsigned int n3_block, unsigned int num_iterations) {
+bool ValidateInput(size_t n1, size_t n2, size_t n3,
+                   size_t n1_block, size_t n2_block,
+                   size_t n3_block, size_t num_iterations) {
   bool error = false;
 
   if ((n1 < kHalfLength) || (n2 < kHalfLength) || (n3 < kHalfLength)) {


### PR DESCRIPTION
# Description
The array offset might be negative value but its type is "unsigned int", so it gets incorrect address of array element. Fixed by using "size_t" type for the related variables.

Fixes # (issue) 

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
- [X ] Command Line

# Checklist for Moving samples:
Links and Details can be found in the samples WG Teams Files. 

- [ ] Review sample design with domain reviewers https://github.com/oneapi-src/oneAPI-samples/wiki/Reviewers-and-Domain-Experts 
- [ ] Implement coding guidelines and ensure code quality.
- [ ] Adhere to sample.json specification. https://github.com/oneapi-src/oneAPI-samples/wiki/sample-json-specification
- [ ] Run jsonlint on sample.json to verify json syntax. www.jsonlint.com
- [ ] Adhere to readme template 
- [ ] Ensure/create CI test configurations for sample (ciTests field) https://github.com/oneapi-src/oneAPI-samples/wiki/sample-json-ci-test-object
- [ ] Enforce format via clang-format config file
- [ ] Review DPC++ code with Paul Peterseon. (GitHub User: pmpeter1)
- [ ] Review readme with Tom Lenth or Joe Oster. (GitHub User: JoeOster)
- [ ] Tested using Dev Cloud when applicable
- [ ] Implement fixes for ONSAM Jiras
- [ ] If you have new dependencies/binaries, inform Samples Project Manager Swapna R Dontharaju (@srdontha) or @JoeOster

