### PR TITLE
Simplified build process of PointPillars sample

### DIFF
--- a/AI-and-Analytics/End-to-end-Workloads/LidarObjectDetection-PointPillars/CMakeLists.txt
+++ b/AI-and-Analytics/End-to-end-Workloads/LidarObjectDetection-PointPillars/CMakeLists.txt
@@ -89,7 +89,7 @@ target_include_directories(${PROJECT_NAME} PUBLIC
   ${CMAKE_SOURCE_DIR}/include
 )
 
-target_compile_options(${PROJECT_NAME} PRIVATE -fsycl -Wall -Wextra -Wformat-security)
+target_compile_options(${PROJECT_NAME} PRIVATE -fsycl)
 
 target_compile_definitions(${PROJECT_NAME} PUBLIC -DCL_TARGET_OPENCL_VERSION=220)
 
@@ -109,7 +109,9 @@ target_link_libraries(example.exe PRIVATE
   Boost::program_options
 )
 
-configure_file(${CMAKE_SOURCE_DIR}/data/model/pfe.onnx ${CMAKE_CURRENT_BINARY_DIR}/pfe.onnx COPYONLY)
-configure_file(${CMAKE_SOURCE_DIR}/data/model/rpn.onnx ${CMAKE_CURRENT_BINARY_DIR}/rpn.onnx COPYONLY)
+# Get the required model files and copy the input point cloud
+message(STATUS "Getting model files")
+execute_process(COMMAND wget https://github.com/k0suke-murakami/kitti_pretrained_point_pillars/raw/master/pfe.onnx -q -O ${CMAKE_CURRENT_BINARY_DIR}/pfe.onnx)
+execute_process(COMMAND wget https://github.com/k0suke-murakami/kitti_pretrained_point_pillars/raw/master/rpn.onnx -q -O ${CMAKE_CURRENT_BINARY_DIR}/rpn.onnx)
 configure_file(${CMAKE_SOURCE_DIR}/data/example.pcd ${CMAKE_CURRENT_BINARY_DIR}/example.pcd COPYONLY)
 

--- a/AI-and-Analytics/End-to-end-Workloads/LidarObjectDetection-PointPillars/README.md
+++ b/AI-and-Analytics/End-to-end-Workloads/LidarObjectDetection-PointPillars/README.md
@@ -54,20 +54,13 @@ $ source /opt/intel/openvino_2021/bin/setupvars.sh
 $ source /opt/intel/oneapi/setvars.sh
 ```
 
-2. Download the PFE and RPN models in ONNX format
-``` 
-$ cd data/model
-$ wget https://github.com/k0suke-murakami/kitti_pretrained_point_pillars/raw/master/pfe.onnx
-$ wget https://github.com/k0suke-murakami/kitti_pretrained_point_pillars/raw/master/rpn.onnx
-$ cd ../..
-```
-
 2. Build the program using the following `cmake` commands. 
 ``` 
 $ mkdir build && cd build
 $ cmake ..
 $ make
 ```
+Please note that cmake will also download the ONNX models required for the two inference steps executed with the Intel® Distribution of OpenVINO™ toolkit.
 
 ## Running the `PointPillars` Sample Program
 After a successful build, the sample program can be run as follows:


### PR DESCRIPTION
# Description
To simplify the use of the PointPillars sample we added the following improvements

- Removed the need to download model files manually. This happens now automatically via cmake
- Clean up of compiler flags


## Type of change

Please delete options that are not relevant. Add a 'X' to the one that is applicable. 

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Command Line