### PR TITLE
Fix broken link on top-level README

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,5 +95,5 @@ Third party program Licenses can be found here: [third-party-programs.txt](https
 
 ## Contribute
 
-See [CONTRIBUTING](https://github.com/oneapi-src/oneAPI-samples/blob/master/CONTRIBUTING.md)
-for more information.
+See [GitHub Steps for Contribution](https://github.com/oneapi-src/oneAPI-samples/wiki/Github-Steps-for-Contribution)
+and [Contributing a New Sample](https://github.com/oneapi-src/oneAPI-samples/wiki/Contributing-a-New-Sample).


### PR DESCRIPTION
Signed-off-by: Audrey Kertesz <audrey.kertesz@intel.com>

# Description

Update the link for how to contribute to code samples. I've included two links -- one to the "steps for contribution" wiki page and a second to the "contributing a new sample" wiki page.


## Type of change

Please delete options that are not relevant. Add a 'X' to the one that is applicable. 

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Sample Migration (Moving sample from old repository after completing checklist established)

# How Has This Been Tested?

Checked links work :)