### PR TITLE
Add numeric header for std::iota

### DIFF
--- a/Libraries/oneTBB/tbb-async-sycl/src/tbb-async-sycl.cpp
+++ b/Libraries/oneTBB/tbb-async-sycl/src/tbb-async-sycl.cpp
@@ -9,6 +9,7 @@
 #include <atomic>
 #include <iostream>
 #include <thread>
+#include <numeric>
 
 #include <CL/sycl.hpp>
 

--- a/Libraries/oneTBB/tbb-task-sycl/src/tbb-task-sycl.cpp
+++ b/Libraries/oneTBB/tbb-task-sycl/src/tbb-task-sycl.cpp
@@ -6,6 +6,7 @@
 
 #include <array>
 #include <iostream>
+#include <numeric>
 
 #include <CL/sycl.hpp>
 


### PR DESCRIPTION
# Description

Fix tbb-async-sycl sample on Linux with oneAPI compiler 2021.2.0 (2021.x.0.0121).

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] Command Line
- [ ] oneapi-cli
- [ ] Visual Studio
- [ ] Eclipse IDE
- [x] VSCode

# Checklist for Moving samples:
Links and Details can be found in the samples WG Teams Files. 

- [ ] Review sample design with domain reviewers https://github.com/oneapi-src/oneAPI-samples/wiki/Reviewers-and-Domain-Experts 
- [ ] Implement coding guidelines and ensure code quality.
- [ ] Adhere to sample.json specification. https://github.com/oneapi-src/oneAPI-samples/wiki/sample-json-specification
- [ ] Run jsonlint on sample.json to verify json syntax. www.jsonlint.com
- [ ] Adhere to readme template 
- [ ] Ensure/create CI test configurations for sample (ciTests field) https://github.com/oneapi-src/oneAPI-samples/wiki/sample-json-ci-test-object
- [ ] Enforce format via clang-format config file
- [ ] Review DPC++ code with Paul Peterseon. (GitHub User: pmpeter1)
- [ ] Review readme with Tom Lenth or Joe Oster. (GitHub User: JoeOster)
- [ ] Tested using Dev Cloud when applicable
- [ ] Implement fixes for ONSAM Jiras
- [ ] If you have new dependencies/binaries, inform Samples Project Manager Swapna R Dontharaju (@srdontha) or @JoeOster

