### PR TITLE
[QRD-FPGA] Correctly pass the floating point optimization flag to FPGA compile step.

### DIFF
--- a/DirectProgramming/DPC++FPGA/ReferenceDesigns/qrd/src/CMakeLists.txt
+++ b/DirectProgramming/DPC++FPGA/ReferenceDesigns/qrd/src/CMakeLists.txt
@@ -52,7 +52,7 @@ else()
     message(STATUS "\tAn invalid board name was passed in using the FPGA_BOARD flag. Configuring the design to run on the Intel(R) Programmable Acceleration Card (PAC) with Intel Arria(R) 10 GX FPGA. Please refer to the README for the list of valid board names.")
 endif()
 
-set(HARDWARE_COMPILE_FLAGS -fintelfpga -c -DFIXED_ITERATIONS=${FIXED_ITERATIONS} -DROWS_COMPONENT=${ROWS_COMPONENT} -DCOLS_COMPONENT=${COLS_COMPONENT})
+set(HARDWARE_COMPILE_FLAGS -fintelfpga -c -fno-fast-math -DFIXED_ITERATIONS=${FIXED_ITERATIONS} -DROWS_COMPONENT=${ROWS_COMPONENT} -DCOLS_COMPONENT=${COLS_COMPONENT})
 
 # use cmake -D USER_HARDWARE_FLAGS=<flags> to set extra flags for FPGA backend compilation
 separate_arguments(USER_HARDWARE_FLAGS)


### PR DESCRIPTION
Signed-off-by: Abhishek Tiwari <abhishek2.tiwari@intel.com>

# Description
The -fno-fast-math flag was not being propagated to the required sub-commands of the multi-command sequence that generates the FPGA bitstream.
 
This change is a simple fix, it adds the flag to the right Cmake variable to ensure that it is correctly passed to all the commands. 

Without this fix the generated FPGA binary will not achieve the advertised performance on the Arria10 PAC board.

## Type of change

- [ X ] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [ X ] Command Line
- [ X ] oneapi-cli
