### PR TITLE
Readability improvements to FPGA tutorials samples C++ files

### DIFF
--- a/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/compute_units/src/compute_units.cpp
+++ b/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/compute_units/src/compute_units.cpp
@@ -21,8 +21,8 @@ constexpr size_t kEngines = 5;
 
 using Pipes = PipeArray<class MyPipe, float, 1, kEngines + 1>;
 
-// Forward declaration of the kernel name
-// (This will become unnecessary in a future compiler version.)
+// Forward declare the kernel names in the global scope.
+// This FPGA best practice reduces name mangling in the optimization reports.
 class Source;
 class Sink;
 template <std::size_t ID> class ChainComputeUnit;

--- a/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/double_buffering/src/double_buffering.cpp
+++ b/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/double_buffering/src/double_buffering.cpp
@@ -35,6 +35,8 @@ constexpr int kNumRuns = 2;
 
 bool pass = true;
 
+// Forward declare the kernel name in the global scope.
+// This FPGA best practice reduces name mangling in the optimization reports.
 class SimpleVpow;
 
 /*  Kernel function.

--- a/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/explicit_data_movement/src/explicit_data_movement.cpp
+++ b/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/explicit_data_movement/src/explicit_data_movement.cpp
@@ -15,7 +15,8 @@
 using namespace sycl;
 using namespace std::chrono;
 
-// Declare the kernel class name globally to avoid name mangling.
+// Forward declare the kernel names in the global scope.
+// This FPGA best practice reduces name mangling in the optimization reports.
 class ImplicitKernel;
 class ExplicitKernel;
 

--- a/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/loop_carried_dependency/src/loop_carried_dependency.cpp
+++ b/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/loop_carried_dependency/src/loop_carried_dependency.cpp
@@ -13,8 +13,8 @@
 using namespace sycl;
 using namespace std;
 
-// Forward declare the kernel names
-// (This prevents unwanted name mangling in the optimization report.)
+// Forward declare the kernel names in the global scope.
+// This FPGA best practice reduces name mangling in the optimization reports.
 class UnOptKernel;
 class OptKernel;
 

--- a/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/n_way_buffering/src/n_way_buffering.cpp
+++ b/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/n_way_buffering/src/n_way_buffering.cpp
@@ -42,6 +42,8 @@ constexpr int kNumRuns = 4;
 
 bool pass = true;
 
+// Forward declare the kernel name in the global scope.
+// This FPGA best practice reduces name mangling in the optimization reports.
 class SimpleVpow;
 
 /*  Kernel function.

--- a/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/onchip_memory_cache/src/onchip_memory_cache.cpp
+++ b/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/onchip_memory_cache/src/onchip_memory_cache.cpp
@@ -20,6 +20,8 @@ constexpr int kCacheDepth = 5;        // Depth of the cache.
 constexpr int kNumRuns = 2;           // runs twice to show the impact of cache
 constexpr double kNs = 1000000000.0;  // number of nanoseconds in a second
 
+// Forward declare the kernel name in the global scope.
+// This FPGA best practice reduces name mangling in the optimization reports.
 template<bool use_cache>
 class Task;
 

--- a/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/optimize_inner_loop/src/optimize_inner_loop.cpp
+++ b/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/optimize_inner_loop/src/optimize_inner_loop.cpp
@@ -28,13 +28,14 @@ constexpr int kNumKernels = 3;
 constexpr int kRandRangeMax = RAND_RANGE_MAX;
 constexpr double kProbSuccess = 1.0 / kRandRangeMax;
 
-// Declare the kernel class names globally to reduce name mangling.
+// Forward declare the kernel names in the global scope.
+// This FPGA best practice reduces name mangling in the optimization reports.
 // Templating allows us to instantiate multiple versions of the kernel.
 template <int version> class Producer;
 template <int version> class Consumer;
 
 // Declare the pipe class name globally to reduce name mangling.
-// Templating allows us to instantiate multiple versions of pipes for each
+// Templating allows us to instantiate multiple versions of pipes for each 
 // version of the kernel.
 template <int version> class PipeClass;
 

--- a/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/pipe_array/src/pipe_array.cpp
+++ b/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/pipe_array/src/pipe_array.cpp
@@ -30,8 +30,8 @@ using ProducerToConsumerPipeMatrix = PipeArray<  // Defined in "pipe_array.h".
     kNumCols   // array dimension.
     >;
 
-// Forward declaration of the kernel name
-// (This will become unnecessary in a future compiler version.)
+// Forward declare the kernel names in the global scope.
+// This FPGA best practice reduces name mangling in the optimization reports.
 class ProducerTutorial;
 template <size_t consumer_id> class ConsumerTutorial;
 

--- a/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/shannonization/src/IntersectionKernel.hpp
+++ b/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/shannonization/src/IntersectionKernel.hpp
@@ -2,19 +2,12 @@
 #define __INTERSECTIONKERNEL_HPP__
 
 #include <CL/sycl.hpp>
-
-// Header locations and some DPC++ extensions changed between beta09 and beta10
-// Temporarily modify the code sample to accept either version
-#define BETA09 20200827
-#if __SYCL_COMPILER_VERSION <= BETA09
-  #include <CL/sycl/intel/fpga_extensions.hpp>
-  namespace INTEL = sycl::intel;  // Namespace alias for backward compatibility
-#else
-  #include <CL/sycl/INTEL/fpga_extensions.hpp>
-#endif
+#include <CL/sycl/INTEL/fpga_extensions.hpp>
 
 // the kernel class names
 // templated on the version of the kernel
+// Best practice: forward declare the kernel names in the global scope
+// to reduce compiler name mangling in the optimization reports.
 template<int Version> class ProducerA;
 template<int Version> class ProducerB;
 template<int Version> class Worker;

--- a/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/triangular_loop/src/triangular_loop.cpp
+++ b/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/triangular_loop/src/triangular_loop.cpp
@@ -36,7 +36,8 @@ constexpr int kM = 50;
 // do not use with unary operators, e.g., kMin(x++, y++)
 constexpr int Min(int X, int Y) { return (((X) < (Y)) ? (X) : (Y)); };
 
-// Forward declaration of kernel
+// Forward declare the kernel name in the global scope.
+// This FPGA best practice reduces name mangling in the optimization reports.
 class Task;
 
 // This method represents the operation you perform on the loop-carried variable

--- a/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/zero_copy_data_transfer/src/buffer_kernel.hpp
+++ b/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/zero_copy_data_transfer/src/buffer_kernel.hpp
@@ -10,7 +10,8 @@
 using namespace sycl;
 using namespace std::chrono;
 
-// Declare the kernel class name globally to avoid name mangling.
+// Forward declare the kernel name in the global scope.
+// This FPGA best practice reduces name mangling in the optimization reports.
 class BufferWorker;
 
 // kernel using buffers to transfer data

--- a/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/zero_copy_data_transfer/src/restricted_usm_kernel.hpp
+++ b/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/zero_copy_data_transfer/src/restricted_usm_kernel.hpp
@@ -42,7 +42,8 @@ using namespace std::chrono;
 // stalls while reading/writing from/to the Host Memory over PCIe. 
 //
 
-// Declare the kernel class names globally to avoid name mangling.
+// Forward declare the kernel names in the global scope.
+// This FPGA best practice reduces name mangling in the optimization reports.
 class RestrictedUSM;
 class Producer;
 class Consumer;

--- a/DirectProgramming/DPC++FPGA/Tutorials/Features/fpga_reg/src/fpga_reg.cpp
+++ b/DirectProgramming/DPC++FPGA/Tutorials/Features/fpga_reg/src/fpga_reg.cpp
@@ -18,12 +18,12 @@ using namespace std;
 
 // Artificial coefficient and offset data for our math function
 constexpr size_t kSize = 64;
-constexpr int kCoeff[kSize] = {
+constexpr std::array<int, kSize> kCoeff = {
             1,  2,  3,  4,  5,  6,  7,  8,  9,  10, 11, 12, 13, 14, 15, 16,
             17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32,
             33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48,
             49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63, 64};
-constexpr int kOffset[kSize] = {
+constexpr std::array<int, kSize> kOffset = {
             17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32,
             49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63, 64,
             33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48,
@@ -34,10 +34,7 @@ constexpr int kOffset[kSize] = {
 vector<int> GoldenResult(vector<int> vec) {
 
   // The coefficients will be modified with each iteration of the outer loop.
-  int coeff[kSize];
-  for (size_t i = 0; i < kSize; i++) {
-    coeff[i] = kCoeff[i];
-  }
+  std::array coeff = kCoeff;
 
   for (int &val : vec) {
     // Do some arithmetic
@@ -60,8 +57,8 @@ vector<int> GoldenResult(vector<int> vec) {
   return vec;
 }
 
-// Forward declaration of the kernel name
-// (This will become unnecessary in a future compiler version.)
+// Forward declare the kernel name in the global scope.
+// This FPGA best practice reduces name mangling in the optimization reports.
 class SimpleMath;
 
 void RunKernel(const device_selector &selector,
@@ -88,10 +85,7 @@ void RunKernel(const device_selector &selector,
 
         // Force the compiler to implement the coefficient array in FPGA
         // pipeline registers rather than in on-chip memory.
-        [[intel::fpga_register]] int coeff[kSize];
-        for (size_t i = 0; i < kSize; i++) {
-          coeff[i] = kCoeff[i];
-        }
+        [[intel::fpga_register]] std::array coeff = kCoeff;
 
         // The compiler will pipeline the outer loop.
         for (size_t i = 0; i < input_size; ++i) {

--- a/DirectProgramming/DPC++FPGA/Tutorials/Features/kernel_args_restrict/src/kernel_args_restrict.cpp
+++ b/DirectProgramming/DPC++FPGA/Tutorials/Features/kernel_args_restrict/src/kernel_args_restrict.cpp
@@ -18,8 +18,8 @@ constexpr size_t kInSize = 1000000;
 constexpr double kInputMB = (kInSize * sizeof(int)) / (1024 * 1024);
 constexpr int kRandMax = 7777;
 
-// Forward declare the kernel names
-// (This prevents unwanted name mangling in the optimization report.)
+// Forward declare the kernel names in the global scope.
+// This FPGA best practice reduces name mangling in the optimization reports.
 class KernelArgsRestrict;
 class KernelArgsNoRestrict;
 

--- a/DirectProgramming/DPC++FPGA/Tutorials/Features/loop_coalesce/src/loop_coalesce.cpp
+++ b/DirectProgramming/DPC++FPGA/Tutorials/Features/loop_coalesce/src/loop_coalesce.cpp
@@ -23,8 +23,8 @@ constexpr size_t kNumElements = kNumRows * kNumCols;
 constexpr size_t kTotalOps = (4 + (3*kNumCols)) * kNumElements;
 
 
-// Forward declare the kernel name
-// (This prevents unwanted name mangling in the optimization report.)
+// Forward declare the kernel name in the global scope.
+// This FPGA best practice reduces name mangling in the optimization reports.
 template <int N> class KernelCompute;
 
 // The kernel implements a matrix multiplication.

--- a/DirectProgramming/DPC++FPGA/Tutorials/Features/loop_ivdep/src/loop_ivdep.cpp
+++ b/DirectProgramming/DPC++FPGA/Tutorials/Features/loop_ivdep/src/loop_ivdep.cpp
@@ -19,6 +19,8 @@ constexpr size_t kMatrixSize = kRowLength * kRowLength;
 
 using namespace sycl;
 
+// Forward declare the kernel name in the global scope.
+// This FPGA best practice reduces name mangling in the optimization reports.
 template <size_t safe_len> class KernelCompute;
 
 template <size_t safe_len>

--- a/DirectProgramming/DPC++FPGA/Tutorials/Features/loop_unroll/src/loop_unroll.cpp
+++ b/DirectProgramming/DPC++FPGA/Tutorials/Features/loop_unroll/src/loop_unroll.cpp
@@ -15,6 +15,8 @@
 
 using namespace sycl;
 
+// Forward declare the kernel name in the global scope.
+// This FPGA best practice reduces name mangling in the optimization reports.
 template <int unroll_factor> class VAdd;
 
 // This function instantiates the vector add kernel, which contains

--- a/DirectProgramming/DPC++FPGA/Tutorials/Features/lsu_control/src/lsu_control.cpp
+++ b/DirectProgramming/DPC++FPGA/Tutorials/Features/lsu_control/src/lsu_control.cpp
@@ -12,7 +12,8 @@
 
 using namespace sycl;
 
-// Declare Kernel class names globally to reduce name mangling in reports
+// Forward declare the kernel names in the global scope.
+// This FPGA best practice reduces name mangling in the optimization reports.
 class KernelPrefetch;
 class KernelBurst;
 class KernelDefault;

--- a/DirectProgramming/DPC++FPGA/Tutorials/Features/max_concurrency/src/max_concurrency.cpp
+++ b/DirectProgramming/DPC++FPGA/Tutorials/Features/max_concurrency/src/max_concurrency.cpp
@@ -23,6 +23,8 @@ constexpr size_t kMaxValue = 128;
 using FloatArray = std::array<float, kSize>;
 using FloatScalar = std::array<float, 1>;
 
+// Forward declare the kernel name in the global scope.
+// This FPGA best practice reduces name mangling in the optimization reports.
 template <int concurrency> class Kernel;
 
 // Launch a kernel on the device specified by selector.

--- a/DirectProgramming/DPC++FPGA/Tutorials/Features/max_interleaving/src/max_interleaving.cpp
+++ b/DirectProgramming/DPC++FPGA/Tutorials/Features/max_interleaving/src/max_interleaving.cpp
@@ -27,6 +27,8 @@ using FloatScalar = std::array<float, 1>;
 // combinational logic from the use of the parameter values to the result
 float SomethingComplicated(float x, float y) { return sycl::sqrt(x) * sycl::sqrt(y); }
 
+// Forward declare the kernel name in the global scope.
+// This FPGA best practice reduces name mangling in the optimization reports.
 template <int interleaving>
 class KernelCompute;
 

--- a/DirectProgramming/DPC++FPGA/Tutorials/Features/memory_attributes/src/memory_attributes.cpp
+++ b/DirectProgramming/DPC++FPGA/Tutorials/Features/memory_attributes/src/memory_attributes.cpp
@@ -19,8 +19,9 @@ constexpr size_t kMaxVal = 512;
 constexpr size_t kNumTests = 64;
 constexpr size_t kMaxIter = 8;
 
-// the kernel class name
-// templating allows us to easily instantiate different versions of the kernel
+// Forward declare the kernel name in the global scope.
+// This FPGA best practice reduces name mangling in the optimization reports.
+// Templating allows us to easily instantiate different versions of the kernel.
 template<int AttrType>
 class Kernel;
 

--- a/DirectProgramming/DPC++FPGA/Tutorials/Features/pipes/src/pipes.cpp
+++ b/DirectProgramming/DPC++FPGA/Tutorials/Features/pipes/src/pipes.cpp
@@ -21,7 +21,8 @@ using ProducerToConsumerPipe = INTEL::pipe<  // Defined in the SYCL headers.
     int,                                     // The type of data in the pipe.
     4>;                                      // The capacity of the pipe.
 
-// Forward declare the kernel names to reduce name mangling
+// Forward declare the kernel names in the global scope.
+// This FPGA best practice reduces name mangling in the optimization reports.
 class ProducerTutorial;
 class ConsumerTutorial;
 

--- a/DirectProgramming/DPC++FPGA/Tutorials/Features/speculated_iterations/src/speculated_iterations.cpp
+++ b/DirectProgramming/DPC++FPGA/Tutorials/Features/speculated_iterations/src/speculated_iterations.cpp
@@ -27,8 +27,8 @@ constexpr size_t kExpectedIterations = 1e8;
 
 using namespace sycl;
 
-// This is the class used to name the kernel for the runtime.
-// This must be done when the kernel is expressed as a lambda.
+// Forward declare the kernel name in the global scope.
+// This FPGA best practice reduces name mangling in the optimization reports.
 template <int N> class KernelCompute;
 
 template <int spec_iter>

--- a/DirectProgramming/DPC++FPGA/Tutorials/GettingStarted/fast_recompile/src/kernel.cpp
+++ b/DirectProgramming/DPC++FPGA/Tutorials/GettingStarted/fast_recompile/src/kernel.cpp
@@ -7,17 +7,24 @@
 
 #include "kernel.hpp"
 
-// Forward declaration of the kernel name reduces name mangling
-class VectorAdd;
 
 // This file contains 'almost' exclusively device code. The single-source SYCL
 // code has been refactored between host.cpp and kernel.cpp to separate host and
 // device code to the extent that the language permits.
-// Note that ANY change in either this file or kernel.hpp will be detected
+//
+// Note that ANY change in either this file or in kernel.hpp will be detected
 // by the build system as a difference in the dependencies of device.o,
-// triggering the full recompilation of the device code. This is true even of
-// a trivial change, e.g. tweaking the function definition or the names of
-// variables like 'q' or 'h', EVEN THOUGH these are not truly "device code".
+// triggering a full recompilation of the device code. 
+//
+// This is true even of trivial changes, e.g. tweaking the function definition 
+// or the names of variables like 'q' or 'h', EVEN THOUGH these are not truly 
+// "device code".
+
+
+// Forward declare the kernel names in the global scope. This FPGA best practice
+// reduces compiler name mangling in the optimization reports.
+class VectorAdd;
+
 void RunKernel(queue& q, buffer<float,1>& buf_a, buffer<float,1>& buf_b,
                buffer<float,1>& buf_r, size_t size){
     // submit the kernel

--- a/DirectProgramming/DPC++FPGA/Tutorials/GettingStarted/fpga_compile/src/fpga_compile.cpp
+++ b/DirectProgramming/DPC++FPGA/Tutorials/GettingStarted/fpga_compile/src/fpga_compile.cpp
@@ -17,8 +17,9 @@ using namespace sycl;
 // Vector size for this example
 constexpr size_t kSize = 1024;
 
-// Forward declaration of the kernel name
-// (This will become unnecessary in a future compiler version.)
+// Forward declare the kernel name in the global scope to reduce name mangling. 
+// This is an FPGA best practice that makes it easier to identify the kernel in 
+// the optimization reports.
 class VectorAdd;
 
 
@@ -72,7 +73,11 @@ int main() {
         // The kernel uses single_task rather than parallel_for.
         // The task's for loop is executed in pipeline parallel on the FPGA,
         // exploiting the same parallelism as an equivalent parallel_for.
-        h.single_task<VectorAdd>([=]() {
+        //
+        // The "kernel_args_restrict" tells the compiler that a, b, and r
+        // do not alias. For a full explanation, see:
+        //    DPC++FPGA/Tutorials/Features/kernel_args_restrict
+        h.single_task<VectorAdd>([=]() [[intel::kernel_args_restrict]] {
           for (int i = 0; i < kSize; ++i) {
             r[i] = a[i] + b[i];
           }

--- a/DirectProgramming/DPC++FPGA/Tutorials/Tools/dynamic_profiler/src/dynamic_profiler.cpp
+++ b/DirectProgramming/DPC++FPGA/Tutorials/Tools/dynamic_profiler/src/dynamic_profiler.cpp
@@ -24,8 +24,8 @@ using ProducerToConsumerBeforePipe =
 using ProducerToConsumerAfterPipe =
     INTEL::pipe<class ProducerConsumerAfterPipe, float, 20>;
 
-// Forward declare the kernel names
-// (This reduces unwanted name mangling in the optimization report.)
+// Forward declare the kernel names in the global scope.
+// This FPGA best practice reduces name mangling in the optimization report.
 class ProducerBeforeKernel;
 class ConsumerBeforeKernel;
 class ProducerAfterKernel;

--- a/DirectProgramming/DPC++FPGA/Tutorials/Tools/system_profiling/src/double_buffering.cpp
+++ b/DirectProgramming/DPC++FPGA/Tutorials/Tools/system_profiling/src/double_buffering.cpp
@@ -39,6 +39,8 @@ constexpr int kNumRuns = 2;
 
 bool pass = true;
 
+// Forward declare the kernel name in the global scope.
+// This FPGA best practice reduces name mangling in the optimization report.
 class SimpleVpow;
 
 /*  Kernel function.

--- a/DirectProgramming/DPC++FPGA/Tutorials/Tools/use_library/src/use_library.cpp
+++ b/DirectProgramming/DPC++FPGA/Tutorials/Tools/use_library/src/use_library.cpp
@@ -17,8 +17,8 @@ using namespace sycl;
 constexpr float kA = 2.0f;
 constexpr float kB = 3.0f;
 
-// Forward declaration of the kernel name
-// (This will become unnecessary in a future compiler version.)
+// Forward declare the kernel name in the global scope.
+// This FPGA best practice reduces name mangling in the optimization report.
 class KernelCompute;
 
 int main() {


### PR DESCRIPTION
Signed-off-by: Audrey Kertesz <audrey.kertesz@intel.com>

# Description

Minor improvements the DPC++ files for FPGA tutorial samples, in response to user feedback.
  - Motivate the forward declaration of the kernel name in each tutorial
  - Improve the explanatory comments in fast_recompile and fpga_compile
  - Remove a stray namespace backwards compatibility block (no longer needed) 

## Type of change

- [X] Enhancement

# How Has This Been Tested?

- [X] Command Line
