### PR TITLE
Change to -fintelfpga flag for GZIP

### DIFF
--- a/DirectProgramming/DPC++FPGA/ReferenceDesigns/gzip/src/CMakeLists.txt
+++ b/DirectProgramming/DPC++FPGA/ReferenceDesigns/gzip/src/CMakeLists.txt
@@ -66,7 +66,7 @@ set(EMULATOR_COMPILE_FLAGS "-g0 -fintelfpga  -DFPGA_EMULATOR -DNUM_ENGINES=${NUM
 set(EMULATOR_LINK_FLAGS -fintelfpga)
 
 # specify -MMD -fsycl-link-targets=... instead of -fintelfpga to workaround known issue; lower report quality 
-set(HARDWARE_COMPILE_FLAGS -MMD -fsycl-link-targets=spir64_fpga-unknown-unknown-sycldevice -c -DNUM_ENGINES=${NUM_ENGINES})
+set(HARDWARE_COMPILE_FLAGS -MMD -fintelfpga -c -DNUM_ENGINES=${NUM_ENGINES})
 
 # use cmake -D USER_HARDWARE_FLAGS=<flags> to set extra flags for FPGA backend compilation
 separate_arguments(USER_HARDWARE_FLAGS)


### PR DESCRIPTION
# Description

The GZIP makefile has long been using an incorrect flag to dpcpp, resulting in slightly incorrectly RTL and therefore unexpected FMAX for the given seed. This change fixes the flag.

Fixes # (issue) 

## Type of change

Please delete options that are not relevant. Add a 'X' to the one that is applicable. 

- [ X ] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ X  ] Command Line
