### PR TITLE
Update -mkl -> -qmkl compiler flag for 2021.2

### DIFF
--- a/Libraries/oneMKL/black_scholes/GNUmakefile
+++ b/Libraries/oneMKL/black_scholes/GNUmakefile
@@ -14,8 +14,8 @@ mkl_path   := $(MKL)
 acc        := $(strip $(ACC))
 headers    := $(wildcard *.hpp)
 
-cxx_flags  := -O3 -DMKL_ILP64 -I$(MKLROOT)/include -fno-sycl-early-optimizations
-ldxx_flags := -mkl -fsycl-device-code-split=per_kernel
+cxx_flags  := -O3 -DMKL_ILP64 -fno-sycl-early-optimizations
+ldxx_flags := -qmkl -fsycl-device-code-split=per_kernel
 cxx        := dpcpp
 
 ifneq ($(acc),)

--- a/Libraries/oneMKL/block_cholesky_decomposition/GNUmakefile
+++ b/Libraries/oneMKL/block_cholesky_decomposition/GNUmakefile
@@ -5,10 +5,10 @@ all: factor solve
 	./solve
 
 factor: factor.cpp dpbltrf.cpp auxi.cpp
-	dpcpp $^ -o $@ -fsycl-device-code-split=per_kernel -DMKL_ILP64 -I${MKLROOT}/include -mkl
+	dpcpp $^ -o $@ -fsycl-device-code-split=per_kernel -DMKL_ILP64 -qmkl
 
 solve: solve.cpp dpbltrf.cpp dpbltrs.cpp auxi.cpp
-	dpcpp $^ -o $@ -fsycl-device-code-split=per_kernel -DMKL_ILP64 -I${MKLROOT}/include -mkl
+	dpcpp $^ -o $@ -fsycl-device-code-split=per_kernel -DMKL_ILP64 -qmkl
 
 clean:
 	-rm -f factor solve

--- a/Libraries/oneMKL/block_lu_decomposition/GNUmakefile
+++ b/Libraries/oneMKL/block_lu_decomposition/GNUmakefile
@@ -5,10 +5,10 @@ all: factor solve
 	./solve
 
 factor: factor.cpp dgeblttrf.cpp auxi.cpp
-	dpcpp $^ -o $@ -fsycl-device-code-split=per_kernel -DMKL_ILP64 -I${MKLROOT}/include -mkl
+	dpcpp $^ -o $@ -fsycl-device-code-split=per_kernel -DMKL_ILP64 -qmkl
 
 solve: solve.cpp dgeblttrf.cpp dgeblttrs.cpp auxi.cpp
-	dpcpp $^ -o $@ -fsycl-device-code-split=per_kernel -DMKL_ILP64 -I${MKLROOT}/include -mkl
+	dpcpp $^ -o $@ -fsycl-device-code-split=per_kernel -DMKL_ILP64 -qmkl
 
 clean:
 	-rm -f factor solve

--- a/Libraries/oneMKL/computed_tomography/GNUmakefile
+++ b/Libraries/oneMKL/computed_tomography/GNUmakefile
@@ -7,7 +7,7 @@ all: run
 run: computed_tomography
 	./computed_tomography 400 400 input.bmp radon.bmp restored.bmp
 
-DPCPP_OPTS = -I${MKLROOT}/include -mkl -fsycl-device-code-split=per_kernel
+DPCPP_OPTS = -qmkl -fsycl-device-code-split=per_kernel
 
 computed_tomography: computed_tomography.cpp
 	dpcpp $< -o $@ $(DPCPP_OPTS)

--- a/Libraries/oneMKL/matrix_mul_mkl/GNUmakefile
+++ b/Libraries/oneMKL/matrix_mul_mkl/GNUmakefile
@@ -7,7 +7,7 @@ all: run
 run: matrix_mul_mkl
 	./matrix_mul_mkl
 
-DPCPP_OPTS = -I${MKLROOT}/include -mkl -fsycl-device-code-split=per_kernel
+DPCPP_OPTS = -qmkl -fsycl-device-code-split=per_kernel
 
 matrix_mul_mkl: matrix_mul_mkl.cpp
 	dpcpp $< -o $@ $(DPCPP_OPTS)

--- a/Libraries/oneMKL/monte_carlo_european_opt/GNUmakefile
+++ b/Libraries/oneMKL/monte_carlo_european_opt/GNUmakefile
@@ -7,7 +7,7 @@ run_all: mc_european mc_european_usm
 	@echo
 	./mc_european_usm
 
-DPCPP_OPTS = -I${MKLROOT}/include -mkl -DMKL_ILP64 -fsycl-device-code-split=per_kernel
+DPCPP_OPTS = -qmkl -DMKL_ILP64 -fsycl-device-code-split=per_kernel
 
 mc_european: mc_european.cpp
 	dpcpp $< -o $@ $(DPCPP_OPTS)

--- a/Libraries/oneMKL/monte_carlo_european_opt/mc_european.cpp
+++ b/Libraries/oneMKL/monte_carlo_european_opt/mc_european.cpp
@@ -13,6 +13,7 @@
 *******************************************************************************/
 
 #include <iostream>
+#include <numeric>
 #include <vector>
 
 #include <CL/sycl.hpp>

--- a/Libraries/oneMKL/monte_carlo_european_opt/mc_european_usm.cpp
+++ b/Libraries/oneMKL/monte_carlo_european_opt/mc_european_usm.cpp
@@ -13,6 +13,7 @@
 *******************************************************************************/
 
 #include <iostream>
+#include <numeric>
 #include <vector>
 
 #include <CL/sycl.hpp>

--- a/Libraries/oneMKL/monte_carlo_pi/GNUmakefile
+++ b/Libraries/oneMKL/monte_carlo_pi/GNUmakefile
@@ -9,7 +9,7 @@ run_all: mc_pi mc_pi_usm mc_pi_device_api
 	./mc_pi_usm
 	./mc_pi_device_api
 
-DPCPP_OPTS = -I${MKLROOT}/include -mkl -DMKL_ILP64 -fsycl-device-code-split=per_kernel -fno-sycl-early-optimizations
+DPCPP_OPTS = -qmkl -DMKL_ILP64 -fsycl-device-code-split=per_kernel -fno-sycl-early-optimizations
 
 mc_pi: mc_pi.cpp
 	dpcpp $< -o $@ $(DPCPP_OPTS)

--- a/Libraries/oneMKL/monte_carlo_pi/mc_pi.cpp
+++ b/Libraries/oneMKL/monte_carlo_pi/mc_pi.cpp
@@ -13,6 +13,7 @@
 *******************************************************************************/
 
 #include <iostream>
+#include <numeric>
 #include <vector>
 
 #include <CL/sycl.hpp>

--- a/Libraries/oneMKL/monte_carlo_pi/mc_pi_device_api.cpp
+++ b/Libraries/oneMKL/monte_carlo_pi/mc_pi_device_api.cpp
@@ -13,6 +13,7 @@
 *******************************************************************************/
 
 #include <iostream>
+#include <numeric>
 #include <vector>
 
 #include <CL/sycl.hpp>

--- a/Libraries/oneMKL/monte_carlo_pi/mc_pi_usm.cpp
+++ b/Libraries/oneMKL/monte_carlo_pi/mc_pi_usm.cpp
@@ -13,6 +13,7 @@
 *******************************************************************************/
 
 #include <iostream>
+#include <numeric>
 #include <vector>
 
 #include <CL/sycl.hpp>

--- a/Libraries/oneMKL/random_sampling_without_replacement/GNUmakefile
+++ b/Libraries/oneMKL/random_sampling_without_replacement/GNUmakefile
@@ -9,7 +9,7 @@ run_all: lottery lottery_usm lottery_device_api
 		./lottery_usm
 		./lottery_device_api
 
-DPCPP_OPTS = -I${MKLROOT}/include -mkl -DMKL_ILP64 -fsycl-device-code-split=per_kernel -fno-sycl-early-optimizations
+DPCPP_OPTS = -qmkl -DMKL_ILP64 -fsycl-device-code-split=per_kernel -fno-sycl-early-optimizations
 
 lottery: lottery.cpp
 		dpcpp $< -o $@ $(DPCPP_OPTS)

--- a/Libraries/oneMKL/sparse_conjugate_gradient/GNUmakefile
+++ b/Libraries/oneMKL/sparse_conjugate_gradient/GNUmakefile
@@ -7,7 +7,7 @@ all: run
 run: sparse_cg
 	./sparse_cg
 
-DPCPP_OPTS = -I${MKLROOT}/include -mkl -fsycl-device-code-split=per_kernel
+DPCPP_OPTS = -qmkl -fsycl-device-code-split=per_kernel
 
 sparse_cg: sparse_cg.cpp
 	dpcpp $< -o $@ $(DPCPP_OPTS)


### PR DESCRIPTION
This MR updates the oneMKL samples for compatibility with **2021.2 only**. There is a breaking change in the compiler flags for linking oneMKL (was `-mkl`, now `-qmkl`) between 2021.1 and 2021.2. Hence, CI is expected to fail.

Also fixes some compile errors in `monte_carlo_{pi,european_opt}` due to a missing `#include`.

This MR is to be merged after 2021.2 as PR#439 has implemented a fix so that 2021.1 and .2 oneMKL compiler will work, this PR will deprecate that fix