### PR TITLE
Remove beta compatibility code from oneMKL samples

### DIFF
--- a/Libraries/oneMKL/black_scholes/black_scholes.cpp
+++ b/Libraries/oneMKL/black_scholes/black_scholes.cpp
@@ -20,15 +20,8 @@
 #include <vector>
 
 #include <CL/sycl.hpp>
-
-#if __has_include("oneapi/mkl.hpp")
 #include "oneapi/mkl.hpp"
 #include "oneapi/mkl/rng/device.hpp"
-#else
-// Beta09 compatibility -- not needed for new code.
-#include "mkl_sycl.hpp"
-#include "mkl_rng_sycl_device.hpp"
-#endif
 
 using namespace oneapi;
 

--- a/Libraries/oneMKL/block_cholesky_decomposition/dpbltrf.cpp
+++ b/Libraries/oneMKL/block_cholesky_decomposition/dpbltrf.cpp
@@ -10,16 +10,10 @@
 *      Function DPBLTRF for Cholesky factorization of symmetric
 *         positive definite block tridiagonal matrix.
 ************************************************************************/
-#include <CL/sycl.hpp>
 #include <cstdint>
-#include "mkl.h"
 
-#if __has_include("oneapi/mkl.hpp")
+#include <CL/sycl.hpp>
 #include "oneapi/mkl.hpp"
-#else
-// Beta09 compatibility -- not needed for new code.
-#include "mkl_sycl.hpp"
-#endif
 
 using namespace oneapi;
 

--- a/Libraries/oneMKL/block_cholesky_decomposition/dpbltrs.cpp
+++ b/Libraries/oneMKL/block_cholesky_decomposition/dpbltrs.cpp
@@ -11,16 +11,10 @@
 *      Cholesky factored symmetric positive definite block tridiagonal
 *      coefficient matrix.
 ************************************************************************/
-#include <CL/sycl.hpp>
 #include <cstdint>
-#include "mkl.h"
 
-#if __has_include("oneapi/mkl.hpp")
+#include <CL/sycl.hpp>
 #include "oneapi/mkl.hpp"
-#else
-// Beta09 compatibility -- not needed for new code.
-#include "mkl_sycl.hpp"
-#endif
 
 using namespace oneapi;
 

--- a/Libraries/oneMKL/block_cholesky_decomposition/factor.cpp
+++ b/Libraries/oneMKL/block_cholesky_decomposition/factor.cpp
@@ -31,18 +31,12 @@
  *      ||A-L*L^t||_F/||A||_F.
  */
 
-#include <CL/sycl.hpp>
 #include <cstdint>
 #include <iostream>
 #include <vector>
-#include "mkl.h"
 
-#if __has_include("oneapi/mkl.hpp")
+#include <CL/sycl.hpp>
 #include "oneapi/mkl.hpp"
-#else
-// Beta09 compatibility -- not needed for new code.
-#include "mkl_sycl.hpp"
-#endif
 
 using namespace oneapi;
 

--- a/Libraries/oneMKL/block_cholesky_decomposition/solve.cpp
+++ b/Libraries/oneMKL/block_cholesky_decomposition/solve.cpp
@@ -32,18 +32,12 @@
 * To test the solution function TES_RES1 is called.
 */
 
-#include <CL/sycl.hpp>
 #include <cstdint>
 #include <iostream>
 #include <vector>
-#include "mkl.h"
 
-#if __has_include("oneapi/mkl.hpp")
+#include <CL/sycl.hpp>
 #include "oneapi/mkl.hpp"
-#else
-// Beta09 compatibility -- not needed for new code.
-#include "mkl_sycl.hpp"
-#endif
 
 using namespace oneapi;
 

--- a/Libraries/oneMKL/block_lu_decomposition/dgeblttrf.cpp
+++ b/Libraries/oneMKL/block_lu_decomposition/dgeblttrf.cpp
@@ -14,14 +14,7 @@
 ************************************************************************/
 #include <cstdint>
 #include <CL/sycl.hpp>
-#include "mkl.h"
-
-#if __has_include("oneapi/mkl.hpp")
 #include "oneapi/mkl.hpp"
-#else
-// Beta09 compatibility -- not needed for new code.
-#include "mkl_sycl.hpp"
-#endif
 
 using namespace oneapi;
 

--- a/Libraries/oneMKL/block_lu_decomposition/dgeblttrs.cpp
+++ b/Libraries/oneMKL/block_lu_decomposition/dgeblttrs.cpp
@@ -82,14 +82,7 @@
 ***********************************************************************/
 #include <cstdint>
 #include <CL/sycl.hpp>
-#include "mkl.h"
-
-#if __has_include("oneapi/mkl.hpp")
 #include "oneapi/mkl.hpp"
-#else
-// Beta09 compatibility -- not needed for new code.
-#include "mkl_sycl.hpp"
-#endif
 
 using namespace oneapi;
 

--- a/Libraries/oneMKL/block_lu_decomposition/factor.cpp
+++ b/Libraries/oneMKL/block_lu_decomposition/factor.cpp
@@ -24,17 +24,12 @@
 * Input block tridiagonal matrix A is randomly generated.
 */
 
-#include <CL/sycl.hpp>
 #include <cstdint>
 #include <iostream>
 #include <vector>
-#include "mkl.h"
-#if __has_include("oneapi/mkl.hpp")
+
+#include <CL/sycl.hpp>
 #include "oneapi/mkl.hpp"
-#else
-// Beta09 compatibility -- not needed for new code.
-#include "mkl_sycl.hpp"
-#endif
 
 using namespace oneapi;
 

--- a/Libraries/oneMKL/block_lu_decomposition/solve.cpp
+++ b/Libraries/oneMKL/block_lu_decomposition/solve.cpp
@@ -37,17 +37,12 @@
 *
 * ||.|| denotes Frobenius norm of a respective matrix           
 */
-#include <CL/sycl.hpp>
 #include <cstdint>
 #include <iostream>
 #include <vector>
-#include "mkl.h"
-#if __has_include("oneapi/mkl.hpp")
+
+#include <CL/sycl.hpp>
 #include "oneapi/mkl.hpp"
-#else
-// Beta09 compatibility -- not needed for new code.
-#include "mkl_sycl.hpp"
-#endif
 
 using namespace oneapi;
 

--- a/Libraries/oneMKL/computed_tomography/computed_tomography.cpp
+++ b/Libraries/oneMKL/computed_tomography/computed_tomography.cpp
@@ -34,7 +34,6 @@
 *         image using oneMKL DFT DPCPP asynchronous USM API.
 */
 
-#include <CL/sycl.hpp>
 #include <cmath>
 #include <complex>
 #include <cstdarg>
@@ -44,12 +43,8 @@
 #include <string>
 #include <vector>
 
-#if __has_include("oneapi/mkl.hpp")
+#include <CL/sycl.hpp>
 #include "oneapi/mkl.hpp"
-#else
-// For compatibility with beta09 -- not needed for new code.
-#include "mkl_sycl.hpp"
-#endif
 
 #if !defined(M_PI)
 #define M_PI 3.14159265358979323846

--- a/Libraries/oneMKL/matrix_mul_mkl/matrix_mul_mkl.cpp
+++ b/Libraries/oneMKL/matrix_mul_mkl/matrix_mul_mkl.cpp
@@ -9,16 +9,11 @@
 // This samples uses the oneAPI Math Kernel Library (oneMKL) to accelerate
 //     the computation.
 
-#include <CL/sycl.hpp>
 #include <iostream>
 #include <limits>
 
-#if __has_include("oneapi/mkl.hpp")
+#include <CL/sycl.hpp>
 #include "oneapi/mkl.hpp"
-#else
-// Beta09 compatibility -- not needed for new code.
-#include "mkl_sycl.hpp"
-#endif
 
 double rand_uniform();
 bool verify_result(int m, int n, int k, int ldc, double *C, double *C_reference);

--- a/Libraries/oneMKL/monte_carlo_european_opt/mc_european.cpp
+++ b/Libraries/oneMKL/monte_carlo_european_opt/mc_european.cpp
@@ -16,13 +16,7 @@
 #include <vector>
 
 #include <CL/sycl.hpp>
-
-#if __has_include("oneapi/mkl.hpp")
 #include "oneapi/mkl.hpp"
-#else
-// Beta09 compatibility -- not needed for new code.
-#include "mkl_rng_sycl.hpp"
-#endif
 
 using namespace oneapi;
 

--- a/Libraries/oneMKL/monte_carlo_european_opt/mc_european_usm.cpp
+++ b/Libraries/oneMKL/monte_carlo_european_opt/mc_european_usm.cpp
@@ -16,13 +16,7 @@
 #include <vector>
 
 #include <CL/sycl.hpp>
-
-#if __has_include("oneapi/mkl.hpp")
 #include "oneapi/mkl.hpp"
-#else
-// Beta09 compatibility -- not needed for new code.
-#include "mkl_rng_sycl.hpp"
-#endif
 
 using namespace oneapi;
 

--- a/Libraries/oneMKL/monte_carlo_pi/mc_pi.cpp
+++ b/Libraries/oneMKL/monte_carlo_pi/mc_pi.cpp
@@ -16,13 +16,7 @@
 #include <vector>
 
 #include <CL/sycl.hpp>
-
-#if __has_include("oneapi/mkl.hpp")
 #include "oneapi/mkl.hpp"
-#else
-// Beta09 compatibility -- not needed for new code.
-#include "mkl_rng_sycl.hpp"
-#endif
 
 using namespace oneapi;
 

--- a/Libraries/oneMKL/monte_carlo_pi/mc_pi_device_api.cpp
+++ b/Libraries/oneMKL/monte_carlo_pi/mc_pi_device_api.cpp
@@ -16,13 +16,7 @@
 #include <vector>
 
 #include <CL/sycl.hpp>
-
-#if __has_include("oneapi/mkl/rng/device.hpp")
 #include "oneapi/mkl/rng/device.hpp"
-#else
-// Beta09 compatibility -- not needed for new code.
-#include "mkl_rng_sycl_device.hpp"
-#endif
 
 using namespace oneapi;
 

--- a/Libraries/oneMKL/monte_carlo_pi/mc_pi_usm.cpp
+++ b/Libraries/oneMKL/monte_carlo_pi/mc_pi_usm.cpp
@@ -16,13 +16,7 @@
 #include <vector>
 
 #include <CL/sycl.hpp>
-
-#if __has_include("oneapi/mkl.hpp")
 #include "oneapi/mkl.hpp"
-#else
-// Beta09 compatibility -- not needed for new code.
-#include "mkl_rng_sycl.hpp"
-#endif
 
 using namespace oneapi;
 

--- a/Libraries/oneMKL/random_sampling_without_replacement/lottery.cpp
+++ b/Libraries/oneMKL/random_sampling_without_replacement/lottery.cpp
@@ -15,13 +15,7 @@
 #include <iostream>
 
 #include <CL/sycl.hpp>
-
-#if __has_include("oneapi/mkl.hpp")
 #include "oneapi/mkl.hpp"
-#else
-// Beta09 compatibility -- not needed for new code.
-#include "mkl_rng_sycl.hpp"
-#endif
 
 using namespace oneapi;
 

--- a/Libraries/oneMKL/random_sampling_without_replacement/lottery_device_api.cpp
+++ b/Libraries/oneMKL/random_sampling_without_replacement/lottery_device_api.cpp
@@ -15,13 +15,7 @@
 #include <iostream>
 
 #include <CL/sycl.hpp>
-
-#if __has_include("oneapi/mkl/rng/device.hpp")
 #include "oneapi/mkl/rng/device.hpp"
-#else
-// Beta09 compatibility -- not needed for new code.
-#include "mkl_rng_sycl_device.hpp"
-#endif
 
 using namespace oneapi;
 

--- a/Libraries/oneMKL/random_sampling_without_replacement/lottery_usm.cpp
+++ b/Libraries/oneMKL/random_sampling_without_replacement/lottery_usm.cpp
@@ -15,13 +15,7 @@
 #include <iostream>
 
 #include <CL/sycl.hpp>
-
-#if __has_include("oneapi/mkl.hpp")
 #include "oneapi/mkl.hpp"
-#else
-// Beta09 compatibility -- not needed for new code.
-#include "mkl_rng_sycl.hpp"
-#endif
 
 using namespace oneapi;
 

--- a/Libraries/oneMKL/sparse_conjugate_gradient/sparse_cg.cpp
+++ b/Libraries/oneMKL/sparse_conjugate_gradient/sparse_cg.cpp
@@ -43,14 +43,8 @@
 #include <list>
 #include <vector>
 
-#if __has_include("oneapi/mkl.hpp")
-#include "oneapi/mkl.hpp"
-#else
-// Beta09 compatibility -- not needed for new code.
-#include "mkl_sycl.hpp"
-#endif
-
 #include <CL/sycl.hpp>
+#include "oneapi/mkl.hpp"
 
 #include "utils.hpp"
 


### PR DESCRIPTION
# Description

This PR removes old code that was used to support a previous oneMKL beta, prior to oneAPI header restructuring.

# How Has This Been Tested?

- [X] Command Line

