### PR TITLE
Remove unique_ptr to sycl::queue in some FPGA samples

### DIFF
--- a/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/double_buffering/src/double_buffering.cpp
+++ b/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/double_buffering/src/double_buffering.cpp
@@ -53,10 +53,10 @@ class SimpleVpow;
    transfer to occur at the end of overall execution, not at the end of each
    individual kernel execution.
 */
-void SimplePow(std::unique_ptr<queue> &q, buffer<float, 1> &buffer_a,
+void SimplePow(sycl::queue &q, buffer<float, 1> &buffer_a,
                buffer<float, 1> &buffer_b, event &e) {
   // Submit to the queue and execute the kernel
-  e = q->submit([&](handler &h) {
+  e = q.submit([&](handler &h) {
     // Get kernel access to the buffers
     accessor accessor_a(buffer_a, h, read_only);
     accessor accessor_b(buffer_b, h, read_write, noinit);
@@ -81,7 +81,7 @@ void SimplePow(std::unique_ptr<queue> &q, buffer<float, 1> &buffer_a,
   });
 
   event update_host_event;
-  update_host_event = q->submit([&](handler &h) {
+  update_host_event = q.submit([&](handler &h) {
     accessor accessor_b(buffer_b, h, read_only);
 
     /*
@@ -212,12 +212,10 @@ int main() {
   try {
     auto prop_list = property_list{property::queue::enable_profiling()};
 
-    std::unique_ptr<queue> q;
-    q.reset(
-        new queue(device_selector, dpc_common::exception_handler, prop_list));
+    sycl::queue q(device_selector, dpc_common::exception_handler, prop_list);
 
-    platform platform = q->get_context().get_platform();
-    device device = q->get_device();
+    platform platform = q.get_context().get_platform();
+    device device = q.get_device();
     std::cout << "Platform name: "
               << platform.get_info<info::platform::name>().c_str() << "\n";
     std::cout << "Device name: "

--- a/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/n_way_buffering/src/n_way_buffering.cpp
+++ b/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/n_way_buffering/src/n_way_buffering.cpp
@@ -60,10 +60,10 @@ class SimpleVpow;
    to occur at the end of overall execution, not at the end of each individual
    kernel execution.
 */
-void SimplePow(std::unique_ptr<queue> &q, buffer<float, 1> &buffer_a,
+void SimplePow(sycl::queue &q, buffer<float, 1> &buffer_a,
                buffer<float, 1> &buffer_b, event &e) {
   // Submit to the queue and execute the kernel
-  e = q->submit([&](handler &h) {
+  e = q.submit([&](handler &h) {
     // Get kernel access to the buffers
     accessor accessor_a(buffer_a, h, read_only);
     accessor accessor_b(buffer_b, h, read_write, noinit);
@@ -88,7 +88,7 @@ void SimplePow(std::unique_ptr<queue> &q, buffer<float, 1> &buffer_a,
   });
 
   event update_host_event;
-  update_host_event = q->submit([&](handler &h) {
+  update_host_event = q.submit([&](handler &h) {
     accessor accessor_b(buffer_b, h, read_only);
 
     /*
@@ -217,12 +217,10 @@ int main() {
   try {
     auto prop_list = property_list{property::queue::enable_profiling()};
 
-    std::unique_ptr<queue> q;
-    q.reset(
-        new queue(device_selector, dpc_common::exception_handler, prop_list));
+    sycl::queue q(device_selector, dpc_common::exception_handler, prop_list);
 
-    platform platform = q->get_context().get_platform();
-    device device = q->get_device();
+    platform platform = q.get_context().get_platform();
+    device device = q.get_device();
     std::cout << "Platform name: "
               << platform.get_info<info::platform::name>().c_str() << "\n";
     std::cout << "Device name: "

--- a/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/onchip_memory_cache/src/onchip_memory_cache.cpp
+++ b/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/onchip_memory_cache/src/onchip_memory_cache.cpp
@@ -28,10 +28,10 @@ class Task;
 // This kernel function implements two data paths: with and without caching.
 // use_cache specifies which path to take.
 template<bool use_cache>
-void Histogram(std::unique_ptr<queue>& q, buffer<uint32_t>& input_buf,
+void Histogram(sycl::queue &q, buffer<uint32_t>& input_buf,
                buffer<uint32_t>& output_buf, event& e) {
   // Enqueue  kernel
-  e = q->submit([&](handler& h) {
+  e = q.submit([&](handler& h) {
     // Get accessors to the SYCL buffers
     accessor input(input_buf, h, read_only);
     accessor output(output_buf, h, write_only, noinit);
@@ -124,11 +124,10 @@ int main() {
     auto prop_list =
         property_list{property::queue::enable_profiling()};
 
-    std::unique_ptr<queue> q;
-    q.reset(new queue(device_selector, dpc_common::exception_handler, prop_list));
+    sycl::queue q(device_selector, dpc_common::exception_handler, prop_list);
 
-    platform platform = q->get_context().get_platform();
-    device device = q->get_device();
+    platform platform = q.get_context().get_platform();
+    device device = q.get_device();
     std::cout << "Platform name: "
               << platform.get_info<info::platform::name>().c_str() << "\n";
     std::cout << "Device name: "
@@ -184,7 +183,7 @@ int main() {
       }
 
       // Wait for kernels to finish
-      q->wait();
+      q.wait();
 
       // Compute kernel execution time
       t1_kernel = e.get_profiling_info<info::event_profiling::command_start>();

--- a/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/triangular_loop/src/triangular_loop.cpp
+++ b/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/triangular_loop/src/triangular_loop.cpp
@@ -47,11 +47,11 @@ int SomethingComplicated(int x) { return (int)sycl::sqrt((float)x); }
 
 // This kernel function implements two data paths: with and without the
 // optimization. 'optimize' specifies which path to take.
-void TriangularLoop(std::unique_ptr<queue>& q, buffer<uint32_t>& input_buf,
+void TriangularLoop(sycl::queue&q, buffer<uint32_t>& input_buf,
                     buffer<uint32_t>& output_buf, uint32_t n, event& e,
                     bool optimize) {
   // Enqueue kernel
-  e = q->submit([&](handler& h) {
+  e = q.submit([&](handler& h) {
     // Get accessors to the SYCL buffers
     accessor input(input_buf, h, read_only);
     accessor output(output_buf, h, write_only, noinit);
@@ -138,11 +138,10 @@ int main() {
     auto prop_list =
         property_list{property::queue::enable_profiling()};
 
-    std::unique_ptr<queue> q;
-    q.reset(new queue(device_selector, dpc_common::exception_handler, prop_list));
+    sycl::queue q(device_selector, dpc_common::exception_handler, prop_list);
 
-    platform platform = q->get_context().get_platform();
-    device device = q->get_device();
+    platform platform = q.get_context().get_platform();
+    device device = q.get_device();
     std::cout << "Platform name: "
               << platform.get_info<info::platform::name>().c_str() << "\n";
     std::cout << "Device name: "
@@ -201,7 +200,7 @@ int main() {
       }
 
       // Wait for kernels to finish
-      q->wait();
+      q.wait();
 
       t1_kernel = e.get_profiling_info<info::event_profiling::command_start>();
       t2_kernel = e.get_profiling_info<info::event_profiling::command_end>();
@@ -245,14 +244,14 @@ int main() {
   } catch (sycl::exception const& e) {
     // Catches exceptions in the host code
     std::cerr << "Caught a SYCL host exception:\n" << e.what() << "\n";
-    
+
     // Most likely the runtime couldn't find FPGA hardware!
     if (e.get_cl_code() == CL_DEVICE_NOT_FOUND) {
       std::cerr << "If you are targeting an FPGA, please ensure that your "
                    "system has a correctly configured FPGA board.\n";
       std::cerr << "Run sys_check in the oneAPI root directory to verify.\n";
       std::cerr << "If you are targeting the FPGA emulator, compile with "
-                   "-DFPGA_EMULATOR.\n"; 
+                   "-DFPGA_EMULATOR.\n";
     }
     std::terminate();
   }

--- a/DirectProgramming/DPC++FPGA/Tutorials/Tools/system_profiling/src/double_buffering.cpp
+++ b/DirectProgramming/DPC++FPGA/Tutorials/Tools/system_profiling/src/double_buffering.cpp
@@ -57,10 +57,10 @@ class SimpleVpow;
    transfer to occur at the end of overall execution, not at the end of each
    individual kernel execution.
 */
-void SimplePow(std::unique_ptr<queue> &q, buffer<float, 1> &buffer_a,
+void SimplePow(sycl::queue &q, buffer<float, 1> &buffer_a,
                buffer<float, 1> &buffer_b, event &e) {
   // Submit to the queue and execute the kernel
-  e = q->submit([&](handler &h) {
+  e = q.submit([&](handler &h) {
     // Get kernel access to the buffers
     accessor accessor_a(buffer_a, h, read_only);
     accessor accessor_b(buffer_b, h, write_only, noinit);
@@ -85,7 +85,7 @@ void SimplePow(std::unique_ptr<queue> &q, buffer<float, 1> &buffer_a,
   });
 
   event update_host_event;
-  update_host_event = q->submit([&](handler &h) {
+  update_host_event = q.submit([&](handler &h) {
     accessor accessor_b(buffer_b, h, read_only);
     /*
       Explicitly instruct the SYCL runtime to copy the kernel's output buffer
@@ -215,12 +215,10 @@ int main() {
   try {
     auto prop_list = property_list{property::queue::enable_profiling()};
 
-    std::unique_ptr<queue> q;
-    q.reset(
-        new queue(device_selector, dpc_common::exception_handler, prop_list));
+    sycl::queue q(device_selector, dpc_common::exception_handler, prop_list);
 
-    platform platform = q->get_context().get_platform();
-    device device = q->get_device();
+    platform platform = q.get_context().get_platform();
+    device device = q.get_device();
     std::cout << "Platform name: "
               << platform.get_info<info::platform::name>().c_str() << "\n";
     std::cout << "Device name: "


### PR DESCRIPTION
Signed-off-by: Alain Lou alain.lou@intel.com

# Description
This is for FPGA tutorial code samples.

Instead of using unique_ptr, stack allocate sycl::queue directly. @keryell mentioned it already has share_ptr semantics under-the-hood. This way we'll have less confusion about how to use sycl.

## Type of change
[ X ] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
[ X ] Command line 