### PR TITLE
oneMKL samples: replace -mkl flag with full link line

### DIFF
--- a/Libraries/oneMKL/black_scholes/GNUmakefile
+++ b/Libraries/oneMKL/black_scholes/GNUmakefile
@@ -15,7 +15,7 @@ acc        := $(strip $(ACC))
 headers    := $(wildcard *.hpp)
 
 cxx_flags  := -O3 -DMKL_ILP64 -I$(MKLROOT)/include -fno-sycl-early-optimizations
-ldxx_flags := -mkl -fsycl-device-code-split=per_kernel
+ldxx_flags := -L${MKLROOT}/lib/intel64 -lmkl_sycl -lmkl_intel_ilp64 -lmkl_sequential -lmkl_core -lsycl -lOpenCL -lpthread -lm -ldl -fsycl-device-code-split=per_kernel
 cxx        := dpcpp
 
 ifneq ($(acc),)

--- a/Libraries/oneMKL/block_cholesky_decomposition/GNUmakefile
+++ b/Libraries/oneMKL/block_cholesky_decomposition/GNUmakefile
@@ -4,11 +4,14 @@ all: factor solve
 	./factor
 	./solve
 
+MKL_COPTS = -DMKL_ILP64  -I"${MKLROOT}/include"
+MKL_LIBS = -L${MKLROOT}/lib/intel64 -lmkl_sycl -lmkl_intel_ilp64 -lmkl_sequential -lmkl_core -lsycl -lOpenCL -lpthread -lm -ldl
+
 factor: factor.cpp dpbltrf.cpp auxi.cpp
-	dpcpp $^ -o $@ -fsycl-device-code-split=per_kernel -DMKL_ILP64 -I${MKLROOT}/include -mkl
+	dpcpp $^ -o $@ -fsycl-device-code-split=per_kernel $(MKL_COPTS) $(MKL_LIBS)
 
 solve: solve.cpp dpbltrf.cpp dpbltrs.cpp auxi.cpp
-	dpcpp $^ -o $@ -fsycl-device-code-split=per_kernel -DMKL_ILP64 -I${MKLROOT}/include -mkl
+	dpcpp $^ -o $@ -fsycl-device-code-split=per_kernel $(MKL_COPTS) $(MKL_LIBS)
 
 clean:
 	-rm -f factor solve

--- a/Libraries/oneMKL/block_lu_decomposition/GNUmakefile
+++ b/Libraries/oneMKL/block_lu_decomposition/GNUmakefile
@@ -4,11 +4,14 @@ all: factor solve
 	./factor
 	./solve
 
+MKL_COPTS = -DMKL_ILP64  -I"${MKLROOT}/include"
+MKL_LIBS = -L${MKLROOT}/lib/intel64 -lmkl_sycl -lmkl_intel_ilp64 -lmkl_sequential -lmkl_core -lsycl -lOpenCL -lpthread -lm -ldl
+
 factor: factor.cpp dgeblttrf.cpp auxi.cpp
-	dpcpp $^ -o $@ -fsycl-device-code-split=per_kernel -DMKL_ILP64 -I${MKLROOT}/include -mkl
+	dpcpp $^ -o $@ -fsycl-device-code-split=per_kernel $(MKL_COPTS) $(MKL_LIBS)
 
 solve: solve.cpp dgeblttrf.cpp dgeblttrs.cpp auxi.cpp
-	dpcpp $^ -o $@ -fsycl-device-code-split=per_kernel -DMKL_ILP64 -I${MKLROOT}/include -mkl
+	dpcpp $^ -o $@ -fsycl-device-code-split=per_kernel $(MKL_COPTS) $(MKL_LIBS)
 
 clean:
 	-rm -f factor solve

--- a/Libraries/oneMKL/computed_tomography/GNUmakefile
+++ b/Libraries/oneMKL/computed_tomography/GNUmakefile
@@ -7,7 +7,10 @@ all: run
 run: computed_tomography
 	./computed_tomography 400 400 input.bmp radon.bmp restored.bmp
 
-DPCPP_OPTS = -I${MKLROOT}/include -mkl -fsycl-device-code-split=per_kernel
+MKL_COPTS = -DMKL_ILP64  -I"${MKLROOT}/include"
+MKL_LIBS = -L${MKLROOT}/lib/intel64 -lmkl_sycl -lmkl_intel_ilp64 -lmkl_sequential -lmkl_core -lsycl -lOpenCL -lpthread -lm -ldl
+
+DPCPP_OPTS = $(MKL_COPTS) -fsycl-device-code-split=per_kernel $(MKL_LIBS)
 
 computed_tomography: computed_tomography.cpp
 	dpcpp $< -o $@ $(DPCPP_OPTS)

--- a/Libraries/oneMKL/matrix_mul_mkl/GNUmakefile
+++ b/Libraries/oneMKL/matrix_mul_mkl/GNUmakefile
@@ -7,7 +7,10 @@ all: run
 run: matrix_mul_mkl
 	./matrix_mul_mkl
 
-DPCPP_OPTS = -I${MKLROOT}/include -mkl -fsycl-device-code-split=per_kernel
+MKL_COPTS = -DMKL_ILP64  -I"${MKLROOT}/include"
+MKL_LIBS = -L${MKLROOT}/lib/intel64 -lmkl_sycl -lmkl_intel_ilp64 -lmkl_sequential -lmkl_core -lsycl -lOpenCL -lpthread -lm -ldl
+
+DPCPP_OPTS = $(MKL_COPTS) -fsycl-device-code-split=per_kernel $(MKL_LIBS)
 
 matrix_mul_mkl: matrix_mul_mkl.cpp
 	dpcpp $< -o $@ $(DPCPP_OPTS)

--- a/Libraries/oneMKL/monte_carlo_european_opt/GNUmakefile
+++ b/Libraries/oneMKL/monte_carlo_european_opt/GNUmakefile
@@ -7,7 +7,10 @@ run_all: mc_european mc_european_usm
 	@echo
 	./mc_european_usm
 
-DPCPP_OPTS = -I${MKLROOT}/include -mkl -DMKL_ILP64 -fsycl-device-code-split=per_kernel
+MKL_COPTS = -DMKL_ILP64  -I"${MKLROOT}/include"
+MKL_LIBS = -L${MKLROOT}/lib/intel64 -lmkl_sycl -lmkl_intel_ilp64 -lmkl_sequential -lmkl_core -lsycl -lOpenCL -lpthread -lm -ldl
+
+DPCPP_OPTS = $(MKL_COPTS) -fsycl-device-code-split=per_kernel $(MKL_LIBS)
 
 mc_european: mc_european.cpp
 	dpcpp $< -o $@ $(DPCPP_OPTS)

--- a/Libraries/oneMKL/monte_carlo_european_opt/mc_european.cpp
+++ b/Libraries/oneMKL/monte_carlo_european_opt/mc_european.cpp
@@ -13,6 +13,7 @@
 *******************************************************************************/
 
 #include <iostream>
+#include <numeric>
 #include <vector>
 
 #include <CL/sycl.hpp>

--- a/Libraries/oneMKL/monte_carlo_european_opt/mc_european_usm.cpp
+++ b/Libraries/oneMKL/monte_carlo_european_opt/mc_european_usm.cpp
@@ -13,6 +13,7 @@
 *******************************************************************************/
 
 #include <iostream>
+#include <numeric>
 #include <vector>
 
 #include <CL/sycl.hpp>

--- a/Libraries/oneMKL/monte_carlo_pi/GNUmakefile
+++ b/Libraries/oneMKL/monte_carlo_pi/GNUmakefile
@@ -9,7 +9,10 @@ run_all: mc_pi mc_pi_usm mc_pi_device_api
 	./mc_pi_usm
 	./mc_pi_device_api
 
-DPCPP_OPTS = -I${MKLROOT}/include -mkl -DMKL_ILP64 -fsycl-device-code-split=per_kernel -fno-sycl-early-optimizations
+MKL_COPTS = -DMKL_ILP64  -I"${MKLROOT}/include"
+MKL_LIBS = -L${MKLROOT}/lib/intel64 -lmkl_sycl -lmkl_intel_ilp64 -lmkl_sequential -lmkl_core -lsycl -lOpenCL -lpthread -lm -ldl
+
+DPCPP_OPTS = $(MKL_COPTS) -fsycl-device-code-split=per_kernel -fno-sycl-early-optimizations $(MKL_LIBS)
 
 mc_pi: mc_pi.cpp
 	dpcpp $< -o $@ $(DPCPP_OPTS)

--- a/Libraries/oneMKL/monte_carlo_pi/mc_pi.cpp
+++ b/Libraries/oneMKL/monte_carlo_pi/mc_pi.cpp
@@ -13,6 +13,7 @@
 *******************************************************************************/
 
 #include <iostream>
+#include <numeric>
 #include <vector>
 
 #include <CL/sycl.hpp>

--- a/Libraries/oneMKL/monte_carlo_pi/mc_pi_device_api.cpp
+++ b/Libraries/oneMKL/monte_carlo_pi/mc_pi_device_api.cpp
@@ -13,6 +13,7 @@
 *******************************************************************************/
 
 #include <iostream>
+#include <numeric>
 #include <vector>
 
 #include <CL/sycl.hpp>

--- a/Libraries/oneMKL/monte_carlo_pi/mc_pi_usm.cpp
+++ b/Libraries/oneMKL/monte_carlo_pi/mc_pi_usm.cpp
@@ -13,6 +13,7 @@
 *******************************************************************************/
 
 #include <iostream>
+#include <numeric>
 #include <vector>
 
 #include <CL/sycl.hpp>

--- a/Libraries/oneMKL/random_sampling_without_replacement/GNUmakefile
+++ b/Libraries/oneMKL/random_sampling_without_replacement/GNUmakefile
@@ -9,7 +9,10 @@ run_all: lottery lottery_usm lottery_device_api
 		./lottery_usm
 		./lottery_device_api
 
-DPCPP_OPTS = -I${MKLROOT}/include -mkl -DMKL_ILP64 -fsycl-device-code-split=per_kernel -fno-sycl-early-optimizations
+MKL_COPTS = -DMKL_ILP64  -I"${MKLROOT}/include"
+MKL_LIBS = -L${MKLROOT}/lib/intel64 -lmkl_sycl -lmkl_intel_ilp64 -lmkl_sequential -lmkl_core -lsycl -lOpenCL -lpthread -lm -ldl
+
+DPCPP_OPTS = $(MKL_COPTS) -fsycl-device-code-split=per_kernel -fno-sycl-early-optimizations $(MKL_LIBS)
 
 lottery: lottery.cpp
 		dpcpp $< -o $@ $(DPCPP_OPTS)

--- a/Libraries/oneMKL/sparse_conjugate_gradient/GNUmakefile
+++ b/Libraries/oneMKL/sparse_conjugate_gradient/GNUmakefile
@@ -7,7 +7,10 @@ all: run
 run: sparse_cg
 	./sparse_cg
 
-DPCPP_OPTS = -I${MKLROOT}/include -mkl -fsycl-device-code-split=per_kernel
+MKL_COPTS = -DMKL_ILP64  -I"${MKLROOT}/include"
+MKL_LIBS = -L${MKLROOT}/lib/intel64 -lmkl_sycl -lmkl_intel_ilp64 -lmkl_sequential -lmkl_core -lsycl -lOpenCL -lpthread -lm -ldl
+
+DPCPP_OPTS = $(MKL_COPTS) -fsycl-device-code-split=per_kernel $(MKL_LIBS)
 
 sparse_cg: sparse_cg.cpp
 	dpcpp $< -o $@ $(DPCPP_OPTS)


### PR DESCRIPTION
2021.2 introduces a breaking change where the `-mkl` compiler flag is replaced with `-qmkl`. This MR removes usage of the `-mkl` flag so that oneMKL samples work with both 2021.1 and 2021.2. The long term solution is to use `-qmkl` instead, as in #438.

This MR is intended to be merged into master after 2021.2 is tagged, so that master is compatible with both 2021.1 and 2021.2, but the the 2021.2 tag shows the intended, simpler `-qmkl` usage.

Also fixes a compilation error in a few samples due to a missing header file that used to be indirectly included.

FYI: @JoeOster 