### PR TITLE
Update oneVPL samples to support 2021.2.2

### DIFF
--- a/Libraries/oneVPL/dpcpp-blur/README.md
+++ b/Libraries/oneVPL/dpcpp-blur/README.md
@@ -119,6 +119,10 @@ Perform the following steps:
 3. Right-click on the project in Solution Explorer and select Rebuild.
 4. From the top menu, select Debug -> Start without Debugging.
 
+***
+Note: You need Base Toolkit 2021.2 or later to build this sample with the IDE.
+***
+
 
 ## Running the Sample
 

--- a/Libraries/oneVPL/dpcpp-blur/dpcpp-blur.vcxproj
+++ b/Libraries/oneVPL/dpcpp-blur/dpcpp-blur.vcxproj
@@ -90,7 +90,7 @@
       <SubSystem>Console</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <AdditionalLibraryDirectories>$(VPLLIB);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
-      <AdditionalDependencies>libmfx.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>vpl.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <SuppressStartupBanner>false</SuppressStartupBanner>
     </Link>
   </ItemDefinitionGroup>
@@ -110,7 +110,7 @@
       <SubSystem>Console</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <AdditionalLibraryDirectories>$(VPLLIB);$(ONEAPI_ROOT)\vpl\latest\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
-      <AdditionalDependencies>libmfx.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>vpl.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <SuppressStartupBanner>false</SuppressStartupBanner>
     </Link>
   </ItemDefinitionGroup>
@@ -134,7 +134,7 @@
       <OptimizeReferences>true</OptimizeReferences>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <AdditionalLibraryDirectories>$(VPLLIB);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
-      <AdditionalDependencies>libmfx.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>vpl.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <SuppressStartupBanner>false</SuppressStartupBanner>
     </Link>
   </ItemDefinitionGroup>
@@ -158,7 +158,7 @@
       <OptimizeReferences>true</OptimizeReferences>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <AdditionalLibraryDirectories>$(VPLLIB);$(ONEAPI_ROOT)\vpl\latest\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
-      <AdditionalDependencies>libmfx.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>vpl.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <SuppressStartupBanner>false</SuppressStartupBanner>
     </Link>
   </ItemDefinitionGroup>

--- a/Libraries/oneVPL/dpcpp-blur/src/dpcpp-blur.cpp
+++ b/Libraries/oneVPL/dpcpp-blur/src/dpcpp-blur.cpp
@@ -140,12 +140,13 @@ int main(int argc, char *argv[]) {
     mfxLoader loader                    = NULL;
     mfxConfig cfg                       = NULL;
     mfxVariant impl_value               = {};
+    mfxVariant filter_value             = {};
     mfxSession session                  = NULL;
     mfxU16 input_width                  = 0;
     mfxU16 input_height                 = 0;
     mfxU16 out_width                    = 0;
     mfxU16 out_height                   = 0;
-    mfxVideoParam vpp_params            = { 0 };
+    mfxVideoParam vpp_params            = {};
     mfxFrameAllocRequest vpp_request[2] = {};
     mfxU16 num_surfaces_in              = 0;
     mfxU16 num_surfaces_out             = 0;
@@ -154,11 +155,13 @@ int main(int argc, char *argv[]) {
     mfxFrameSurface1 *vpp_surfaces_in   = NULL;
     mfxFrameSurface1 *vpp_surfaces_out  = NULL;
     int available_surface_index         = 0;
-    mfxSyncPoint syncp                  = { 0 };
+    mfxSyncPoint syncp                  = {};
     mfxU32 framenum                     = 0;
     bool is_draining                    = false;
     bool is_stillgoing                  = true;
-    mfxU16 i;
+    mfxU16 i                            = 0;
+    int implIdx                         = 0;
+    mfxImplDescription *idesc           = NULL;
 
 #ifdef __SYCL_COMPILER_VERSION
     printf("\n! DPCPP blur feature enabled\n\n");
@@ -202,15 +205,41 @@ int main(int argc, char *argv[]) {
     cfg = MFXCreateConfig(loader);
     VERIFY(NULL != cfg, "MFXCreateConfig failed")
 
-    impl_value.Type     = MFX_VARIANT_TYPE_U32;
-    impl_value.Data.U32 = MFX_EXTBUFF_VPP_SCALING;
-    sts                 = MFXSetConfigFilterProperty(
+    filter_value.Type     = MFX_VARIANT_TYPE_U32;
+    filter_value.Data.U32 = MFX_EXTBUFF_VPP_SCALING;
+    sts                   = MFXSetConfigFilterProperty(
         cfg,
         (mfxU8 *)"mfxImplDescription.mfxVPPDescription.filter.FilterFourCC",
-        impl_value);
-    VERIFY(MFX_ERR_NONE == sts, "MFXSetConfigFilterProperty failed");
+        filter_value);
+    VERIFY(MFX_ERR_NONE == sts, "MFXSetConfigFilterProperty failed for filter");
 
-    sts = MFXCreateSession(loader, 0, &session);
+    // Find first implementation which supports 2.0 API
+    while (true) {
+        sts = MFXEnumImplementations(loader,
+                                     implIdx,
+                                     MFX_IMPLCAPS_IMPLDESCSTRUCTURE,
+                                     (mfxHDL *)&idesc);
+
+        if (sts != MFX_ERR_NONE)
+            break;
+
+        if (idesc) {
+            printf("Found ApiVersion: %hu.%hu  ", idesc->ApiVersion.Major, idesc->ApiVersion.Minor);
+            printf("   \t%s ", (idesc->Impl == MFX_IMPL_TYPE_SOFTWARE) ? "SW" : "HW");
+
+            if (idesc->ApiVersion.Major >= 2) {
+                sts = MFXCreateSession(loader, implIdx, &session);
+                printf("  session created\n");
+                MFXDispReleaseImplDescription(loader, idesc);
+                break;
+            }
+            else {
+                printf("  skip\n");
+                MFXDispReleaseImplDescription(loader, idesc);
+            }
+        }
+        implIdx++;
+    }
     VERIFY(MFX_ERR_NONE == sts, "Not able to create VPL session supporting VPP");
 
     // Initialize VPP parameters
@@ -378,6 +407,7 @@ end:
     // Clean up resources - It is recommended to close components first, before
     // releasing allocated surfaces, since some surfaces may still be locked by
     // internal resources.
+
     if (loader)
         MFXUnload(loader);
 

--- a/Libraries/oneVPL/hello-decode/CMakeLists.txt
+++ b/Libraries/oneVPL/hello-decode/CMakeLists.txt
@@ -3,7 +3,7 @@ project(hello-decode)
 
 set(TARGET hello-decode)
 set(SOURCES src/hello-decode.cpp)
-set(VPL_NAME mfx)
+
 set(RUNARGS ${CMAKE_CURRENT_SOURCE_DIR}/content/cars_128x96.h265)
 
 # Set default build type to RelWithDebInfo if not specified

--- a/Libraries/oneVPL/hello-decode/README.md
+++ b/Libraries/oneVPL/hello-decode/README.md
@@ -114,6 +114,10 @@ Perform the following steps:
 3. Right-click on the project in Solution Explorer and select Rebuild.
 4. From the top menu, select Debug -> Start without Debugging.
 
+***
+Note: You need Base Toolkit 2021.2 or later to build this sample with the IDE.
+***
+
 
 ## Running the Sample
 

--- a/Libraries/oneVPL/hello-decode/hello-decode.vcxproj
+++ b/Libraries/oneVPL/hello-decode/hello-decode.vcxproj
@@ -90,7 +90,7 @@
       <SubSystem>Console</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <AdditionalLibraryDirectories>$(VPLLIB);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
-      <AdditionalDependencies>libmfx.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>vpl.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <SuppressStartupBanner>false</SuppressStartupBanner>
     </Link>
   </ItemDefinitionGroup>
@@ -110,7 +110,7 @@
       <SubSystem>Console</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <AdditionalLibraryDirectories>$(VPLLIB);$(ONEAPI_ROOT)\vpl\latest\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
-      <AdditionalDependencies>libmfx.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>vpl.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <SuppressStartupBanner>false</SuppressStartupBanner>
     </Link>
   </ItemDefinitionGroup>
@@ -134,7 +134,7 @@
       <OptimizeReferences>true</OptimizeReferences>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <AdditionalLibraryDirectories>$(VPLLIB);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
-      <AdditionalDependencies>libmfx.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>vpl.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <SuppressStartupBanner>false</SuppressStartupBanner>
     </Link>
   </ItemDefinitionGroup>
@@ -158,7 +158,7 @@
       <OptimizeReferences>true</OptimizeReferences>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <AdditionalLibraryDirectories>$(VPLLIB);$(ONEAPI_ROOT)\vpl\latest\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
-      <AdditionalDependencies>libmfx.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>vpl.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <SuppressStartupBanner>false</SuppressStartupBanner>
     </Link>
   </ItemDefinitionGroup>

--- a/Libraries/oneVPL/hello-decode/src/hello-decode.cpp
+++ b/Libraries/oneVPL/hello-decode/src/hello-decode.cpp
@@ -57,14 +57,17 @@ int main(int argc, char *argv[]) {
     mfxStatus sts                     = MFX_ERR_NONE;
     mfxLoader loader                  = NULL;
     mfxConfig cfg                     = NULL;
-    mfxVariant impl_value             = { 0 };
+    mfxVariant impl_value             = {};
+    mfxVariant codec_value            = {};
     mfxSession session                = NULL;
-    mfxBitstream bitstream            = { 0 };
+    mfxBitstream bitstream            = {};
     mfxFrameSurface1 *dec_surface_out = NULL;
-    mfxSyncPoint syncp                = { 0 };
+    mfxSyncPoint syncp                = {};
     mfxU32 framenum                   = 0;
     bool is_draining                  = false;
     bool is_stillgoing                = true;
+    int implIdx                       = 0;
+    mfxImplDescription *idesc         = NULL;
 
     // Setup input and output files
     in_filename = ValidateFileName(argv[1]);
@@ -83,16 +86,42 @@ int main(int argc, char *argv[]) {
     cfg = MFXCreateConfig(loader);
     VERIFY(NULL != cfg, "MFXCreateConfig failed")
 
-    impl_value.Type     = MFX_VARIANT_TYPE_U32;
-    impl_value.Data.U32 = MFX_CODEC_HEVC;
-    sts                 = MFXSetConfigFilterProperty(
+    codec_value.Type     = MFX_VARIANT_TYPE_U32;
+    codec_value.Data.U32 = MFX_CODEC_HEVC;
+    sts                  = MFXSetConfigFilterProperty(
         cfg,
         (mfxU8 *)"mfxImplDescription.mfxDecoderDescription.decoder.CodecID",
-        impl_value);
-    VERIFY(MFX_ERR_NONE == sts, "MFXSetConfigFilterProperty failed");
+        codec_value);
+    VERIFY(MFX_ERR_NONE == sts, "MFXSetConfigFilterProperty failed for codec");
 
-    sts = MFXCreateSession(loader, 0, &session);
-    VERIFY(MFX_ERR_NONE == sts, "Not able to create VPL session supporting HEVC/H265 decode");
+    // Find first implementation which supports 2.0 API
+    while (true) {
+        sts = MFXEnumImplementations(loader,
+                                     implIdx,
+                                     MFX_IMPLCAPS_IMPLDESCSTRUCTURE,
+                                     (mfxHDL *)&idesc);
+
+        if (sts != MFX_ERR_NONE)
+            break;
+
+        if (idesc) {
+            printf("Found ApiVersion: %hu.%hu  ", idesc->ApiVersion.Major, idesc->ApiVersion.Minor);
+            printf("   \t%s ", (idesc->Impl == MFX_IMPL_TYPE_SOFTWARE) ? "SW" : "HW");
+
+            if (idesc->ApiVersion.Major >= 2) {
+                sts = MFXCreateSession(loader, implIdx, &session);
+                printf("  session created\n");
+                MFXDispReleaseImplDescription(loader, idesc);
+                break;
+            }
+            else {
+                printf("  skip\n");
+                MFXDispReleaseImplDescription(loader, idesc);
+            }
+        }
+        implIdx++;
+    }
+    VERIFY(MFX_ERR_NONE == sts, "Not able to create 2.x VPL session supporting HEVC/H265 decode");
 
     // Prepare input bitstream and start decoding
     bitstream.MaxLength = BITSTREAM_BUFFER_SIZE;
@@ -184,6 +213,7 @@ end:
     // Clean up resources - It is recommended to close components first, before
     // releasing allocated surfaces, since some surfaces may still be locked by
     // internal resources.
+
     if (loader)
         MFXUnload(loader);
 

--- a/Libraries/oneVPL/hello-encode/README.md
+++ b/Libraries/oneVPL/hello-encode/README.md
@@ -114,6 +114,10 @@ Perform the following steps:
 3. Right-click on the project in Solution Explorer and select Rebuild.
 4. From the top menu, select Debug -> Start without Debugging.
 
+***
+Note: You need Base Toolkit 2021.2 or later to build this sample with the IDE.
+***
+
 
 ## Running the Sample
 

--- a/Libraries/oneVPL/hello-encode/hello-encode.vcxproj
+++ b/Libraries/oneVPL/hello-encode/hello-encode.vcxproj
@@ -90,7 +90,7 @@
       <SubSystem>Console</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <AdditionalLibraryDirectories>$(VPLLIB);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
-      <AdditionalDependencies>libmfx.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>vpl.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <SuppressStartupBanner>false</SuppressStartupBanner>
     </Link>
   </ItemDefinitionGroup>
@@ -110,7 +110,7 @@
       <SubSystem>Console</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <AdditionalLibraryDirectories>$(VPLLIB);$(ONEAPI_ROOT)\vpl\latest\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
-      <AdditionalDependencies>libmfx.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>vpl.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <SuppressStartupBanner>false</SuppressStartupBanner>
     </Link>
   </ItemDefinitionGroup>
@@ -134,7 +134,7 @@
       <OptimizeReferences>true</OptimizeReferences>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <AdditionalLibraryDirectories>$(VPLLIB);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
-      <AdditionalDependencies>libmfx.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>vpl.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <SuppressStartupBanner>false</SuppressStartupBanner>
     </Link>
   </ItemDefinitionGroup>
@@ -158,7 +158,7 @@
       <OptimizeReferences>true</OptimizeReferences>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <AdditionalLibraryDirectories>$(VPLLIB);$(ONEAPI_ROOT)\vpl\latest\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
-      <AdditionalDependencies>libmfx.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>vpl.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <SuppressStartupBanner>false</SuppressStartupBanner>
     </Link>
   </ItemDefinitionGroup>

--- a/Libraries/oneVPL/hello-vpp/README.md
+++ b/Libraries/oneVPL/hello-vpp/README.md
@@ -18,6 +18,8 @@ I420 format video elementary stream as an argument, processes it with oneVPL and
 writes the resized output to `out.i420` in I420 raw video format.
 
 
+## Key Implementation details
+
 | Configuration     | Default setting
 | ----------------- | ----------------------------------
 | Target device     | CPU
@@ -31,6 +33,7 @@ Code samples are licensed under the MIT license. See
 [License.txt](https://github.com/oneapi-src/oneAPI-samples/blob/master/License.txt) for details.
 
 Third party program Licenses can be found here: [third-party-programs.txt](https://github.com/oneapi-src/oneAPI-samples/blob/master/third-party-programs.txt)
+
 
 ## Building the `hello-vpp` Program
 
@@ -103,10 +106,49 @@ Perform the following steps:
 
 
 ### On a Windows* System Using Visual Studio* Version 2017 or Newer
-- Build the program using VS2017 or VS2019
-    - Right-click on the solution file and open using either VS2017 or VS2019 IDE.
-    - Right-click on the project in Solution Explorer and select Rebuild.
-    - From the top menu, select Debug -> Start without Debugging.
+
+#### Building the program using CMake
+
+1. Install the prerequisite software. To build and run the sample, you need to
+   install prerequisite software and set up your environment:
+
+   - Intel® oneAPI Base Toolkit for Windows*
+   - [CMake](https://cmake.org)
+
+2. Set up your environment using the following command.
+   ```
+   <oneapi_install_dir>\setvars.bat
+   ```
+   Here `<oneapi_install_dir>` represents the root folder of your oneAPI
+   installation, which is `C:\Program Files (x86)\Intel\oneAPI\`
+   when installed using default options. If you customized the installation
+   folder, the `setvars.bat` is in your custom location.  Note that if a
+   compiler is not part of your oneAPI installation, you should run in a Visual
+   Studio 64-bit command prompt.
+
+3. Build the program using the following commands:
+   ```
+   mkdir build
+   cd build
+   cmake ..
+   cmake --build .
+   ```
+
+4. Run the program using the following command:
+   ```
+   cmake --build . --target run
+   ```
+
+#### Building the program using VS2017 or VS2019 IDE
+
+1. Install the Intel® oneAPI Base Toolkit for Windows*
+2. Right-click on the solution file and open using either VS2017 or VS2019 IDE.
+3. Right-click on the project in Solution Explorer and select Rebuild.
+4. From the top menu, select Debug -> Start without Debugging.
+
+***
+Note: You need Base Toolkit 2021.2 or later to build this sample with the IDE.
+***
 
 ## Running the Sample
 

--- a/Libraries/oneVPL/hello-vpp/hello-vpp.vcxproj
+++ b/Libraries/oneVPL/hello-vpp/hello-vpp.vcxproj
@@ -90,7 +90,7 @@
       <SubSystem>Console</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <AdditionalLibraryDirectories>$(VPLLIB);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
-      <AdditionalDependencies>libmfx.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>vpl.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <SuppressStartupBanner>false</SuppressStartupBanner>
     </Link>
   </ItemDefinitionGroup>
@@ -110,7 +110,7 @@
       <SubSystem>Console</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <AdditionalLibraryDirectories>$(VPLLIB);$(ONEAPI_ROOT)\vpl\latest\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
-      <AdditionalDependencies>libmfx.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>vpl.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <SuppressStartupBanner>false</SuppressStartupBanner>
     </Link>
   </ItemDefinitionGroup>
@@ -134,7 +134,7 @@
       <OptimizeReferences>true</OptimizeReferences>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <AdditionalLibraryDirectories>$(VPLLIB);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
-      <AdditionalDependencies>libmfx.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>vpl.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <SuppressStartupBanner>false</SuppressStartupBanner>
     </Link>
   </ItemDefinitionGroup>
@@ -158,7 +158,7 @@
       <OptimizeReferences>true</OptimizeReferences>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <AdditionalLibraryDirectories>$(VPLLIB);$(ONEAPI_ROOT)\vpl\latest\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
-      <AdditionalDependencies>libmfx.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>vpl.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <SuppressStartupBanner>false</SuppressStartupBanner>
     </Link>
   </ItemDefinitionGroup>


### PR DESCRIPTION
This is coupled with 2021.2.2 component release.

# Description

Import lib name has been changed for oneVPL 2021.2.2.  This impacts solution files since they require explicit file names to find libraries as opposed to using package configuration methods.

Ensure implementation supports 2.0 API

The oneVPL dispatcher has been extended to support hardware implementations with API versions lower than 2.0. Samples now correctly follow the oneVPL specification and check for implementation capabilities explicitly instead of assuming the first implementation found supports API 2.0.

# How Has This Been Tested?

- [x] Visual Studio
- [x] CMake 



