### PR TITLE
CMake cleanup + add Agilex support to FPGA samples

### DIFF
--- a/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/buffered_host_streaming/CMakeLists.txt
+++ b/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/buffered_host_streaming/CMakeLists.txt
@@ -1,11 +1,17 @@
-set(CMAKE_CXX_COMPILER "dpcpp")
-if(WIN32)
-    set(CMAKE_C_COMPILER "clang-cl")
+if(UNIX)
+    # Direct CMake to use dpcpp rather than the default C++ compiler/linker
+    set(CMAKE_CXX_COMPILER dpcpp)
+else() # Windows
+    # Force CMake to use dpcpp rather than the default C++ compiler/linker
+    # (needed on Windows only)
+    include (CMakeForceCompiler)
+    CMAKE_FORCE_CXX_COMPILER (dpcpp IntelDPCPP)
+    include (Platform/Windows-Clang)
 endif()
 
-cmake_minimum_required (VERSION 2.8)
+cmake_minimum_required (VERSION 3.4)
 
-project(BufferedHostStreaming)
+project(BufferedHostStreaming CXX)
 
 set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})
 set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})

--- a/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/buffered_host_streaming/src/CMakeLists.txt
+++ b/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/buffered_host_streaming/src/CMakeLists.txt
@@ -1,3 +1,6 @@
+# To see a Makefile equivalent of this build system:
+# https://github.com/oneapi-src/oneAPI-samples/blob/master/DirectProgramming/DPC++/ProjectTemplates/makefile-fpga
+
 set(SOURCE_FILE buffered_host_streaming.cpp)
 set(TARGET_NAME buffered_host_streaming)
 set(EMULATOR_TARGET ${TARGET_NAME}.fpga_emu)
@@ -5,67 +8,62 @@ set(FPGA_TARGET ${TARGET_NAME}.fpga)
 set(REPORTS_TARGET ${TARGET_NAME}_report)
 
 # USM is only supported on the PAC S10 board
-set(S10_PAC_USM_BOARD_NAME "intel_s10sx_pac:pac_s10_usm")
+set(FPGA_BOARD "intel_s10sx_pac:pac_s10_usm")
 
-# Flags
-if(WIN32)
-    set(THREAD_FLAG "")
-else()
+if(UNIX)
     set(THREAD_FLAG "-lpthread")
+else() # Windows
+    set(WIN_FLAG "/EHsc") # This is a Windows-specific flag that enables exception handling in host code
 endif()
 
-set(EMULATOR_COMPILE_FLAGS "-fintelfpga -Wall -DFPGA_EMULATOR")
+# A DPC++ ahead-of-time (AoT) compile processes the device code in two stages.
+# 1. The "compile" stage compiles the device code to an intermediate representation (SPIR-V).
+# 2. The "link" stage invokes the compiler's FPGA backend before linking.
+#    For this reason, FPGA backend flags must be passed as link flags in CMake.
+set(EMULATOR_COMPILE_FLAGS "${WIN_FLAG} -fintelfpga -Wall -DFPGA_EMULATOR")
 set(EMULATOR_LINK_FLAGS "-fintelfpga ${THREAD_FLAG}")
-set(HARDWARE_COMPILE_FLAGS "-fintelfpga -c")
-set(HARDWARE_LINK_FLAGS "-fintelfpga ${THREAD_FLAG} -Wall -Xshardware -Xsboard=${S10_PAC_USM_BOARD_NAME} -reuse-exe=${CMAKE_BINARY_DIR}/${FPGA_TARGET} ${USER_HARDWARE_FLAGS}")
+set(HARDWARE_COMPILE_FLAGS "${WIN_FLAG} -fintelfpga")
+set(HARDWARE_LINK_FLAGS "-fintelfpga ${THREAD_FLAG} -Wall -Xshardware -Xsboard=${FPGA_BOARD} ${USER_HARDWARE_FLAGS}")
 # use cmake -D USER_HARDWARE_FLAGS=<flags> to set extra flags for FPGA backend compilation
 
+###############################################################################
+### FPGA Emulator
+###############################################################################
+# To compile in a single command:
+#    dpcpp -fintelfpga -DFPGA_EMULATOR buffered_host_streaming.cpp -o buffered_host_streaming.fpga_emu
+# CMake executes:
+#    [compile] dpcpp -fintelfpga -DFPGA_EMULATOR -o buffered_host_streaming.cpp.o -c buffered_host_streaming.cpp
+#    [link]    dpcpp -fintelfpga buffered_host_streaming.cpp.o -o buffered_host_streaming.fpga_emu
+add_executable(${EMULATOR_TARGET} ${SOURCE_FILE}) # CMake automatically adds #include'd headers to the dependency list
+set_target_properties(${EMULATOR_TARGET} PROPERTIES COMPILE_FLAGS "${EMULATOR_COMPILE_FLAGS}")
+set_target_properties(${EMULATOR_TARGET} PROPERTIES LINK_FLAGS "${EMULATOR_LINK_FLAGS}")
+add_custom_target(fpga_emu DEPENDS ${EMULATOR_TARGET})
 
-# FPGA emulator
-if(WIN32)
-    set(WIN_EMULATOR_TARGET ${EMULATOR_TARGET}.exe)
-    add_custom_target(fpga_emu DEPENDS ${WIN_EMULATOR_TARGET})
-    separate_arguments(WIN_EMULATOR_COMPILE_FLAGS WINDOWS_COMMAND "${EMULATOR_COMPILE_FLAGS}")
-    add_custom_command(OUTPUT ${WIN_EMULATOR_TARGET} 
-                       COMMAND ${CMAKE_CXX_COMPILER} /EHsc ${WIN_EMULATOR_COMPILE_FLAGS} ${CMAKE_CURRENT_SOURCE_DIR}/${SOURCE_FILE} -o ${CMAKE_BINARY_DIR}/${WIN_EMULATOR_TARGET}
-                       DEPENDS ${SOURCE_FILE})
-else()
-    add_executable(${EMULATOR_TARGET} ${SOURCE_FILE})
-    add_custom_target(fpga_emu DEPENDS ${EMULATOR_TARGET})
-    set_target_properties(${EMULATOR_TARGET} PROPERTIES COMPILE_FLAGS ${EMULATOR_COMPILE_FLAGS})
-    set_target_properties(${EMULATOR_TARGET} PROPERTIES LINK_FLAGS ${EMULATOR_LINK_FLAGS})
-endif()
+###############################################################################
+### Generate Report
+###############################################################################
+# To compile manually:
+#   dpcpp -fintelfpga -Xshardware -Xsboard=<FPGA_BOARD> -fsycl-link=early buffered_host_streaming.cpp -o buffered_host_streaming_report.a
+set(FPGA_EARLY_IMAGE ${TARGET_NAME}_report.a)
+# The compile output is not an executable, but an intermediate compilation result unique to DPC++.
+add_executable(${FPGA_EARLY_IMAGE} ${SOURCE_FILE})
+add_custom_target(report DEPENDS ${FPGA_EARLY_IMAGE})
+set_target_properties(${FPGA_EARLY_IMAGE} PROPERTIES COMPILE_FLAGS "${HARDWARE_COMPILE_FLAGS}")
+set_target_properties(${FPGA_EARLY_IMAGE} PROPERTIES LINK_FLAGS "${HARDWARE_LINK_FLAGS} -fsycl-link=early")
+# fsycl-link=early stops the compiler after RTL generation, before invoking Quartus
 
-# FPGA hardware
-if(WIN32)
-    add_custom_target(fpga COMMAND echo "An FPGA hardware target is not provided on Windows. See README for details.")
-else()
-    add_executable(${FPGA_TARGET} EXCLUDE_FROM_ALL ${SOURCE_FILE})
-    add_custom_target(fpga DEPENDS ${FPGA_TARGET})
-    set_target_properties(${FPGA_TARGET} PROPERTIES COMPILE_FLAGS ${HARDWARE_COMPILE_FLAGS})
-    set_target_properties(${FPGA_TARGET} PROPERTIES LINK_FLAGS ${HARDWARE_LINK_FLAGS})
-endif()
-
-# FPGA hardware report
-if(WIN32)
-    set(DEVICE_OBJ_FILE ${TARGET_NAME}_report.a)
-    add_custom_target(report DEPENDS ${DEVICE_OBJ_FILE})
-    separate_arguments(HARDWARE_LINK_FLAGS_LIST WINDOWS_COMMAND "${HARDWARE_LINK_FLAGS}")
-    add_custom_command(OUTPUT ${DEVICE_OBJ_FILE} 
-                       COMMAND ${CMAKE_CXX_COMPILER} /EHsc ${HARDWARE_LINK_FLAGS_LIST} -fsycl-link ${CMAKE_CURRENT_SOURCE_DIR}/${SOURCE_FILE} -o ${CMAKE_BINARY_DIR}/${DEVICE_OBJ_FILE}
-                       DEPENDS ${SOURCE_FILE})
-else()
-    configure_file(${CMAKE_CURRENT_SOURCE_DIR}/${SOURCE_FILE} ${SOURCE_FILE} COPYONLY)
-    configure_file(${CMAKE_CURRENT_SOURCE_DIR}/common.hpp common.hpp COPYONLY)
-    configure_file(${CMAKE_CURRENT_SOURCE_DIR}/HostStreamer.hpp HostStreamer.hpp COPYONLY)
-    configure_file(${CMAKE_CURRENT_SOURCE_DIR}/streaming_with_api.hpp streaming_with_api.hpp COPYONLY)
-    configure_file(${CMAKE_CURRENT_SOURCE_DIR}/streaming_without_api.hpp streaming_without_api.hpp COPYONLY)
-
-    separate_arguments(HARDWARE_LINK_FLAGS_LIST UNIX_COMMAND "${HARDWARE_LINK_FLAGS}")
-    separate_arguments(CMAKE_CXX_FLAGS_LIST UNIX_COMMAND "${CMAKE_CXX_FLAGS}")
-    add_custom_command(OUTPUT ${REPORTS_TARGET}
-                       COMMAND ${CMAKE_CXX_COMPILER} ${CMAKE_CXX_FLAGS_LIST} ${HARDWARE_LINK_FLAGS_LIST} -fsycl-link ${SOURCE_FILE} -o ${CMAKE_BINARY_DIR}/${REPORTS_TARGET}
-                       DEPENDS ${SOURCE_FILE})
-    add_custom_target(report DEPENDS ${REPORTS_TARGET})
-endif()
+###############################################################################
+### FPGA Hardware
+###############################################################################
+# To compile in a single command:
+#   dpcpp -fintelfpga -Xshardware -Xsboard=<FPGA_BOARD> buffered_host_streaming.cpp -o buffered_host_streaming.fpga
+# CMake executes:
+#   [compile] dpcpp -fintelfpga -o buffered_host_streaming.cpp.o -c buffered_host_streaming.cpp
+#   [link]    dpcpp -fintelfpga -Xshardware -Xsboard=<FPGA_BOARD> buffered_host_streaming.cpp.o -o buffered_host_streaming.fpga
+add_executable(${FPGA_TARGET} EXCLUDE_FROM_ALL ${SOURCE_FILE})
+add_custom_target(fpga DEPENDS ${FPGA_TARGET})
+set_target_properties(${FPGA_TARGET} PROPERTIES COMPILE_FLAGS "${HARDWARE_COMPILE_FLAGS}")
+set_target_properties(${FPGA_TARGET} PROPERTIES LINK_FLAGS "${HARDWARE_LINK_FLAGS} -reuse-exe=${CMAKE_BINARY_DIR}/${FPGA_TARGET}")
+# The -reuse-exe flag enables rapid recompilation of host-only code changes.
+# See DPC++FPGA/GettingStarted/fast_recompile for details.
 

--- a/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/compute_units/CMakeLists.txt
+++ b/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/compute_units/CMakeLists.txt
@@ -1,11 +1,17 @@
-set(CMAKE_CXX_COMPILER "dpcpp")
-if(WIN32)
-    set(CMAKE_C_COMPILER "clang-cl")
+if(UNIX)
+    # Direct CMake to use dpcpp rather than the default C++ compiler/linker
+    set(CMAKE_CXX_COMPILER dpcpp)
+else() # Windows
+    # Force CMake to use dpcpp rather than the default C++ compiler/linker 
+    # (needed on Windows only)
+    include (CMakeForceCompiler)
+    CMAKE_FORCE_CXX_COMPILER (dpcpp IntelDPCPP)
+    include (Platform/Windows-Clang)
 endif()
 
-cmake_minimum_required (VERSION 2.8)
+cmake_minimum_required (VERSION 3.4)
 
-project(ComputeUnits)
+project(ComputeUnits CXX)
 
 set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})
 set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})

--- a/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/compute_units/src/CMakeLists.txt
+++ b/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/compute_units/src/CMakeLists.txt
@@ -1,77 +1,74 @@
+# To see a Makefile equivalent of this build system:
+# https://github.com/oneapi-src/oneAPI-samples/blob/master/DirectProgramming/DPC++/ProjectTemplates/makefile-fpga
+
 set(SOURCE_FILE compute_units.cpp)
 set(TARGET_NAME compute_units)
 set(EMULATOR_TARGET ${TARGET_NAME}.fpga_emu)
 set(FPGA_TARGET ${TARGET_NAME}.fpga)
 
 # FPGA board selection
-set(A10_PAC_BOARD_NAME "intel_a10gx_pac:pac_a10")
-set(S10_PAC_BOARD_NAME "intel_s10sx_pac:pac_s10")
-set(SELECTED_BOARD ${A10_PAC_BOARD_NAME})
-if (NOT DEFINED FPGA_BOARD)
-    message(STATUS "\tFPGA_BOARD was not specified. Configuring the design to run on the Intel(R) Programmable Acceleration Card (PAC) with Intel Arria(R) 10 GX FPGA. Please refer to the README for information on board selection.")
-elseif(FPGA_BOARD STREQUAL ${A10_PAC_BOARD_NAME})
-    message(STATUS "\tConfiguring the design to run on the Intel(R) Programmable Acceleration Card (PAC) with Intel Arria(R) 10 GX FPGA.")
-elseif(FPGA_BOARD STREQUAL ${S10_PAC_BOARD_NAME})
-    message(STATUS "\tConfiguring the design to run on the Intel(R) Programmable Acceleration Card (PAC) D5005 (with Intel Stratix(R) 10 SX FPGA).")
-    set(SELECTED_BOARD ${S10_PAC_BOARD_NAME})
+if(NOT DEFINED FPGA_BOARD)
+    set(FPGA_BOARD "intel_a10gx_pac:pac_a10")
+    message(STATUS "FPGA_BOARD was not specified.\
+                    \nConfiguring the design to run on the default FPGA board ${FPGA_BOARD} (Intel(R) PAC with Intel Arria(R) 10 GX FPGA). \
+                    \nPlease refer to the README for information on board selection.")
 else()
-    message(STATUS "\tAn invalid board name was passed in using the FPGA_BOARD flag. Configuring the design to run on the Intel(R) Programmable Acceleration Card (PAC) with Intel Arria(R) 10 GX FPGA. Please refer to the README for the list of valid board names.")
+    message(STATUS "Configuring the design to run on FPGA board ${FPGA_BOARD}")
 endif()
 
-# Flags
-set(EMULATOR_COMPILE_FLAGS "-fintelfpga -DFPGA_EMULATOR")
+# This is a Windows-specific flag that enables exception handling in host code
+if(WIN32)
+    set(WIN_FLAG "/EHsc")
+endif()
+
+# A DPC++ ahead-of-time (AoT) compile processes the device code in two stages.
+# 1. The "compile" stage compiles the device code to an intermediate representation (SPIR-V).
+# 2. The "link" stage invokes the compiler's FPGA backend before linking.
+#    For this reason, FPGA backend flags must be passed as link flags in CMake.
+set(EMULATOR_COMPILE_FLAGS "${WIN_FLAG} -fintelfpga -DFPGA_EMULATOR")
 set(EMULATOR_LINK_FLAGS "-fintelfpga")
-set(HARDWARE_COMPILE_FLAGS "-fintelfpga")
-set(HARDWARE_LINK_FLAGS "-fintelfpga -Xshardware -Xsboard=${SELECTED_BOARD} ${USER_HARDWARE_FLAGS}")
+set(HARDWARE_COMPILE_FLAGS "${WIN_FLAG} -fintelfpga")
+set(HARDWARE_LINK_FLAGS "-fintelfpga -Xshardware -Xsboard=${FPGA_BOARD} ${USER_HARDWARE_FLAGS}")
 # use cmake -D USER_HARDWARE_FLAGS=<flags> to set extra flags for FPGA backend compilation
 
+###############################################################################
+### FPGA Emulator
+###############################################################################
+# To compile in a single command:
+#    dpcpp -fintelfpga -DFPGA_EMULATOR compute_units.cpp -o compute_units.fpga_emu
+# CMake executes:
+#    [compile] dpcpp -fintelfpga -DFPGA_EMULATOR -o compute_units.cpp.o -c compute_units.cpp
+#    [link]    dpcpp -fintelfpga compute_units.cpp.o -o compute_units.fpga_emu
+add_executable(${EMULATOR_TARGET} ${SOURCE_FILE}) # CMake automatically adds #include'd headers to the dependency list
+set_target_properties(${EMULATOR_TARGET} PROPERTIES COMPILE_FLAGS "${EMULATOR_COMPILE_FLAGS}")
+set_target_properties(${EMULATOR_TARGET} PROPERTIES LINK_FLAGS "${EMULATOR_LINK_FLAGS}")
+add_custom_target(fpga_emu DEPENDS ${EMULATOR_TARGET})
 
-# FPGA emulator
-if(WIN32)
-    set(WIN_EMULATOR_TARGET ${EMULATOR_TARGET}.exe)
-    add_custom_target(fpga_emu DEPENDS ${WIN_EMULATOR_TARGET})
-    separate_arguments(WIN_EMULATOR_COMPILE_FLAGS WINDOWS_COMMAND "${EMULATOR_COMPILE_FLAGS}")
-    add_custom_command(OUTPUT ${WIN_EMULATOR_TARGET} 
-                       COMMAND ${CMAKE_CXX_COMPILER} /EHsc ${WIN_EMULATOR_COMPILE_FLAGS} ${CMAKE_CURRENT_SOURCE_DIR}/${SOURCE_FILE} -o ${CMAKE_BINARY_DIR}/${WIN_EMULATOR_TARGET}
-                       DEPENDS ${SOURCE_FILE})
-else()
-    add_executable(${EMULATOR_TARGET} ${SOURCE_FILE})
-    add_custom_target(fpga_emu DEPENDS ${EMULATOR_TARGET})
-    set_target_properties(${EMULATOR_TARGET} PROPERTIES COMPILE_FLAGS ${EMULATOR_COMPILE_FLAGS})
-    set_target_properties(${EMULATOR_TARGET} PROPERTIES LINK_FLAGS ${EMULATOR_LINK_FLAGS})
-endif()
+###############################################################################
+### Generate Report
+###############################################################################
+# To compile manually:
+#   dpcpp -fintelfpga -Xshardware -Xsboard=<FPGA_BOARD> -fsycl-link=early compute_units.cpp -o compute_units_report.a
+set(FPGA_EARLY_IMAGE ${TARGET_NAME}_report.a)
+# The compile output is not an executable, but an intermediate compilation result unique to DPC++.
+add_executable(${FPGA_EARLY_IMAGE} ${SOURCE_FILE})
+add_custom_target(report DEPENDS ${FPGA_EARLY_IMAGE})
+set_target_properties(${FPGA_EARLY_IMAGE} PROPERTIES COMPILE_FLAGS "${HARDWARE_COMPILE_FLAGS}")
+set_target_properties(${FPGA_EARLY_IMAGE} PROPERTIES LINK_FLAGS "${HARDWARE_LINK_FLAGS} -fsycl-link=early")
+# fsycl-link=early stops the compiler after RTL generation, before invoking Quartus
 
-# FPGA hardware
-if(WIN32)
-    add_custom_target(fpga COMMAND echo "An FPGA hardware target is not provided on Windows. See README for details.")
-else()
-    add_executable(${FPGA_TARGET} EXCLUDE_FROM_ALL ${SOURCE_FILE})
-    add_custom_target(fpga DEPENDS ${FPGA_TARGET})
-    set_target_properties(${FPGA_TARGET} PROPERTIES COMPILE_FLAGS ${HARDWARE_COMPILE_FLAGS})
-    set_target_properties(${FPGA_TARGET} PROPERTIES LINK_FLAGS ${HARDWARE_LINK_FLAGS})
-endif()
+###############################################################################
+### FPGA Hardware
+###############################################################################
+# To compile in a single command:
+#   dpcpp -fintelfpga -Xshardware -Xsboard=<FPGA_BOARD> compute_units.cpp -o compute_units.fpga
+# CMake executes:
+#   [compile] dpcpp -fintelfpga -o compute_units.cpp.o -c compute_units.cpp
+#   [link]    dpcpp -fintelfpga -Xshardware -Xsboard=<FPGA_BOARD> compute_units.cpp.o -o compute_units.fpga
+add_executable(${FPGA_TARGET} EXCLUDE_FROM_ALL ${SOURCE_FILE})
+add_custom_target(fpga DEPENDS ${FPGA_TARGET})
+set_target_properties(${FPGA_TARGET} PROPERTIES COMPILE_FLAGS "${HARDWARE_COMPILE_FLAGS}")
+set_target_properties(${FPGA_TARGET} PROPERTIES LINK_FLAGS "${HARDWARE_LINK_FLAGS} -reuse-exe=${CMAKE_BINARY_DIR}/${FPGA_TARGET}")
 
-# Generate report
-if(WIN32)
-    set(DEVICE_OBJ_FILE ${TARGET_NAME}_report.a)
-    add_custom_target(report DEPENDS ${DEVICE_OBJ_FILE})
-    separate_arguments(HARDWARE_LINK_FLAGS_LIST WINDOWS_COMMAND "${HARDWARE_LINK_FLAGS}")
-    add_custom_command(OUTPUT ${DEVICE_OBJ_FILE} 
-                       COMMAND ${CMAKE_CXX_COMPILER} /EHsc ${HARDWARE_LINK_FLAGS_LIST} -fsycl-link ${CMAKE_CURRENT_SOURCE_DIR}/${SOURCE_FILE} -o ${CMAKE_BINARY_DIR}/${DEVICE_OBJ_FILE}
-                       DEPENDS ${SOURCE_FILE} compute_units.hpp pipe_array.hpp unroller.hpp pipe_array_internal.hpp)
-else()
-    set(DEVICE_OBJ_FILE ${TARGET_NAME}_report.a)
-    add_custom_target(report DEPENDS ${DEVICE_OBJ_FILE})
-
-    configure_file(${CMAKE_CURRENT_SOURCE_DIR}/${SOURCE_FILE} ${SOURCE_FILE} COPYONLY)
-    configure_file(${CMAKE_CURRENT_SOURCE_DIR}/compute_units.hpp compute_units.hpp COPYONLY)
-    configure_file(${CMAKE_CURRENT_SOURCE_DIR}/pipe_array.hpp pipe_array.hpp COPYONLY)
-    configure_file(${CMAKE_CURRENT_SOURCE_DIR}/unroller.hpp unroller.hpp COPYONLY)
-    configure_file(${CMAKE_CURRENT_SOURCE_DIR}/pipe_array_internal.hpp pipe_array_internal.hpp COPYONLY)
-
-    separate_arguments(HARDWARE_LINK_FLAGS_LIST UNIX_COMMAND "${HARDWARE_LINK_FLAGS}")
-    separate_arguments(CMAKE_CXX_FLAGS_LIST UNIX_COMMAND "${CMAKE_CXX_FLAGS}")
-    add_custom_command(OUTPUT ${DEVICE_OBJ_FILE} 
-                    COMMAND ${CMAKE_CXX_COMPILER} ${CMAKE_CXX_FLAGS_LIST} ${HARDWARE_LINK_FLAGS_LIST} -fsycl-link ${SOURCE_FILE} -o ${CMAKE_BINARY_DIR}/${DEVICE_OBJ_FILE}
-                    DEPENDS ${SOURCE_FILE} compute_units.hpp pipe_array.hpp unroller.hpp pipe_array_internal.hpp)
-endif()
+# The -reuse-exe flag enables rapid recompilation of host-only code changes.
+# See DPC++FPGA/GettingStarted/fast_recompile for details.

--- a/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/double_buffering/CMakeLists.txt
+++ b/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/double_buffering/CMakeLists.txt
@@ -1,11 +1,17 @@
-set(CMAKE_CXX_COMPILER "dpcpp")
-if(WIN32)
-    set(CMAKE_C_COMPILER "clang-cl")
+if(UNIX)
+    # Direct CMake to use dpcpp rather than the default C++ compiler/linker
+    set(CMAKE_CXX_COMPILER dpcpp)
+else() # Windows
+    # Force CMake to use dpcpp rather than the default C++ compiler/linker 
+    # (needed on Windows only)
+    include (CMakeForceCompiler)
+    CMAKE_FORCE_CXX_COMPILER (dpcpp IntelDPCPP)
+    include (Platform/Windows-Clang)
 endif()
 
-cmake_minimum_required (VERSION 2.8)
+cmake_minimum_required (VERSION 3.4)
 
-project(DoubleBuffering)
+project(DoubleBuffering CXX)
 
 set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})
 set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})

--- a/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/double_buffering/src/CMakeLists.txt
+++ b/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/double_buffering/src/CMakeLists.txt
@@ -1,72 +1,73 @@
+# To see a Makefile equivalent of this build system:
+# https://github.com/oneapi-src/oneAPI-samples/blob/master/DirectProgramming/DPC++/ProjectTemplates/makefile-fpga
+
 set(SOURCE_FILE double_buffering.cpp)
 set(TARGET_NAME double_buffering)
-
 set(EMULATOR_TARGET ${TARGET_NAME}.fpga_emu)
 set(FPGA_TARGET ${TARGET_NAME}.fpga)
 
 # FPGA board selection
-set(A10_PAC_BOARD_NAME "intel_a10gx_pac:pac_a10")
-set(S10_PAC_BOARD_NAME "intel_s10sx_pac:pac_s10")
-set(SELECTED_BOARD ${A10_PAC_BOARD_NAME})
-if (NOT DEFINED FPGA_BOARD)
-    message(STATUS "\tFPGA_BOARD was not specified. Configuring the design to run on the Intel(R) Programmable Acceleration Card (PAC) with Intel Arria(R) 10 GX FPGA. Please refer to the README for information on board selection.")
-elseif(FPGA_BOARD STREQUAL ${A10_PAC_BOARD_NAME})
-    message(STATUS "\tConfiguring the design to run on the Intel(R) Programmable Acceleration Card (PAC) with Intel Arria(R) 10 GX FPGA.")
-elseif(FPGA_BOARD STREQUAL ${S10_PAC_BOARD_NAME})
-    message(STATUS "\tConfiguring the design to run on the Intel(R) Programmable Acceleration Card (PAC) D5005 (with Intel Stratix(R) 10 SX FPGA).")
-    set(SELECTED_BOARD ${S10_PAC_BOARD_NAME})
+if(NOT DEFINED FPGA_BOARD)
+    set(FPGA_BOARD "intel_a10gx_pac:pac_a10")
+    message(STATUS "FPGA_BOARD was not specified.\
+                    \nConfiguring the design to run on the default FPGA board ${FPGA_BOARD} (Intel(R) PAC with Intel Arria(R) 10 GX FPGA). \
+                    \nPlease refer to the README for information on board selection.")
 else()
-    message(STATUS "\tAn invalid board name was passed in using the FPGA_BOARD flag. Configuring the design to run on the Intel(R) Programmable Acceleration Card (PAC) with Intel Arria(R) 10 GX FPGA. Please refer to the README for the list of valid board names.")
+    message(STATUS "Configuring the design to run on FPGA board ${FPGA_BOARD}")
 endif()
 
-# Flags
-set(EMULATOR_COMPILE_FLAGS "-fintelfpga -DFPGA_EMULATOR")
+# This is a Windows-specific flag that enables exception handling in host code
+if(WIN32)
+    set(WIN_FLAG "/EHsc")
+endif()
+
+# A DPC++ ahead-of-time (AoT) compile processes the device code in two stages.
+# 1. The "compile" stage compiles the device code to an intermediate representation (SPIR-V).
+# 2. The "link" stage invokes the compiler's FPGA backend before linking.
+#    For this reason, FPGA backend flags must be passed as link flags in CMake.
+set(EMULATOR_COMPILE_FLAGS "${WIN_FLAG} -fintelfpga -DFPGA_EMULATOR ${MATH_FLAGS}")
 set(EMULATOR_LINK_FLAGS "-fintelfpga")
-set(HARDWARE_COMPILE_FLAGS "-fintelfpga")
-set(HARDWARE_LINK_FLAGS "-fintelfpga -Xshardware -Xsboard=${SELECTED_BOARD} ${USER_HARDWARE_FLAGS}")
+set(HARDWARE_COMPILE_FLAGS "${WIN_FLAG} -fintelfpga ${MATH_FLAGS}")
+set(HARDWARE_LINK_FLAGS "-fintelfpga -Xshardware -Xsboard=${FPGA_BOARD} ${USER_HARDWARE_FLAGS}")
 # use cmake -D USER_HARDWARE_FLAGS=<flags> to set extra flags for FPGA backend compilation
 
+###############################################################################
+### FPGA Emulator
+###############################################################################
+# To compile in a single command:
+#    dpcpp -fintelfpga -DFPGA_EMULATOR double_buffering.cpp -o double_buffering.fpga_emu
+# CMake executes:
+#    [compile] dpcpp -fintelfpga -DFPGA_EMULATOR -o double_buffering.cpp.o -c double_buffering.cpp
+#    [link]    dpcpp -fintelfpga double_buffering.cpp.o -o double_buffering.fpga_emu
+add_executable(${EMULATOR_TARGET} ${SOURCE_FILE})
+set_target_properties(${EMULATOR_TARGET} PROPERTIES COMPILE_FLAGS "${EMULATOR_COMPILE_FLAGS}")
+set_target_properties(${EMULATOR_TARGET} PROPERTIES LINK_FLAGS "${EMULATOR_LINK_FLAGS}")
+add_custom_target(fpga_emu DEPENDS ${EMULATOR_TARGET})
 
-# FPGA emulator
-if(WIN32)
-    set(WIN_EMULATOR_TARGET ${EMULATOR_TARGET}.exe)
-    add_custom_target(fpga_emu DEPENDS ${WIN_EMULATOR_TARGET})
-    separate_arguments(WIN_EMULATOR_COMPILE_FLAGS WINDOWS_COMMAND "${EMULATOR_COMPILE_FLAGS}")
-    add_custom_command(OUTPUT ${WIN_EMULATOR_TARGET} 
-                       COMMAND ${CMAKE_CXX_COMPILER} /EHsc ${WIN_EMULATOR_COMPILE_FLAGS} ${CMAKE_CURRENT_SOURCE_DIR}/${SOURCE_FILE} -o ${CMAKE_BINARY_DIR}/${WIN_EMULATOR_TARGET}
-                       DEPENDS ${SOURCE_FILE})
-else()
-    add_executable(${EMULATOR_TARGET} ${SOURCE_FILE})
-    add_custom_target(fpga_emu DEPENDS ${EMULATOR_TARGET})
-    set_target_properties(${EMULATOR_TARGET} PROPERTIES COMPILE_FLAGS ${EMULATOR_COMPILE_FLAGS})
-    set_target_properties(${EMULATOR_TARGET} PROPERTIES LINK_FLAGS ${EMULATOR_LINK_FLAGS})
-endif()
+###############################################################################
+### Generate Report
+###############################################################################
+# To compile manually:
+#   dpcpp -fintelfpga -Xshardware -Xsboard=<FPGA_BOARD> -fsycl-link=early double_buffering.cpp -o double_buffering_report.a
+set(FPGA_EARLY_IMAGE ${TARGET_NAME}_report.a)
+# The compile output is not an executable, but an intermediate compilation result unique to DPC++.
+add_executable(${FPGA_EARLY_IMAGE} ${SOURCE_FILE})
+add_custom_target(report DEPENDS ${FPGA_EARLY_IMAGE})
+set_target_properties(${FPGA_EARLY_IMAGE} PROPERTIES COMPILE_FLAGS "${HARDWARE_COMPILE_FLAGS}")
+set_target_properties(${FPGA_EARLY_IMAGE} PROPERTIES LINK_FLAGS "${HARDWARE_LINK_FLAGS} -fsycl-link=early")
+# fsycl-link=early stops the compiler after RTL generation, before invoking Quartus
 
-# FPGA hardware
-if(WIN32)
-    add_custom_target(fpga COMMAND echo "An FPGA hardware target is not provided on Windows. See README for details.")
-else()
-    add_executable(${FPGA_TARGET} EXCLUDE_FROM_ALL ${SOURCE_FILE})
-    add_custom_target(fpga DEPENDS ${FPGA_TARGET})
-    set_target_properties(${FPGA_TARGET} PROPERTIES COMPILE_FLAGS ${HARDWARE_COMPILE_FLAGS})
-    set_target_properties(${FPGA_TARGET} PROPERTIES LINK_FLAGS ${HARDWARE_LINK_FLAGS})
-endif()
-
-# Generate report
-if(WIN32)
-    set(DEVICE_OBJ_FILE ${TARGET_NAME}_report.a)
-    add_custom_target(report DEPENDS ${DEVICE_OBJ_FILE})
-    separate_arguments(HARDWARE_LINK_FLAGS_LIST WINDOWS_COMMAND "${HARDWARE_LINK_FLAGS}")
-    add_custom_command(OUTPUT ${DEVICE_OBJ_FILE} 
-                       COMMAND ${CMAKE_CXX_COMPILER} /EHsc ${HARDWARE_LINK_FLAGS_LIST} -fsycl-link ${CMAKE_CURRENT_SOURCE_DIR}/${SOURCE_FILE} -o ${CMAKE_BINARY_DIR}/${DEVICE_OBJ_FILE}
-                       DEPENDS ${SOURCE_FILE})
-else()
-    set(DEVICE_OBJ_FILE ${TARGET_NAME}_report.a)
-    add_custom_target(report DEPENDS ${DEVICE_OBJ_FILE})
-    configure_file(${CMAKE_CURRENT_SOURCE_DIR}/${SOURCE_FILE} ${SOURCE_FILE} COPYONLY)
-    separate_arguments(HARDWARE_LINK_FLAGS_LIST UNIX_COMMAND "${HARDWARE_LINK_FLAGS}")
-    separate_arguments(CMAKE_CXX_FLAGS_LIST UNIX_COMMAND "${CMAKE_CXX_FLAGS}")
-    add_custom_command(OUTPUT ${DEVICE_OBJ_FILE} 
-                       COMMAND ${CMAKE_CXX_COMPILER} ${CMAKE_CXX_FLAGS_LIST} ${HARDWARE_LINK_FLAGS_LIST} -fsycl-link ${SOURCE_FILE} -o ${CMAKE_BINARY_DIR}/${DEVICE_OBJ_FILE}
-                       DEPENDS ${SOURCE_FILE})
-endif()
+###############################################################################
+### FPGA Hardware
+###############################################################################
+# To compile in a single command:
+#   dpcpp -fintelfpga -Xshardware -Xsboard=<FPGA_BOARD> double_buffering.cpp -o double_buffering.fpga
+# CMake executes:
+#   [compile] dpcpp -fintelfpga -o double_buffering.cpp.o -c double_buffering.cpp
+#   [link]    dpcpp -fintelfpga -Xshardware -Xsboard=<FPGA_BOARD> double_buffering.cpp.o -o double_buffering.fpga
+add_executable(${FPGA_TARGET} EXCLUDE_FROM_ALL ${SOURCE_FILE})
+add_custom_target(fpga DEPENDS ${FPGA_TARGET})
+set_target_properties(${FPGA_TARGET} PROPERTIES COMPILE_FLAGS "${HARDWARE_COMPILE_FLAGS}")
+set_target_properties(${FPGA_TARGET} PROPERTIES LINK_FLAGS "${HARDWARE_LINK_FLAGS} -reuse-exe=${CMAKE_BINARY_DIR}/${FPGA_TARGET}")
+# The -reuse-exe flag enables rapid recompilation of host-only code changes.
+# See DPC++FPGA/GettingStarted/fast_recompile for details.

--- a/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/explicit_data_movement/CMakeLists.txt
+++ b/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/explicit_data_movement/CMakeLists.txt
@@ -1,11 +1,17 @@
-
-set(CMAKE_CXX_COMPILER "dpcpp")
-if(WIN32)
-    set(CMAKE_C_COMPILER "clang-cl")
+if(UNIX)
+    # Direct CMake to use dpcpp rather than the default C++ compiler/linker
+    set(CMAKE_CXX_COMPILER dpcpp)
+else() # Windows
+    # Force CMake to use dpcpp rather than the default C++ compiler/linker 
+    # (needed on Windows only)
+    include (CMakeForceCompiler)
+    CMAKE_FORCE_CXX_COMPILER (dpcpp IntelDPCPP)
+    include (Platform/Windows-Clang)
 endif()
-cmake_minimum_required (VERSION 2.8)
 
-project(ExplicitDataMovement)
+cmake_minimum_required (VERSION 3.4)
+
+project(ExplicitDataMovement CXX)
 
 set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})
 set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})

--- a/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/explicit_data_movement/src/CMakeLists.txt
+++ b/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/explicit_data_movement/src/CMakeLists.txt
@@ -1,71 +1,73 @@
+# To see a Makefile equivalent of this build system:
+# https://github.com/oneapi-src/oneAPI-samples/blob/master/DirectProgramming/DPC++/ProjectTemplates/makefile-fpga
+
 set(SOURCE_FILE explicit_data_movement.cpp)
 set(TARGET_NAME explicit_data_movement)
 set(EMULATOR_TARGET ${TARGET_NAME}.fpga_emu)
 set(FPGA_TARGET ${TARGET_NAME}.fpga)
-set(REPORTS_TARGET ${TARGET_NAME}_report)
 
 # FPGA board selection
-set(A10_PAC_BOARD_NAME "intel_a10gx_pac:pac_a10")
-set(S10_PAC_BOARD_NAME "intel_s10sx_pac:pac_s10")
-set(SELECTED_BOARD ${A10_PAC_BOARD_NAME})
-if (NOT DEFINED FPGA_BOARD)
-    message(STATUS "\tFPGA_BOARD was not specified. Configuring the design to run on the Intel(R) Programmable Acceleration Card (PAC) with Intel Arria(R) 10 GX FPGA. Please refer to the README for information on board selection.")
-elseif(FPGA_BOARD STREQUAL ${A10_PAC_BOARD_NAME})
-    message(STATUS "\tConfiguring the design to run on the Intel(R) Programmable Acceleration Card (PAC) with Intel Arria(R) 10 GX FPGA.")
-elseif(FPGA_BOARD STREQUAL ${S10_PAC_BOARD_NAME})
-    message(STATUS "\tConfiguring the design to run on the Intel(R) Programmable Acceleration Card (PAC) D5005 (with Intel Stratix(R) 10 SX FPGA).")
-    set(SELECTED_BOARD ${S10_PAC_BOARD_NAME})
+if(NOT DEFINED FPGA_BOARD)
+    set(FPGA_BOARD "intel_a10gx_pac:pac_a10")
+    message(STATUS "FPGA_BOARD was not specified.\
+                    \nConfiguring the design to run on the default FPGA board ${FPGA_BOARD} (Intel(R) PAC with Intel Arria(R) 10 GX FPGA). \
+                    \nPlease refer to the README for information on board selection.")
 else()
-    message(STATUS "\tAn invalid board name was passed in using the FPGA_BOARD flag. Configuring the design to run on the Intel(R) Programmable Acceleration Card (PAC) with Intel Arria(R) 10 GX FPGA. Please refer to the README for the list of valid board names.")
+    message(STATUS "Configuring the design to run on FPGA board ${FPGA_BOARD}")
 endif()
 
-# Flags
-set(EMULATOR_COMPILE_FLAGS "-fintelfpga -DFPGA_EMULATOR")
+# This is a Windows-specific flag that enables exception handling in host code
+if(WIN32)
+    set(WIN_FLAG "/EHsc")
+endif()
+
+# A DPC++ ahead-of-time (AoT) compile processes the device code in two stages.
+# 1. The "compile" stage compiles the device code to an intermediate representation (SPIR-V).
+# 2. The "link" stage invokes the compiler's FPGA backend before linking.
+#    For this reason, FPGA backend flags must be passed as link flags in CMake.
+set(EMULATOR_COMPILE_FLAGS "${WIN_FLAG} -fintelfpga -DFPGA_EMULATOR")
 set(EMULATOR_LINK_FLAGS "-fintelfpga")
-set(HARDWARE_COMPILE_FLAGS "-fintelfpga")
-set(HARDWARE_LINK_FLAGS "-fintelfpga -Xshardware -Xsboard=${SELECTED_BOARD} ${USER_HARDWARE_FLAGS}")
+set(HARDWARE_COMPILE_FLAGS "${WIN_FLAG} -fintelfpga")
+set(HARDWARE_LINK_FLAGS "-fintelfpga -Xshardware -Xsboard=${FPGA_BOARD} ${USER_HARDWARE_FLAGS}")
 # use cmake -D USER_HARDWARE_FLAGS=<flags> to set extra flags for FPGA backend compilation
 
+###############################################################################
+### FPGA Emulator
+###############################################################################
+# To compile in a single command:
+#    dpcpp -fintelfpga -DFPGA_EMULATOR explicit_data_movement.cpp -o explicit_data_movement.fpga_emu
+# CMake executes:
+#    [compile] dpcpp -fintelfpga -DFPGA_EMULATOR -o explicit_data_movement.cpp.o -c explicit_data_movement.cpp
+#    [link]    dpcpp -fintelfpga explicit_data_movement.cpp.o -o explicit_data_movement.fpga_emu
+add_executable(${EMULATOR_TARGET} ${SOURCE_FILE})
+set_target_properties(${EMULATOR_TARGET} PROPERTIES COMPILE_FLAGS "${EMULATOR_COMPILE_FLAGS}")
+set_target_properties(${EMULATOR_TARGET} PROPERTIES LINK_FLAGS "${EMULATOR_LINK_FLAGS}")
+add_custom_target(fpga_emu DEPENDS ${EMULATOR_TARGET})
 
-# FPGA emulator
-if(WIN32)
-    set(WIN_EMULATOR_TARGET ${EMULATOR_TARGET}.exe)
-    add_custom_target(fpga_emu DEPENDS ${WIN_EMULATOR_TARGET})
-    separate_arguments(WIN_EMULATOR_COMPILE_FLAGS WINDOWS_COMMAND "${EMULATOR_COMPILE_FLAGS}")
-    add_custom_command(OUTPUT ${WIN_EMULATOR_TARGET} 
-                    COMMAND ${CMAKE_CXX_COMPILER} /EHsc ${WIN_EMULATOR_COMPILE_FLAGS} ${CMAKE_CURRENT_SOURCE_DIR}/${SOURCE_FILE} -o ${CMAKE_BINARY_DIR}/${WIN_EMULATOR_TARGET}
-                    DEPENDS ${SOURCE_FILE})
-else()
-    add_executable(${EMULATOR_TARGET} ${SOURCE_FILE})
-    add_custom_target(fpga_emu DEPENDS ${EMULATOR_TARGET})
-    set_target_properties(${EMULATOR_TARGET} PROPERTIES COMPILE_FLAGS ${EMULATOR_COMPILE_FLAGS})
-    set_target_properties(${EMULATOR_TARGET} PROPERTIES LINK_FLAGS ${EMULATOR_LINK_FLAGS})
-endif()
+###############################################################################
+### Generate Report
+###############################################################################
+# To compile manually:
+#   dpcpp -fintelfpga -Xshardware -Xsboard=<FPGA_BOARD> -fsycl-link=early explicit_data_movement.cpp -o explicit_data_movement_report.a
+set(FPGA_EARLY_IMAGE ${TARGET_NAME}_report.a)
+# The compile output is not an executable, but an intermediate compilation result unique to DPC++.
+add_executable(${FPGA_EARLY_IMAGE} ${SOURCE_FILE})
+add_custom_target(report DEPENDS ${FPGA_EARLY_IMAGE})
+set_target_properties(${FPGA_EARLY_IMAGE} PROPERTIES COMPILE_FLAGS "${HARDWARE_COMPILE_FLAGS}")
+set_target_properties(${FPGA_EARLY_IMAGE} PROPERTIES LINK_FLAGS "${HARDWARE_LINK_FLAGS} -fsycl-link=early")
+# fsycl-link=early stops the compiler after RTL generation, before invoking Quartus
 
-# FPGA hardware
-if(WIN32)
-    add_custom_target(fpga COMMAND echo "An FPGA hardware target is not provided on Windows. See README for details.")
-else()
-    add_executable(${FPGA_TARGET} EXCLUDE_FROM_ALL ${SOURCE_FILE})
-    add_custom_target(fpga DEPENDS ${FPGA_TARGET})
-    set_target_properties(${FPGA_TARGET} PROPERTIES COMPILE_FLAGS ${HARDWARE_COMPILE_FLAGS})
-    set_target_properties(${FPGA_TARGET} PROPERTIES LINK_FLAGS ${HARDWARE_LINK_FLAGS})
-endif()
-
-# Generate report
-if(WIN32)
-    set(DEVICE_OBJ_FILE ${TARGET_NAME}_report.a)
-    add_custom_target(report DEPENDS ${DEVICE_OBJ_FILE})
-    separate_arguments(HARDWARE_LINK_FLAGS_LIST WINDOWS_COMMAND "${HARDWARE_LINK_FLAGS}")
-    add_custom_command(OUTPUT ${DEVICE_OBJ_FILE} 
-                    COMMAND ${CMAKE_CXX_COMPILER} /EHsc ${HARDWARE_LINK_FLAGS_LIST} -fsycl-link ${CMAKE_CURRENT_SOURCE_DIR}/${SOURCE_FILE} -o ${CMAKE_BINARY_DIR}/${DEVICE_OBJ_FILE}
-                    DEPENDS ${SOURCE_FILE})
-else()
-    configure_file(${CMAKE_CURRENT_SOURCE_DIR}/${SOURCE_FILE} ${SOURCE_FILE} COPYONLY)
-    separate_arguments(HARDWARE_LINK_FLAGS_LIST UNIX_COMMAND "${HARDWARE_LINK_FLAGS}")
-    separate_arguments(CMAKE_CXX_FLAGS_LIST UNIX_COMMAND "${CMAKE_CXX_FLAGS}")
-    add_custom_command(OUTPUT ${REPORTS_TARGET}
-                       COMMAND ${CMAKE_CXX_COMPILER} ${CMAKE_CXX_FLAGS_LIST} ${HARDWARE_LINK_FLAGS_LIST} -fsycl-link ${SOURCE_FILE} -o ${CMAKE_BINARY_DIR}/${REPORTS_TARGET}
-                       DEPENDS ${SOURCE_FILE})
-    add_custom_target(report DEPENDS ${REPORTS_TARGET})
-endif()
+###############################################################################
+### FPGA Hardware
+###############################################################################
+# To compile in a single command:
+#   dpcpp -fintelfpga -Xshardware -Xsboard=<FPGA_BOARD> explicit_data_movement.cpp -o explicit_data_movement.fpga
+# CMake executes:
+#   [compile] dpcpp -fintelfpga -o explicit_data_movement.cpp.o -c explicit_data_movement.cpp
+#   [link]    dpcpp -fintelfpga -Xshardware -Xsboard=<FPGA_BOARD> explicit_data_movement.cpp.o -o explicit_data_movement.fpga
+add_executable(${FPGA_TARGET} EXCLUDE_FROM_ALL ${SOURCE_FILE})
+add_custom_target(fpga DEPENDS ${FPGA_TARGET})
+set_target_properties(${FPGA_TARGET} PROPERTIES COMPILE_FLAGS "${HARDWARE_COMPILE_FLAGS}")
+set_target_properties(${FPGA_TARGET} PROPERTIES LINK_FLAGS "${HARDWARE_LINK_FLAGS} -reuse-exe=${CMAKE_BINARY_DIR}/${FPGA_TARGET}")
+# The -reuse-exe flag enables rapid recompilation of host-only code changes.
+# See DPC++FPGA/GettingStarted/fast_recompile for details.

--- a/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/loop_carried_dependency/CMakeLists.txt
+++ b/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/loop_carried_dependency/CMakeLists.txt
@@ -1,11 +1,17 @@
-set(CMAKE_CXX_COMPILER "dpcpp")
-if(WIN32)
-    set(CMAKE_C_COMPILER "clang-cl")
+if(UNIX)
+    # Direct CMake to use dpcpp rather than the default C++ compiler/linker
+    set(CMAKE_CXX_COMPILER dpcpp)
+else() # Windows
+    # Force CMake to use dpcpp rather than the default C++ compiler/linker 
+    # (needed on Windows only)
+    include (CMakeForceCompiler)
+    CMAKE_FORCE_CXX_COMPILER (dpcpp IntelDPCPP)
+    include (Platform/Windows-Clang)
 endif()
 
-cmake_minimum_required (VERSION 2.8)
+cmake_minimum_required (VERSION 3.4)
 
-project(RemoveLoopCarriedDependency)
+project(RemoveLoopCarriedDependency CXX)
 
 set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})
 set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})

--- a/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/loop_carried_dependency/src/CMakeLists.txt
+++ b/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/loop_carried_dependency/src/CMakeLists.txt
@@ -1,72 +1,73 @@
+# To see a Makefile equivalent of this build system:
+# https://github.com/oneapi-src/oneAPI-samples/blob/master/DirectProgramming/DPC++/ProjectTemplates/makefile-fpga
+
 set(SOURCE_FILE loop_carried_dependency.cpp)
 set(TARGET_NAME loop_carried_dependency)
 set(EMULATOR_TARGET ${TARGET_NAME}.fpga_emu)
 set(FPGA_TARGET ${TARGET_NAME}.fpga)
 
-
 # FPGA board selection
-set(A10_PAC_BOARD_NAME "intel_a10gx_pac:pac_a10")
-set(S10_PAC_BOARD_NAME "intel_s10sx_pac:pac_s10")
-set(SELECTED_BOARD ${A10_PAC_BOARD_NAME})
-if (NOT DEFINED FPGA_BOARD)
-    message(STATUS "\tFPGA_BOARD was not specified. Configuring the design to run on the Intel(R) Programmable Acceleration Card (PAC) with Intel Arria(R) 10 GX FPGA. Please refer to the README for information on board selection.")
-elseif(FPGA_BOARD STREQUAL ${A10_PAC_BOARD_NAME})
-    message(STATUS "\tConfiguring the design to run on the Intel(R) Programmable Acceleration Card (PAC) with Intel Arria(R) 10 GX FPGA.")
-elseif(FPGA_BOARD STREQUAL ${S10_PAC_BOARD_NAME})
-    message(STATUS "\tConfiguring the design to run on the Intel(R) Programmable Acceleration Card (PAC) D5005 (with Intel Stratix(R) 10 SX FPGA).")
-    set(SELECTED_BOARD ${S10_PAC_BOARD_NAME})
+if(NOT DEFINED FPGA_BOARD)
+    set(FPGA_BOARD "intel_a10gx_pac:pac_a10")
+    message(STATUS "FPGA_BOARD was not specified.\
+                    \nConfiguring the design to run on the default FPGA board ${FPGA_BOARD} (Intel(R) PAC with Intel Arria(R) 10 GX FPGA). \
+                    \nPlease refer to the README for information on board selection.")
 else()
-    message(STATUS "\tAn invalid board name was passed in using the FPGA_BOARD flag. Configuring the design to run on the Intel(R) Programmable Acceleration Card (PAC) with Intel Arria(R) 10 GX FPGA. Please refer to the README for the list of valid board names.")
+    message(STATUS "Configuring the design to run on FPGA board ${FPGA_BOARD}")
 endif()
 
-# Flags
-set(EMULATOR_COMPILE_FLAGS "-fintelfpga -DFPGA_EMULATOR")
+# This is a Windows-specific flag that enables exception handling in host code
+if(WIN32)
+    set(WIN_FLAG "/EHsc")
+endif()
+
+# A DPC++ ahead-of-time (AoT) compile processes the device code in two stages.
+# 1. The "compile" stage compiles the device code to an intermediate representation (SPIR-V).
+# 2. The "link" stage invokes the compiler's FPGA backend before linking.
+#    For this reason, FPGA backend flags must be passed as link flags in CMake.
+set(EMULATOR_COMPILE_FLAGS "${WIN_FLAG} -fintelfpga -DFPGA_EMULATOR")
 set(EMULATOR_LINK_FLAGS "-fintelfpga")
-set(HARDWARE_COMPILE_FLAGS "-fintelfpga")
-set(HARDWARE_LINK_FLAGS "-fintelfpga -Xshardware -Xsboard=${SELECTED_BOARD} ${USER_HARDWARE_FLAGS}")
+set(HARDWARE_COMPILE_FLAGS "${WIN_FLAG} -fintelfpga")
+set(HARDWARE_LINK_FLAGS "-fintelfpga -Xshardware -Xsboard=${FPGA_BOARD} ${USER_HARDWARE_FLAGS}")
 # use cmake -D USER_HARDWARE_FLAGS=<flags> to set extra flags for FPGA backend compilation
 
+###############################################################################
+### FPGA Emulator
+###############################################################################
+# To compile in a single command:
+#    dpcpp -fintelfpga -DFPGA_EMULATOR loop_carried_dependency.cpp -o loop_carried_dependency.fpga_emu
+# CMake executes:
+#    [compile] dpcpp -fintelfpga -DFPGA_EMULATOR -o loop_carried_dependency.cpp.o -c loop_carried_dependency.cpp
+#    [link]    dpcpp -fintelfpga loop_carried_dependency.cpp.o -o loop_carried_dependency.fpga_emu
+add_executable(${EMULATOR_TARGET} ${SOURCE_FILE})
+set_target_properties(${EMULATOR_TARGET} PROPERTIES COMPILE_FLAGS "${EMULATOR_COMPILE_FLAGS}")
+set_target_properties(${EMULATOR_TARGET} PROPERTIES LINK_FLAGS "${EMULATOR_LINK_FLAGS}")
+add_custom_target(fpga_emu DEPENDS ${EMULATOR_TARGET})
 
-# FPGA emulator
-if(WIN32)
-    set(WIN_EMULATOR_TARGET ${EMULATOR_TARGET}.exe)
-    add_custom_target(fpga_emu DEPENDS ${WIN_EMULATOR_TARGET})
-    separate_arguments(WIN_EMULATOR_COMPILE_FLAGS WINDOWS_COMMAND "${EMULATOR_COMPILE_FLAGS}")
-    add_custom_command(OUTPUT ${WIN_EMULATOR_TARGET} 
-                       COMMAND ${CMAKE_CXX_COMPILER} /EHsc ${WIN_EMULATOR_COMPILE_FLAGS} ${CMAKE_CURRENT_SOURCE_DIR}/${SOURCE_FILE} -o ${CMAKE_BINARY_DIR}/${WIN_EMULATOR_TARGET}
-                       DEPENDS ${SOURCE_FILE})
-else()
-    add_executable(${EMULATOR_TARGET} ${SOURCE_FILE})
-    add_custom_target(fpga_emu DEPENDS ${EMULATOR_TARGET})
-    set_target_properties(${EMULATOR_TARGET} PROPERTIES COMPILE_FLAGS ${EMULATOR_COMPILE_FLAGS})
-    set_target_properties(${EMULATOR_TARGET} PROPERTIES LINK_FLAGS ${EMULATOR_LINK_FLAGS})
-endif()
+###############################################################################
+### Generate Report
+###############################################################################
+# To compile manually:
+#   dpcpp -fintelfpga -Xshardware -Xsboard=<FPGA_BOARD> -fsycl-link=early loop_carried_dependency.cpp -o loop_carried_dependency_report.a
+set(FPGA_EARLY_IMAGE ${TARGET_NAME}_report.a)
+# The compile output is not an executable, but an intermediate compilation result unique to DPC++.
+add_executable(${FPGA_EARLY_IMAGE} ${SOURCE_FILE})
+add_custom_target(report DEPENDS ${FPGA_EARLY_IMAGE})
+set_target_properties(${FPGA_EARLY_IMAGE} PROPERTIES COMPILE_FLAGS "${HARDWARE_COMPILE_FLAGS}")
+set_target_properties(${FPGA_EARLY_IMAGE} PROPERTIES LINK_FLAGS "${HARDWARE_LINK_FLAGS} -fsycl-link=early")
+# fsycl-link=early stops the compiler after RTL generation, before invoking Quartus
 
-# FPGA hardware
-if(WIN32)
-    add_custom_target(fpga COMMAND echo "An FPGA hardware target is not provided on Windows. See README for details.")
-else()
-    add_executable(${FPGA_TARGET} EXCLUDE_FROM_ALL ${SOURCE_FILE})
-    add_custom_target(fpga DEPENDS ${FPGA_TARGET})
-    set_target_properties(${FPGA_TARGET} PROPERTIES COMPILE_FLAGS ${HARDWARE_COMPILE_FLAGS})
-    set_target_properties(${FPGA_TARGET} PROPERTIES LINK_FLAGS ${HARDWARE_LINK_FLAGS})
-endif()
-
-# Generate report
-if(WIN32)
-    set(DEVICE_OBJ_FILE ${TARGET_NAME}_report.a)
-    add_custom_target(report DEPENDS ${DEVICE_OBJ_FILE})
-    separate_arguments(HARDWARE_LINK_FLAGS_LIST WINDOWS_COMMAND "${HARDWARE_LINK_FLAGS}")
-    add_custom_command(OUTPUT ${DEVICE_OBJ_FILE} 
-                       COMMAND ${CMAKE_CXX_COMPILER} /EHsc ${HARDWARE_LINK_FLAGS_LIST} -fsycl-link ${CMAKE_CURRENT_SOURCE_DIR}/${SOURCE_FILE} -o ${CMAKE_BINARY_DIR}/${DEVICE_OBJ_FILE}
-                       DEPENDS ${SOURCE_FILE})
-else()
-    set(DEVICE_OBJ_FILE ${TARGET_NAME}_report.a)
-    add_custom_target(report DEPENDS ${DEVICE_OBJ_FILE})
-    configure_file(${CMAKE_CURRENT_SOURCE_DIR}/${SOURCE_FILE} ${SOURCE_FILE} COPYONLY)
-    separate_arguments(HARDWARE_LINK_FLAGS_LIST UNIX_COMMAND "${HARDWARE_LINK_FLAGS}")
-    separate_arguments(CMAKE_CXX_FLAGS_LIST UNIX_COMMAND "${CMAKE_CXX_FLAGS}")
-    add_custom_command(OUTPUT ${DEVICE_OBJ_FILE} 
-                       COMMAND ${CMAKE_CXX_COMPILER} ${CMAKE_CXX_FLAGS_LIST} ${HARDWARE_LINK_FLAGS_LIST} -fsycl-link ${SOURCE_FILE} -o ${CMAKE_BINARY_DIR}/${DEVICE_OBJ_FILE}
-                       DEPENDS ${SOURCE_FILE})
-endif()
+###############################################################################
+### FPGA Hardware
+###############################################################################
+# To compile in a single command:
+#   dpcpp -fintelfpga -Xshardware -Xsboard=<FPGA_BOARD> loop_carried_dependency.cpp -o loop_carried_dependency.fpga
+# CMake executes:
+#   [compile] dpcpp -fintelfpga -o loop_carried_dependency.cpp.o -c loop_carried_dependency.cpp
+#   [link]    dpcpp -fintelfpga -Xshardware -Xsboard=<FPGA_BOARD> loop_carried_dependency.cpp.o -o loop_carried_dependency.fpga
+add_executable(${FPGA_TARGET} EXCLUDE_FROM_ALL ${SOURCE_FILE})
+add_custom_target(fpga DEPENDS ${FPGA_TARGET})
+set_target_properties(${FPGA_TARGET} PROPERTIES COMPILE_FLAGS "${HARDWARE_COMPILE_FLAGS}")
+set_target_properties(${FPGA_TARGET} PROPERTIES LINK_FLAGS "${HARDWARE_LINK_FLAGS} -reuse-exe=${CMAKE_BINARY_DIR}/${FPGA_TARGET}")
+# The -reuse-exe flag enables rapid recompilation of host-only code changes.
+# See DPC++FPGA/GettingStarted/fast_recompile for details.

--- a/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/n_way_buffering/CMakeLists.txt
+++ b/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/n_way_buffering/CMakeLists.txt
@@ -1,12 +1,17 @@
-set(CMAKE_CXX_COMPILER "dpcpp")
-if(WIN32)
-    set(CMAKE_C_COMPILER "clang-cl")
+if(UNIX)
+    # Direct CMake to use dpcpp rather than the default C++ compiler/linker
+    set(CMAKE_CXX_COMPILER dpcpp)
+else() # Windows
+    # Force CMake to use dpcpp rather than the default C++ compiler/linker 
+    # (needed on Windows only)
+    include (CMakeForceCompiler)
+    CMAKE_FORCE_CXX_COMPILER (dpcpp IntelDPCPP)
+    include (Platform/Windows-Clang)
 endif()
 
+cmake_minimum_required (VERSION 3.4)
 
-cmake_minimum_required (VERSION 2.8)
-
-project(NWayBuffering)
+project(NWayBuffering CXX)
 
 set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})
 set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})

--- a/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/n_way_buffering/src/CMakeLists.txt
+++ b/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/n_way_buffering/src/CMakeLists.txt
@@ -1,78 +1,74 @@
+# To see a Makefile equivalent of this build system:
+# https://github.com/oneapi-src/oneAPI-samples/blob/master/DirectProgramming/DPC++/ProjectTemplates/makefile-fpga
 set(SOURCE_FILE n_way_buffering.cpp)
 set(TARGET_NAME n_way_buffering)
 set(EMULATOR_TARGET ${TARGET_NAME}.fpga_emu)
 set(FPGA_TARGET ${TARGET_NAME}.fpga)
 
 # FPGA board selection
-set(A10_PAC_BOARD_NAME "intel_a10gx_pac:pac_a10")
-set(S10_PAC_BOARD_NAME "intel_s10sx_pac:pac_s10")
-set(SELECTED_BOARD ${A10_PAC_BOARD_NAME})
-if (NOT DEFINED FPGA_BOARD)
-    message(STATUS "\tFPGA_BOARD was not specified. Configuring the design to run on the Intel(R) Programmable Acceleration Card (PAC) with Intel Arria(R) 10 GX FPGA. Please refer to the README for information on board selection.")
-elseif(FPGA_BOARD STREQUAL ${A10_PAC_BOARD_NAME})
-    message(STATUS "\tConfiguring the design to run on the Intel(R) Programmable Acceleration Card (PAC) with Intel Arria(R) 10 GX FPGA.")
-elseif(FPGA_BOARD STREQUAL ${S10_PAC_BOARD_NAME})
-    message(STATUS "\tConfiguring the design to run on the Intel(R) Programmable Acceleration Card (PAC) D5005 (with Intel Stratix(R) 10 SX FPGA).")
-    set(SELECTED_BOARD ${S10_PAC_BOARD_NAME})
+if(NOT DEFINED FPGA_BOARD)
+    set(FPGA_BOARD "intel_a10gx_pac:pac_a10")
+    message(STATUS "FPGA_BOARD was not specified.\
+                    \nConfiguring the design to run on the default FPGA board ${FPGA_BOARD} (Intel(R) PAC with Intel Arria(R) 10 GX FPGA). \
+                    \nPlease refer to the README for information on board selection.")
+
 else()
-    message(STATUS "\tAn invalid board name was passed in using the FPGA_BOARD flag. Configuring the design to run on the Intel(R) Programmable Acceleration Card (PAC) with Intel Arria(R) 10 GX FPGA. Please refer to the README for the list of valid board names.")
+    message(STATUS "Configuring the design to run on FPGA board ${FPGA_BOARD}")
 endif()
 
-# Flags
-set(EMULATOR_COMPILE_FLAGS "-fintelfpga -DFPGA_EMULATOR")
+# This is a Windows-specific flag that enables exception handling in host code
+if(WIN32)
+    set(WIN_FLAG "/EHsc")
+endif()
+
+# A DPC++ ahead-of-time (AoT) compile processes the device code in two stages.
+# 1. The "compile" stage compiles the device code to an intermediate representation (SPIR-V).
+# 2. The "link" stage invokes the compiler's FPGA backend before linking.
+#    For this reason, FPGA backend flags must be passed as link flags in CMake.
+set(EMULATOR_COMPILE_FLAGS "${WIN_FLAG} -fintelfpga -DFPGA_EMULATOR")
 set(EMULATOR_LINK_FLAGS " -lpthread -fintelfpga")
-set(HARDWARE_LINK_FLAGS "-fintelfpga -Xshardware -Xsboard=${SELECTED_BOARD} ${USER_HARDWARE_FLAGS}")
+set(HARDWARE_COMPILE_FLAGS "${WIN_FLAG} -fintelfpga")
+set(HARDWARE_LINK_FLAGS "-lpthread -fintelfpga -Xshardware -Xsboard=${FPGA_BOARD} ${USER_HARDWARE_FLAGS}")
 # use cmake -D USER_HARDWARE_FLAGS=<flags> to set extra flags for FPGA backend compilation
 
+###############################################################################
+### FPGA Emulator
+###############################################################################
+# To compile in a single command:
+#    dpcpp -fintelfpga -DFPGA_EMULATOR n_way_buffering.cpp -o n_way_buffering.fpga_emu
+# CMake executes:
+#    [compile] dpcpp -fintelfpga -DFPGA_EMULATOR -o n_way_buffering.cpp.o -c n_way_buffering.cpp
+#    [link]    dpcpp -fintelfpga n_way_buffering.cpp.o -o n_way_buffering.fpga_emu
+add_executable(${EMULATOR_TARGET} ${SOURCE_FILE}) # CMake automatically adds #include'd headers to the dependency list
+set_target_properties(${EMULATOR_TARGET} PROPERTIES COMPILE_FLAGS "${EMULATOR_COMPILE_FLAGS}")
+set_target_properties(${EMULATOR_TARGET} PROPERTIES LINK_FLAGS "${EMULATOR_LINK_FLAGS}")
+add_custom_target(fpga_emu DEPENDS ${EMULATOR_TARGET})
 
-# FPGA emulator
-if(WIN32)
-    set(WIN_EMULATOR_TARGET ${EMULATOR_TARGET}.exe)
-    add_custom_target(fpga_emu DEPENDS ${WIN_EMULATOR_TARGET})
-    separate_arguments(WIN_EMULATOR_COMPILE_FLAGS WINDOWS_COMMAND "${EMULATOR_COMPILE_FLAGS}")
-    add_custom_command(OUTPUT ${WIN_EMULATOR_TARGET} 
-                       COMMAND ${CMAKE_CXX_COMPILER} /EHsc ${WIN_EMULATOR_COMPILE_FLAGS} ${CMAKE_CURRENT_SOURCE_DIR}/${SOURCE_FILE} -o ${CMAKE_BINARY_DIR}/${WIN_EMULATOR_TARGET}
-                       DEPENDS ${SOURCE_FILE})
-else()
-    add_executable(${EMULATOR_TARGET} ${SOURCE_FILE})
-    add_custom_target(fpga_emu DEPENDS ${EMULATOR_TARGET})
-    set_target_properties(${EMULATOR_TARGET} PROPERTIES COMPILE_FLAGS ${EMULATOR_COMPILE_FLAGS})
-    set_target_properties(${EMULATOR_TARGET} PROPERTIES LINK_FLAGS ${EMULATOR_LINK_FLAGS})
-endif()
 
-# FPGA hardware
-if(WIN32)
-    add_custom_target(fpga COMMAND echo "An FPGA hardware target is not provided on Windows. See README for details.")
-else()
-    set(FPGA_OBJ_FILE "dev_fpga.o")
-    add_custom_target(fpga DEPENDS ${FPGA_TARGET})
-    separate_arguments(CMAKE_CXX_FLAGS_LIST UNIX_COMMAND "${CMAKE_CXX_FLAGS}")
-    add_custom_command(OUTPUT ${FPGA_OBJ_FILE} 
-                       COMMAND ${CMAKE_CXX_COMPILER} ${CMAKE_CXX_FLAGS_LIST} -fintelfpga -c ${CMAKE_CURRENT_SOURCE_DIR}/${SOURCE_FILE} -o ${FPGA_OBJ_FILE} 
-                       DEPENDS ${SOURCE_FILE})
-    separate_arguments(HARDWARE_LINK_FLAGS_LIST UNIX_COMMAND "${HARDWARE_LINK_FLAGS}")
-    add_custom_command(OUTPUT ${FPGA_TARGET} 
-                       COMMAND ${CMAKE_CXX_COMPILER} ${CMAKE_CXX_FLAGS_LIST} ${HARDWARE_LINK_FLAGS_LIST} ${FPGA_OBJ_FILE} -o  ${CMAKE_BINARY_DIR}/${FPGA_TARGET} -lpthread
-                       DEPENDS ${FPGA_OBJ_FILE})
-endif()
+###############################################################################
+### Generate Report
+###############################################################################
+# To compile manually:
+#   dpcpp -fintelfpga -lpthread -Xshardware -Xsboard=<FPGA_BOARD> -fsycl-link=early n_way_buffering.cpp -o n_way_buffering_report.a
+set(FPGA_EARLY_IMAGE ${TARGET_NAME}_report.a)
+# The compile output is not an executable, but an intermediate compilation result unique to DPC++.
+add_executable(${FPGA_EARLY_IMAGE} ${SOURCE_FILE})
+add_custom_target(report DEPENDS ${FPGA_EARLY_IMAGE})
+set_target_properties(${FPGA_EARLY_IMAGE} PROPERTIES COMPILE_FLAGS "${HARDWARE_COMPILE_FLAGS}")
+set_target_properties(${FPGA_EARLY_IMAGE} PROPERTIES LINK_FLAGS "${HARDWARE_LINK_FLAGS} -fsycl-link=early")
+# fsycl-link=early stops the compiler after RTL generation, before invoking Quartus
 
-# Generate report
-if(WIN32)
-    set(DEVICE_OBJ_FILE ${TARGET_NAME}_report.a)
-    add_custom_target(report DEPENDS ${DEVICE_OBJ_FILE})
-    separate_arguments(HARDWARE_LINK_FLAGS_LIST WINDOWS_COMMAND "${HARDWARE_LINK_FLAGS}")
-    separate_arguments(CMAKE_CXX_FLAGS_LIST WINDOWS_COMMAND "${CMAKE_CXX_FLAGS}")
-    add_custom_command(OUTPUT ${DEVICE_OBJ_FILE} 
-                       COMMAND ${CMAKE_CXX_COMPILER} /EHsc ${CMAKE_CXX_FLAGS_LIST} ${HARDWARE_LINK_FLAGS_LIST} -fsycl-link ${CMAKE_CURRENT_SOURCE_DIR}/${SOURCE_FILE} -o ${CMAKE_BINARY_DIR}/${DEVICE_OBJ_FILE}
-                       DEPENDS ${SOURCE_FILE})
-else()
-    set(DEVICE_OBJ_FILE ${TARGET_NAME}_report.a)
-    add_custom_target(report DEPENDS ${DEVICE_OBJ_FILE})
-    configure_file(${CMAKE_CURRENT_SOURCE_DIR}/${SOURCE_FILE} ${SOURCE_FILE} COPYONLY)
-    separate_arguments(HARDWARE_LINK_FLAGS_LIST UNIX_COMMAND "${HARDWARE_LINK_FLAGS}")
-    separate_arguments(CMAKE_CXX_FLAGS_LIST UNIX_COMMAND "${CMAKE_CXX_FLAGS}")
-    add_custom_command(OUTPUT ${DEVICE_OBJ_FILE} 
-                       COMMAND ${CMAKE_CXX_COMPILER} ${CMAKE_CXX_FLAGS_LIST} ${HARDWARE_LINK_FLAGS_LIST} -fsycl-link ${SOURCE_FILE} -o ${CMAKE_BINARY_DIR}/${DEVICE_OBJ_FILE}
-                       DEPENDS ${SOURCE_FILE})
-endif()
-
+###############################################################################
+### FPGA Hardware
+###############################################################################
+# To compile in a single command:
+#   dpcpp -fintelfpga -Xshardware -Xsboard=<FPGA_BOARD> n_way_buffering.cpp -o n_way_buffering.fpga
+# CMake executes:
+#   [compile] dpcpp -fintelfpga -o n_way_buffering.cpp.o -c n_way_buffering.cpp
+#   [link]    dpcpp -fintelfpga -lpthread -Xshardware -Xsboard=<FPGA_BOARD> n_way_buffering.cpp.o -o n_way_buffering.fpga
+add_executable(${FPGA_TARGET} EXCLUDE_FROM_ALL ${SOURCE_FILE})
+add_custom_target(fpga DEPENDS ${FPGA_TARGET})
+set_target_properties(${FPGA_TARGET} PROPERTIES COMPILE_FLAGS "${HARDWARE_COMPILE_FLAGS}")
+set_target_properties(${FPGA_TARGET} PROPERTIES LINK_FLAGS "${HARDWARE_LINK_FLAGS} -reuse-exe=${CMAKE_BINARY_DIR}/${FPGA_TARGET}")
+# The -reuse-exe flag enables rapid recompilation of host-only code changes.
+# See DPC++FPGA/GettingStarted/fast_recompile for details.

--- a/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/onchip_memory_cache/CMakeLists.txt
+++ b/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/onchip_memory_cache/CMakeLists.txt
@@ -1,11 +1,17 @@
-set(CMAKE_CXX_COMPILER "dpcpp")
-if(WIN32)
-    set(CMAKE_C_COMPILER "clang-cl")
+if(UNIX)
+    # Direct CMake to use dpcpp rather than the default C++ compiler/linker
+    set(CMAKE_CXX_COMPILER dpcpp)
+else() # Windows
+    # Force CMake to use dpcpp rather than the default C++ compiler/linker 
+    # (needed on Windows only)
+    include (CMakeForceCompiler)
+    CMAKE_FORCE_CXX_COMPILER (dpcpp IntelDPCPP)
+    include (Platform/Windows-Clang)
 endif()
 
-cmake_minimum_required (VERSION 2.8)
+cmake_minimum_required (VERSION 3.4)
 
-project(OnchipMemoryCache)
+project(OnchipMemoryCache CXX)
 
 set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})
 set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})

--- a/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/onchip_memory_cache/src/CMakeLists.txt
+++ b/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/onchip_memory_cache/src/CMakeLists.txt
@@ -1,71 +1,73 @@
+# To see a Makefile equivalent of this build system:
+# https://github.com/oneapi-src/oneAPI-samples/blob/master/DirectProgramming/DPC++/ProjectTemplates/makefile-fpga
+
 set(SOURCE_FILE onchip_memory_cache.cpp)
 set(TARGET_NAME onchip_memory_cache)
 set(EMULATOR_TARGET ${TARGET_NAME}.fpga_emu)
 set(FPGA_TARGET ${TARGET_NAME}.fpga)
 
 # FPGA board selection
-set(A10_PAC_BOARD_NAME "intel_a10gx_pac:pac_a10")
-set(S10_PAC_BOARD_NAME "intel_s10sx_pac:pac_s10")
-set(SELECTED_BOARD ${A10_PAC_BOARD_NAME})
-if (NOT DEFINED FPGA_BOARD)
-    message(STATUS "\tFPGA_BOARD was not specified. Configuring the design to run on the Intel(R) Programmable Acceleration Card (PAC) with Intel Arria(R) 10 GX FPGA. Please refer to the README for information on board selection.")
-elseif(FPGA_BOARD STREQUAL ${A10_PAC_BOARD_NAME})
-    message(STATUS "\tConfiguring the design to run on the Intel(R) Programmable Acceleration Card (PAC) with Intel Arria(R) 10 GX FPGA.")
-elseif(FPGA_BOARD STREQUAL ${S10_PAC_BOARD_NAME})
-    message(STATUS "\tConfiguring the design to run on the Intel(R) Programmable Acceleration Card (PAC) D5005 (with Intel Stratix(R) 10 SX FPGA).")
-    set(SELECTED_BOARD ${S10_PAC_BOARD_NAME})
+if(NOT DEFINED FPGA_BOARD)
+    set(FPGA_BOARD "intel_a10gx_pac:pac_a10")
+    message(STATUS "FPGA_BOARD was not specified.\
+                    \nConfiguring the design to run on the default FPGA board ${FPGA_BOARD} (Intel(R) PAC with Intel Arria(R) 10 GX FPGA). \
+                    \nPlease refer to the README for information on board selection.")
 else()
-    message(STATUS "\tAn invalid board name was passed in using the FPGA_BOARD flag. Configuring the design to run on the Intel(R) Programmable Acceleration Card (PAC) with Intel Arria(R) 10 GX FPGA. Please refer to the README for the list of valid board names.")
+    message(STATUS "Configuring the design to run on FPGA board ${FPGA_BOARD}")
 endif()
 
-# Flags
-set(EMULATOR_COMPILE_FLAGS "-fintelfpga -DFPGA_EMULATOR")
+# This is a Windows-specific flag that enables exception handling in host code
+if(WIN32)
+    set(WIN_FLAG "/EHsc")
+endif()
+
+# A DPC++ ahead-of-time (AoT) compile processes the device code in two stages.
+# 1. The "compile" stage compiles the device code to an intermediate representation (SPIR-V).
+# 2. The "link" stage invokes the compiler's FPGA backend before linking.
+#    For this reason, FPGA backend flags must be passed as link flags in CMake.
+set(EMULATOR_COMPILE_FLAGS "${WIN_FLAG} -fintelfpga -DFPGA_EMULATOR")
 set(EMULATOR_LINK_FLAGS "-fintelfpga")
-set(HARDWARE_COMPILE_FLAGS "-fintelfpga")
-set(HARDWARE_LINK_FLAGS "-fintelfpga -Xshardware -Xsboard=${SELECTED_BOARD} ${USER_HARDWARE_FLAGS}")
+set(HARDWARE_COMPILE_FLAGS "${WIN_FLAG} -fintelfpga")
+set(HARDWARE_LINK_FLAGS "-fintelfpga -Xshardware -Xsboard=${FPGA_BOARD} ${USER_HARDWARE_FLAGS}")
 # use cmake -D USER_HARDWARE_FLAGS=<flags> to set extra flags for FPGA backend compilation
 
+###############################################################################
+### FPGA Emulator
+###############################################################################
+# To compile in a single command:
+#    dpcpp -fintelfpga -DFPGA_EMULATOR onchip_memory_cache.cpp -o onchip_memory_cache.fpga_emu
+# CMake executes:
+#    [compile] dpcpp -fintelfpga -DFPGA_EMULATOR -o onchip_memory_cache.cpp.o -c onchip_memory_cache.cpp
+#    [link]    dpcpp -fintelfpga onchip_memory_cache.cpp.o -o onchip_memory_cache.fpga_emu
+add_executable(${EMULATOR_TARGET} ${SOURCE_FILE})
+set_target_properties(${EMULATOR_TARGET} PROPERTIES COMPILE_FLAGS "${EMULATOR_COMPILE_FLAGS}")
+set_target_properties(${EMULATOR_TARGET} PROPERTIES LINK_FLAGS "${EMULATOR_LINK_FLAGS}")
+add_custom_target(fpga_emu DEPENDS ${EMULATOR_TARGET})
 
-# FPGA emulator
-if(WIN32)
-    set(WIN_EMULATOR_TARGET ${EMULATOR_TARGET}.exe)
-    add_custom_target(fpga_emu DEPENDS ${WIN_EMULATOR_TARGET})
-    separate_arguments(WIN_EMULATOR_COMPILE_FLAGS WINDOWS_COMMAND "${EMULATOR_COMPILE_FLAGS}")
-    add_custom_command(OUTPUT ${WIN_EMULATOR_TARGET} 
-                       COMMAND ${CMAKE_CXX_COMPILER} /EHsc ${WIN_EMULATOR_COMPILE_FLAGS} ${CMAKE_CURRENT_SOURCE_DIR}/${SOURCE_FILE} -o ${CMAKE_BINARY_DIR}/${WIN_EMULATOR_TARGET}
-                       DEPENDS ${SOURCE_FILE})
-else()
-    add_executable(${EMULATOR_TARGET} ${SOURCE_FILE})
-    add_custom_target(fpga_emu DEPENDS ${EMULATOR_TARGET})
-    set_target_properties(${EMULATOR_TARGET} PROPERTIES COMPILE_FLAGS ${EMULATOR_COMPILE_FLAGS})
-    set_target_properties(${EMULATOR_TARGET} PROPERTIES LINK_FLAGS ${EMULATOR_LINK_FLAGS})
-endif()
+###############################################################################
+### Generate Report
+###############################################################################
+# To compile manually:
+#   dpcpp -fintelfpga -Xshardware -Xsboard=<FPGA_BOARD> -fsycl-link=early onchip_memory_cache.cpp -o onchip_memory_cache_report.a
+set(FPGA_EARLY_IMAGE ${TARGET_NAME}_report.a)
+# The compile output is not an executable, but an intermediate compilation result unique to DPC++.
+add_executable(${FPGA_EARLY_IMAGE} ${SOURCE_FILE})
+add_custom_target(report DEPENDS ${FPGA_EARLY_IMAGE})
+set_target_properties(${FPGA_EARLY_IMAGE} PROPERTIES COMPILE_FLAGS "${HARDWARE_COMPILE_FLAGS}")
+set_target_properties(${FPGA_EARLY_IMAGE} PROPERTIES LINK_FLAGS "${HARDWARE_LINK_FLAGS} -fsycl-link=early")
+# fsycl-link=early stops the compiler after RTL generation, before invoking Quartus
 
-# FPGA hardware
-if(WIN32)
-    add_custom_target(fpga COMMAND echo "An FPGA hardware target is not provided on Windows. See README for details.")
-else()
-    add_executable(${FPGA_TARGET} EXCLUDE_FROM_ALL ${SOURCE_FILE})
-    add_custom_target(fpga DEPENDS ${FPGA_TARGET})
-    set_target_properties(${FPGA_TARGET} PROPERTIES COMPILE_FLAGS ${HARDWARE_COMPILE_FLAGS})
-    set_target_properties(${FPGA_TARGET} PROPERTIES LINK_FLAGS ${HARDWARE_LINK_FLAGS})
-endif()
-
-# Generate report
-if(WIN32)
-    set(DEVICE_OBJ_FILE ${TARGET_NAME}_report.a)
-    add_custom_target(report DEPENDS ${DEVICE_OBJ_FILE})
-    separate_arguments(HARDWARE_LINK_FLAGS_LIST WINDOWS_COMMAND "${HARDWARE_LINK_FLAGS}")
-    add_custom_command(OUTPUT ${DEVICE_OBJ_FILE} 
-                       COMMAND ${CMAKE_CXX_COMPILER} /EHsc ${HARDWARE_LINK_FLAGS_LIST} -fsycl-link ${CMAKE_CURRENT_SOURCE_DIR}/${SOURCE_FILE} -o ${CMAKE_BINARY_DIR}/${DEVICE_OBJ_FILE}
-                       DEPENDS ${SOURCE_FILE})
-else()
-    set(DEVICE_OBJ_FILE ${TARGET_NAME}_report.a)
-    add_custom_target(report DEPENDS ${DEVICE_OBJ_FILE})
-    configure_file(${CMAKE_CURRENT_SOURCE_DIR}/${SOURCE_FILE} ${SOURCE_FILE} COPYONLY)
-    separate_arguments(HARDWARE_LINK_FLAGS_LIST UNIX_COMMAND "${HARDWARE_LINK_FLAGS}")
-    separate_arguments(CMAKE_CXX_FLAGS_LIST UNIX_COMMAND "${CMAKE_CXX_FLAGS}")
-    add_custom_command(OUTPUT ${DEVICE_OBJ_FILE} 
-                       COMMAND ${CMAKE_CXX_COMPILER} ${CMAKE_CXX_FLAGS_LIST} ${HARDWARE_LINK_FLAGS_LIST} -fsycl-link ${SOURCE_FILE} -o ${CMAKE_BINARY_DIR}/${DEVICE_OBJ_FILE}
-                       DEPENDS ${SOURCE_FILE})
-endif()
+###############################################################################
+### FPGA Hardware
+###############################################################################
+# To compile in a single command:
+#   dpcpp -fintelfpga -Xshardware -Xsboard=<FPGA_BOARD> onchip_memory_cache.cpp -o onchip_memory_cache.fpga
+# CMake executes:
+#   [compile] dpcpp -fintelfpga -o onchip_memory_cache.cpp.o -c onchip_memory_cache.cpp
+#   [link]    dpcpp -fintelfpga -Xshardware -Xsboard=<FPGA_BOARD> onchip_memory_cache.cpp.o -o onchip_memory_cache.fpga
+add_executable(${FPGA_TARGET} EXCLUDE_FROM_ALL ${SOURCE_FILE})
+add_custom_target(fpga DEPENDS ${FPGA_TARGET})
+set_target_properties(${FPGA_TARGET} PROPERTIES COMPILE_FLAGS "${HARDWARE_COMPILE_FLAGS}")
+set_target_properties(${FPGA_TARGET} PROPERTIES LINK_FLAGS "${HARDWARE_LINK_FLAGS} -reuse-exe=${CMAKE_BINARY_DIR}/${FPGA_TARGET}")
+# The -reuse-exe flag enables rapid recompilation of host-only code changes.
+# See DPC++FPGA/GettingStarted/fast_recompile for details.

--- a/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/optimize_inner_loop/CMakeLists.txt
+++ b/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/optimize_inner_loop/CMakeLists.txt
@@ -1,10 +1,17 @@
-set(CMAKE_CXX_COMPILER "dpcpp")
-if(WIN32)
-    set(CMAKE_C_COMPILER "clang-cl")
+if(UNIX)
+    # Direct CMake to use dpcpp rather than the default C++ compiler/linker
+    set(CMAKE_CXX_COMPILER dpcpp)
+else() # Windows
+    # Force CMake to use dpcpp rather than the default C++ compiler/linker 
+    # (needed on Windows only)
+    include (CMakeForceCompiler)
+    CMAKE_FORCE_CXX_COMPILER (dpcpp IntelDPCPP)
+    include (Platform/Windows-Clang)
 endif()
-cmake_minimum_required (VERSION 2.8)
 
-project(OptimizingInnerLoopThroughput)
+cmake_minimum_required (VERSION 3.4)
+
+project(OptimizingInnerLoopThroughput CXX)
 
 set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})
 set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})

--- a/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/optimize_inner_loop/src/CMakeLists.txt
+++ b/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/optimize_inner_loop/src/CMakeLists.txt
@@ -1,71 +1,73 @@
+# To see a Makefile equivalent of this build system:
+# https://github.com/oneapi-src/oneAPI-samples/blob/master/DirectProgramming/DPC++/ProjectTemplates/makefile-fpga
+
 set(SOURCE_FILE optimize_inner_loop.cpp)
 set(TARGET_NAME optimize_inner_loop)
 set(EMULATOR_TARGET ${TARGET_NAME}.fpga_emu)
 set(FPGA_TARGET ${TARGET_NAME}.fpga)
-set(REPORTS_TARGET ${TARGET_NAME}_report)
 
 # FPGA board selection
-set(A10_PAC_BOARD_NAME "intel_a10gx_pac:pac_a10")
-set(S10_PAC_BOARD_NAME "intel_s10sx_pac:pac_s10")
-set(SELECTED_BOARD ${A10_PAC_BOARD_NAME})
-if (NOT DEFINED FPGA_BOARD)
-    message(STATUS "\tFPGA_BOARD was not specified. Configuring the design to run on the Intel(R) Programmable Acceleration Card (PAC) with Intel Arria(R) 10 GX FPGA. Please refer to the README for information on board selection.")
-elseif(FPGA_BOARD STREQUAL ${A10_PAC_BOARD_NAME})
-    message(STATUS "\tConfiguring the design to run on the Intel(R) Programmable Acceleration Card (PAC) with Intel Arria(R) 10 GX FPGA.")
-elseif(FPGA_BOARD STREQUAL ${S10_PAC_BOARD_NAME})
-    message(STATUS "\tConfiguring the design to run on the Intel(R) Programmable Acceleration Card (PAC) D5005 (with Intel Stratix(R) 10 SX FPGA).")
-    set(SELECTED_BOARD ${S10_PAC_BOARD_NAME})
+if(NOT DEFINED FPGA_BOARD)
+    set(FPGA_BOARD "intel_a10gx_pac:pac_a10")
+    message(STATUS "FPGA_BOARD was not specified.\
+                    \nConfiguring the design to run on the default FPGA board ${FPGA_BOARD} (Intel(R) PAC with Intel Arria(R) 10 GX FPGA). \
+                    \nPlease refer to the README for information on board selection.")
 else()
-    message(STATUS "\tAn invalid board name was passed in using the FPGA_BOARD flag. Configuring the design to run on the Intel(R) Programmable Acceleration Card (PAC) with Intel Arria(R) 10 GX FPGA. Please refer to the README for the list of valid board names.")
+    message(STATUS "Configuring the design to run on FPGA board ${FPGA_BOARD}")
 endif()
 
-# Flags
-set(EMULATOR_COMPILE_FLAGS "-fintelfpga -DFPGA_EMULATOR")
+# This is a Windows-specific flag that enables exception handling in host code
+if(WIN32)
+    set(WIN_FLAG "/EHsc")
+endif()
+
+# A DPC++ ahead-of-time (AoT) compile processes the device code in two stages.
+# 1. The "compile" stage compiles the device code to an intermediate representation (SPIR-V).
+# 2. The "link" stage invokes the compiler's FPGA backend before linking.
+#    For this reason, FPGA backend flags must be passed as link flags in CMake.
+set(EMULATOR_COMPILE_FLAGS "${WIN_FLAG} -fintelfpga -DFPGA_EMULATOR")
 set(EMULATOR_LINK_FLAGS "-fintelfpga")
-set(HARDWARE_COMPILE_FLAGS "-fintelfpga")
-set(HARDWARE_LINK_FLAGS "-fintelfpga -Xshardware -Xsboard=${SELECTED_BOARD} ${USER_HARDWARE_FLAGS}")
+set(HARDWARE_COMPILE_FLAGS "${WIN_FLAG} -fintelfpga")
+set(HARDWARE_LINK_FLAGS "-fintelfpga -Xshardware -Xsboard=${FPGA_BOARD} ${USER_HARDWARE_FLAGS}")
 # use cmake -D USER_HARDWARE_FLAGS=<flags> to set extra flags for FPGA backend compilation
 
+###############################################################################
+### FPGA Emulator
+###############################################################################
+# To compile in a single command:
+#    dpcpp -fintelfpga -DFPGA_EMULATOR optimize_inner_loop.cpp -o optimize_inner_loop.fpga_emu
+# CMake executes:
+#    [compile] dpcpp -fintelfpga -DFPGA_EMULATOR -o optimize_inner_loop.cpp.o -c optimize_inner_loop.cpp
+#    [link]    dpcpp -fintelfpga optimize_inner_loop.cpp.o -o optimize_inner_loop.fpga_emu
+add_executable(${EMULATOR_TARGET} ${SOURCE_FILE})
+set_target_properties(${EMULATOR_TARGET} PROPERTIES COMPILE_FLAGS "${EMULATOR_COMPILE_FLAGS}")
+set_target_properties(${EMULATOR_TARGET} PROPERTIES LINK_FLAGS "${EMULATOR_LINK_FLAGS}")
+add_custom_target(fpga_emu DEPENDS ${EMULATOR_TARGET})
 
-# FPGA emulator
-if(WIN32)
-    set(WIN_EMULATOR_TARGET ${EMULATOR_TARGET}.exe)
-    add_custom_target(fpga_emu DEPENDS ${WIN_EMULATOR_TARGET})
-    separate_arguments(WIN_EMULATOR_COMPILE_FLAGS WINDOWS_COMMAND "${EMULATOR_COMPILE_FLAGS}")
-    add_custom_command(OUTPUT ${WIN_EMULATOR_TARGET} 
-                       COMMAND ${CMAKE_CXX_COMPILER} /EHsc ${WIN_EMULATOR_COMPILE_FLAGS} ${CMAKE_CURRENT_SOURCE_DIR}/${SOURCE_FILE} -o ${CMAKE_BINARY_DIR}/${WIN_EMULATOR_TARGET}
-                       DEPENDS ${SOURCE_FILE})
-else()
-    add_executable(${EMULATOR_TARGET} ${SOURCE_FILE})
-    add_custom_target(fpga_emu DEPENDS ${EMULATOR_TARGET})
-    set_target_properties(${EMULATOR_TARGET} PROPERTIES COMPILE_FLAGS ${EMULATOR_COMPILE_FLAGS})
-    set_target_properties(${EMULATOR_TARGET} PROPERTIES LINK_FLAGS ${EMULATOR_LINK_FLAGS})
-endif()
+###############################################################################
+### Generate Report
+###############################################################################
+# To compile manually:
+#   dpcpp -fintelfpga -Xshardware -Xsboard=<FPGA_BOARD> -fsycl-link=early optimize_inner_loop.cpp -o optimize_inner_loop_report.a
+set(FPGA_EARLY_IMAGE ${TARGET_NAME}_report.a)
+# The compile output is not an executable, but an intermediate compilation result unique to DPC++.
+add_executable(${FPGA_EARLY_IMAGE} ${SOURCE_FILE})
+add_custom_target(report DEPENDS ${FPGA_EARLY_IMAGE})
+set_target_properties(${FPGA_EARLY_IMAGE} PROPERTIES COMPILE_FLAGS "${HARDWARE_COMPILE_FLAGS}")
+set_target_properties(${FPGA_EARLY_IMAGE} PROPERTIES LINK_FLAGS "${HARDWARE_LINK_FLAGS} -fsycl-link=early")
+# fsycl-link=early stops the compiler after RTL generation, before invoking Quartus
 
-# FPGA hardware
-if(WIN32)
-    add_custom_target(fpga COMMAND echo "An FPGA hardware target is not provided on Windows. See README for details.")
-else()
-    add_executable(${FPGA_TARGET} EXCLUDE_FROM_ALL ${SOURCE_FILE})
-    add_custom_target(fpga DEPENDS ${FPGA_TARGET})
-    set_target_properties(${FPGA_TARGET} PROPERTIES COMPILE_FLAGS ${HARDWARE_COMPILE_FLAGS})
-    set_target_properties(${FPGA_TARGET} PROPERTIES LINK_FLAGS ${HARDWARE_LINK_FLAGS})
-endif()
-
-# Generate report
-if(WIN32)
-    set(DEVICE_OBJ_FILE ${TARGET_NAME}_report.a)
-    add_custom_target(report DEPENDS ${DEVICE_OBJ_FILE})
-    separate_arguments(HARDWARE_LINK_FLAGS_LIST WINDOWS_COMMAND "${HARDWARE_LINK_FLAGS}")
-    add_custom_command(OUTPUT ${DEVICE_OBJ_FILE} 
-                       COMMAND ${CMAKE_CXX_COMPILER} /EHsc ${HARDWARE_LINK_FLAGS_LIST} -fsycl-link ${CMAKE_CURRENT_SOURCE_DIR}/${SOURCE_FILE} -o ${CMAKE_BINARY_DIR}/${DEVICE_OBJ_FILE}
-                       DEPENDS ${SOURCE_FILE})
-else()
-    configure_file(${CMAKE_CURRENT_SOURCE_DIR}/${SOURCE_FILE} ${SOURCE_FILE} COPYONLY)
-    separate_arguments(HARDWARE_LINK_FLAGS_LIST UNIX_COMMAND "${HARDWARE_LINK_FLAGS}")
-    separate_arguments(CMAKE_CXX_FLAGS_LIST UNIX_COMMAND "${CMAKE_CXX_FLAGS}")
-    add_custom_command(OUTPUT ${REPORTS_TARGET}
-                       COMMAND ${CMAKE_CXX_COMPILER} ${CMAKE_CXX_FLAGS_LIST} ${HARDWARE_LINK_FLAGS_LIST} -fsycl-link ${SOURCE_FILE} -o ${CMAKE_BINARY_DIR}/${REPORTS_TARGET}
-                       DEPENDS ${SOURCE_FILE})
-    add_custom_target(report DEPENDS ${REPORTS_TARGET})
-endif()
+###############################################################################
+### FPGA Hardware
+###############################################################################
+# To compile in a single command:
+#   dpcpp -fintelfpga -Xshardware -Xsboard=<FPGA_BOARD> optimize_inner_loop.cpp -o optimize_inner_loop.fpga
+# CMake executes:
+#   [compile] dpcpp -fintelfpga -o optimize_inner_loop.cpp.o -c optimize_inner_loop.cpp
+#   [link]    dpcpp -fintelfpga -Xshardware -Xsboard=<FPGA_BOARD> optimize_inner_loop.cpp.o -o optimize_inner_loop.fpga
+add_executable(${FPGA_TARGET} EXCLUDE_FROM_ALL ${SOURCE_FILE})
+add_custom_target(fpga DEPENDS ${FPGA_TARGET})
+set_target_properties(${FPGA_TARGET} PROPERTIES COMPILE_FLAGS "${HARDWARE_COMPILE_FLAGS}")
+set_target_properties(${FPGA_TARGET} PROPERTIES LINK_FLAGS "${HARDWARE_LINK_FLAGS} -reuse-exe=${CMAKE_BINARY_DIR}/${FPGA_TARGET}")
+# The -reuse-exe flag enables rapid recompilation of host-only code changes.
+# See DPC++FPGA/GettingStarted/fast_recompile for details.

--- a/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/pipe_array/CMakeLists.txt
+++ b/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/pipe_array/CMakeLists.txt
@@ -1,11 +1,17 @@
-set(CMAKE_CXX_COMPILER "dpcpp")
-if(WIN32)
-    set(CMAKE_C_COMPILER "clang-cl")
+if(UNIX)
+    # Direct CMake to use dpcpp rather than the default C++ compiler/linker
+    set(CMAKE_CXX_COMPILER dpcpp)
+else() # Windows
+    # Force CMake to use dpcpp rather than the default C++ compiler/linker 
+    # (needed on Windows only)
+    include (CMakeForceCompiler)
+    CMAKE_FORCE_CXX_COMPILER (dpcpp IntelDPCPP)
+    include (Platform/Windows-Clang)
 endif()
 
-cmake_minimum_required (VERSION 2.8)
+cmake_minimum_required (VERSION 3.4)
 
-project(PipeArray)
+project(PipeArray CXX)
 
 set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})
 set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})

--- a/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/pipe_array/src/CMakeLists.txt
+++ b/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/pipe_array/src/CMakeLists.txt
@@ -1,76 +1,73 @@
+# To see a Makefile equivalent of this build system:
+# https://github.com/oneapi-src/oneAPI-samples/blob/master/DirectProgramming/DPC++/ProjectTemplates/makefile-fpga
+
 set(SOURCE_FILE pipe_array.cpp)
 set(TARGET_NAME pipe_array)
 set(EMULATOR_TARGET ${TARGET_NAME}.fpga_emu)
 set(FPGA_TARGET ${TARGET_NAME}.fpga)
 
 # FPGA board selection
-set(A10_PAC_BOARD_NAME "intel_a10gx_pac:pac_a10")
-set(S10_PAC_BOARD_NAME "intel_s10sx_pac:pac_s10")
-set(SELECTED_BOARD ${A10_PAC_BOARD_NAME})
-if (NOT DEFINED FPGA_BOARD)
-    message(STATUS "\tFPGA_BOARD was not specified. Configuring the design to run on the Intel(R) Programmable Acceleration Card (PAC) with Intel Arria(R) 10 GX FPGA. Please refer to the README for information on board selection.")
-elseif(FPGA_BOARD STREQUAL ${A10_PAC_BOARD_NAME})
-    message(STATUS "\tConfiguring the design to run on the Intel(R) Programmable Acceleration Card (PAC) with Intel Arria(R) 10 GX FPGA.")
-elseif(FPGA_BOARD STREQUAL ${S10_PAC_BOARD_NAME})
-    message(STATUS "\tConfiguring the design to run on the Intel(R) Programmable Acceleration Card (PAC) D5005 (with Intel Stratix(R) 10 SX FPGA).")
-    set(SELECTED_BOARD ${S10_PAC_BOARD_NAME})
+if(NOT DEFINED FPGA_BOARD)
+    set(FPGA_BOARD "intel_a10gx_pac:pac_a10")
+    message(STATUS "FPGA_BOARD was not specified.\
+                    \nConfiguring the design to run on the default FPGA board ${FPGA_BOARD} (Intel(R) PAC with Intel Arria(R) 10 GX FPGA). \
+                    \nPlease refer to the README for information on board selection.")
 else()
-    message(STATUS "\tAn invalid board name was passed in using the FPGA_BOARD flag. Configuring the design to run on the Intel(R) Programmable Acceleration Card (PAC) with Intel Arria(R) 10 GX FPGA. Please refer to the README for the list of valid board names.")
+    message(STATUS "Configuring the design to run on FPGA board ${FPGA_BOARD}")
 endif()
 
-# Flags
-set(EMULATOR_COMPILE_FLAGS "-fintelfpga -DFPGA_EMULATOR")
+# This is a Windows-specific flag that enables exception handling in host code
+if(WIN32)
+    set(WIN_FLAG "/EHsc")
+endif()
+
+# A DPC++ ahead-of-time (AoT) compile processes the device code in two stages.
+# 1. The "compile" stage compiles the device code to an intermediate representation (SPIR-V).
+# 2. The "link" stage invokes the compiler's FPGA backend before linking.
+#    For this reason, FPGA backend flags must be passed as link flags in CMake.
+set(EMULATOR_COMPILE_FLAGS "${WIN_FLAG} -fintelfpga -DFPGA_EMULATOR")
 set(EMULATOR_LINK_FLAGS "-fintelfpga")
-set(HARDWARE_COMPILE_FLAGS "-fintelfpga")
-set(HARDWARE_LINK_FLAGS "-fintelfpga -Xshardware -Xsboard=${SELECTED_BOARD} ${USER_HARDWARE_FLAGS}")
+set(HARDWARE_COMPILE_FLAGS "${WIN_FLAG} -fintelfpga")
+set(HARDWARE_LINK_FLAGS "-fintelfpga -Xshardware -Xsboard=${FPGA_BOARD} ${USER_HARDWARE_FLAGS}")
 # use cmake -D USER_HARDWARE_FLAGS=<flags> to set extra flags for FPGA backend compilation
 
+###############################################################################
+### FPGA Emulator
+###############################################################################
+# To compile in a single command:
+#    dpcpp -fintelfpga -DFPGA_EMULATOR pipe_array.cpp -o pipe_array.fpga_emu
+# CMake executes:
+#    [compile] dpcpp -fintelfpga -DFPGA_EMULATOR -o pipe_array.cpp.o -c pipe_array.cpp
+#    [link]    dpcpp -fintelfpga pipe_array.cpp.o -o pipe_array.fpga_emu
+add_executable(${EMULATOR_TARGET} ${SOURCE_FILE}) # CMake automatically adds #include'd headers to the dependency list
+set_target_properties(${EMULATOR_TARGET} PROPERTIES COMPILE_FLAGS "${EMULATOR_COMPILE_FLAGS}")
+set_target_properties(${EMULATOR_TARGET} PROPERTIES LINK_FLAGS "${EMULATOR_LINK_FLAGS}")
+add_custom_target(fpga_emu DEPENDS ${EMULATOR_TARGET})
 
-# FPGA emulator
-if(WIN32)
-    set(WIN_EMULATOR_TARGET ${EMULATOR_TARGET}.exe)
-    add_custom_target(fpga_emu DEPENDS ${WIN_EMULATOR_TARGET})
-    separate_arguments(WIN_EMULATOR_COMPILE_FLAGS WINDOWS_COMMAND "${EMULATOR_COMPILE_FLAGS}")
-    add_custom_command(OUTPUT ${WIN_EMULATOR_TARGET} 
-                       COMMAND ${CMAKE_CXX_COMPILER} /EHsc ${WIN_EMULATOR_COMPILE_FLAGS} ${CMAKE_CURRENT_SOURCE_DIR}/${SOURCE_FILE} -o ${CMAKE_BINARY_DIR}/${WIN_EMULATOR_TARGET}
-                       DEPENDS ${SOURCE_FILE})
-else()
-    add_executable(${EMULATOR_TARGET} ${SOURCE_FILE})
-    add_custom_target(fpga_emu DEPENDS ${EMULATOR_TARGET})
-    set_target_properties(${EMULATOR_TARGET} PROPERTIES COMPILE_FLAGS ${EMULATOR_COMPILE_FLAGS})
-    set_target_properties(${EMULATOR_TARGET} PROPERTIES LINK_FLAGS ${EMULATOR_LINK_FLAGS})
-endif()
+###############################################################################
+### Generate Report
+###############################################################################
+# To compile manually:
+#   dpcpp -fintelfpga -Xshardware -Xsboard=<FPGA_BOARD> -fsycl-link=early pipe_array.cpp -o pipe_array_report.a
+set(FPGA_EARLY_IMAGE ${TARGET_NAME}_report.a)
+# The compile output is not an executable, but an intermediate compilation result unique to DPC++.
+add_executable(${FPGA_EARLY_IMAGE} ${SOURCE_FILE})
+add_custom_target(report DEPENDS ${FPGA_EARLY_IMAGE})
+set_target_properties(${FPGA_EARLY_IMAGE} PROPERTIES COMPILE_FLAGS "${HARDWARE_COMPILE_FLAGS}")
+set_target_properties(${FPGA_EARLY_IMAGE} PROPERTIES LINK_FLAGS "${HARDWARE_LINK_FLAGS} -fsycl-link=early")
+# fsycl-link=early stops the compiler after RTL generation, before invoking Quartus
 
-# FPGA hardware
-if(WIN32)
-    add_custom_target(fpga COMMAND echo "An FPGA hardware target is not provided on Windows. See README for details.")
-else()
-    add_executable(${FPGA_TARGET} EXCLUDE_FROM_ALL ${SOURCE_FILE})
-    add_custom_target(fpga DEPENDS ${FPGA_TARGET})
-    set_target_properties(${FPGA_TARGET} PROPERTIES COMPILE_FLAGS ${HARDWARE_COMPILE_FLAGS})
-    set_target_properties(${FPGA_TARGET} PROPERTIES LINK_FLAGS ${HARDWARE_LINK_FLAGS})
-endif()
-
-# Generate report
-if(WIN32)
-    set(DEVICE_OBJ_FILE ${TARGET_NAME}_report.a)
-    add_custom_target(report DEPENDS ${DEVICE_OBJ_FILE})
-    separate_arguments(HARDWARE_LINK_FLAGS_LIST WINDOWS_COMMAND "${HARDWARE_LINK_FLAGS}")
-    add_custom_command(OUTPUT ${DEVICE_OBJ_FILE} 
-                       COMMAND ${CMAKE_CXX_COMPILER} /EHsc ${HARDWARE_LINK_FLAGS_LIST} -fsycl-link ${CMAKE_CURRENT_SOURCE_DIR}/${SOURCE_FILE} -o ${CMAKE_BINARY_DIR}/${DEVICE_OBJ_FILE}
-                       DEPENDS ${SOURCE_FILE} pipe_array.hpp unroller.hpp pipe_array_internal.hpp)
-else()
-    set(DEVICE_OBJ_FILE ${TARGET_NAME}_report.a)
-    add_custom_target(report DEPENDS ${DEVICE_OBJ_FILE})
-
-    configure_file(${CMAKE_CURRENT_SOURCE_DIR}/${SOURCE_FILE} ${SOURCE_FILE} COPYONLY)
-    configure_file(${CMAKE_CURRENT_SOURCE_DIR}/pipe_array.hpp pipe_array.hpp COPYONLY)
-    configure_file(${CMAKE_CURRENT_SOURCE_DIR}/unroller.hpp unroller.hpp COPYONLY)
-    configure_file(${CMAKE_CURRENT_SOURCE_DIR}/pipe_array_internal.hpp pipe_array_internal.hpp COPYONLY)
-
-    separate_arguments(HARDWARE_LINK_FLAGS_LIST UNIX_COMMAND "${HARDWARE_LINK_FLAGS}")
-    separate_arguments(CMAKE_CXX_FLAGS_LIST UNIX_COMMAND "${CMAKE_CXX_FLAGS}")
-    add_custom_command(OUTPUT ${DEVICE_OBJ_FILE} 
-                       COMMAND ${CMAKE_CXX_COMPILER} ${CMAKE_CXX_FLAGS_LIST} ${HARDWARE_LINK_FLAGS_LIST} -fsycl-link ${SOURCE_FILE} -o ${CMAKE_BINARY_DIR}/${DEVICE_OBJ_FILE}
-                       DEPENDS ${SOURCE_FILE} pipe_array.hpp unroller.hpp pipe_array_internal.hpp)
-endif()
+###############################################################################
+### FPGA Hardware
+###############################################################################
+# To compile in a single command:
+#   dpcpp -fintelfpga -Xshardware -Xsboard=<FPGA_BOARD> pipe_array.cpp -o pipe_array.fpga
+# CMake executes:
+#   [compile] dpcpp -fintelfpga -o pipe_array.cpp.o -c pipe_array.cpp
+#   [link]    dpcpp -fintelfpga -Xshardware -Xsboard=<FPGA_BOARD> pipe_array.cpp.o -o pipe_array.fpga
+add_executable(${FPGA_TARGET} EXCLUDE_FROM_ALL ${SOURCE_FILE})
+add_custom_target(fpga DEPENDS ${FPGA_TARGET})
+set_target_properties(${FPGA_TARGET} PROPERTIES COMPILE_FLAGS "${HARDWARE_COMPILE_FLAGS}")
+set_target_properties(${FPGA_TARGET} PROPERTIES LINK_FLAGS "${HARDWARE_LINK_FLAGS} -reuse-exe=${CMAKE_BINARY_DIR}/${FPGA_TARGET}")
+# The -reuse-exe flag enables rapid recompilation of host-only code changes.
+# See DPC++FPGA/GettingStarted/fast_recompile for details.

--- a/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/shannonization/CMakeLists.txt
+++ b/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/shannonization/CMakeLists.txt
@@ -1,11 +1,17 @@
-set(CMAKE_CXX_COMPILER "dpcpp")
-if(WIN32)
-    set(CMAKE_C_COMPILER "clang-cl")
+if(UNIX)
+    # Direct CMake to use dpcpp rather than the default C++ compiler/linker
+    set(CMAKE_CXX_COMPILER dpcpp)
+else() # Windows
+    # Force CMake to use dpcpp rather than the default C++ compiler/linker 
+    # (needed on Windows only)
+    include (CMakeForceCompiler)
+    CMAKE_FORCE_CXX_COMPILER (dpcpp IntelDPCPP)
+    include (Platform/Windows-Clang)
 endif()
 
-cmake_minimum_required (VERSION 2.8)
+cmake_minimum_required (VERSION 3.4)
 
-project(Shannonization)
+project(Shannonization CXX)
 
 set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})
 set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})

--- a/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/shannonization/src/CMakeLists.txt
+++ b/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/shannonization/src/CMakeLists.txt
@@ -1,3 +1,6 @@
+# To see a Makefile equivalent of this build system:
+# https://github.com/oneapi-src/oneAPI-samples/blob/master/DirectProgramming/DPC++/ProjectTemplates/makefile-fpga
+
 set(SOURCE_FILE shannonization.cpp)
 set(TARGET_NAME shannonization)
 set(EMULATOR_TARGET ${TARGET_NAME}.fpga_emu)
@@ -5,77 +8,85 @@ set(FPGA_TARGET ${TARGET_NAME}.fpga)
 set(REPORTS_TARGET ${TARGET_NAME}_report)
 
 # FPGA board selection
-set(A10_PAC_BOARD_NAME "intel_a10gx_pac:pac_a10")
-set(S10_PAC_BOARD_NAME "intel_s10sx_pac:pac_s10")
-set(SELECTED_BOARD ${A10_PAC_BOARD_NAME})
-if (NOT DEFINED FPGA_BOARD)
-    message(STATUS "\tFPGA_BOARD was not specified. Configuring the design to run on the Intel(R) Programmable Acceleration Card (PAC) with Intel Arria(R) 10 GX FPGA. Please refer to the README for information on board selection.")
-elseif(FPGA_BOARD STREQUAL ${A10_PAC_BOARD_NAME})
-    message(STATUS "\tConfiguring the design to run on the Intel(R) Programmable Acceleration Card (PAC) with Intel Arria(R) 10 GX FPGA.")
-elseif(FPGA_BOARD STREQUAL ${S10_PAC_BOARD_NAME})
-    message(STATUS "\tConfiguring the design to run on the Intel(R) Programmable Acceleration Card (PAC) D5005 (with Intel Stratix(R) 10 SX FPGA).")
-    set(SELECTED_BOARD ${S10_PAC_BOARD_NAME})
+if(NOT DEFINED FPGA_BOARD)
+    set(FPGA_BOARD "intel_a10gx_pac:pac_a10")
+    set(DEVICE_FLAG "-DA10")
+    message(STATUS "FPGA_BOARD was not specified.\
+                    \nConfiguring the design to run on the default FPGA board ${FPGA_BOARD} (Intel(R) PAC with Intel Arria(R) 10 GX FPGA). \
+                    \nPlease refer to the README for information on board selection.")
 else()
-    message(STATUS "\tAn invalid board name was passed in using the FPGA_BOARD flag. Configuring the design to run on the Intel(R) Programmable Acceleration Card (PAC) with Intel Arria(R) 10 GX FPGA. Please refer to the README for the list of valid board names.")
+    if(FPGA_BOARD STREQUAL "intel_a10gx_pac:pac_a10")
+        set(DEVICE_FLAG "-DA10")
+    elseif(FPGA_BOARD STREQUAL "intel_s10sx_pac:pac_s10" OR FPGA_BOARD STREQUAL "intel_s10sx_pac:pac_s10_usm")
+        set(DEVICE_FLAG "-DS10")
+    elseif(FPGA_BOARD MATCHES ".agilex.*")
+        set(DEVICE_FLAG "-DAgilex")
+    endif()
+    message(STATUS "Configuring the design to run on FPGA board ${FPGA_BOARD}")
 endif()
 
-# Flags
+if(NOT DEFINED DEVICE_FLAG)
+    message(FATAL_ERROR "An unrecognized or custom board was passed, but DEVICE_FLAG was not specified. \
+                         Please make sure you have set -DDEVICE_FLAG=-DA10 or -DDEVICE_FLAG=-DS10.")
+endif()
+
+# This is a Windows-specific flag that enables exception handling in host code
+if(WIN32)
+    set(WIN_FLAG "/EHsc")
+endif()
+
+# A DPC++ ahead-of-time (AoT) compile processes the device code in two stages.
+# 1. The "compile" stage compiles the device code to an intermediate representation (SPIR-V).
+# 2. The "link" stage invokes the compiler's FPGA backend before linking.
+#    For this reason, FPGA backend flags must be passed as link flags in CMake.
+set(EMULATOR_COMPILE_FLAGS "${WIN_FLAG} -fintelfpga -DFPGA_EMULATOR ${DEVICE_FLAG}")
+set(EMULATOR_LINK_FLAGS "-fintelfpga")
+set(HARDWARE_COMPILE_FLAGS "${WIN_FLAG} -fintelfpga ${DEVICE_FLAG}")
+if(FPGA_BOARD MATCHES ".s10.*")
+    # hyper-optimized-handshaking only applies to Intel Stratix 10 FPGAs
+    set(HARDWARE_LINK_FLAGS "-fintelfpga -Xshardware -Xshyper-optimized-handshaking=off -Xsboard=${FPGA_BOARD} ${DEVICE_FLAG} ${USER_HARDWARE_FLAGS}")
+else()
+    set(HARDWARE_LINK_FLAGS "-fintelfpga -Xshardware -Xsboard=${FPGA_BOARD} ${DEVICE_FLAG} ${USER_HARDWARE_FLAGS}")
+endif()
 # use cmake -D USER_HARDWARE_FLAGS=<flags> to set extra flags for FPGA backend compilation
-if(SELECTED_BOARD STREQUAL ${A10_PAC_BOARD_NAME})
-    set(EMULATOR_COMPILE_FLAGS "-fintelfpga -DFPGA_EMULATOR -DA10")
-    set(EMULATOR_LINK_FLAGS "-fintelfpga")
-    set(HARDWARE_LINK_FLAGS "-fintelfpga -Xshardware -Xsboard=${SELECTED_BOARD} -DA10 ${USER_HARDWARE_FLAGS}")
-    set(HARDWARE_COMPILE_FLAGS "-fintelfpga -DA10")
-else()
-    set(EMULATOR_COMPILE_FLAGS "-fintelfpga -DFPGA_EMULATOR -DS10")
-    set(EMULATOR_LINK_FLAGS "-fintelfpga")    
-    set(HARDWARE_LINK_FLAGS "-fintelfpga -Xshardware -Xshyper-optimized-handshaking=off -Xsboard=${SELECTED_BOARD} -DS10 ${USER_HARDWARE_FLAGS}")
-    set(HARDWARE_COMPILE_FLAGS "-fintelfpga -DS10")
-endif()
 
+###############################################################################
+### FPGA Emulator
+###############################################################################
+# To compile in a single command:
+#    dpcpp -fintelfpga -DFPGA_EMULATOR shannonization.cpp -o shannonization.fpga_emu
+# CMake executes:
+#    [compile] dpcpp -fintelfpga -DFPGA_EMULATOR -o shannonization.cpp.o -c shannonization.cpp
+#    [link]    dpcpp -fintelfpga shannonization.cpp.o -o shannonization.fpga_emu
+add_executable(${EMULATOR_TARGET} ${SOURCE_FILE}) # CMake automatically adds #include'd headers to the dependency list
+set_target_properties(${EMULATOR_TARGET} PROPERTIES COMPILE_FLAGS "${EMULATOR_COMPILE_FLAGS}")
+set_target_properties(${EMULATOR_TARGET} PROPERTIES LINK_FLAGS "${EMULATOR_LINK_FLAGS}")
+add_custom_target(fpga_emu DEPENDS ${EMULATOR_TARGET})
 
-# FPGA emulator
-if(WIN32)
-    set(WIN_EMULATOR_TARGET ${EMULATOR_TARGET}.exe)
-    add_custom_target(fpga_emu DEPENDS ${WIN_EMULATOR_TARGET})
-    separate_arguments(WIN_EMULATOR_COMPILE_FLAGS WINDOWS_COMMAND "${EMULATOR_COMPILE_FLAGS}")
-    add_custom_command(OUTPUT ${WIN_EMULATOR_TARGET} 
-                       COMMAND ${CMAKE_CXX_COMPILER} /EHsc ${WIN_EMULATOR_COMPILE_FLAGS} ${CMAKE_CURRENT_SOURCE_DIR}/${SOURCE_FILE} -o ${CMAKE_BINARY_DIR}/${WIN_EMULATOR_TARGET}
-                       DEPENDS ${SOURCE_FILE} IntersectionKernel.hpp)
-else()
-    add_executable(${EMULATOR_TARGET} ${SOURCE_FILE})
-    set_target_properties(${EMULATOR_TARGET} PROPERTIES COMPILE_FLAGS "${EMULATOR_COMPILE_FLAGS}")
-    set_target_properties(${EMULATOR_TARGET} PROPERTIES LINK_FLAGS "${EMULATOR_LINK_FLAGS}")
-    add_custom_target(fpga_emu DEPENDS ${EMULATOR_TARGET})
-endif()
+###############################################################################
+### Generate Report
+###############################################################################
+# To compile manually:
+#   dpcpp -fintelfpga -Xshardware -Xsboard=<FPGA_BOARD> -fsycl-link=early shannonization.cpp -o shannonization_report.a
+set(FPGA_EARLY_IMAGE ${TARGET_NAME}_report.a)
+# The compile output is not an executable, but an intermediate compilation result unique to DPC++.
+add_executable(${FPGA_EARLY_IMAGE} ${SOURCE_FILE})
+add_custom_target(report DEPENDS ${FPGA_EARLY_IMAGE})
+set_target_properties(${FPGA_EARLY_IMAGE} PROPERTIES COMPILE_FLAGS "${HARDWARE_COMPILE_FLAGS}")
+set_target_properties(${FPGA_EARLY_IMAGE} PROPERTIES LINK_FLAGS "${HARDWARE_LINK_FLAGS} -fsycl-link=early")
+# fsycl-link=early stops the compiler after RTL generation, before invoking Quartus
 
-# FPGA hardware
-if(WIN32)
-    add_custom_target(fpga COMMAND echo "An FPGA hardware target is not provided on Windows. See README for details.")
-else()
-    add_executable(${FPGA_TARGET} EXCLUDE_FROM_ALL ${SOURCE_FILE})
-    add_custom_target(fpga DEPENDS ${FPGA_TARGET})
-    set_target_properties(${FPGA_TARGET} PROPERTIES COMPILE_FLAGS "${HARDWARE_COMPILE_FLAGS}")
-    set_target_properties(${FPGA_TARGET} PROPERTIES LINK_FLAGS ${HARDWARE_LINK_FLAGS})
-endif()
-
-# Generate report
-if(WIN32)
-    set(DEVICE_OBJ_FILE ${TARGET_NAME}_report.a)
-    add_custom_target(report DEPENDS ${DEVICE_OBJ_FILE})
-    separate_arguments(HARDWARE_LINK_FLAGS_LIST WINDOWS_COMMAND "${HARDWARE_LINK_FLAGS}")
-    add_custom_command(OUTPUT ${DEVICE_OBJ_FILE} 
-                       COMMAND ${CMAKE_CXX_COMPILER} /EHsc ${HARDWARE_LINK_FLAGS_LIST} -fsycl-link ${CMAKE_CURRENT_SOURCE_DIR}/${SOURCE_FILE} -o ${CMAKE_BINARY_DIR}/${DEVICE_OBJ_FILE}
-                       DEPENDS ${SOURCE_FILE})
-else()
-    configure_file(${CMAKE_CURRENT_SOURCE_DIR}/${SOURCE_FILE} ${SOURCE_FILE} COPYONLY)
-    configure_file(${CMAKE_CURRENT_SOURCE_DIR}/IntersectionKernel.hpp IntersectionKernel.hpp COPYONLY)
-
-    separate_arguments(HARDWARE_LINK_FLAGS_LIST UNIX_COMMAND "${HARDWARE_LINK_FLAGS}")
-    separate_arguments(CMAKE_CXX_FLAGS_LIST UNIX_COMMAND "${CMAKE_CXX_FLAGS}")
-    add_custom_command(OUTPUT ${REPORTS_TARGET}
-                       COMMAND ${CMAKE_CXX_COMPILER} ${CMAKE_CXX_FLAGS_LIST} ${HARDWARE_LINK_FLAGS_LIST} -fsycl-link ${SOURCE_FILE} -o ${CMAKE_BINARY_DIR}/${REPORTS_TARGET}
-                       DEPENDS ${SOURCE_FILE} IntersectionKernel.hpp)
-    add_custom_target(report DEPENDS ${REPORTS_TARGET})
-endif()
-
+###############################################################################
+### FPGA Hardware
+###############################################################################
+# To compile in a single command:
+#   dpcpp -fintelfpga -Xshardware -Xsboard=<FPGA_BOARD> shannonization.cpp -o shannonization.fpga
+# CMake executes:
+#   [compile] dpcpp -fintelfpga -o shannonization.cpp.o -c shannonization.cpp
+#   [link]    dpcpp -fintelfpga -Xshardware -Xsboard=<FPGA_BOARD> shannonization.cpp.o -o shannonization.fpga
+add_executable(${FPGA_TARGET} EXCLUDE_FROM_ALL ${SOURCE_FILE})
+add_custom_target(fpga DEPENDS ${FPGA_TARGET})
+set_target_properties(${FPGA_TARGET} PROPERTIES COMPILE_FLAGS "${HARDWARE_COMPILE_FLAGS}")
+set_target_properties(${FPGA_TARGET} PROPERTIES LINK_FLAGS "${HARDWARE_LINK_FLAGS} -reuse-exe=${CMAKE_BINARY_DIR}/${FPGA_TARGET}")
+# The -reuse-exe flag enables rapid recompilation of host-only code changes.
+# See DPC++FPGA/GettingStarted/fast_recompile for details.

--- a/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/shannonization/src/shannonization.cpp
+++ b/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/shannonization/src/shannonization.cpp
@@ -1,8 +1,3 @@
-//==============================================================
-//Copyright Intel Corporation
-//
-// SPDX-License-Identifier: MIT
-// =============================================================
 #include <algorithm>
 #include <numeric>
 #include <type_traits>
@@ -287,11 +282,11 @@ int main(int argc, char** argv) {
   // can be seen in the "Block Scheduled Fmax" columns in the 
   // "Loop Analysis" tab of the HTML reports.
   //
-  // On Stratix 10, the same discussion applies, but version 0
+  // On Stratix 10 and Agilex, the same discussion applies, but version 0
   // can only achieve an II of 3 while versions 1 and 2 can only achieve
-  // an II of 2. On Stratix 10, we can achieve an II of 1 if we use non-blocking
-  // pipe reads in the IntersectionKernel, which is shown in version 3 of the
-  // kernel.
+  // an II of 2. On Stratix 10 and Agilex, we can achieve an II of 1 if we use
+  // non-blocking pipe reads in the IntersectionKernel, which is shown in
+  // version 3 of the kernel.
   //
 #if defined(A10)
     success &= Intersection<0,2>(q, a, b, golden_n);
@@ -303,8 +298,16 @@ int main(int argc, char** argv) {
     success &= Intersection<1,2>(q, a, b, golden_n);
     success &= Intersection<2,2>(q, a, b, golden_n);
     success &= Intersection<3,1>(q, a, b, golden_n);
+#elif defined(Agilex)
+    success &= Intersection<0,3>(q, a, b, golden_n);
+    success &= Intersection<1,2>(q, a, b, golden_n);
+    success &= Intersection<2,2>(q, a, b, golden_n);
+    success &= Intersection<3,1>(q, a, b, golden_n);
 #else
-      static_assert(false, "Unknown FPGA architecture!");
+    success &= Intersection<0,3>(q, a, b, golden_n);
+    success &= Intersection<1,3>(q, a, b, golden_n);
+    success &= Intersection<2,3>(q, a, b, golden_n);
+    success &= Intersection<3,3>(q, a, b, golden_n);
 #endif
 
     if (success) {

--- a/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/simple_host_streaming/CMakeLists.txt
+++ b/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/simple_host_streaming/CMakeLists.txt
@@ -1,11 +1,17 @@
-set(CMAKE_CXX_COMPILER "dpcpp")
-if(WIN32)
-    set(CMAKE_C_COMPILER "clang-cl")
+if(UNIX)
+    # Direct CMake to use dpcpp rather than the default C++ compiler/linker
+    set(CMAKE_CXX_COMPILER dpcpp)
+else() # Windows
+    # Force CMake to use dpcpp rather than the default C++ compiler/linker
+    # (needed on Windows only)
+    include (CMakeForceCompiler)
+    CMAKE_FORCE_CXX_COMPILER (dpcpp IntelDPCPP)
+    include (Platform/Windows-Clang)
 endif()
 
-cmake_minimum_required (VERSION 2.8)
+cmake_minimum_required (VERSION 3.4)
 
-project(SimpleHostStreaming)
+project(SimpleHostStreaming CXX)
 
 set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})
 set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})

--- a/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/simple_host_streaming/src/CMakeLists.txt
+++ b/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/simple_host_streaming/src/CMakeLists.txt
@@ -1,3 +1,6 @@
+# To see a Makefile equivalent of this build system:
+# https://github.com/oneapi-src/oneAPI-samples/blob/master/DirectProgramming/DPC++/ProjectTemplates/makefile-fpga
+
 set(SOURCE_FILE simple_host_streaming.cpp)
 set(TARGET_NAME simple_host_streaming)
 set(EMULATOR_TARGET ${TARGET_NAME}.fpga_emu)
@@ -5,59 +8,60 @@ set(FPGA_TARGET ${TARGET_NAME}.fpga)
 set(REPORTS_TARGET ${TARGET_NAME}_report)
 
 # USM is only supported on the PAC S10 board
-set(S10_PAC_USM_BOARD_NAME "intel_s10sx_pac:pac_s10_usm")
+set(FPGA_BOARD "intel_s10sx_pac:pac_s10_usm")
 
-# Flags
-set(EMULATOR_COMPILE_FLAGS "-fintelfpga -Wall -DFPGA_EMULATOR")
+# This is a Windows-specific flag that enables exception handling in host code
+if(WIN32)
+    set(WIN_FLAG "/EHsc")
+endif()
+
+# A DPC++ ahead-of-time (AoT) compile processes the device code in two stages.
+# 1. The "compile" stage compiles the device code to an intermediate representation (SPIR-V).
+# 2. The "link" stage invokes the compiler's FPGA backend before linking.
+#    For this reason, FPGA backend flags must be passed as link flags in CMake.
+set(EMULATOR_COMPILE_FLAGS "${WIN_FLAG} -fintelfpga -Wall -DFPGA_EMULATOR ${DEVICE_FLAG}")
 set(EMULATOR_LINK_FLAGS "-fintelfpga")
-set(HARDWARE_COMPILE_FLAGS "-fintelfpga -c")
-set(HARDWARE_LINK_FLAGS "-fintelfpga -Wall -Xshardware -Xsboard=${S10_PAC_USM_BOARD_NAME} -reuse-exe=${CMAKE_BINARY_DIR}/${FPGA_TARGET} ${USER_HARDWARE_FLAGS}")
+set(HARDWARE_COMPILE_FLAGS "${WIN_FLAG} -fintelfpga ${DEVICE_FLAG}")
+set(HARDWARE_LINK_FLAGS "-fintelfpga -Wall -Xshardware -Xshyper-optimized-handshaking=off -Xsboard=${FPGA_BOARD} ${DEVICE_FLAG} ${USER_HARDWARE_FLAGS}")
 # use cmake -D USER_HARDWARE_FLAGS=<flags> to set extra flags for FPGA backend compilation
 
+###############################################################################
+### FPGA Emulator
+###############################################################################
+# To compile in a single command:
+#    dpcpp -fintelfpga -DFPGA_EMULATOR simple_host_streaming.cpp -o simple_host_streaming.fpga_emu
+# CMake executes:
+#    [compile] dpcpp -fintelfpga -DFPGA_EMULATOR -o simple_host_streaming.cpp.o -c simple_host_streaming.cpp
+#    [link]    dpcpp -fintelfpga simple_host_streaming.cpp.o -o simple_host_streaming.fpga_emu
+add_executable(${EMULATOR_TARGET} ${SOURCE_FILE}) # CMake automatically adds #include'd headers to the dependency list
+set_target_properties(${EMULATOR_TARGET} PROPERTIES COMPILE_FLAGS "${EMULATOR_COMPILE_FLAGS}")
+set_target_properties(${EMULATOR_TARGET} PROPERTIES LINK_FLAGS "${EMULATOR_LINK_FLAGS}")
+add_custom_target(fpga_emu DEPENDS ${EMULATOR_TARGET})
 
-# FPGA emulator
-if(WIN32)
-    set(WIN_EMULATOR_TARGET ${EMULATOR_TARGET}.exe)
-    add_custom_target(fpga_emu DEPENDS ${WIN_EMULATOR_TARGET})
-    separate_arguments(WIN_EMULATOR_COMPILE_FLAGS WINDOWS_COMMAND "${EMULATOR_COMPILE_FLAGS}")
-    add_custom_command(OUTPUT ${WIN_EMULATOR_TARGET} 
-                       COMMAND ${CMAKE_CXX_COMPILER} /EHsc ${WIN_EMULATOR_COMPILE_FLAGS} ${CMAKE_CURRENT_SOURCE_DIR}/${SOURCE_FILE} -o ${CMAKE_BINARY_DIR}/${WIN_EMULATOR_TARGET}
-                       DEPENDS ${SOURCE_FILE})
-else()
-    add_executable(${EMULATOR_TARGET} ${SOURCE_FILE})
-    add_custom_target(fpga_emu DEPENDS ${EMULATOR_TARGET})
-    set_target_properties(${EMULATOR_TARGET} PROPERTIES COMPILE_FLAGS ${EMULATOR_COMPILE_FLAGS})
-    set_target_properties(${EMULATOR_TARGET} PROPERTIES LINK_FLAGS ${EMULATOR_LINK_FLAGS})
-endif()
+###############################################################################
+### Generate Report
+###############################################################################
+# To compile manually:
+#   dpcpp -fintelfpga -Xshardware -Xshyper-optimized-handshaking=off -Xsboard=<FPGA_BOARD> -fsycl-link=early simple_host_streaming.cpp -o simple_host_streaming_report.a
+set(FPGA_EARLY_IMAGE ${TARGET_NAME}_report.a)
+# The compile output is not an executable, but an intermediate compilation result unique to DPC++.
+add_executable(${FPGA_EARLY_IMAGE} ${SOURCE_FILE})
+add_custom_target(report DEPENDS ${FPGA_EARLY_IMAGE})
+set_target_properties(${FPGA_EARLY_IMAGE} PROPERTIES COMPILE_FLAGS "${HARDWARE_COMPILE_FLAGS}")
+set_target_properties(${FPGA_EARLY_IMAGE} PROPERTIES LINK_FLAGS "${HARDWARE_LINK_FLAGS} -fsycl-link=early")
+# fsycl-link=early stops the compiler after RTL generation, before invoking Quartus
 
-# FPGA hardware
-if(WIN32)
-    add_custom_target(fpga COMMAND echo "An FPGA hardware target is not provided on Windows. See README for details.")
-else()
-    add_executable(${FPGA_TARGET} EXCLUDE_FROM_ALL ${SOURCE_FILE})
-    add_custom_target(fpga DEPENDS ${FPGA_TARGET})
-    set_target_properties(${FPGA_TARGET} PROPERTIES COMPILE_FLAGS ${HARDWARE_COMPILE_FLAGS})
-    set_target_properties(${FPGA_TARGET} PROPERTIES LINK_FLAGS ${HARDWARE_LINK_FLAGS})
-endif()
-
-# FPGA hardware report
-if(WIN32)
-    set(DEVICE_OBJ_FILE ${TARGET_NAME}_report.a)
-    add_custom_target(report DEPENDS ${DEVICE_OBJ_FILE})
-    separate_arguments(HARDWARE_LINK_FLAGS_LIST WINDOWS_COMMAND "${HARDWARE_LINK_FLAGS}")
-    add_custom_command(OUTPUT ${DEVICE_OBJ_FILE} 
-                       COMMAND ${CMAKE_CXX_COMPILER} /EHsc ${HARDWARE_LINK_FLAGS_LIST} -fsycl-link ${CMAKE_CURRENT_SOURCE_DIR}/${SOURCE_FILE} -o ${CMAKE_BINARY_DIR}/${DEVICE_OBJ_FILE}
-                       DEPENDS ${SOURCE_FILE})
-else()
-    configure_file(${CMAKE_CURRENT_SOURCE_DIR}/${SOURCE_FILE} ${SOURCE_FILE} COPYONLY)
-    configure_file(${CMAKE_CURRENT_SOURCE_DIR}/multi_kernel.hpp multi_kernel.hpp COPYONLY)
-    configure_file(${CMAKE_CURRENT_SOURCE_DIR}/single_kernel.hpp single_kernel.hpp COPYONLY)
-
-    separate_arguments(HARDWARE_LINK_FLAGS_LIST UNIX_COMMAND "${HARDWARE_LINK_FLAGS}")
-    separate_arguments(CMAKE_CXX_FLAGS_LIST UNIX_COMMAND "${CMAKE_CXX_FLAGS}")
-    add_custom_command(OUTPUT ${REPORTS_TARGET}
-                       COMMAND ${CMAKE_CXX_COMPILER} ${CMAKE_CXX_FLAGS_LIST} ${HARDWARE_LINK_FLAGS_LIST} -fsycl-link ${SOURCE_FILE} -o ${CMAKE_BINARY_DIR}/${REPORTS_TARGET}
-                       DEPENDS ${SOURCE_FILE})
-    add_custom_target(report DEPENDS ${REPORTS_TARGET})
-endif()
-
+###############################################################################
+### FPGA Hardware
+###############################################################################
+# To compile in a single command:
+#   dpcpp -fintelfpga -Xshardware -Xshyper-optimized-handshaking=off -Xsboard=<FPGA_BOARD> simple_host_streaming.cpp -o simple_host_streaming.fpga
+# CMake executes:
+#   [compile] dpcpp -fintelfpga -o simple_host_streaming.cpp.o -c simple_host_streaming.cpp
+#   [link]    dpcpp -fintelfpga -Xshardware -Xshyper-optimized-handshaking=off -Xsboard=<FPGA_BOARD> simple_host_streaming.cpp.o -o simple_host_streaming.fpga
+add_executable(${FPGA_TARGET} EXCLUDE_FROM_ALL ${SOURCE_FILE})
+add_custom_target(fpga DEPENDS ${FPGA_TARGET})
+set_target_properties(${FPGA_TARGET} PROPERTIES COMPILE_FLAGS "${HARDWARE_COMPILE_FLAGS}")
+set_target_properties(${FPGA_TARGET} PROPERTIES LINK_FLAGS "${HARDWARE_LINK_FLAGS} -reuse-exe=${CMAKE_BINARY_DIR}/${FPGA_TARGET}")
+# The -reuse-exe flag enables rapid recompilation of host-only code changes.
+# See DPC++FPGA/GettingStarted/fast_recompile for details.

--- a/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/triangular_loop/CMakeLists.txt
+++ b/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/triangular_loop/CMakeLists.txt
@@ -1,11 +1,17 @@
-set(CMAKE_CXX_COMPILER "dpcpp")
-if(WIN32)
-    set(CMAKE_C_COMPILER "clang-cl")
+if(UNIX)
+    # Direct CMake to use dpcpp rather than the default C++ compiler/linker
+    set(CMAKE_CXX_COMPILER dpcpp)
+else() # Windows
+    # Force CMake to use dpcpp rather than the default C++ compiler/linker 
+    # (needed on Windows only)
+    include (CMakeForceCompiler)
+    CMAKE_FORCE_CXX_COMPILER (dpcpp IntelDPCPP)
+    include (Platform/Windows-Clang)
 endif()
 
-cmake_minimum_required (VERSION 2.8)
+cmake_minimum_required (VERSION 3.4)
 
-project(TriangularLoop)
+project(TriangularLoop CXX)
 
 set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})
 set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})

--- a/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/triangular_loop/src/CMakeLists.txt
+++ b/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/triangular_loop/src/CMakeLists.txt
@@ -1,72 +1,73 @@
+# To see a Makefile equivalent of this build system:
+# https://github.com/oneapi-src/oneAPI-samples/blob/master/DirectProgramming/DPC++/ProjectTemplates/makefile-fpga
+
 set(SOURCE_FILE triangular_loop.cpp)
 set(TARGET_NAME triangular_loop)
 set(EMULATOR_TARGET ${TARGET_NAME}.fpga_emu)
 set(FPGA_TARGET ${TARGET_NAME}.fpga)
 
 # FPGA board selection
-set(A10_PAC_BOARD_NAME "intel_a10gx_pac:pac_a10")
-set(S10_PAC_BOARD_NAME "intel_s10sx_pac:pac_s10")
-set(SELECTED_BOARD ${A10_PAC_BOARD_NAME})
-if (NOT DEFINED FPGA_BOARD)
-    message(STATUS "\tFPGA_BOARD was not specified. Configuring the design to run on the Intel(R) Programmable Acceleration Card (PAC) with Intel Arria(R) 10 GX FPGA. Please refer to the README for information on board selection.")
-elseif(FPGA_BOARD STREQUAL ${A10_PAC_BOARD_NAME})
-    message(STATUS "\tConfiguring the design to run on the Intel(R) Programmable Acceleration Card (PAC) with Intel Arria(R) 10 GX FPGA.")
-elseif(FPGA_BOARD STREQUAL ${S10_PAC_BOARD_NAME})
-    message(STATUS "\tConfiguring the design to run on the Intel(R) Programmable Acceleration Card (PAC) D5005 (with Intel Stratix(R) 10 SX FPGA).")
-    set(SELECTED_BOARD ${S10_PAC_BOARD_NAME})
+if(NOT DEFINED FPGA_BOARD)
+    set(FPGA_BOARD "intel_a10gx_pac:pac_a10")
+    message(STATUS "FPGA_BOARD was not specified.\
+                    \nConfiguring the design to run on the default FPGA board ${FPGA_BOARD} (Intel(R) PAC with Intel Arria(R) 10 GX FPGA). \
+                    \nPlease refer to the README for information on board selection.")
 else()
-    message(STATUS "\tAn invalid board name was passed in using the FPGA_BOARD flag. Configuring the design to run on the Intel(R) Programmable Acceleration Card (PAC) with Intel Arria(R) 10 GX FPGA. Please refer to the README for the list of valid board names.")
+    message(STATUS "Configuring the design to run on FPGA board ${FPGA_BOARD}")
 endif()
 
-# Flags
-set(EMULATOR_COMPILE_FLAGS "-fintelfpga -DFPGA_EMULATOR")
+# This is a Windows-specific flag that enables exception handling in host code
+if(WIN32)
+    set(WIN_FLAG "/EHsc")
+endif()
+
+# A DPC++ ahead-of-time (AoT) compile processes the device code in two stages.
+# 1. The "compile" stage compiles the device code to an intermediate representation (SPIR-V).
+# 2. The "link" stage invokes the compiler's FPGA backend before linking.
+#    For this reason, FPGA backend flags must be passed as link flags in CMake.
+set(EMULATOR_COMPILE_FLAGS "${WIN_FLAG} -fintelfpga -DFPGA_EMULATOR")
 set(EMULATOR_LINK_FLAGS "-fintelfpga")
-set(HARDWARE_COMPILE_FLAGS "-fintelfpga")
-set(HARDWARE_LINK_FLAGS "-fintelfpga -Xshardware -Xsboard=${SELECTED_BOARD} ${USER_HARDWARE_FLAGS}")
+set(HARDWARE_COMPILE_FLAGS "${WIN_FLAG} -fintelfpga")
+set(HARDWARE_LINK_FLAGS "-fintelfpga -Xshardware -Xsboard=${FPGA_BOARD} ${USER_HARDWARE_FLAGS}")
 # use cmake -D USER_HARDWARE_FLAGS=<flags> to set extra flags for FPGA backend compilation
 
+###############################################################################
+### FPGA Emulator
+###############################################################################
+# To compile in a single command:
+#    dpcpp -fintelfpga -DFPGA_EMULATOR triangular_loop.cpp -o triangular_loop.fpga_emu
+# CMake executes:
+#    [compile] dpcpp -fintelfpga -DFPGA_EMULATOR -o triangular_loop.cpp.o -c triangular_loop.cpp
+#    [link]    dpcpp -fintelfpga triangular_loop.cpp.o -o triangular_loop.fpga_emu
+add_executable(${EMULATOR_TARGET} ${SOURCE_FILE})
+set_target_properties(${EMULATOR_TARGET} PROPERTIES COMPILE_FLAGS "${EMULATOR_COMPILE_FLAGS}")
+set_target_properties(${EMULATOR_TARGET} PROPERTIES LINK_FLAGS "${EMULATOR_LINK_FLAGS}")
+add_custom_target(fpga_emu DEPENDS ${EMULATOR_TARGET})
 
-# FPGA emulator
-if(WIN32)
-    set(WIN_EMULATOR_TARGET ${EMULATOR_TARGET}.exe)
-    add_custom_target(fpga_emu DEPENDS ${WIN_EMULATOR_TARGET})
-    separate_arguments(WIN_EMULATOR_COMPILE_FLAGS WINDOWS_COMMAND "${EMULATOR_COMPILE_FLAGS}")
-    add_custom_command(OUTPUT ${WIN_EMULATOR_TARGET} 
-                       COMMAND ${CMAKE_CXX_COMPILER} /EHsc ${WIN_EMULATOR_COMPILE_FLAGS} ${CMAKE_CURRENT_SOURCE_DIR}/${SOURCE_FILE} -o ${CMAKE_BINARY_DIR}/${WIN_EMULATOR_TARGET}
-                       DEPENDS ${SOURCE_FILE})
-else()
-    add_executable(${EMULATOR_TARGET} ${SOURCE_FILE})
-    add_custom_target(fpga_emu DEPENDS ${EMULATOR_TARGET})
-    set_target_properties(${EMULATOR_TARGET} PROPERTIES COMPILE_FLAGS ${EMULATOR_COMPILE_FLAGS})
-    set_target_properties(${EMULATOR_TARGET} PROPERTIES LINK_FLAGS ${EMULATOR_LINK_FLAGS})
-endif()
+###############################################################################
+### Generate Report
+###############################################################################
+# To compile manually:
+#   dpcpp -fintelfpga -Xshardware -Xsboard=<FPGA_BOARD> -fsycl-link=early triangular_loop.cpp -o triangular_loop_report.a
+set(FPGA_EARLY_IMAGE ${TARGET_NAME}_report.a)
+# The compile output is not an executable, but an intermediate compilation result unique to DPC++.
+add_executable(${FPGA_EARLY_IMAGE} ${SOURCE_FILE})
+add_custom_target(report DEPENDS ${FPGA_EARLY_IMAGE})
+set_target_properties(${FPGA_EARLY_IMAGE} PROPERTIES COMPILE_FLAGS "${HARDWARE_COMPILE_FLAGS}")
+set_target_properties(${FPGA_EARLY_IMAGE} PROPERTIES LINK_FLAGS "${HARDWARE_LINK_FLAGS} -fsycl-link=early")
+# fsycl-link=early stops the compiler after RTL generation, before invoking Quartus
 
-# FPGA hardware
-if(WIN32)
-    add_custom_target(fpga COMMAND echo "An FPGA hardware target is not provided on Windows. See README for details.")
-else()
-    add_executable(${FPGA_TARGET} EXCLUDE_FROM_ALL ${SOURCE_FILE})
-    add_custom_target(fpga DEPENDS ${FPGA_TARGET})
-    set_target_properties(${FPGA_TARGET} PROPERTIES COMPILE_FLAGS ${HARDWARE_COMPILE_FLAGS})
-    set_target_properties(${FPGA_TARGET} PROPERTIES LINK_FLAGS ${HARDWARE_LINK_FLAGS})
-endif()
-
-# Generate report
-if(WIN32)
-    set(DEVICE_OBJ_FILE ${TARGET_NAME}_report.a)
-    add_custom_target(report DEPENDS ${DEVICE_OBJ_FILE})
-    separate_arguments(HARDWARE_LINK_FLAGS_LIST WINDOWS_COMMAND "${HARDWARE_LINK_FLAGS}")
-    separate_arguments(CMAKE_CXX_FLAGS_LIST WINDOWS_COMMAND "${CMAKE_CXX_FLAGS}")
-    add_custom_command(OUTPUT ${DEVICE_OBJ_FILE} 
-                       COMMAND ${CMAKE_CXX_COMPILER} /EHsc ${CMAKE_CXX_FLAGS_LIST} ${HARDWARE_LINK_FLAGS_LIST} -fsycl-link ${CMAKE_CURRENT_SOURCE_DIR}/${SOURCE_FILE} -o ${CMAKE_BINARY_DIR}/${DEVICE_OBJ_FILE}
-                       DEPENDS ${SOURCE_FILE})
-else()
-    set(DEVICE_OBJ_FILE ${TARGET_NAME}_report.a)
-    add_custom_target(report DEPENDS ${DEVICE_OBJ_FILE})
-    configure_file(${CMAKE_CURRENT_SOURCE_DIR}/${SOURCE_FILE} ${SOURCE_FILE} COPYONLY)
-    separate_arguments(HARDWARE_LINK_FLAGS_LIST UNIX_COMMAND "${HARDWARE_LINK_FLAGS}")
-    separate_arguments(CMAKE_CXX_FLAGS_LIST UNIX_COMMAND "${CMAKE_CXX_FLAGS}")
-    add_custom_command(OUTPUT ${DEVICE_OBJ_FILE} 
-                       COMMAND ${CMAKE_CXX_COMPILER} ${CMAKE_CXX_FLAGS_LIST} ${HARDWARE_LINK_FLAGS_LIST} -fsycl-link ${SOURCE_FILE} -o ${CMAKE_BINARY_DIR}/${DEVICE_OBJ_FILE}
-                       DEPENDS ${SOURCE_FILE})
-endif()
+###############################################################################
+### FPGA Hardware
+###############################################################################
+# To compile in a single command:
+#   dpcpp -fintelfpga -Xshardware -Xsboard=<FPGA_BOARD> triangular_loop.cpp -o triangular_loop.fpga
+# CMake executes:
+#   [compile] dpcpp -fintelfpga -o triangular_loop.cpp.o -c triangular_loop.cpp
+#   [link]    dpcpp -fintelfpga -Xshardware -Xsboard=<FPGA_BOARD> triangular_loop.cpp.o -o triangular_loop.fpga
+add_executable(${FPGA_TARGET} EXCLUDE_FROM_ALL ${SOURCE_FILE})
+add_custom_target(fpga DEPENDS ${FPGA_TARGET})
+set_target_properties(${FPGA_TARGET} PROPERTIES COMPILE_FLAGS "${HARDWARE_COMPILE_FLAGS}")
+set_target_properties(${FPGA_TARGET} PROPERTIES LINK_FLAGS "${HARDWARE_LINK_FLAGS} -reuse-exe=${CMAKE_BINARY_DIR}/${FPGA_TARGET}")
+# The -reuse-exe flag enables rapid recompilation of host-only code changes.
+# See DPC++FPGA/GettingStarted/fast_recompile for details.

--- a/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/zero_copy_data_transfer/CMakeLists.txt
+++ b/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/zero_copy_data_transfer/CMakeLists.txt
@@ -1,11 +1,17 @@
-set(CMAKE_CXX_COMPILER "dpcpp")
-if(WIN32)
-    set(CMAKE_C_COMPILER "clang-cl")
+if(UNIX)
+    # Direct CMake to use dpcpp rather than the default C++ compiler/linker
+    set(CMAKE_CXX_COMPILER dpcpp)
+else() # Windows
+    # Force CMake to use dpcpp rather than the default C++ compiler/linker 
+    # (needed on Windows only)
+    include (CMakeForceCompiler)
+    CMAKE_FORCE_CXX_COMPILER (dpcpp IntelDPCPP)
+    include (Platform/Windows-Clang)
 endif()
 
-cmake_minimum_required (VERSION 2.8)
+cmake_minimum_required (VERSION 3.4)
 
-project(ZeroCopyDataTransfer)
+project(ZeroCopyDataTransfer CXX)
 
 set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})
 set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})

--- a/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/zero_copy_data_transfer/src/CMakeLists.txt
+++ b/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/zero_copy_data_transfer/src/CMakeLists.txt
@@ -1,3 +1,6 @@
+# To see a Makefile equivalent of this build system:
+# https://github.com/oneapi-src/oneAPI-samples/blob/master/DirectProgramming/DPC++/ProjectTemplates/makefile-fpga
+
 set(SOURCE_FILE zero_copy_data_transfer.cpp)
 set(TARGET_NAME zero_copy_data_transfer)
 set(EMULATOR_TARGET ${TARGET_NAME}.fpga_emu)
@@ -5,59 +8,60 @@ set(FPGA_TARGET ${TARGET_NAME}.fpga)
 set(REPORTS_TARGET ${TARGET_NAME}_report)
 
 # USM is only supported on the PAC S10 board
-set(S10_PAC_USM_BOARD_NAME "intel_s10sx_pac:pac_s10_usm")
+set(FPGA_BOARD "intel_s10sx_pac:pac_s10_usm")
 
-# Flags
-set(EMULATOR_COMPILE_FLAGS "-fintelfpga -Wall -DFPGA_EMULATOR")
+# This is a Windows-specific flag that enables exception handling in host code
+if(WIN32)
+    set(WIN_FLAG "/EHsc")
+endif()
+
+# A DPC++ ahead-of-time (AoT) compile processes the device code in two stages.
+# 1. The "compile" stage compiles the device code to an intermediate representation (SPIR-V).
+# 2. The "link" stage invokes the compiler's FPGA backend before linking.
+#    For this reason, FPGA backend flags must be passed as link flags in CMake.
+set(EMULATOR_COMPILE_FLAGS "${WIN_FLAG} -fintelfpga -Wall -DFPGA_EMULATOR ${DEVICE_FLAG}")
 set(EMULATOR_LINK_FLAGS "-fintelfpga")
-set(HARDWARE_COMPILE_FLAGS "-fintelfpga -c")
-set(HARDWARE_LINK_FLAGS "-fintelfpga -Wall -Xshardware -Xsboard=${S10_PAC_USM_BOARD_NAME} ${USER_HARDWARE_FLAGS}")
+set(HARDWARE_COMPILE_FLAGS "${WIN_FLAG} -fintelfpga -Wall ${DEVICE_FLAG}")
+set(HARDWARE_LINK_FLAGS "-fintelfpga -Xshardware -Xshyper-optimized-handshaking=off -Xsboard=${FPGA_BOARD} ${DEVICE_FLAG} ${USER_HARDWARE_FLAGS}")
 # use cmake -D USER_HARDWARE_FLAGS=<flags> to set extra flags for FPGA backend compilation
 
+###############################################################################
+### FPGA Emulator
+###############################################################################
+# To compile in a single command:
+#    dpcpp -fintelfpga -DFPGA_EMULATOR zero_copy_data_transfer.cpp -o zero_copy_data_transfer.fpga_emu
+# CMake executes:
+#    [compile] dpcpp -fintelfpga -DFPGA_EMULATOR -o zero_copy_data_transfer.cpp.o -c zero_copy_data_transfer.cpp
+#    [link]    dpcpp -fintelfpga zero_copy_data_transfer.cpp.o -o zero_copy_data_transfer.fpga_emu
+add_executable(${EMULATOR_TARGET} ${SOURCE_FILE}) # CMake automatically adds #include'd headers to the dependency list
+set_target_properties(${EMULATOR_TARGET} PROPERTIES COMPILE_FLAGS "${EMULATOR_COMPILE_FLAGS}")
+set_target_properties(${EMULATOR_TARGET} PROPERTIES LINK_FLAGS "${EMULATOR_LINK_FLAGS}")
+add_custom_target(fpga_emu DEPENDS ${EMULATOR_TARGET})
 
-# FPGA emulator
-if(WIN32)
-    set(WIN_EMULATOR_TARGET ${EMULATOR_TARGET}.exe)
-    add_custom_target(fpga_emu DEPENDS ${WIN_EMULATOR_TARGET})
-    separate_arguments(WIN_EMULATOR_COMPILE_FLAGS WINDOWS_COMMAND "${EMULATOR_COMPILE_FLAGS}")
-    add_custom_command(OUTPUT ${WIN_EMULATOR_TARGET} 
-                       COMMAND ${CMAKE_CXX_COMPILER} /EHsc ${WIN_EMULATOR_COMPILE_FLAGS} ${CMAKE_CURRENT_SOURCE_DIR}/${SOURCE_FILE} -o ${CMAKE_BINARY_DIR}/${WIN_EMULATOR_TARGET}
-                       DEPENDS ${SOURCE_FILE})
-else()
-    add_executable(${EMULATOR_TARGET} ${SOURCE_FILE})
-    add_custom_target(fpga_emu DEPENDS ${EMULATOR_TARGET})
-    set_target_properties(${EMULATOR_TARGET} PROPERTIES COMPILE_FLAGS ${EMULATOR_COMPILE_FLAGS})
-    set_target_properties(${EMULATOR_TARGET} PROPERTIES LINK_FLAGS ${EMULATOR_LINK_FLAGS})
-endif()
+###############################################################################
+### Generate Report
+###############################################################################
+# To compile manually:
+#   dpcpp -fintelfpga -Xshardware -Xsboard=<FPGA_BOARD> -fsycl-link=early zero_copy_data_transfer.cpp -o zero_copy_data_transfer_report.a
+set(FPGA_EARLY_IMAGE ${TARGET_NAME}_report.a)
+# The compile output is not an executable, but an intermediate compilation result unique to DPC++.
+add_executable(${FPGA_EARLY_IMAGE} ${SOURCE_FILE})
+add_custom_target(report DEPENDS ${FPGA_EARLY_IMAGE})
+set_target_properties(${FPGA_EARLY_IMAGE} PROPERTIES COMPILE_FLAGS "${HARDWARE_COMPILE_FLAGS}")
+set_target_properties(${FPGA_EARLY_IMAGE} PROPERTIES LINK_FLAGS "${HARDWARE_LINK_FLAGS} -fsycl-link=early")
+# fsycl-link=early stops the compiler after RTL generation, before invoking Quartus
 
-# FPGA hardware
-if(WIN32)
-    add_custom_target(fpga COMMAND echo "An FPGA hardware target is not provided on Windows. See README for details.")
-else()
-    add_executable(${FPGA_TARGET} EXCLUDE_FROM_ALL ${SOURCE_FILE})
-    add_custom_target(fpga DEPENDS ${FPGA_TARGET})
-    set_target_properties(${FPGA_TARGET} PROPERTIES COMPILE_FLAGS ${HARDWARE_COMPILE_FLAGS})
-    set_target_properties(${FPGA_TARGET} PROPERTIES LINK_FLAGS ${HARDWARE_LINK_FLAGS})
-endif()
-
-# FPGA hardware report
-if(WIN32)
-    set(DEVICE_OBJ_FILE ${TARGET_NAME}_report.a)
-    add_custom_target(report DEPENDS ${DEVICE_OBJ_FILE})
-    separate_arguments(HARDWARE_LINK_FLAGS_LIST WINDOWS_COMMAND "${HARDWARE_LINK_FLAGS}")
-    add_custom_command(OUTPUT ${DEVICE_OBJ_FILE} 
-                       COMMAND ${CMAKE_CXX_COMPILER} /EHsc ${HARDWARE_LINK_FLAGS_LIST} -fsycl-link ${CMAKE_CURRENT_SOURCE_DIR}/${SOURCE_FILE} -o ${CMAKE_BINARY_DIR}/${DEVICE_OBJ_FILE}
-                       DEPENDS ${SOURCE_FILE})
-else()
-    configure_file(${CMAKE_CURRENT_SOURCE_DIR}/${SOURCE_FILE} ${SOURCE_FILE} COPYONLY)
-    configure_file(${CMAKE_CURRENT_SOURCE_DIR}/buffer_kernel.hpp buffer_kernel.hpp COPYONLY)
-    configure_file(${CMAKE_CURRENT_SOURCE_DIR}/restricted_usm_kernel.hpp restricted_usm_kernel.hpp COPYONLY)
-
-    separate_arguments(HARDWARE_LINK_FLAGS_LIST UNIX_COMMAND "${HARDWARE_LINK_FLAGS}")
-    separate_arguments(CMAKE_CXX_FLAGS_LIST UNIX_COMMAND "${CMAKE_CXX_FLAGS}")
-    add_custom_command(OUTPUT ${REPORTS_TARGET}
-                       COMMAND ${CMAKE_CXX_COMPILER} ${CMAKE_CXX_FLAGS_LIST} ${HARDWARE_LINK_FLAGS_LIST} -fsycl-link ${SOURCE_FILE} -o ${CMAKE_BINARY_DIR}/${REPORTS_TARGET}
-                       DEPENDS ${SOURCE_FILE})
-    add_custom_target(report DEPENDS ${REPORTS_TARGET})
-endif()
-
+###############################################################################
+### FPGA Hardware
+###############################################################################
+# To compile in a single command:
+#   dpcpp -fintelfpga -Xshardware -Xsboard=<FPGA_BOARD> zero_copy_data_transfer.cpp -o zero_copy_data_transfer.fpga
+# CMake executes:
+#   [compile] dpcpp -fintelfpga -o zero_copy_data_transfer.cpp.o -c zero_copy_data_transfer.cpp
+#   [link]    dpcpp -fintelfpga -Xshardware -Xsboard=<FPGA_BOARD> zero_copy_data_transfer.cpp.o -o zero_copy_data_transfer.fpga
+add_executable(${FPGA_TARGET} EXCLUDE_FROM_ALL ${SOURCE_FILE})
+add_custom_target(fpga DEPENDS ${FPGA_TARGET})
+set_target_properties(${FPGA_TARGET} PROPERTIES COMPILE_FLAGS "${HARDWARE_COMPILE_FLAGS}")
+set_target_properties(${FPGA_TARGET} PROPERTIES LINK_FLAGS "${HARDWARE_LINK_FLAGS} -reuse-exe=${CMAKE_BINARY_DIR}/${FPGA_TARGET}")
+# The -reuse-exe flag enables rapid recompilation of host-only code changes.
+# See DPC++FPGA/GettingStarted/fast_recompile for details.

--- a/DirectProgramming/DPC++FPGA/Tutorials/Features/fpga_reg/CMakeLists.txt
+++ b/DirectProgramming/DPC++FPGA/Tutorials/Features/fpga_reg/CMakeLists.txt
@@ -1,11 +1,17 @@
-set(CMAKE_CXX_COMPILER "dpcpp")
-if(WIN32)
-    set(CMAKE_C_COMPILER "clang-cl")
+if(UNIX)
+    # Direct CMake to use dpcpp rather than the default C++ compiler/linker
+    set(CMAKE_CXX_COMPILER dpcpp)
+else() # Windows
+    # Force CMake to use dpcpp rather than the default C++ compiler/linker 
+    # (needed on Windows only)
+    include (CMakeForceCompiler)
+    CMAKE_FORCE_CXX_COMPILER (dpcpp IntelDPCPP)
+    include (Platform/Windows-Clang)
 endif()
 
-cmake_minimum_required (VERSION 2.8)
+cmake_minimum_required (VERSION 3.4)
 
-project(FPGARegister)
+project(FPGARegister CXX)
 
 set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})
 set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})

--- a/DirectProgramming/DPC++FPGA/Tutorials/Features/fpga_reg/src/CMakeLists.txt
+++ b/DirectProgramming/DPC++FPGA/Tutorials/Features/fpga_reg/src/CMakeLists.txt
@@ -1,3 +1,6 @@
+# To see a Makefile equivalent of this build system:
+# https://github.com/oneapi-src/oneAPI-samples/blob/master/DirectProgramming/DPC++/ProjectTemplates/makefile-fpga
+
 set(SOURCE_FILE fpga_reg.cpp)
 set(TARGET_NAME fpga_reg)
 set(TARGET_NAME_REG fpga_reg_registered)
@@ -6,95 +9,76 @@ set(FPGA_TARGET ${TARGET_NAME}.fpga)
 set(FPGA_TARGET_REG ${TARGET_NAME_REG}.fpga)
 
 # FPGA board selection
-set(A10_PAC_BOARD_NAME "intel_a10gx_pac:pac_a10")
-set(S10_PAC_BOARD_NAME "intel_s10sx_pac:pac_s10")
-set(SELECTED_BOARD ${A10_PAC_BOARD_NAME})
-if (NOT DEFINED FPGA_BOARD)
-    message(STATUS "\tFPGA_BOARD was not specified. Configuring the design to run on the Intel(R) Programmable Acceleration Card (PAC) with Intel Arria(R) 10 GX FPGA. Please refer to the README for information on board selection.")
-elseif(FPGA_BOARD STREQUAL ${A10_PAC_BOARD_NAME})
-    message(STATUS "\tConfiguring the design to run on the Intel(R) Programmable Acceleration Card (PAC) with Intel Arria(R) 10 GX FPGA.")
-elseif(FPGA_BOARD STREQUAL ${S10_PAC_BOARD_NAME})
-    message(STATUS "\tConfiguring the design to run on the Intel(R) Programmable Acceleration Card (PAC) D5005 (with Intel Stratix(R) 10 SX FPGA).")
-    set(SELECTED_BOARD ${S10_PAC_BOARD_NAME})
+if(NOT DEFINED FPGA_BOARD)
+    set(FPGA_BOARD "intel_a10gx_pac:pac_a10")
+    message(STATUS "FPGA_BOARD was not specified.\
+                    \nConfiguring the design to run on the default FPGA board ${FPGA_BOARD} (Intel(R) PAC with Intel Arria(R) 10 GX FPGA). \
+                    \nPlease refer to the README for information on board selection.")
 else()
-    message(STATUS "\tAn invalid board name was passed in using the FPGA_BOARD flag. Configuring the design to run on the Intel(R) Programmable Acceleration Card (PAC) with Intel Arria(R) 10 GX FPGA. Please refer to the README for the list of valid board names.")
+    message(STATUS "Configuring the design to run on FPGA board ${FPGA_BOARD}")
 endif()
 
-# Flags
-set(EMULATOR_COMPILE_FLAGS "-fintelfpga -DFPGA_EMULATOR")
+# This is a Windows-specific flag that enables exception handling in host code
+if(WIN32)
+    set(WIN_FLAG "/EHsc")
+endif()
+
+# A DPC++ ahead-of-time (AoT) compile processes the device code in two stages.
+# 1. The "compile" stage compiles the device code to an intermediate representation (SPIR-V).
+# 2. The "link" stage invokes the compiler's FPGA backend before linking.
+#    For this reason, FPGA backend flags must be passed as link flags in CMake.
+set(EMULATOR_COMPILE_FLAGS "${WIN_FLAG} -fintelfpga -DFPGA_EMULATOR")
 set(EMULATOR_LINK_FLAGS "-fintelfpga")
-set(HARDWARE_COMPILE_FLAGS "-fintelfpga")
-set(HARDWARE_LINK_FLAGS "-fintelfpga -Xshardware -Xsboard=${SELECTED_BOARD} ${USER_HARDWARE_FLAGS}")
+set(HARDWARE_COMPILE_FLAGS "${WIN_FLAG} -fintelfpga")
+set(HARDWARE_LINK_FLAGS "-fintelfpga -Xshardware -Xsboard=${FPGA_BOARD} ${USER_HARDWARE_FLAGS}")
 # use cmake -D USER_HARDWARE_FLAGS=<flags> to set extra flags for FPGA backend compilation
 
+###############################################################################
+### FPGA Emulator
+###############################################################################
+# To compile in a single command:
+#    dpcpp -fintelfpga -DFPGA_EMULATOR fpga_compile.cpp -o fpga_compile.fpga_emu
+# CMake executes:
+#    [compile] dpcpp -fintelfpga -DFPGA_EMULATOR -o fpga_compile.cpp.o -c fpga_compile.cpp
+#    [link]    dpcpp -fintelfpga fpga_compile.cpp.o -o fpga_compile.fpga_emu
+add_executable(${EMULATOR_TARGET} ${SOURCE_FILE})
+set_target_properties(${EMULATOR_TARGET} PROPERTIES COMPILE_FLAGS "${EMULATOR_COMPILE_FLAGS}")
+set_target_properties(${EMULATOR_TARGET} PROPERTIES LINK_FLAGS "${EMULATOR_LINK_FLAGS}")
+add_custom_target(fpga_emu DEPENDS ${EMULATOR_TARGET})
 
-# FPGA emulator
-if(WIN32)
-    set(WIN_EMULATOR_TARGET ${EMULATOR_TARGET}.exe)
-    add_custom_target(fpga_emu DEPENDS ${WIN_EMULATOR_TARGET})
-    separate_arguments(WIN_EMULATOR_COMPILE_FLAGS WINDOWS_COMMAND "${EMULATOR_COMPILE_FLAGS}")
-    add_custom_command(OUTPUT ${WIN_EMULATOR_TARGET} 
-                       COMMAND ${CMAKE_CXX_COMPILER} /EHsc ${WIN_EMULATOR_COMPILE_FLAGS} ${CMAKE_CURRENT_SOURCE_DIR}/${SOURCE_FILE} -o ${CMAKE_BINARY_DIR}/${WIN_EMULATOR_TARGET}
-                       DEPENDS ${SOURCE_FILE})
-else()
-    add_executable(${EMULATOR_TARGET} ${SOURCE_FILE})
-    add_custom_target(fpga_emu DEPENDS ${EMULATOR_TARGET})
-    set_target_properties(${EMULATOR_TARGET} PROPERTIES COMPILE_FLAGS ${EMULATOR_COMPILE_FLAGS})
-    set_target_properties(${EMULATOR_TARGET} PROPERTIES LINK_FLAGS ${EMULATOR_LINK_FLAGS})
-endif()
+###############################################################################
+### Generate Report
+###############################################################################
+# To compile manually:
+#   dpcpp -fintelfpga -Xshardware -Xsboard=<FPGA_BOARD> -fsycl-link=early fpga_reg.cpp -o fpga_reg_report.a
+set(FPGA_EARLY_IMAGE ${TARGET_NAME}_report.a)
+set(FPGA_EARLY_IMAGE_REG ${TARGET_NAME_REG}_report.a)
+# The compile output is not an executable, but an intermediate compilation result unique to DPC++.
+add_executable(${FPGA_EARLY_IMAGE} ${SOURCE_FILE})
+add_executable(${FPGA_EARLY_IMAGE_REG} ${SOURCE_FILE})
+add_custom_target(report DEPENDS ${FPGA_EARLY_IMAGE} ${FPGA_EARLY_IMAGE_REG})
+set_target_properties(${FPGA_EARLY_IMAGE} PROPERTIES COMPILE_FLAGS "${HARDWARE_COMPILE_FLAGS}")
+set_target_properties(${FPGA_EARLY_IMAGE} PROPERTIES LINK_FLAGS "${HARDWARE_LINK_FLAGS} -fsycl-link=early")
 
-# FPGA hardware
-if(WIN32)
-    add_custom_target(fpga COMMAND echo "An FPGA hardware target is not provided on Windows. See README for details.")
-else()
-    add_executable(${FPGA_TARGET} EXCLUDE_FROM_ALL ${SOURCE_FILE})
-    add_executable(${FPGA_TARGET_REG} EXCLUDE_FROM_ALL ${SOURCE_FILE})
-    add_custom_target(fpga DEPENDS ${FPGA_TARGET} ${FPGA_TARGET_REG})
+set_target_properties(${FPGA_EARLY_IMAGE_REG} PROPERTIES COMPILE_FLAGS "${HARDWARE_COMPILE_FLAGS} -DUSE_FPGA_REG")
+set_target_properties(${FPGA_EARLY_IMAGE_REG} PROPERTIES LINK_FLAGS "${HARDWARE_LINK_FLAGS} -fsycl-link=early")
+# fsycl-link=early stops the compiler after RTL generation, before invoking Quartus
 
-    set_target_properties(${FPGA_TARGET} PROPERTIES COMPILE_FLAGS ${HARDWARE_COMPILE_FLAGS})
-    set_target_properties(${FPGA_TARGET} PROPERTIES LINK_FLAGS ${HARDWARE_LINK_FLAGS})
+###############################################################################
+### FPGA Hardware
+###############################################################################
+# To compile in a single command:
+#   dpcpp -fintelfpga -Xshardware -Xsboard=<FPGA_BOARD> fpga_reg.cpp -o fpga_reg.fpga
+# CMake executes:
+#   [compile] dpcpp -fintelfpga -o fpga_reg.cpp.o -c fpga_reg.cpp
+#   [link]    dpcpp -fintelfpga -Xshardware -Xsboard=<FPGA_BOARD> fpga_reg.cpp.o -o fpga_reg.fpga
+add_executable(${FPGA_TARGET} EXCLUDE_FROM_ALL ${SOURCE_FILE})
+add_executable(${FPGA_TARGET_REG} EXCLUDE_FROM_ALL ${SOURCE_FILE})
+add_custom_target(fpga DEPENDS ${FPGA_TARGET} ${FPGA_TARGET_REG})
+set_target_properties(${FPGA_TARGET} PROPERTIES COMPILE_FLAGS "${HARDWARE_COMPILE_FLAGS}")
+set_target_properties(${FPGA_TARGET} PROPERTIES LINK_FLAGS "${HARDWARE_LINK_FLAGS} -reuse-exe=${CMAKE_BINARY_DIR}/${FPGA_TARGET}")
+# The -reuse-exe flag enables rapid recompilation of host-only code changes.
+# See DPC++FPGA/GettingStarted/fast_recompile for details.
+set_target_properties(${FPGA_TARGET_REG} PROPERTIES COMPILE_FLAGS "${HARDWARE_COMPILE_FLAGS} -DUSE_FPGA_REG")
+set_target_properties(${FPGA_TARGET_REG} PROPERTIES LINK_FLAGS "${HARDWARE_LINK_FLAGS} -reuse-exe=${CMAKE_BINARY_DIR}/${FPGA_TARGET_REG}")
 
-    set_target_properties(${FPGA_TARGET_REG} PROPERTIES COMPILE_FLAGS "${HARDWARE_COMPILE_FLAGS} -DUSE_FPGA_REG")
-    set_target_properties(${FPGA_TARGET_REG} PROPERTIES LINK_FLAGS ${HARDWARE_LINK_FLAGS})
-endif()
-
-# report
-if(WIN32)
-    set(REPORT ${TARGET_NAME}_report.a)
-    set(REPORT_REG ${TARGET_NAME_REG}_report.a)
-
-    add_custom_target(report DEPENDS ${REPORT} ${REPORT_REG})
-
-    configure_file(${CMAKE_CURRENT_SOURCE_DIR}/${SOURCE_FILE} ${CMAKE_BINARY_DIR}/${TARGET_NAME}/${SOURCE_FILE} COPYONLY)
-    configure_file(${CMAKE_CURRENT_SOURCE_DIR}/${SOURCE_FILE} ${CMAKE_BINARY_DIR}/${TARGET_NAME_REG}/${SOURCE_FILE} COPYONLY)
-
-    separate_arguments(HARDWARE_LINK_FLAGS_LIST WINDOWS_COMMAND "${HARDWARE_LINK_FLAGS}")
-    separate_arguments(CMAKE_CXX_FLAGS_LIST WINDOWS_COMMAND "${CMAKE_CXX_FLAGS}")
-    
-    add_custom_command(OUTPUT ${REPORT}
-        COMMAND ${CMAKE_CXX_COMPILER} /EHsc ${CMAKE_CXX_FLAGS_LIST} ${HARDWARE_LINK_FLAGS_LIST} -fsycl-link ${CMAKE_BINARY_DIR}/${TARGET_NAME}/${SOURCE_FILE} -o ${CMAKE_BINARY_DIR}/${REPORT}
-                 DEPENDS ${SOURCE_FILE})
-
-    add_custom_command(OUTPUT ${REPORT_REG}
-        COMMAND ${CMAKE_CXX_COMPILER} /EHsc ${CMAKE_CXX_FLAGS_LIST} ${HARDWARE_LINK_FLAGS_LIST} -DUSE_FPGA_REG -fsycl-link ${CMAKE_BINARY_DIR}/${TARGET_NAME_REG}/${SOURCE_FILE} -o ${CMAKE_BINARY_DIR}/${REPORT_REG}
-                 DEPENDS ${SOURCE_FILE})
-
-else()
-    set(REPORT ${TARGET_NAME}_report.a)
-    set(REPORT_REG ${TARGET_NAME_REG}_report.a)
-
-    add_custom_target(report DEPENDS ${REPORT} ${REPORT_REG})
-
-    configure_file(${CMAKE_CURRENT_SOURCE_DIR}/${SOURCE_FILE} ${SOURCE_FILE} COPYONLY)
-
-    separate_arguments(HARDWARE_LINK_FLAGS_LIST UNIX_COMMAND "${HARDWARE_LINK_FLAGS}")
-    separate_arguments(CMAKE_CXX_FLAGS_LIST UNIX_COMMAND "${CMAKE_CXX_FLAGS}")
-
-    add_custom_command(OUTPUT ${REPORT}
-                 COMMAND ${CMAKE_CXX_COMPILER} ${CMAKE_CXX_FLAGS_LIST} ${HARDWARE_LINK_FLAGS_LIST} -fsycl-link ${SOURCE_FILE} -o ${CMAKE_BINARY_DIR}/${REPORT}
-                 DEPENDS ${SOURCE_FILE})
-
-    add_custom_command(OUTPUT ${REPORT_REG}
-                 COMMAND ${CMAKE_CXX_COMPILER} ${CMAKE_CXX_FLAGS_LIST} ${HARDWARE_LINK_FLAGS_LIST} -DUSE_FPGA_REG -fsycl-link ${SOURCE_FILE} -o ${CMAKE_BINARY_DIR}/${REPORT_REG}
-                 DEPENDS ${SOURCE_FILE})
-endif()

--- a/DirectProgramming/DPC++FPGA/Tutorials/Features/kernel_args_restrict/CMakeLists.txt
+++ b/DirectProgramming/DPC++FPGA/Tutorials/Features/kernel_args_restrict/CMakeLists.txt
@@ -1,11 +1,17 @@
-set(CMAKE_CXX_COMPILER "dpcpp")
-if(WIN32)
-    set(CMAKE_C_COMPILER "clang-cl")
+if(UNIX)
+    # Direct CMake to use dpcpp rather than the default C++ compiler/linker
+    set(CMAKE_CXX_COMPILER dpcpp)
+else() # Windows
+    # Force CMake to use dpcpp rather than the default C++ compiler/linker 
+    # (needed on Windows only)
+    include (CMakeForceCompiler)
+    CMAKE_FORCE_CXX_COMPILER (dpcpp IntelDPCPP)
+    include (Platform/Windows-Clang)
 endif()
 
-cmake_minimum_required (VERSION 2.8)
+cmake_minimum_required (VERSION 3.4)
 
-project(KernelArgsRestrict)
+project(KernelArgsRestrict CXX)
 
 set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})
 set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})

--- a/DirectProgramming/DPC++FPGA/Tutorials/Features/kernel_args_restrict/src/CMakeLists.txt
+++ b/DirectProgramming/DPC++FPGA/Tutorials/Features/kernel_args_restrict/src/CMakeLists.txt
@@ -1,73 +1,73 @@
+# To see a Makefile equivalent of this build system:
+# https://github.com/oneapi-src/oneAPI-samples/blob/master/DirectProgramming/DPC++/ProjectTemplates/makefile-fpga
+
 set(SOURCE_FILE kernel_args_restrict.cpp)
 set(TARGET_NAME kernel_args_restrict)
 set(EMULATOR_TARGET ${TARGET_NAME}.fpga_emu)
 set(FPGA_TARGET ${TARGET_NAME}.fpga)
 
 # FPGA board selection
-set(A10_PAC_BOARD_NAME "intel_a10gx_pac:pac_a10")
-set(S10_PAC_BOARD_NAME "intel_s10sx_pac:pac_s10")
-set(SELECTED_BOARD ${A10_PAC_BOARD_NAME})
 if(NOT DEFINED FPGA_BOARD)
-    message(STATUS "\tFPGA_BOARD was not specified. Configuring the design to run on the Intel(R) Programmable Acceleration Card (PAC) with Intel Arria(R) 10 GX FPGA. Please refer to the README for information on board selection.")
-elseif(FPGA_BOARD STREQUAL ${A10_PAC_BOARD_NAME})
-    message(STATUS "\tConfiguring the design to run on the Intel(R) Programmable Acceleration Card (PAC) with Intel Arria(R) 10 GX FPGA.")
-elseif(FPGA_BOARD STREQUAL ${S10_PAC_BOARD_NAME})
-    message(STATUS "\tConfiguring the design to run on the Intel(R) Programmable Acceleration Card (PAC) D5005 (with Intel Stratix(R) 10 SX FPGA).")
-    set(SELECTED_BOARD ${S10_PAC_BOARD_NAME})
+    set(FPGA_BOARD "intel_a10gx_pac:pac_a10")
+    message(STATUS "FPGA_BOARD was not specified.\
+                    \nConfiguring the design to run on the default FPGA board ${FPGA_BOARD} (Intel(R) PAC with Intel Arria(R) 10 GX FPGA). \
+                    \nPlease refer to the README for information on board selection.")
 else()
-    message(STATUS "\tAn invalid board name was passed in using the FPGA_BOARD flag. Configuring the design to run on the Intel(R) Programmable Acceleration Card (PAC) with Intel Arria(R) 10 GX FPGA. Please refer to the README for the list of valid board names.")
+    message(STATUS "Configuring the design to run on FPGA board ${FPGA_BOARD}")
 endif()
 
-# Flags
-set(EMULATOR_COMPILE_FLAGS "-fintelfpga -DFPGA_EMULATOR")
+# This is a Windows-specific flag that enables exception handling in host code
+if(WIN32)
+    set(WIN_FLAG "/EHsc")
+endif()
+
+# A DPC++ ahead-of-time (AoT) compile processes the device code in two stages.
+# 1. The "compile" stage compiles the device code to an intermediate representation (SPIR-V).
+# 2. The "link" stage invokes the compiler's FPGA backend before linking.
+#    For this reason, FPGA backend flags must be passed as link flags in CMake.
+set(EMULATOR_COMPILE_FLAGS "${WIN_FLAG} -fintelfpga -DFPGA_EMULATOR")
 set(EMULATOR_LINK_FLAGS "-fintelfpga")
-set(HARDWARE_COMPILE_FLAGS "-fintelfpga")
-set(HARDWARE_LINK_FLAGS "-fintelfpga -Xshardware -Xsboard=${SELECTED_BOARD} ${USER_HARDWARE_FLAGS}")
+set(HARDWARE_COMPILE_FLAGS "${WIN_FLAG} -fintelfpga")
+set(HARDWARE_LINK_FLAGS "-fintelfpga -Xshardware -Xsboard=${FPGA_BOARD} ${USER_HARDWARE_FLAGS}")
 # use cmake -D USER_HARDWARE_FLAGS=<flags> to set extra flags for FPGA backend compilation
 
+###############################################################################
+### FPGA Emulator
+###############################################################################
+# To compile in a single command:
+#    dpcpp -fintelfpga -DFPGA_EMULATOR kernel_args_restrict.cpp -o kernel_args_restrict.fpga_emu
+# CMake executes:
+#    [compile] dpcpp -fintelfpga -DFPGA_EMULATOR -o kernel_args_restrict.cpp.o -c kernel_args_restrict.cpp
+#    [link]    dpcpp -fintelfpga kernel_args_restrict.cpp.o -o kernel_args_restrict.fpga_emu
+add_executable(${EMULATOR_TARGET} ${SOURCE_FILE})
+set_target_properties(${EMULATOR_TARGET} PROPERTIES COMPILE_FLAGS "${EMULATOR_COMPILE_FLAGS}")
+set_target_properties(${EMULATOR_TARGET} PROPERTIES LINK_FLAGS "${EMULATOR_LINK_FLAGS}")
+add_custom_target(fpga_emu DEPENDS ${EMULATOR_TARGET})
 
-# FPGA emulator
-if(WIN32)
-    set(WIN_EMULATOR_TARGET ${EMULATOR_TARGET}.exe)
-    add_custom_target(fpga_emu DEPENDS ${WIN_EMULATOR_TARGET})
-    separate_arguments(WIN_EMULATOR_COMPILE_FLAGS WINDOWS_COMMAND "${EMULATOR_COMPILE_FLAGS}")
-    add_custom_command(OUTPUT ${WIN_EMULATOR_TARGET} 
-                       COMMAND ${CMAKE_CXX_COMPILER} /EHsc ${WIN_EMULATOR_COMPILE_FLAGS} ${CMAKE_CURRENT_SOURCE_DIR}/${SOURCE_FILE} -o ${CMAKE_BINARY_DIR}/${WIN_EMULATOR_TARGET}
-                       DEPENDS ${SOURCE_FILE})
-else()
-    add_executable(${EMULATOR_TARGET} ${SOURCE_FILE})
-    add_custom_target(fpga_emu DEPENDS ${EMULATOR_TARGET})
-    set_target_properties(${EMULATOR_TARGET} PROPERTIES COMPILE_FLAGS ${EMULATOR_COMPILE_FLAGS})
-    set_target_properties(${EMULATOR_TARGET} PROPERTIES LINK_FLAGS ${EMULATOR_LINK_FLAGS})
-endif()
+###############################################################################
+### Generate Report
+###############################################################################
+# To compile manually:
+#   dpcpp -fintelfpga -Xshardware -Xsboard=<FPGA_BOARD> -fsycl-link=early kernel_args_restrict.cpp -o kernel_args_restrict_report.a
+set(FPGA_EARLY_IMAGE ${TARGET_NAME}_report.a)
+# The compile output is not an executable, but an intermediate compilation result unique to DPC++.
+add_executable(${FPGA_EARLY_IMAGE} ${SOURCE_FILE})
+add_custom_target(report DEPENDS ${FPGA_EARLY_IMAGE})
+set_target_properties(${FPGA_EARLY_IMAGE} PROPERTIES COMPILE_FLAGS "${HARDWARE_COMPILE_FLAGS}")
+set_target_properties(${FPGA_EARLY_IMAGE} PROPERTIES LINK_FLAGS "${HARDWARE_LINK_FLAGS} -fsycl-link=early")
+# fsycl-link=early stops the compiler after RTL generation, before invoking Quartus
 
-# FPGA hardware
-if(WIN32)
-    add_custom_target(fpga COMMAND echo "An FPGA hardware target is not provided on Windows. See README for details.")
-else()
-    add_executable(${FPGA_TARGET} EXCLUDE_FROM_ALL ${SOURCE_FILE})
-    add_custom_target(fpga DEPENDS ${FPGA_TARGET})
-    set_target_properties(${FPGA_TARGET} PROPERTIES COMPILE_FLAGS "${HARDWARE_COMPILE_FLAGS}")
-    set_target_properties(${FPGA_TARGET} PROPERTIES LINK_FLAGS ${HARDWARE_LINK_FLAGS})
-endif()
-
-# Generate report
-if(WIN32)
-    set(REPORT ${TARGET_NAME}_report.a)
-    add_custom_target(report DEPENDS ${REPORT})
-    configure_file(${CMAKE_CURRENT_SOURCE_DIR}/${SOURCE_FILE} ${CMAKE_BINARY_DIR}/${TARGET_NAME}/${SOURCE_FILE} COPYONLY)
-    separate_arguments(HARDWARE_LINK_FLAGS_LIST WINDOWS_COMMAND "${HARDWARE_LINK_FLAGS}")
-    separate_arguments(CMAKE_CXX_FLAGS_LIST WINDOWS_COMMAND "${CMAKE_CXX_FLAGS}")
-    add_custom_command(OUTPUT ${REPORT}
-                       COMMAND ${CMAKE_CXX_COMPILER} /EHsc ${CMAKE_CXX_FLAGS_LIST} ${HARDWARE_LINK_FLAGS_LIST} -fsycl-link ${CMAKE_BINARY_DIR}/${TARGET_NAME}/${SOURCE_FILE} -o ${CMAKE_BINARY_DIR}/${REPORT}
-                       DEPENDS ${SOURCE_FILE})
-else()
-    set(REPORT ${TARGET_NAME}_report.a)
-    add_custom_target(report DEPENDS ${REPORT})
-    configure_file(${CMAKE_CURRENT_SOURCE_DIR}/${SOURCE_FILE} ${SOURCE_FILE} COPYONLY)
-    separate_arguments(HARDWARE_LINK_FLAGS_LIST UNIX_COMMAND "${HARDWARE_LINK_FLAGS}")
-    separate_arguments(CMAKE_CXX_FLAGS_LIST UNIX_COMMAND "${CMAKE_CXX_FLAGS}")
-    add_custom_command(OUTPUT ${REPORT}
-                       COMMAND ${CMAKE_CXX_COMPILER} ${CMAKE_CXX_FLAGS_LIST} ${HARDWARE_LINK_FLAGS_LIST} -fsycl-link ${SOURCE_FILE} -o ${CMAKE_BINARY_DIR}/${REPORT}
-                       DEPENDS ${SOURCE_FILE})
-endif()
+###############################################################################
+### FPGA Hardware
+###############################################################################
+# To compile in a single command:
+#   dpcpp -fintelfpga -Xshardware -Xsboard=<FPGA_BOARD> kernel_args_restrict.cpp -o kernel_args_restrict.fpga
+# CMake executes:
+#   [compile] dpcpp -fintelfpga -o kernel_args_restrict.cpp.o -c kernel_args_restrict.cpp
+#   [link]    dpcpp -fintelfpga -Xshardware -Xsboard=<FPGA_BOARD> kernel_args_restrict.cpp.o -o kernel_args_restrict.fpga
+add_executable(${FPGA_TARGET} EXCLUDE_FROM_ALL ${SOURCE_FILE})
+add_custom_target(fpga DEPENDS ${FPGA_TARGET})
+set_target_properties(${FPGA_TARGET} PROPERTIES COMPILE_FLAGS "${HARDWARE_COMPILE_FLAGS}")
+set_target_properties(${FPGA_TARGET} PROPERTIES LINK_FLAGS "${HARDWARE_LINK_FLAGS} -reuse-exe=${CMAKE_BINARY_DIR}/${FPGA_TARGET}")
+# The -reuse-exe flag enables rapid recompilation of host-only code changes.
+# See DPC++FPGA/GettingStarted/fast_recompile for details.

--- a/DirectProgramming/DPC++FPGA/Tutorials/Features/loop_coalesce/CMakeLists.txt
+++ b/DirectProgramming/DPC++FPGA/Tutorials/Features/loop_coalesce/CMakeLists.txt
@@ -1,11 +1,17 @@
-set(CMAKE_CXX_COMPILER "dpcpp")
-if(WIN32)
-    set(CMAKE_C_COMPILER "clang-cl")
+if(UNIX)
+    # Direct CMake to use dpcpp rather than the default C++ compiler/linker
+    set(CMAKE_CXX_COMPILER dpcpp)
+else() # Windows
+    # Force CMake to use dpcpp rather than the default C++ compiler/linker 
+    # (needed on Windows only)
+    include (CMakeForceCompiler)
+    CMAKE_FORCE_CXX_COMPILER (dpcpp IntelDPCPP)
+    include (Platform/Windows-Clang)
 endif()
 
-cmake_minimum_required (VERSION 2.8)
+cmake_minimum_required (VERSION 3.4)
 
-project(LoopCoalesce)
+project(LoopCoalesce CXX)
 
 set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})
 set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})

--- a/DirectProgramming/DPC++FPGA/Tutorials/Features/loop_coalesce/src/CMakeLists.txt
+++ b/DirectProgramming/DPC++FPGA/Tutorials/Features/loop_coalesce/src/CMakeLists.txt
@@ -1,72 +1,73 @@
+# To see a Makefile equivalent of this build system:
+# https://github.com/oneapi-src/oneAPI-samples/blob/master/DirectProgramming/DPC++/ProjectTemplates/makefile-fpga
+
 set(SOURCE_FILE loop_coalesce.cpp)
 set(TARGET_NAME loop_coalesce)
 set(EMULATOR_TARGET ${TARGET_NAME}.fpga_emu)
 set(FPGA_TARGET ${TARGET_NAME}.fpga)
 
 # FPGA board selection
-set(A10_PAC_BOARD_NAME "intel_a10gx_pac:pac_a10")
-set(S10_PAC_BOARD_NAME "intel_s10sx_pac:pac_s10")
-set(SELECTED_BOARD ${A10_PAC_BOARD_NAME})
 if(NOT DEFINED FPGA_BOARD)
-    message(STATUS "\tFPGA_BOARD was not specified. Configuring the design to run on the Intel(R) Programmable Acceleration Card (PAC) with Intel Arria(R) 10 GX FPGA. Please refer to the README for information on board selection.")
-elseif(FPGA_BOARD STREQUAL ${A10_PAC_BOARD_NAME})
-    message(STATUS "\tConfiguring the design to run on the Intel(R) Programmable Acceleration Card (PAC) with Intel Arria(R) 10 GX FPGA.")
-elseif(FPGA_BOARD STREQUAL ${S10_PAC_BOARD_NAME})
-    message(STATUS "\tConfiguring the design to run on the Intel(R) Programmable Acceleration Card (PAC) D5005 (with Intel Stratix(R) 10 SX FPGA).")
-    set(SELECTED_BOARD ${S10_PAC_BOARD_NAME})
+    set(FPGA_BOARD "intel_a10gx_pac:pac_a10")
+    message(STATUS "FPGA_BOARD was not specified.\
+                    \nConfiguring the design to run on the default FPGA board ${FPGA_BOARD} (Intel(R) PAC with Intel Arria(R) 10 GX FPGA). \
+                    \nPlease refer to the README for information on board selection.")
 else()
-    message(STATUS "\tAn invalid board name was passed in using the FPGA_BOARD flag. Configuring the design to run on the Intel(R) Programmable Acceleration Card (PAC) with Intel Arria(R) 10 GX FPGA. Please refer to the README for the list of valid board names.")
+    message(STATUS "Configuring the design to run on FPGA board ${FPGA_BOARD}")
 endif()
 
-# Flags
-set(EMULATOR_COMPILE_FLAGS "-fintelfpga -DFPGA_EMULATOR")
+# This is a Windows-specific flag that enables exception handling in host code
+if(WIN32)
+    set(WIN_FLAG "/EHsc")
+endif()
+
+# A DPC++ ahead-of-time (AoT) compile processes the device code in two stages.
+# 1. The "compile" stage compiles the device code to an intermediate representation (SPIR-V).
+# 2. The "link" stage invokes the compiler's FPGA backend before linking.
+#    For this reason, FPGA backend flags must be passed as link flags in CMake.
+set(EMULATOR_COMPILE_FLAGS "${WIN_FLAG} -fintelfpga -DFPGA_EMULATOR")
 set(EMULATOR_LINK_FLAGS "-fintelfpga")
-set(HARDWARE_COMPILE_FLAGS "-fintelfpga")
-set(HARDWARE_LINK_FLAGS "-fintelfpga -Xshardware -Xsboard=${SELECTED_BOARD} ${USER_HARDWARE_FLAGS}")
+set(HARDWARE_COMPILE_FLAGS "${WIN_FLAG} -fintelfpga")
+set(HARDWARE_LINK_FLAGS "-fintelfpga -Xshardware -Xsboard=${FPGA_BOARD} ${USER_HARDWARE_FLAGS}")
 # use cmake -D USER_HARDWARE_FLAGS=<flags> to set extra flags for FPGA backend compilation
 
+###############################################################################
+### FPGA Emulator
+###############################################################################
+# To compile in a single command:
+#    dpcpp -fintelfpga -DFPGA_EMULATOR loop_coalesce.cpp -o loop_coalesce.fpga_emu
+# CMake executes:
+#    [compile] dpcpp -fintelfpga -DFPGA_EMULATOR -o loop_coalesce.cpp.o -c loop_coalesce.cpp
+#    [link]    dpcpp -fintelfpga loop_coalesce.cpp.o -o loop_coalesce.fpga_emu
+add_executable(${EMULATOR_TARGET} ${SOURCE_FILE})
+set_target_properties(${EMULATOR_TARGET} PROPERTIES COMPILE_FLAGS "${EMULATOR_COMPILE_FLAGS}")
+set_target_properties(${EMULATOR_TARGET} PROPERTIES LINK_FLAGS "${EMULATOR_LINK_FLAGS}")
+add_custom_target(fpga_emu DEPENDS ${EMULATOR_TARGET})
 
-# FPGA emulator
-if(WIN32)
-    set(WIN_EMULATOR_TARGET ${EMULATOR_TARGET}.exe)
-    add_custom_target(fpga_emu DEPENDS ${WIN_EMULATOR_TARGET})
-    separate_arguments(WIN_EMULATOR_COMPILE_FLAGS WINDOWS_COMMAND "${EMULATOR_COMPILE_FLAGS}")
-    add_custom_command(OUTPUT ${WIN_EMULATOR_TARGET} 
-                       COMMAND ${CMAKE_CXX_COMPILER} /EHsc ${WIN_EMULATOR_COMPILE_FLAGS} ${CMAKE_CURRENT_SOURCE_DIR}/${SOURCE_FILE} -o ${CMAKE_BINARY_DIR}/${WIN_EMULATOR_TARGET}
-                       DEPENDS ${SOURCE_FILE})
-else()
-    add_executable(${EMULATOR_TARGET} ${SOURCE_FILE})
-    add_custom_target(fpga_emu DEPENDS ${EMULATOR_TARGET})
-    set_target_properties(${EMULATOR_TARGET} PROPERTIES COMPILE_FLAGS ${EMULATOR_COMPILE_FLAGS})
-    set_target_properties(${EMULATOR_TARGET} PROPERTIES LINK_FLAGS ${EMULATOR_LINK_FLAGS})
-endif()
+###############################################################################
+### Generate Report
+###############################################################################
+# To compile manually:
+#   dpcpp -fintelfpga -Xshardware -Xsboard=<FPGA_BOARD> -fsycl-link=early loop_coalesce.cpp -o loop_coalesce_report.a
+set(FPGA_EARLY_IMAGE ${TARGET_NAME}_report.a)
+# The compile output is not an executable, but an intermediate compilation result unique to DPC++.
+add_executable(${FPGA_EARLY_IMAGE} ${SOURCE_FILE})
+add_custom_target(report DEPENDS ${FPGA_EARLY_IMAGE})
+set_target_properties(${FPGA_EARLY_IMAGE} PROPERTIES COMPILE_FLAGS "${HARDWARE_COMPILE_FLAGS}")
+set_target_properties(${FPGA_EARLY_IMAGE} PROPERTIES LINK_FLAGS "${HARDWARE_LINK_FLAGS} -fsycl-link=early")
+# fsycl-link=early stops the compiler after RTL generation, before invoking Quartus
 
-# FPGA hardware
-if(WIN32)
-    add_custom_target(fpga COMMAND echo "An FPGA hardware target is not provided on Windows. See README for details.")
-else()
-    add_executable(${FPGA_TARGET} EXCLUDE_FROM_ALL ${SOURCE_FILE})
-    add_custom_target(fpga DEPENDS ${FPGA_TARGET})
-    set_target_properties(${FPGA_TARGET} PROPERTIES COMPILE_FLAGS ${HARDWARE_COMPILE_FLAGS})
-    set_target_properties(${FPGA_TARGET} PROPERTIES LINK_FLAGS ${HARDWARE_LINK_FLAGS})
-endif()
-
-# Generate report
-if(WIN32)
-    set(DEVICE_OBJ_FILE ${TARGET_NAME}_report.a)
-    add_custom_target(report DEPENDS ${DEVICE_OBJ_FILE})
-    separate_arguments(HARDWARE_LINK_FLAGS_LIST WINDOWS_COMMAND "${HARDWARE_LINK_FLAGS}")
-    separate_arguments(CMAKE_CXX_FLAGS_LIST WINDOWS_COMMAND "${CMAKE_CXX_FLAGS}")
-    add_custom_command(OUTPUT ${DEVICE_OBJ_FILE} 
-                       COMMAND ${CMAKE_CXX_COMPILER} /EHsc ${CMAKE_CXX_FLAGS_LIST} ${HARDWARE_LINK_FLAGS_LIST} -fsycl-link ${CMAKE_CURRENT_SOURCE_DIR}/${SOURCE_FILE} -o ${CMAKE_BINARY_DIR}/${DEVICE_OBJ_FILE}
-                       DEPENDS ${SOURCE_FILE})
-else()
-    set(DEVICE_OBJ_FILE ${TARGET_NAME}_report.a)
-    add_custom_target(report DEPENDS ${DEVICE_OBJ_FILE})
-    configure_file(${CMAKE_CURRENT_SOURCE_DIR}/${SOURCE_FILE} ${SOURCE_FILE} COPYONLY)
-    separate_arguments(HARDWARE_LINK_FLAGS_LIST UNIX_COMMAND "${HARDWARE_LINK_FLAGS}")
-    separate_arguments(CMAKE_CXX_FLAGS_LIST UNIX_COMMAND "${CMAKE_CXX_FLAGS}")
-    add_custom_command(OUTPUT ${DEVICE_OBJ_FILE} 
-                       COMMAND ${CMAKE_CXX_COMPILER} ${CMAKE_CXX_FLAGS_LIST} ${HARDWARE_LINK_FLAGS_LIST} -fsycl-link ${SOURCE_FILE} -o ${CMAKE_BINARY_DIR}/${DEVICE_OBJ_FILE}
-                       DEPENDS ${SOURCE_FILE})
-endif()
+###############################################################################
+### FPGA Hardware
+###############################################################################
+# To compile in a single command:
+#   dpcpp -fintelfpga -Xshardware -Xsboard=<FPGA_BOARD> loop_coalesce.cpp -o loop_coalesce.fpga
+# CMake executes:
+#   [compile] dpcpp -fintelfpga -o loop_coalesce.cpp.o -c loop_coalesce.cpp
+#   [link]    dpcpp -fintelfpga -Xshardware -Xsboard=<FPGA_BOARD> loop_coalesce.cpp.o -o loop_coalesce.fpga
+add_executable(${FPGA_TARGET} EXCLUDE_FROM_ALL ${SOURCE_FILE})
+add_custom_target(fpga DEPENDS ${FPGA_TARGET})
+set_target_properties(${FPGA_TARGET} PROPERTIES COMPILE_FLAGS "${HARDWARE_COMPILE_FLAGS}")
+set_target_properties(${FPGA_TARGET} PROPERTIES LINK_FLAGS "${HARDWARE_LINK_FLAGS} -reuse-exe=${CMAKE_BINARY_DIR}/${FPGA_TARGET}")
+# The -reuse-exe flag enables rapid recompilation of host-only code changes.
+# See DPC++FPGA/GettingStarted/fast_recompile for details.

--- a/DirectProgramming/DPC++FPGA/Tutorials/Features/loop_ivdep/CMakeLists.txt
+++ b/DirectProgramming/DPC++FPGA/Tutorials/Features/loop_ivdep/CMakeLists.txt
@@ -1,11 +1,17 @@
-set(CMAKE_CXX_COMPILER "dpcpp")
-if(WIN32)
-    set(CMAKE_C_COMPILER "clang-cl")
+if(UNIX)
+    # Direct CMake to use dpcpp rather than the default C++ compiler/linker
+    set(CMAKE_CXX_COMPILER dpcpp)
+else() # Windows
+    # Force CMake to use dpcpp rather than the default C++ compiler/linker 
+    # (needed on Windows only)
+    include (CMakeForceCompiler)
+    CMAKE_FORCE_CXX_COMPILER (dpcpp IntelDPCPP)
+    include (Platform/Windows-Clang)
 endif()
 
-cmake_minimum_required (VERSION 2.8)
+cmake_minimum_required (VERSION 3.4)
 
-project(LoopIvdep)
+project(LoopIvdep CXX)
 
 set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})
 set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})

--- a/DirectProgramming/DPC++FPGA/Tutorials/Features/loop_ivdep/src/CMakeLists.txt
+++ b/DirectProgramming/DPC++FPGA/Tutorials/Features/loop_ivdep/src/CMakeLists.txt
@@ -1,72 +1,73 @@
+# To see a Makefile equivalent of this build system:
+# https://github.com/oneapi-src/oneAPI-samples/blob/master/DirectProgramming/DPC++/ProjectTemplates/makefile-fpga
+
 set(SOURCE_FILE loop_ivdep.cpp)
 set(TARGET_NAME loop_ivdep)
 set(EMULATOR_TARGET ${TARGET_NAME}.fpga_emu)
 set(FPGA_TARGET ${TARGET_NAME}.fpga)
 
 # FPGA board selection
-set(A10_PAC_BOARD_NAME "intel_a10gx_pac:pac_a10")
-set(S10_PAC_BOARD_NAME "intel_s10sx_pac:pac_s10")
-set(SELECTED_BOARD ${A10_PAC_BOARD_NAME})
-if (NOT DEFINED FPGA_BOARD)
-    message(STATUS "\tFPGA_BOARD was not specified. Configuring the design to run on the Intel(R) Programmable Acceleration Card (PAC) with Intel Arria(R) 10 GX FPGA. Please refer to the README for information on board selection.")
-elseif(FPGA_BOARD STREQUAL ${A10_PAC_BOARD_NAME})
-    message(STATUS "\tConfiguring the design to run on the Intel(R) Programmable Acceleration Card (PAC) with Intel Arria(R) 10 GX FPGA.")
-elseif(FPGA_BOARD STREQUAL ${S10_PAC_BOARD_NAME})
-    message(STATUS "\tConfiguring the design to run on the Intel(R) Programmable Acceleration Card (PAC) D5005 (with Intel Stratix(R) 10 SX FPGA).")
-    set(SELECTED_BOARD ${S10_PAC_BOARD_NAME})
+if(NOT DEFINED FPGA_BOARD)
+    set(FPGA_BOARD "intel_a10gx_pac:pac_a10")
+    message(STATUS "FPGA_BOARD was not specified.\
+                    \nConfiguring the design to run on the default FPGA board ${FPGA_BOARD} (Intel(R) PAC with Intel Arria(R) 10 GX FPGA). \
+                    \nPlease refer to the README for information on board selection.")
 else()
-    message(STATUS "\tAn invalid board name was passed in using the FPGA_BOARD flag. Configuring the design to run on the Intel(R) Programmable Acceleration Card (PAC) with Intel Arria(R) 10 GX FPGA. Please refer to the README for the list of valid board names.")
+    message(STATUS "Configuring the design to run on FPGA board ${FPGA_BOARD}")
 endif()
 
-# Flags
-set(EMULATOR_COMPILE_FLAGS "-fintelfpga -DFPGA_EMULATOR")
+# This is a Windows-specific flag that enables exception handling in host code
+if(WIN32)
+    set(WIN_FLAG "/EHsc")
+endif()
+
+# A DPC++ ahead-of-time (AoT) compile processes the device code in two stages.
+# 1. The "compile" stage compiles the device code to an intermediate representation (SPIR-V).
+# 2. The "link" stage invokes the compiler's FPGA backend before linking.
+#    For this reason, FPGA backend flags must be passed as link flags in CMake.
+set(EMULATOR_COMPILE_FLAGS "${WIN_FLAG} -fintelfpga -DFPGA_EMULATOR")
 set(EMULATOR_LINK_FLAGS "-fintelfpga")
-set(HARDWARE_COMPILE_FLAGS "-fintelfpga")
-set(HARDWARE_LINK_FLAGS "-fintelfpga -Xshardware -Xsboard=${SELECTED_BOARD} ${USER_HARDWARE_FLAGS}")
+set(HARDWARE_COMPILE_FLAGS "${WIN_FLAG} -fintelfpga")
+set(HARDWARE_LINK_FLAGS "-fintelfpga -Xshardware -Xsboard=${FPGA_BOARD} ${USER_HARDWARE_FLAGS}")
 # use cmake -D USER_HARDWARE_FLAGS=<flags> to set extra flags for FPGA backend compilation
 
+###############################################################################
+### FPGA Emulator
+###############################################################################
+# To compile in a single command:
+#    dpcpp -fintelfpga -DFPGA_EMULATOR loop_ivdep.cpp -o loop_ivdep.fpga_emu
+# CMake executes:
+#    [compile] dpcpp -fintelfpga -DFPGA_EMULATOR -o loop_ivdep.cpp.o -c loop_ivdep.cpp
+#    [link]    dpcpp -fintelfpga loop_ivdep.cpp.o -o loop_ivdep.fpga_emu
+add_executable(${EMULATOR_TARGET} ${SOURCE_FILE})
+set_target_properties(${EMULATOR_TARGET} PROPERTIES COMPILE_FLAGS "${EMULATOR_COMPILE_FLAGS}")
+set_target_properties(${EMULATOR_TARGET} PROPERTIES LINK_FLAGS "${EMULATOR_LINK_FLAGS}")
+add_custom_target(fpga_emu DEPENDS ${EMULATOR_TARGET})
 
-# FPGA emulator
-if(WIN32)
-    set(WIN_EMULATOR_TARGET ${EMULATOR_TARGET}.exe)
-    add_custom_target(fpga_emu DEPENDS ${WIN_EMULATOR_TARGET})
-    separate_arguments(WIN_EMULATOR_COMPILE_FLAGS WINDOWS_COMMAND "${EMULATOR_COMPILE_FLAGS}")
-    separate_arguments(CMAKE_CXX_FLAGS_LIST WINDOWS_COMMAND "${CMAKE_CXX_FLAGS}")
-    add_custom_command(OUTPUT ${WIN_EMULATOR_TARGET} 
-                       COMMAND ${CMAKE_CXX_COMPILER} /EHsc ${CMAKE_CXX_FLAGS_LIST} ${WIN_EMULATOR_COMPILE_FLAGS} ${CMAKE_CURRENT_SOURCE_DIR}/${SOURCE_FILE} -o ${CMAKE_BINARY_DIR}/${WIN_EMULATOR_TARGET}
-                       DEPENDS ${SOURCE_FILE})
-else()
-    add_executable(${EMULATOR_TARGET} ${SOURCE_FILE})
-    add_custom_target(fpga_emu DEPENDS ${EMULATOR_TARGET})
-    set_target_properties(${EMULATOR_TARGET} PROPERTIES COMPILE_FLAGS ${EMULATOR_COMPILE_FLAGS})
-    set_target_properties(${EMULATOR_TARGET} PROPERTIES LINK_FLAGS ${EMULATOR_LINK_FLAGS})
-endif()
+###############################################################################
+### Generate Report
+###############################################################################
+# To compile manually:
+#   dpcpp -fintelfpga -Xshardware -Xsboard=<FPGA_BOARD> -fsycl-link=early loop_ivdep.cpp -o loop_ivdep_report.a
+set(FPGA_EARLY_IMAGE ${TARGET_NAME}_report.a)
+# The compile output is not an executable, but an intermediate compilation result unique to DPC++.
+add_executable(${FPGA_EARLY_IMAGE} ${SOURCE_FILE})
+add_custom_target(report DEPENDS ${FPGA_EARLY_IMAGE})
+set_target_properties(${FPGA_EARLY_IMAGE} PROPERTIES COMPILE_FLAGS "${HARDWARE_COMPILE_FLAGS}")
+set_target_properties(${FPGA_EARLY_IMAGE} PROPERTIES LINK_FLAGS "${HARDWARE_LINK_FLAGS} -fsycl-link=early")
+# fsycl-link=early stops the compiler after RTL generation, before invoking Quartus
 
-# FPGA hardware
-if(WIN32)
-    add_custom_target(fpga COMMAND echo "An FPGA hardware target is not provided on Windows. See README for details.")
-else()
-    add_executable(${FPGA_TARGET} EXCLUDE_FROM_ALL ${SOURCE_FILE})
-    add_custom_target(fpga DEPENDS ${FPGA_TARGET})
-    set_target_properties(${FPGA_TARGET} PROPERTIES COMPILE_FLAGS ${HARDWARE_COMPILE_FLAGS})
-    set_target_properties(${FPGA_TARGET} PROPERTIES LINK_FLAGS ${HARDWARE_LINK_FLAGS})
-endif()
-
-# Generate report
-if(WIN32)
-    set(DEVICE_OBJ_FILE ${TARGET_NAME}_report.a)
-    add_custom_target(report DEPENDS ${DEVICE_OBJ_FILE})
-    separate_arguments(HARDWARE_LINK_FLAGS_LIST WINDOWS_COMMAND "${HARDWARE_LINK_FLAGS}")
-    add_custom_command(OUTPUT ${DEVICE_OBJ_FILE} 
-                       COMMAND ${CMAKE_CXX_COMPILER} /EHsc ${HARDWARE_LINK_FLAGS_LIST} -fsycl-link ${CMAKE_CURRENT_SOURCE_DIR}/${SOURCE_FILE} -o ${CMAKE_BINARY_DIR}/${DEVICE_OBJ_FILE}
-                       DEPENDS ${SOURCE_FILE})
-else()
-    set(DEVICE_OBJ_FILE ${TARGET_NAME}_report.a)
-    add_custom_target(report DEPENDS ${DEVICE_OBJ_FILE})
-    configure_file(${CMAKE_CURRENT_SOURCE_DIR}/${SOURCE_FILE} ${SOURCE_FILE} COPYONLY)
-    separate_arguments(HARDWARE_LINK_FLAGS_LIST UNIX_COMMAND "${HARDWARE_LINK_FLAGS}")
-    separate_arguments(CMAKE_CXX_FLAGS_LIST UNIX_COMMAND "${CMAKE_CXX_FLAGS}")
-    add_custom_command(OUTPUT ${DEVICE_OBJ_FILE} 
-                       COMMAND ${CMAKE_CXX_COMPILER} ${CMAKE_CXX_FLAGS_LIST} ${HARDWARE_LINK_FLAGS_LIST} -fsycl-link ${SOURCE_FILE} -o ${CMAKE_BINARY_DIR}/${DEVICE_OBJ_FILE}
-                       DEPENDS ${SOURCE_FILE})
-endif()
+###############################################################################
+### FPGA Hardware
+###############################################################################
+# To compile in a single command:
+#   dpcpp -fintelfpga -Xshardware -Xsboard=<FPGA_BOARD> loop_ivdep.cpp -o loop_ivdep.fpga
+# CMake executes:
+#   [compile] dpcpp -fintelfpga -o loop_ivdep.cpp.o -c loop_ivdep.cpp
+#   [link]    dpcpp -fintelfpga -Xshardware -Xsboard=<FPGA_BOARD> loop_ivdep.cpp.o -o loop_ivdep.fpga
+add_executable(${FPGA_TARGET} EXCLUDE_FROM_ALL ${SOURCE_FILE})
+add_custom_target(fpga DEPENDS ${FPGA_TARGET})
+set_target_properties(${FPGA_TARGET} PROPERTIES COMPILE_FLAGS "${HARDWARE_COMPILE_FLAGS}")
+set_target_properties(${FPGA_TARGET} PROPERTIES LINK_FLAGS "${HARDWARE_LINK_FLAGS} -reuse-exe=${CMAKE_BINARY_DIR}/${FPGA_TARGET}")
+# The -reuse-exe flag enables rapid recompilation of host-only code changes.
+# See DPC++FPGA/GettingStarted/fast_recompile for details.

--- a/DirectProgramming/DPC++FPGA/Tutorials/Features/loop_unroll/CMakeLists.txt
+++ b/DirectProgramming/DPC++FPGA/Tutorials/Features/loop_unroll/CMakeLists.txt
@@ -1,11 +1,17 @@
-set(CMAKE_CXX_COMPILER "dpcpp")
-if(WIN32)
-    set(CMAKE_C_COMPILER "clang-cl")
+if(UNIX)
+    # Direct CMake to use dpcpp rather than the default C++ compiler/linker
+    set(CMAKE_CXX_COMPILER dpcpp)
+else() # Windows
+    # Force CMake to use dpcpp rather than the default C++ compiler/linker 
+    # (needed on Windows only)
+    include (CMakeForceCompiler)
+    CMAKE_FORCE_CXX_COMPILER (dpcpp IntelDPCPP)
+    include (Platform/Windows-Clang)
 endif()
 
-cmake_minimum_required (VERSION 2.8)
+cmake_minimum_required (VERSION 3.4)
 
-project(LoopUnroll)
+project(LoopUnroll CXX)
 
 set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})
 set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})

--- a/DirectProgramming/DPC++FPGA/Tutorials/Features/loop_unroll/src/CMakeLists.txt
+++ b/DirectProgramming/DPC++FPGA/Tutorials/Features/loop_unroll/src/CMakeLists.txt
@@ -1,71 +1,73 @@
+# To see a Makefile equivalent of this build system:
+# https://github.com/oneapi-src/oneAPI-samples/blob/master/DirectProgramming/DPC++/ProjectTemplates/makefile-fpga
+
 set(SOURCE_FILE loop_unroll.cpp)
 set(TARGET_NAME loop_unroll)
 set(EMULATOR_TARGET ${TARGET_NAME}.fpga_emu)
 set(FPGA_TARGET ${TARGET_NAME}.fpga)
 
 # FPGA board selection
-set(A10_PAC_BOARD_NAME "intel_a10gx_pac:pac_a10")
-set(S10_PAC_BOARD_NAME "intel_s10sx_pac:pac_s10")
-set(SELECTED_BOARD ${A10_PAC_BOARD_NAME})
-if (NOT DEFINED FPGA_BOARD)
-    message(STATUS "\tFPGA_BOARD was not specified. Configuring the design to run on the Intel(R) Programmable Acceleration Card (PAC) with Intel Arria(R) 10 GX FPGA. Please refer to the README for information on board selection.")
-elseif(FPGA_BOARD STREQUAL ${A10_PAC_BOARD_NAME})
-    message(STATUS "\tConfiguring the design to run on the Intel(R) Programmable Acceleration Card (PAC) with Intel Arria(R) 10 GX FPGA.")
-elseif(FPGA_BOARD STREQUAL ${S10_PAC_BOARD_NAME})
-    message(STATUS "\tConfiguring the design to run on the Intel(R) Programmable Acceleration Card (PAC) D5005 (with Intel Stratix(R) 10 SX FPGA).")
-    set(SELECTED_BOARD ${S10_PAC_BOARD_NAME})
+if(NOT DEFINED FPGA_BOARD)
+    set(FPGA_BOARD "intel_a10gx_pac:pac_a10")
+    message(STATUS "FPGA_BOARD was not specified.\
+                    \nConfiguring the design to run on the default FPGA board ${FPGA_BOARD} (Intel(R) PAC with Intel Arria(R) 10 GX FPGA). \
+                    \nPlease refer to the README for information on board selection.")
 else()
-    message(STATUS "\tAn invalid board name was passed in using the FPGA_BOARD flag. Configuring the design to run on the Intel(R) Programmable Acceleration Card (PAC) with Intel Arria(R) 10 GX FPGA. Please refer to the README for the list of valid board names.")
+    message(STATUS "Configuring the design to run on FPGA board ${FPGA_BOARD}")
 endif()
 
-# Flags
-set(EMULATOR_COMPILE_FLAGS "-fintelfpga -DFPGA_EMULATOR")
+# This is a Windows-specific flag that enables exception handling in host code
+if(WIN32)
+    set(WIN_FLAG "/EHsc")
+endif()
+
+# A DPC++ ahead-of-time (AoT) compile processes the device code in two stages.
+# 1. The "compile" stage compiles the device code to an intermediate representation (SPIR-V).
+# 2. The "link" stage invokes the compiler's FPGA backend before linking.
+#    For this reason, FPGA backend flags must be passed as link flags in CMake.
+set(EMULATOR_COMPILE_FLAGS "${WIN_FLAG} -fintelfpga -DFPGA_EMULATOR")
 set(EMULATOR_LINK_FLAGS "-fintelfpga")
-set(HARDWARE_COMPILE_FLAGS "-fintelfpga")
-set(HARDWARE_LINK_FLAGS "-fintelfpga -Xshardware -Xsboard=${SELECTED_BOARD} ${USER_HARDWARE_FLAGS}")
+set(HARDWARE_COMPILE_FLAGS "${WIN_FLAG} -fintelfpga")
+set(HARDWARE_LINK_FLAGS "-fintelfpga -Xshardware -Xsboard=${FPGA_BOARD} ${USER_HARDWARE_FLAGS}")
 # use cmake -D USER_HARDWARE_FLAGS=<flags> to set extra flags for FPGA backend compilation
 
+###############################################################################
+### FPGA Emulator
+###############################################################################
+# To compile in a single command:
+#    dpcpp -fintelfpga -DFPGA_EMULATOR loop_unroll.cpp -o loop_unroll.fpga_emu
+# CMake executes:
+#    [compile] dpcpp -fintelfpga -DFPGA_EMULATOR -o loop_unroll.cpp.o -c loop_unroll.cpp
+#    [link]    dpcpp -fintelfpga loop_unroll.cpp.o -o loop_unroll.fpga_emu
+add_executable(${EMULATOR_TARGET} ${SOURCE_FILE})
+set_target_properties(${EMULATOR_TARGET} PROPERTIES COMPILE_FLAGS "${EMULATOR_COMPILE_FLAGS}")
+set_target_properties(${EMULATOR_TARGET} PROPERTIES LINK_FLAGS "${EMULATOR_LINK_FLAGS}")
+add_custom_target(fpga_emu DEPENDS ${EMULATOR_TARGET})
 
-# FPGA emulator
-if(WIN32)
-    set(WIN_EMULATOR_TARGET ${EMULATOR_TARGET}.exe)
-    add_custom_target(fpga_emu DEPENDS ${WIN_EMULATOR_TARGET})
-    separate_arguments(WIN_EMULATOR_COMPILE_FLAGS WINDOWS_COMMAND "${EMULATOR_COMPILE_FLAGS}")
-    add_custom_command(OUTPUT ${WIN_EMULATOR_TARGET} 
-                       COMMAND ${CMAKE_CXX_COMPILER} /EHsc ${WIN_EMULATOR_COMPILE_FLAGS} ${CMAKE_CURRENT_SOURCE_DIR}/${SOURCE_FILE} -o ${CMAKE_BINARY_DIR}/${WIN_EMULATOR_TARGET}
-                       DEPENDS ${SOURCE_FILE})
-else()
-    add_executable(${EMULATOR_TARGET} ${SOURCE_FILE})
-    add_custom_target(fpga_emu DEPENDS ${EMULATOR_TARGET})
-    set_target_properties(${EMULATOR_TARGET} PROPERTIES COMPILE_FLAGS ${EMULATOR_COMPILE_FLAGS})
-    set_target_properties(${EMULATOR_TARGET} PROPERTIES LINK_FLAGS ${EMULATOR_LINK_FLAGS})
-endif()
+###############################################################################
+### Generate Report
+###############################################################################
+# To compile manually:
+#   dpcpp -fintelfpga -Xshardware -Xsboard=<FPGA_BOARD> -fsycl-link=early loop_unroll.cpp -o loop_unroll_report.a
+set(FPGA_EARLY_IMAGE ${TARGET_NAME}_report.a)
+# The compile output is not an executable, but an intermediate compilation result unique to DPC++.
+add_executable(${FPGA_EARLY_IMAGE} ${SOURCE_FILE})
+add_custom_target(report DEPENDS ${FPGA_EARLY_IMAGE})
+set_target_properties(${FPGA_EARLY_IMAGE} PROPERTIES COMPILE_FLAGS "${HARDWARE_COMPILE_FLAGS}")
+set_target_properties(${FPGA_EARLY_IMAGE} PROPERTIES LINK_FLAGS "${HARDWARE_LINK_FLAGS} -fsycl-link=early")
+# fsycl-link=early stops the compiler after RTL generation, before invoking Quartus
 
-# FPGA hardware
-if(WIN32)
-    add_custom_target(fpga COMMAND echo "An FPGA hardware target is not provided on Windows. See README for details.")
-else()
-    add_executable(${FPGA_TARGET} EXCLUDE_FROM_ALL ${SOURCE_FILE})
-    add_custom_target(fpga DEPENDS ${FPGA_TARGET})
-    set_target_properties(${FPGA_TARGET} PROPERTIES COMPILE_FLAGS ${HARDWARE_COMPILE_FLAGS})
-    set_target_properties(${FPGA_TARGET} PROPERTIES LINK_FLAGS ${HARDWARE_LINK_FLAGS})
-endif()
-
-# Generate report
-if(WIN32)
-    set(DEVICE_OBJ_FILE ${TARGET_NAME}_report.a)
-    add_custom_target(report DEPENDS ${DEVICE_OBJ_FILE})
-    separate_arguments(HARDWARE_LINK_FLAGS_LIST WINDOWS_COMMAND "${HARDWARE_LINK_FLAGS}")
-    add_custom_command(OUTPUT ${DEVICE_OBJ_FILE} 
-                       COMMAND ${CMAKE_CXX_COMPILER} /EHsc ${HARDWARE_LINK_FLAGS_LIST} -fsycl-link ${CMAKE_CURRENT_SOURCE_DIR}/${SOURCE_FILE} -o ${CMAKE_BINARY_DIR}/${DEVICE_OBJ_FILE}
-                       DEPENDS ${SOURCE_FILE})
-else()
-    set(DEVICE_OBJ_FILE ${TARGET_NAME}_report.a)
-    add_custom_target(report DEPENDS ${DEVICE_OBJ_FILE})
-    configure_file(${CMAKE_CURRENT_SOURCE_DIR}/${SOURCE_FILE} ${SOURCE_FILE} COPYONLY)
-    separate_arguments(HARDWARE_LINK_FLAGS_LIST UNIX_COMMAND "${HARDWARE_LINK_FLAGS}")
-    separate_arguments(CMAKE_CXX_FLAGS_LIST UNIX_COMMAND "${CMAKE_CXX_FLAGS}")
-    add_custom_command(OUTPUT ${DEVICE_OBJ_FILE} 
-                       COMMAND ${CMAKE_CXX_COMPILER} ${CMAKE_CXX_FLAGS_LIST} ${HARDWARE_LINK_FLAGS_LIST} -fsycl-link ${SOURCE_FILE} -o ${CMAKE_BINARY_DIR}/${DEVICE_OBJ_FILE}
-                       DEPENDS ${SOURCE_FILE})
-endif()
+###############################################################################
+### FPGA Hardware
+###############################################################################
+# To compile in a single command:
+#   dpcpp -fintelfpga -Xshardware -Xsboard=<FPGA_BOARD> loop_unroll.cpp -o loop_unroll.fpga
+# CMake executes:
+#   [compile] dpcpp -fintelfpga -o loop_unroll.cpp.o -c loop_unroll.cpp
+#   [link]    dpcpp -fintelfpga -Xshardware -Xsboard=<FPGA_BOARD> loop_unroll.cpp.o -o loop_unroll.fpga
+add_executable(${FPGA_TARGET} EXCLUDE_FROM_ALL ${SOURCE_FILE})
+add_custom_target(fpga DEPENDS ${FPGA_TARGET})
+set_target_properties(${FPGA_TARGET} PROPERTIES COMPILE_FLAGS "${HARDWARE_COMPILE_FLAGS}")
+set_target_properties(${FPGA_TARGET} PROPERTIES LINK_FLAGS "${HARDWARE_LINK_FLAGS} -reuse-exe=${CMAKE_BINARY_DIR}/${FPGA_TARGET}")
+# The -reuse-exe flag enables rapid recompilation of host-only code changes.
+# See DPC++FPGA/GettingStarted/fast_recompile for details.

--- a/DirectProgramming/DPC++FPGA/Tutorials/Features/lsu_control/CMakeLists.txt
+++ b/DirectProgramming/DPC++FPGA/Tutorials/Features/lsu_control/CMakeLists.txt
@@ -1,11 +1,17 @@
-set(CMAKE_CXX_COMPILER "dpcpp")
-if(WIN32)
-    set(CMAKE_C_COMPILER "clang-cl")
+if(UNIX)
+    # Direct CMake to use dpcpp rather than the default C++ compiler/linker
+    set(CMAKE_CXX_COMPILER dpcpp)
+else() # Windows
+    # Force CMake to use dpcpp rather than the default C++ compiler/linker 
+    # (needed on Windows only)
+    include (CMakeForceCompiler)
+    CMAKE_FORCE_CXX_COMPILER (dpcpp IntelDPCPP)
+    include (Platform/Windows-Clang)
 endif()
 
-cmake_minimum_required (VERSION 2.8)
+cmake_minimum_required (VERSION 3.4)
 
-project(LSUControl)
+project(LSUControl CXX)
 
 set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})
 set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})

--- a/DirectProgramming/DPC++FPGA/Tutorials/Features/lsu_control/src/CMakeLists.txt
+++ b/DirectProgramming/DPC++FPGA/Tutorials/Features/lsu_control/src/CMakeLists.txt
@@ -1,79 +1,78 @@
+# To see a Makefile equivalent of this build system:
+# https://github.com/oneapi-src/oneAPI-samples/blob/master/DirectProgramming/DPC++/ProjectTemplates/makefile-fpga
+
 set(SOURCE_FILE lsu_control.cpp)
 set(TARGET_NAME lsu_control)
 set(EMULATOR_TARGET ${TARGET_NAME}.fpga_emu)
 set(FPGA_TARGET ${TARGET_NAME}.fpga)
 
 # FPGA board selection
-set(A10_PAC_BOARD_NAME "intel_a10gx_pac:pac_a10")
-set(S10_PAC_BOARD_NAME "intel_s10sx_pac:pac_s10")
-set(SELECTED_BOARD ${A10_PAC_BOARD_NAME})
-if (NOT DEFINED FPGA_BOARD)
-    message(STATUS "\tFPGA_BOARD was not specified. Configuring the design to run on the Intel(R) Programmable Acceleration Card (PAC) with Intel Arria(R) 10 GX FPGA. Please refer to the README for information on board selection.")
-elseif(FPGA_BOARD STREQUAL ${A10_PAC_BOARD_NAME})
-    message(STATUS "\tConfiguring the design to run on the Intel(R) Programmable Acceleration Card (PAC) with Intel Arria(R) 10 GX FPGA.")
-elseif(FPGA_BOARD STREQUAL ${S10_PAC_BOARD_NAME})
-    message(STATUS "\tConfiguring the design to run on the Intel(R) Programmable Acceleration Card (PAC) D5005 (with Intel Stratix(R) 10 SX FPGA).")
-    set(SELECTED_BOARD ${S10_PAC_BOARD_NAME})
+if(NOT DEFINED FPGA_BOARD)
+    set(FPGA_BOARD "intel_a10gx_pac:pac_a10")
+    message(STATUS "FPGA_BOARD was not specified.\
+                    \nConfiguring the design to run on the default FPGA board ${FPGA_BOARD} (Intel(R) PAC with Intel Arria(R) 10 GX FPGA). \
+                    \nPlease refer to the README for information on board selection.")
 else()
-    message(STATUS "\tAn invalid board name was passed in using the FPGA_BOARD flag. Configuring the design to run on the Intel(R) Programmable Acceleration Card (PAC) with Intel Arria(R) 10 GX FPGA. Please refer to the README for the list of valid board names.")
+    message(STATUS "Configuring the design to run on FPGA board ${FPGA_BOARD}")
 endif()
 
-# Flags
+# This is a Windows-specific flag that enables exception handling in host code
+if(WIN32)
+    set(WIN_FLAG "/EHsc")
+endif()
+
+# A DPC++ ahead-of-time (AoT) compile processes the device code in two stages.
+# 1. The "compile" stage compiles the device code to an intermediate representation (SPIR-V).
+# 2. The "link" stage invokes the compiler's FPGA backend before linking.
+#    For this reason, FPGA backend flags must be passed as link flags in CMake.
+set(EMULATOR_COMPILE_FLAGS "${WIN_FLAG} -fintelfpga -DFPGA_EMULATOR")
 set(EMULATOR_LINK_FLAGS "-fintelfpga")
-
+set(HARDWARE_COMPILE_FLAGS "${WIN_FLAG} -fintelfpga")
+if(FPGA_BOARD STREQUAL "intel_a10gx_pac:pac_a10")
+    # hyper-optimized-handshaking does not apply to Intel Arria 10 FPGAs
+    set(HARDWARE_LINK_FLAGS "-fintelfpga -Xshardware -Xsboard=${FPGA_BOARD} ${USER_HARDWARE_FLAGS}")
+else()
+    set(HARDWARE_LINK_FLAGS "-fintelfpga -Xshardware -Xshyper-optimized-handshaking=off -Xsboard=${FPGA_BOARD} ${USER_HARDWARE_FLAGS}")
+endif()
 # use cmake -D USER_HARDWARE_FLAGS=<flags> to set extra flags for FPGA backend compilation
-IF(SELECTED_BOARD STREQUAL ${A10_PAC_BOARD_NAME})
-    set(HARDWARE_LINK_FLAGS "-fintelfpga -Xshardware -Xsboard=${SELECTED_BOARD} ${USER_HARDWARE_FLAGS}")
-    set(HARDWARE_COMPILE_FLAGS "-fintelfpga")
-    set(EMULATOR_COMPILE_FLAGS "-fintelfpga -DFPGA_EMULATOR")
-ELSE()
-    set(HARDWARE_LINK_FLAGS "-fintelfpga -Xshardware -Xshyper-optimized-handshaking=off -Xsboard=${SELECTED_BOARD} ${USER_HARDWARE_FLAGS}")
-    set(HARDWARE_COMPILE_FLAGS "-fintelfpga")
-    set(EMULATOR_COMPILE_FLAGS "-fintelfpga -DFPGA_EMULATOR")
-ENDIF()
 
-# FPGA emulator
-if(WIN32)
-    set(WIN_EMULATOR_TARGET ${EMULATOR_TARGET}.exe)
-    add_custom_target(fpga_emu DEPENDS ${WIN_EMULATOR_TARGET})
-    separate_arguments(WIN_EMULATOR_COMPILE_FLAGS WINDOWS_COMMAND "${EMULATOR_COMPILE_FLAGS}")
-    add_custom_command(OUTPUT ${WIN_EMULATOR_TARGET} 
-                       COMMAND ${CMAKE_CXX_COMPILER} /EHsc ${WIN_EMULATOR_COMPILE_FLAGS} ${CMAKE_CURRENT_SOURCE_DIR}/${SOURCE_FILE} -o ${CMAKE_BINARY_DIR}/${WIN_EMULATOR_TARGET}
-                       DEPENDS ${SOURCE_FILE})
-else()
-    add_executable(${EMULATOR_TARGET} ${SOURCE_FILE})
-    add_custom_target(fpga_emu DEPENDS ${EMULATOR_TARGET})
-    set_target_properties(${EMULATOR_TARGET} PROPERTIES COMPILE_FLAGS ${EMULATOR_COMPILE_FLAGS})
-    set_target_properties(${EMULATOR_TARGET} PROPERTIES LINK_FLAGS ${EMULATOR_LINK_FLAGS})
-endif()
+###############################################################################
+### FPGA Emulator
+###############################################################################
+# To compile in a single command:
+#    dpcpp -fintelfpga -DFPGA_EMULATOR lsu_control.cpp -o lsu_control.fpga_emu
+# CMake executes:
+#    [compile] dpcpp -fintelfpga -DFPGA_EMULATOR -o lsu_control.cpp.o -c lsu_control.cpp
+#    [link]    dpcpp -fintelfpga lsu_control.cpp.o -o lsu_control.fpga_emu
+add_executable(${EMULATOR_TARGET} ${SOURCE_FILE})
+set_target_properties(${EMULATOR_TARGET} PROPERTIES COMPILE_FLAGS "${EMULATOR_COMPILE_FLAGS}")
+set_target_properties(${EMULATOR_TARGET} PROPERTIES LINK_FLAGS "${EMULATOR_LINK_FLAGS}")
+add_custom_target(fpga_emu DEPENDS ${EMULATOR_TARGET})
 
-# FPGA hardware
-if(WIN32)
-    add_custom_target(fpga COMMAND echo "An FPGA hardware target is not provided on Windows. See README for details.")
-else()
-    add_executable(${FPGA_TARGET} EXCLUDE_FROM_ALL ${SOURCE_FILE})
-    add_custom_target(fpga DEPENDS ${FPGA_TARGET})
-    set_target_properties(${FPGA_TARGET} PROPERTIES COMPILE_FLAGS ${HARDWARE_COMPILE_FLAGS})
-    set_target_properties(${FPGA_TARGET} PROPERTIES LINK_FLAGS ${HARDWARE_LINK_FLAGS})
-endif()
+###############################################################################
+### Generate Report
+###############################################################################
+# To compile manually:
+#   dpcpp -fintelfpga -Xshardware -Xsboard=<FPGA_BOARD> -fsycl-link=early lsu_control.cpp -o lsu_control_report.a
+set(FPGA_EARLY_IMAGE ${TARGET_NAME}_report.a)
+# The compile output is not an executable, but an intermediate compilation result unique to DPC++.
+add_executable(${FPGA_EARLY_IMAGE} ${SOURCE_FILE})
+add_custom_target(report DEPENDS ${FPGA_EARLY_IMAGE})
+set_target_properties(${FPGA_EARLY_IMAGE} PROPERTIES COMPILE_FLAGS "${HARDWARE_COMPILE_FLAGS}")
+set_target_properties(${FPGA_EARLY_IMAGE} PROPERTIES LINK_FLAGS "${HARDWARE_LINK_FLAGS} -fsycl-link=early")
+# fsycl-link=early stops the compiler after RTL generation, before invoking Quartus
 
-# Generate report
-if(WIN32)
-    set(DEVICE_OBJ_FILE ${TARGET_NAME}_report.a)
-    add_custom_target(report DEPENDS ${DEVICE_OBJ_FILE})
-    separate_arguments(HARDWARE_LINK_FLAGS_LIST WINDOWS_COMMAND "${HARDWARE_LINK_FLAGS}")
-    separate_arguments(CMAKE_CXX_FLAGS_LIST WINDOWS_COMMAND "${CMAKE_CXX_FLAGS}")
-    configure_file(${CMAKE_CURRENT_SOURCE_DIR}/${SOURCE_FILE} ${CMAKE_BINARY_DIR}/${TARGET_NAME}/${SOURCE_FILE} COPYONLY)
-    add_custom_command(OUTPUT ${DEVICE_OBJ_FILE}
-                       COMMAND ${CMAKE_CXX_COMPILER} /EHsc ${CMAKE_CXX_FLAGS_LIST} ${HARDWARE_LINK_FLAGS_LIST} -fsycl-link ${CMAKE_BINARY_DIR}/${TARGET_NAME}/${SOURCE_FILE} -o ${CMAKE_BINARY_DIR}/${DEVICE_OBJ_FILE}
-                       DEPENDS ${SOURCE_FILE})
-else()
-    set(DEVICE_OBJ_FILE ${TARGET_NAME}_report.a)
-    add_custom_target(report DEPENDS ${DEVICE_OBJ_FILE})
-    configure_file(${CMAKE_CURRENT_SOURCE_DIR}/${SOURCE_FILE} ${SOURCE_FILE} COPYONLY)
-    separate_arguments(HARDWARE_LINK_FLAGS_LIST UNIX_COMMAND "${HARDWARE_LINK_FLAGS}")
-    separate_arguments(CMAKE_CXX_FLAGS_LIST UNIX_COMMAND "${CMAKE_CXX_FLAGS}")
-    add_custom_command(OUTPUT ${DEVICE_OBJ_FILE}
-                       COMMAND ${CMAKE_CXX_COMPILER} ${CMAKE_CXX_FLAGS_LIST} ${HARDWARE_LINK_FLAGS_LIST} -fsycl-link ${SOURCE_FILE} -o ${CMAKE_BINARY_DIR}/${DEVICE_OBJ_FILE}
-                       DEPENDS ${SOURCE_FILE})
-endif()
+###############################################################################
+### FPGA Hardware
+###############################################################################
+# To compile in a single command:
+#   dpcpp -fintelfpga -Xshardware -Xsboard=<FPGA_BOARD> lsu_control.cpp -o lsu_control.fpga
+# CMake executes:
+#   [compile] dpcpp -fintelfpga -o lsu_control.cpp.o -c lsu_control.cpp
+#   [link]    dpcpp -fintelfpga -Xshardware -Xsboard=<FPGA_BOARD> lsu_control.cpp.o -o lsu_control.fpga
+add_executable(${FPGA_TARGET} EXCLUDE_FROM_ALL ${SOURCE_FILE})
+add_custom_target(fpga DEPENDS ${FPGA_TARGET})
+set_target_properties(${FPGA_TARGET} PROPERTIES COMPILE_FLAGS "${HARDWARE_COMPILE_FLAGS}")
+set_target_properties(${FPGA_TARGET} PROPERTIES LINK_FLAGS "${HARDWARE_LINK_FLAGS} -reuse-exe=${CMAKE_BINARY_DIR}/${FPGA_TARGET}")
+# The -reuse-exe flag enables rapid recompilation of host-only code changes.
+# See DPC++FPGA/GettingStarted/fast_recompile for details.

--- a/DirectProgramming/DPC++FPGA/Tutorials/Features/max_concurrency/CMakeLists.txt
+++ b/DirectProgramming/DPC++FPGA/Tutorials/Features/max_concurrency/CMakeLists.txt
@@ -1,11 +1,17 @@
-set(CMAKE_CXX_COMPILER "dpcpp")
-if(WIN32)
-    set(CMAKE_C_COMPILER "clang-cl")
+if(UNIX)
+    # Direct CMake to use dpcpp rather than the default C++ compiler/linker
+    set(CMAKE_CXX_COMPILER dpcpp)
+else() # Windows
+    # Force CMake to use dpcpp rather than the default C++ compiler/linker 
+    # (needed on Windows only)
+    include (CMakeForceCompiler)
+    CMAKE_FORCE_CXX_COMPILER (dpcpp IntelDPCPP)
+    include (Platform/Windows-Clang)
 endif()
 
-cmake_minimum_required (VERSION 2.8)
+cmake_minimum_required (VERSION 3.4)
 
-project(MaxConcurrency)
+project(MaxConcurrency CXX)
 
 set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})
 set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})

--- a/DirectProgramming/DPC++FPGA/Tutorials/Features/max_concurrency/README.md
+++ b/DirectProgramming/DPC++FPGA/Tutorials/Features/max_concurrency/README.md
@@ -156,27 +156,27 @@ On the main report page, scroll down to the section titled "Estimated Resource U
 
 ### Example of Output
 ```
-Max concurrency 0 kernel time : 1459.89 ms
-Throughput for kernel with max_concurrency 0: 0.561 GFlops
-Max concurrency 1 kernel time : 2890.810 ms
-Throughput for kernel with max_concurrency 1: 0.283 GFlops
-Max concurrency 2 kernel time : 1460.227 ms
-Throughput for kernel with max_concurrency 2: 0.561 GFlops
-Max concurrency 4 kernel time : 1459.970 ms
-Throughput for kernel with max_concurrency 4: 0.561 GFlops
-Max concurrency 8 kernel time : 1460.034 ms
-Throughput for kernel with max_concurrency 8: 0.561 GFlops
-Max concurrency 16 kernel time : 1459.901 ms
-Throughput for kernel with max_concurrency 16: 0.561 GFlops
+Max concurrency 0 kernel time : 1457.47 ms
+Throughput for kernel with max_concurrency 0: 562 MIPS
+Max concurrency 1 kernel time : 2947.784 ms
+Throughput for kernel with max_concurrency 1: 278 MIPS
+Max concurrency 2 kernel time : 1471.743 ms
+Throughput for kernel with max_concurrency 2: 557 MIPS
+Max concurrency 4 kernel time : 1457.460 ms
+Throughput for kernel with max_concurrency 4: 562 MIPS
+Max concurrency 8 kernel time : 1457.461 ms
+Throughput for kernel with max_concurrency 8: 562 MIPS
+Max concurrency 16 kernel time : 1457.463 ms
+Throughput for kernel with max_concurrency 16: 562 MIPS
 PASSED: The results are correct
 ```
 
 ### Discussion of Results
 
-The stdout output shows the giga-floating point operations per second (GFlops) for each kernel. 
+The stdout output shows the million instructions per second (MIPS) for each kernel. 
 
-When run on the Intel® PAC with Intel Arria10® 10 GX FPGA hardware board, we see that the throughput doubles from using max_concurrency 1 to max_concurrency 2. Further increasing the value of max_concurrency does not increase the GFlops achieved, i.e., increasing the max_concurrency above 2 will spend additional RAM resources for no additional throughput gain. As such, for this tutorial design, maximal throughput is best achieved by using max_concurrency 2. 
+When run on the Intel® PAC with Intel Arria10® 10 GX FPGA hardware board, we see that the throughput doubles from using max_concurrency 1 to max_concurrency 2. Further increasing the value of max_concurrency does not increase the MIPS achieved, i.e., increasing the max_concurrency above 2 will spend additional RAM resources for no additional throughput gain. As such, for this tutorial design, maximal throughput is best achieved by using max_concurrency 2. 
 
 Using max_concurrency 0 (or equivalently omitting the attribute entirely) also produced good throughput, indicating that the compiler's default heuristic chose a concurrency of 2 or higher in this case.
 
-When run on the FPGA emulator, the max_concurrency attribute has no effect on runtime. You may notice that the emulator achieved higher throughput than the FPGA in this example. This is because this trivial example uses only a tiny fraction of the spacial compute resources available on the FPGA.
+When run on the FPGA emulator, the max_concurrency attribute has no effect on runtime. You may notice that the emulator achieved higher throughput than the FPGA in this example. This is because this trivial example uses only a tiny fraction of the spatial compute resources available on the FPGA.

--- a/DirectProgramming/DPC++FPGA/Tutorials/Features/max_concurrency/max_concurrency.vcxproj
+++ b/DirectProgramming/DPC++FPGA/Tutorials/Features/max_concurrency/max_concurrency.vcxproj
@@ -104,7 +104,7 @@
       <ConformanceMode>true</ConformanceMode>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
       <EnableFPGACompilationAhead>true</EnableFPGACompilationAhead>
-      <AdditionalOptions>/fp:precise /Qfma- -DFPGA_EMULATOR %(AdditionalOptions)</AdditionalOptions>
+      <AdditionalOptions>-DFPGA_EMULATOR %(AdditionalOptions)</AdditionalOptions>
       <ObjectFileName>$(IntDir)max_concurrency.obj</ObjectFileName>
       <AdditionalIncludeDirectories>$(ONEAPI_ROOT)dev-utilities\latest\include</AdditionalIncludeDirectories>
     </ClCompile>
@@ -143,7 +143,7 @@
       <ConformanceMode>true</ConformanceMode>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
       <EnableFPGACompilationAhead>true</EnableFPGACompilationAhead>
-      <AdditionalOptions>/fp:precise /Qfma- -DFPGA_EMULATOR %(AdditionalOptions)</AdditionalOptions>
+      <AdditionalOptions>-DFPGA_EMULATOR %(AdditionalOptions)</AdditionalOptions>
       <ObjectFileName>$(IntDir)max_concurrency.obj</ObjectFileName>
       <AdditionalIncludeDirectories>$(ONEAPI_ROOT)dev-utilities\latest\include</AdditionalIncludeDirectories>
     </ClCompile>

--- a/DirectProgramming/DPC++FPGA/Tutorials/Features/max_concurrency/src/CMakeLists.txt
+++ b/DirectProgramming/DPC++FPGA/Tutorials/Features/max_concurrency/src/CMakeLists.txt
@@ -1,72 +1,79 @@
+# To see a Makefile equivalent of this build system:
+# https://github.com/oneapi-src/oneAPI-samples/blob/master/DirectProgramming/DPC++/ProjectTemplates/makefile-fpga
+
 set(SOURCE_FILE max_concurrency.cpp)
 set(TARGET_NAME max_concurrency)
 set(EMULATOR_TARGET ${TARGET_NAME}.fpga_emu)
 set(FPGA_TARGET ${TARGET_NAME}.fpga)
 
 # FPGA board selection
-set(A10_PAC_BOARD_NAME "intel_a10gx_pac:pac_a10")
-set(S10_PAC_BOARD_NAME "intel_s10sx_pac:pac_s10")
-set(SELECTED_BOARD ${A10_PAC_BOARD_NAME})
-if (NOT DEFINED FPGA_BOARD)
-    message(STATUS "\tFPGA_BOARD was not specified. Configuring the design to run on the Intel(R) Programmable Acceleration Card (PAC) with Intel Arria(R) 10 GX FPGA. Please refer to the README for information on board selection.")
-elseif(FPGA_BOARD STREQUAL ${A10_PAC_BOARD_NAME})
-    message(STATUS "\tConfiguring the design to run on the Intel(R) Programmable Acceleration Card (PAC) with Intel Arria(R) 10 GX FPGA.")
-elseif(FPGA_BOARD STREQUAL ${S10_PAC_BOARD_NAME})
-    message(STATUS "\tConfiguring the design to run on the Intel(R) Programmable Acceleration Card (PAC) D5005 (with Intel Stratix(R) 10 SX FPGA).")
-    set(SELECTED_BOARD ${S10_PAC_BOARD_NAME})
+if(NOT DEFINED FPGA_BOARD)
+    set(FPGA_BOARD "intel_a10gx_pac:pac_a10")
+    message(STATUS "FPGA_BOARD was not specified.\
+                    \nConfiguring the design to run on the default FPGA board ${FPGA_BOARD} (Intel(R) PAC with Intel Arria(R) 10 GX FPGA). \
+                    \nPlease refer to the README for information on board selection.")
 else()
-    message(STATUS "\tAn invalid board name was passed in using the FPGA_BOARD flag. Configuring the design to run on the Intel(R) Programmable Acceleration Card (PAC) with Intel Arria(R) 10 GX FPGA. Please refer to the README for the list of valid board names.")
+    message(STATUS "Configuring the design to run on FPGA board ${FPGA_BOARD}")
 endif()
 
-# Flags
-set(EMULATOR_COMPILE_FLAGS "-fintelfpga -DFPGA_EMULATOR -fp-model=precise -no-fma")
+# This is a Windows-specific flag that enables exception handling in host code
+if(WIN32)
+    set(WIN_FLAG "/EHsc")
+endif()
+
+# A DPC++ ahead-of-time (AoT) compile processes the device code in two stages.
+# 1. The "compile" stage compiles the device code to an intermediate representation (SPIR-V).
+# 2. The "link" stage invokes the compiler's FPGA backend before linking.
+#    For this reason, FPGA backend flags must be passed as link flags in CMake.
+set(EMULATOR_COMPILE_FLAGS "${WIN_FLAG} -fintelfpga -DFPGA_EMULATOR")
 set(EMULATOR_LINK_FLAGS "-fintelfpga")
-set(AOC_SEED_FLAG "-Xsseed=4 -Xsparallel=2")
-set(HARDWARE_COMPILE_FLAGS "-fintelfpga -fno-fast-math")
-set(HARDWARE_LINK_FLAGS "-fintelfpga -Xshardware -Xsboard=${SELECTED_BOARD} ${AOC_SEED_FLAG} ${USER_HARDWARE_FLAGS}")
+set(AOC_SEED_FLAG "-Xsseed=4 -Xsparallel=2") # Special flags passed to to Quartus
+set(HARDWARE_COMPILE_FLAGS "${WIN_FLAG} -fintelfpga")
+if(FPGA_BOARD STREQUAL "intel_a10gx_pac:pac_a10")
+    # hyper-optimized-handshaking does not apply to Intel Arria 10 FPGAs
+    set(HARDWARE_LINK_FLAGS "-fintelfpga -Xshardware -Xsboard=${FPGA_BOARD} ${AOC_SEED_FLAG} ${USER_HARDWARE_FLAGS}")
+else()
+    set(HARDWARE_LINK_FLAGS "-fintelfpga -Xshardware -Xshyper-optimized-handshaking=off -Xsboard=${FPGA_BOARD} ${AOC_SEED_FLAG} ${USER_HARDWARE_FLAGS}")
+endif()
 # use cmake -D USER_HARDWARE_FLAGS=<flags> to set extra flags for FPGA backend compilation
 
+###############################################################################
+### FPGA Emulator
+###############################################################################
+# To compile in a single command:
+#    dpcpp -fintelfpga -DFPGA_EMULATOR lsu_control.cpp -o lsu_control.fpga_emu
+# CMake executes:
+#    [compile] dpcpp -fintelfpga -DFPGA_EMULATOR -o lsu_control.cpp.o -c lsu_control.cpp
+#    [link]    dpcpp -fintelfpga lsu_control.cpp.o -o lsu_control.fpga_emu
+add_executable(${EMULATOR_TARGET} ${SOURCE_FILE})
+set_target_properties(${EMULATOR_TARGET} PROPERTIES COMPILE_FLAGS "${EMULATOR_COMPILE_FLAGS}")
+set_target_properties(${EMULATOR_TARGET} PROPERTIES LINK_FLAGS "${EMULATOR_LINK_FLAGS}")
+add_custom_target(fpga_emu DEPENDS ${EMULATOR_TARGET})
 
-# FPGA emulator
-if(WIN32)
-    set(WIN_EMULATOR_TARGET ${EMULATOR_TARGET}.exe)
-    add_custom_target(fpga_emu DEPENDS ${WIN_EMULATOR_TARGET})
-    separate_arguments(WIN_EMULATOR_COMPILE_FLAGS WINDOWS_COMMAND "${EMULATOR_COMPILE_FLAGS}")
-    add_custom_command(OUTPUT ${WIN_EMULATOR_TARGET} 
-                       COMMAND ${CMAKE_CXX_COMPILER} /EHsc /fp:precise /Qfma- ${WIN_EMULATOR_COMPILE_FLAGS} ${CMAKE_CURRENT_SOURCE_DIR}/${SOURCE_FILE} -o ${CMAKE_BINARY_DIR}/${WIN_EMULATOR_TARGET}
-                       DEPENDS ${SOURCE_FILE})
-else()
-    add_executable(${EMULATOR_TARGET} ${SOURCE_FILE})
-    add_custom_target(fpga_emu DEPENDS ${EMULATOR_TARGET})
-    set_target_properties(${EMULATOR_TARGET} PROPERTIES COMPILE_FLAGS ${EMULATOR_COMPILE_FLAGS})
-    set_target_properties(${EMULATOR_TARGET} PROPERTIES LINK_FLAGS ${EMULATOR_LINK_FLAGS})
-endif()
+###############################################################################
+### Generate Report
+###############################################################################
+# To compile manually:
+#   dpcpp -fintelfpga -Xshardware -Xsboard=<FPGA_BOARD> -Xsseed=4 -Xsparallel=2 -fsycl-link=early lsu_control.cpp -o lsu_control_report.a
+set(FPGA_EARLY_IMAGE ${TARGET_NAME}_report.a)
+# The compile output is not an executable, but an intermediate compilation result unique to DPC++.
+add_executable(${FPGA_EARLY_IMAGE} ${SOURCE_FILE})
+add_custom_target(report DEPENDS ${FPGA_EARLY_IMAGE})
+set_target_properties(${FPGA_EARLY_IMAGE} PROPERTIES COMPILE_FLAGS "${HARDWARE_COMPILE_FLAGS}")
+set_target_properties(${FPGA_EARLY_IMAGE} PROPERTIES LINK_FLAGS "${HARDWARE_LINK_FLAGS} -fsycl-link=early")
+# fsycl-link=early stops the compiler after RTL generation, before invoking Quartus
 
-# FPGA hardware
-if(WIN32)
-    add_custom_target(fpga COMMAND echo "An FPGA hardware target is not provided on Windows. See README for details.")
-else()
-    add_executable(${FPGA_TARGET} EXCLUDE_FROM_ALL ${SOURCE_FILE})
-    add_custom_target(fpga DEPENDS ${FPGA_TARGET})
-    set_target_properties(${FPGA_TARGET} PROPERTIES COMPILE_FLAGS ${HARDWARE_COMPILE_FLAGS})
-    set_target_properties(${FPGA_TARGET} PROPERTIES LINK_FLAGS ${HARDWARE_LINK_FLAGS})
-endif()
-
-# Generate report
-if(WIN32)
-    set(DEVICE_OBJ_FILE ${TARGET_NAME}_report.a)
-    add_custom_target(report DEPENDS ${DEVICE_OBJ_FILE})
-    separate_arguments(HARDWARE_LINK_FLAGS_LIST WINDOWS_COMMAND "${HARDWARE_LINK_FLAGS}")
-    add_custom_command(OUTPUT ${DEVICE_OBJ_FILE} 
-                       COMMAND ${CMAKE_CXX_COMPILER} /EHsc ${HARDWARE_LINK_FLAGS_LIST} -fsycl-link ${CMAKE_CURRENT_SOURCE_DIR}/${SOURCE_FILE} -o ${CMAKE_BINARY_DIR}/${DEVICE_OBJ_FILE}
-                       DEPENDS ${SOURCE_FILE})
-else()
-    set(DEVICE_OBJ_FILE ${TARGET_NAME}_report.a)
-    add_custom_target(report DEPENDS ${DEVICE_OBJ_FILE})
-    configure_file(${CMAKE_CURRENT_SOURCE_DIR}/${SOURCE_FILE} ${SOURCE_FILE} COPYONLY)
-    separate_arguments(HARDWARE_LINK_FLAGS_LIST UNIX_COMMAND "${HARDWARE_LINK_FLAGS}")
-    separate_arguments(CMAKE_CXX_FLAGS_LIST UNIX_COMMAND "${CMAKE_CXX_FLAGS}")
-    add_custom_command(OUTPUT ${DEVICE_OBJ_FILE} 
-                       COMMAND ${CMAKE_CXX_COMPILER} ${CMAKE_CXX_FLAGS_LIST} ${HARDWARE_LINK_FLAGS_LIST} -fsycl-link ${SOURCE_FILE} -o ${CMAKE_BINARY_DIR}/${DEVICE_OBJ_FILE}
-                       DEPENDS ${SOURCE_FILE})
-endif()
+###############################################################################
+### FPGA Hardware
+###############################################################################
+# To compile in a single command:
+#   dpcpp -fintelfpga -Xshardware -Xsboard=<FPGA_BOARD> -Xsseed=4 -Xsparallel=2 lsu_control.cpp -o lsu_control.fpga
+# CMake executes:
+#   [compile] dpcpp -fintelfpga -o lsu_control.cpp.o -c lsu_control.cpp
+#   [link]    dpcpp -fintelfpga -Xshardware -Xsboard=<FPGA_BOARD> -Xsseed=4 -Xsparallel=2 lsu_control.cpp.o -o lsu_control.fpga
+add_executable(${FPGA_TARGET} EXCLUDE_FROM_ALL ${SOURCE_FILE})
+add_custom_target(fpga DEPENDS ${FPGA_TARGET})
+set_target_properties(${FPGA_TARGET} PROPERTIES COMPILE_FLAGS "${HARDWARE_COMPILE_FLAGS}")
+set_target_properties(${FPGA_TARGET} PROPERTIES LINK_FLAGS "${HARDWARE_LINK_FLAGS} -reuse-exe=${CMAKE_BINARY_DIR}/${FPGA_TARGET}")
+# The -reuse-exe flag enables rapid recompilation of host-only code changes.
+# See DPC++FPGA/GettingStarted/fast_recompile for details.

--- a/DirectProgramming/DPC++FPGA/Tutorials/Features/max_concurrency/src/max_concurrency.cpp
+++ b/DirectProgramming/DPC++FPGA/Tutorials/Features/max_concurrency/src/max_concurrency.cpp
@@ -20,49 +20,46 @@ constexpr size_t kMaxIter = 50000;
 constexpr size_t kTotalOps = 2 * kMaxIter * kSize;
 constexpr size_t kMaxValue = 128;
 
-using FloatArray = std::array<float, kSize>;
-using FloatScalar = std::array<float, 1>;
+using IntArray = std::array<int, kSize>;
+using IntScalar = std::array<int, 1>;
 
 // Forward declare the kernel name in the global scope.
 // This FPGA best practice reduces name mangling in the optimization reports.
-template <int concurrency> class Kernel;
+template <int concurrency>
+class Kernel;
 
 // Launch a kernel on the device specified by selector.
 // The kernel's functionality is designed to show the
 // performance impact of the max_concurrency attribute.
 template <int concurrency>
-void PartialSumWithShift(const device_selector &selector,
-                         const FloatArray &array, float shift,
-                         FloatScalar &result) {
+void PartialSumWithShift(const device_selector &selector, const IntArray &array,
+                         int shift, IntScalar &result) {
   double kernel_time = 0.0;
 
   try {
-
     queue q(selector, dpc_common::exception_handler,
             property::queue::enable_profiling{});
 
     buffer buffer_array(array);
-    buffer<float, 1> buffer_result(result.data(), 1);
+    buffer<int, 1> buffer_result(result.data(), 1);
 
     event e = q.submit([&](handler &h) {
       accessor accessor_array(buffer_array, h, read_only);
       accessor accessor_result(buffer_result, h, write_only, noinit);
 
-      h.single_task<Kernel<concurrency>>([=]()
-                                          [[intel::kernel_args_restrict]] {
-        float r = 0;
+      h.single_task<Kernel<concurrency>>([=]() [[intel::kernel_args_restrict]] {
+        int r = 0;
 
         // At most concurrency iterations of the outer loop will be
         // active at one time.
         // This limits memory usage, since each iteration of the outer
         // loop requires its own copy of a1.
-        [[intel::max_concurrency(concurrency)]]
-        for (size_t i = 0; i < kMaxIter; i++) {
-          float a1[kSize];
+        [[intel::max_concurrency(concurrency)]] for (size_t i = 0; i < kMaxIter;
+                                                     i++) {
+          int a1[kSize];
           for (size_t j = 0; j < kSize; j++)
             a1[j] = accessor_array[(i * 4 + j) % kSize] * shift;
-          for (size_t j = 0; j < kSize; j++)
-            r += a1[j];
+          for (size_t j = 0; j < kSize; j++) r += a1[j];
         }
         accessor_result[0] = r;
       });
@@ -88,8 +85,8 @@ void PartialSumWithShift(const device_selector &selector,
     std::terminate();
   }
 
-  // The performance of the kernel is measured in GFlops, based on:
-  // 1) the number of floating-point operations performed by the kernel.
+  // The performance of the kernel is measured in MIPS, based on:
+  // 1) the number of arithmetic operations performed by the kernel.
   //    This can be calculated easily for the simple example kernel.
   // 2) the kernel execution time reported by SYCL event profiling.
   std::cout << "Max concurrency " << concurrency << " "
@@ -97,19 +94,17 @@ void PartialSumWithShift(const device_selector &selector,
   std::cout << "Throughput for kernel with max_concurrency " << concurrency
             << ": ";
   std::cout << std::fixed << std::setprecision(3)
-            << ((double)(kTotalOps) / kernel_time) / 1e6f << " GFlops\n";
+            << ((double)(kTotalOps) / kernel_time) / 1e3f << " MIPS\n";
 }
 
 // Calculates the expected results. Used to verify that the kernel
 // is functionally correct.
-float GoldenResult(const FloatArray &A, float shift) {
-  float gr = 0;
+int GoldenResult(const IntArray &A, int shift) {
+  int gr = 0;
   for (size_t i = 0; i < kMaxIter; i++) {
-    float a1[kSize];
-    for (size_t j = 0; j < kSize; j++)
-      a1[j] = A[(i * 4 + j) % kSize] * shift;
-    for (size_t j = 0; j < kSize; j++)
-      gr += a1[j];
+    int a1[kSize];
+    for (size_t j = 0; j < kSize; j++) a1[j] = A[(i * 4 + j) % kSize] * shift;
+    for (size_t j = 0; j < kSize; j++) gr += a1[j];
   }
   return gr;
 }
@@ -117,14 +112,13 @@ float GoldenResult(const FloatArray &A, float shift) {
 int main() {
   bool success = true;
 
-  FloatArray A;
-  FloatScalar R0, R1, R2, R3, R4, R5;
+  IntArray A;
+  IntScalar R0, R1, R2, R3, R4, R5;
 
-  float shift = (float)(rand() % kMaxValue);
+  int shift = rand() % kMaxValue;
 
   // initialize the input data
-  for (size_t i = 0; i < kSize; i++)
-    A[i] = rand() % kMaxValue;
+  for (size_t i = 0; i < kSize; i++) A[i] = rand() % kMaxValue;
 
 #if defined(FPGA_EMULATOR)
   INTEL::fpga_emulator_selector selector;
@@ -135,8 +129,8 @@ int main() {
   // Run the kernel with different values of the max_concurrency
   // attribute, to determine the optimal concurrency.
   // In this case, the optimal max_concurrency is 2 since this
-  // achieves the highest GFlops. Higher values of max_concurrency
-  // consume additional RAM without increasing GFlops.
+  // achieves the highest throughput. Higher values of max_concurrency
+  // consume additional RAM without increasing throughput.
   PartialSumWithShift<0>(selector, A, shift, R0);
   PartialSumWithShift<1>(selector, A, shift, R1);
   PartialSumWithShift<2>(selector, A, shift, R2);
@@ -145,7 +139,7 @@ int main() {
   PartialSumWithShift<16>(selector, A, shift, R5);
 
   // compute the actual result here
-  float gr = GoldenResult(A, shift);
+  int gr = GoldenResult(A, shift);
 
   // verify the results are correct
   if (gr != R0[0]) {

--- a/DirectProgramming/DPC++FPGA/Tutorials/Features/max_interleaving/CMakeLists.txt
+++ b/DirectProgramming/DPC++FPGA/Tutorials/Features/max_interleaving/CMakeLists.txt
@@ -1,10 +1,17 @@
-set(CMAKE_CXX_COMPILER "dpcpp")
-if(WIN32)
-    set(CMAKE_C_COMPILER "clang-cl")
+if(UNIX)
+    # Direct CMake to use dpcpp rather than the default C++ compiler/linker
+    set(CMAKE_CXX_COMPILER dpcpp)
+else() # Windows
+    # Force CMake to use dpcpp rather than the default C++ compiler/linker 
+    # (needed on Windows only)
+    include (CMakeForceCompiler)
+    CMAKE_FORCE_CXX_COMPILER (dpcpp IntelDPCPP)
+    include (Platform/Windows-Clang)
 endif()
-cmake_minimum_required (VERSION 2.8)
 
-project(MaxInterleaving)
+cmake_minimum_required (VERSION 3.4)
+
+project(MaxInterleaving CXX)
 
 set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})
 set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})

--- a/DirectProgramming/DPC++FPGA/Tutorials/Features/max_interleaving/src/CMakeLists.txt
+++ b/DirectProgramming/DPC++FPGA/Tutorials/Features/max_interleaving/src/CMakeLists.txt
@@ -1,71 +1,75 @@
+# To see a Makefile equivalent of this build system:
+# https://github.com/oneapi-src/oneAPI-samples/blob/master/DirectProgramming/DPC++/ProjectTemplates/makefile-fpga
+
 set(SOURCE_FILE max_interleaving.cpp)
 set(TARGET_NAME max_interleaving)
 set(EMULATOR_TARGET ${TARGET_NAME}.fpga_emu)
 set(FPGA_TARGET ${TARGET_NAME}.fpga)
 
 # FPGA board selection
-set(A10_PAC_BOARD_NAME "intel_a10gx_pac:pac_a10")
-set(S10_PAC_BOARD_NAME "intel_s10sx_pac:pac_s10")
-set(SELECTED_BOARD ${A10_PAC_BOARD_NAME})
-if (NOT DEFINED FPGA_BOARD)
-    message(STATUS "\tFPGA_BOARD was not specified. Configuring the design to run on the Intel(R) Programmable Acceleration Card (PAC) with Intel Arria(R) 10 GX FPGA. Please refer to the README for information on board selection.")
-elseif(FPGA_BOARD STREQUAL ${A10_PAC_BOARD_NAME})
-    message(STATUS "\tConfiguring the design to run on the Intel(R) Programmable Acceleration Card (PAC) with Intel Arria(R) 10 GX FPGA.")
-elseif(FPGA_BOARD STREQUAL ${S10_PAC_BOARD_NAME})
-    message(STATUS "\tConfiguring the design to run on the Intel(R) Programmable Acceleration Card (PAC) D5005 (with Intel Stratix(R) 10 SX FPGA).")
-    set(SELECTED_BOARD ${S10_PAC_BOARD_NAME})
+if(NOT DEFINED FPGA_BOARD)
+    set(FPGA_BOARD "intel_a10gx_pac:pac_a10")
+    message(STATUS "FPGA_BOARD was not specified.\
+                    \nConfiguring the design to run on the default FPGA board ${FPGA_BOARD} (Intel(R) PAC with Intel Arria(R) 10 GX FPGA). \
+                    \nPlease refer to the README for information on board selection.")
 else()
-    message(STATUS "\tAn invalid board name was passed in using the FPGA_BOARD flag. Configuring the design to run on the Intel(R) Programmable Acceleration Card (PAC) with Intel Arria(R) 10 GX FPGA. Please refer to the README for the list of valid board names.")
+    message(STATUS "Configuring the design to run on FPGA board ${FPGA_BOARD}")
 endif()
 
-# Flags
-set(EMULATOR_COMPILE_FLAGS "-fintelfpga -DFPGA_EMULATOR")
+# This is a Windows-specific flag that enables exception handling in host code
+if(WIN32)
+    set(WIN_FLAG "/EHsc")
+endif()
+
+# A DPC++ ahead-of-time (AoT) compile processes the device code in two stages.
+# 1. The "compile" stage compiles the device code to an intermediate representation (SPIR-V).
+# 2. The "link" stage invokes the compiler's FPGA backend before linking.
+#    For this reason, FPGA backend flags must be passed as link flags in CMake.
+set(EMULATOR_COMPILE_FLAGS "${WIN_FLAG} -fintelfpga -DFPGA_EMULATOR")
 set(EMULATOR_LINK_FLAGS "-fintelfpga")
-set(HARDWARE_COMPILE_FLAGS "-fintelfpga")
-set(HARDWARE_LINK_FLAGS "-fintelfpga -Xshardware -Xsboard=${SELECTED_BOARD} ${USER_HARDWARE_FLAGS}")
+set(HARDWARE_COMPILE_FLAGS "${WIN_FLAG} -fintelfpga")
+set(HARDWARE_LINK_FLAGS "-fintelfpga -Xshardware -Xsboard=${FPGA_BOARD} ${USER_HARDWARE_FLAGS}")
 # use cmake -D USER_HARDWARE_FLAGS=<flags> to set extra flags for FPGA backend compilation
 
 
-# FPGA emulator
-if(WIN32)
-    set(WIN_EMULATOR_TARGET ${EMULATOR_TARGET}.exe)
-    add_custom_target(fpga_emu DEPENDS ${WIN_EMULATOR_TARGET})
-    separate_arguments(WIN_EMULATOR_COMPILE_FLAGS WINDOWS_COMMAND "${EMULATOR_COMPILE_FLAGS}")
-    add_custom_command(OUTPUT ${WIN_EMULATOR_TARGET} 
-                       COMMAND ${CMAKE_CXX_COMPILER} /EHsc ${WIN_EMULATOR_COMPILE_FLAGS} ${CMAKE_CURRENT_SOURCE_DIR}/${SOURCE_FILE} -o ${CMAKE_BINARY_DIR}/${WIN_EMULATOR_TARGET}
-                       DEPENDS ${SOURCE_FILE})
-else()
-    add_executable(${EMULATOR_TARGET} ${SOURCE_FILE})
-    add_custom_target(fpga_emu DEPENDS ${EMULATOR_TARGET})
-    set_target_properties(${EMULATOR_TARGET} PROPERTIES COMPILE_FLAGS ${EMULATOR_COMPILE_FLAGS})
-    set_target_properties(${EMULATOR_TARGET} PROPERTIES LINK_FLAGS ${EMULATOR_LINK_FLAGS})
-endif()
+###############################################################################
+### FPGA Emulator
+###############################################################################
+# To compile in a single command:
+#    dpcpp -fintelfpga -DFPGA_EMULATOR max_interleaving.cpp -o max_interleaving.fpga_emu
+# CMake executes:
+#    [compile] dpcpp -fintelfpga -DFPGA_EMULATOR -o max_interleaving.cpp.o -c max_interleaving.cpp
+#    [link]    dpcpp -fintelfpga max_interleaving.cpp.o -o max_interleaving.fpga_emu
+add_executable(${EMULATOR_TARGET} ${SOURCE_FILE})
+set_target_properties(${EMULATOR_TARGET} PROPERTIES COMPILE_FLAGS "${EMULATOR_COMPILE_FLAGS}")
+set_target_properties(${EMULATOR_TARGET} PROPERTIES LINK_FLAGS "${EMULATOR_LINK_FLAGS}")
+add_custom_target(fpga_emu DEPENDS ${EMULATOR_TARGET})
 
-# FPGA hardware
-if(WIN32)
-    add_custom_target(fpga COMMAND echo "An FPGA hardware target is not provided on Windows. See README for details.")
-else()
-    add_executable(${FPGA_TARGET} EXCLUDE_FROM_ALL ${SOURCE_FILE})
-    add_custom_target(fpga DEPENDS ${FPGA_TARGET})
-    set_target_properties(${FPGA_TARGET} PROPERTIES COMPILE_FLAGS ${HARDWARE_COMPILE_FLAGS})
-    set_target_properties(${FPGA_TARGET} PROPERTIES LINK_FLAGS ${HARDWARE_LINK_FLAGS})
-endif()
+###############################################################################
+### Generate Report
+###############################################################################
+# To compile manually:
+#   dpcpp -fintelfpga -Xshardware -Xsboard=<FPGA_BOARD> -fsycl-link=early max_interleaving.cpp -o max_interleaving_report.a
+set(FPGA_EARLY_IMAGE ${TARGET_NAME}_report.a)
+# The compile output is not an executable, but an intermediate compilation result unique to DPC++.
+add_executable(${FPGA_EARLY_IMAGE} ${SOURCE_FILE})
+add_custom_target(report DEPENDS ${FPGA_EARLY_IMAGE})
+set_target_properties(${FPGA_EARLY_IMAGE} PROPERTIES COMPILE_FLAGS "${HARDWARE_COMPILE_FLAGS}")
+set_target_properties(${FPGA_EARLY_IMAGE} PROPERTIES LINK_FLAGS "${HARDWARE_LINK_FLAGS} -fsycl-link=early")
+# fsycl-link=early stops the compiler after RTL generation, before invoking Quartus
 
-# Generate report
-if(WIN32)
-    set(DEVICE_OBJ_FILE ${TARGET_NAME}_report.a)
-    add_custom_target(report DEPENDS ${DEVICE_OBJ_FILE})
-    separate_arguments(HARDWARE_LINK_FLAGS_LIST WINDOWS_COMMAND "${HARDWARE_LINK_FLAGS}")
-    add_custom_command(OUTPUT ${DEVICE_OBJ_FILE} 
-                       COMMAND ${CMAKE_CXX_COMPILER} /EHsc ${HARDWARE_LINK_FLAGS_LIST} -fsycl-link ${CMAKE_CURRENT_SOURCE_DIR}/${SOURCE_FILE} -o ${CMAKE_BINARY_DIR}/${DEVICE_OBJ_FILE}
-                       DEPENDS ${SOURCE_FILE})
-else()
-    set(DEVICE_OBJ_FILE ${TARGET_NAME}_report.a)
-    add_custom_target(report DEPENDS ${DEVICE_OBJ_FILE})
-    configure_file(${CMAKE_CURRENT_SOURCE_DIR}/${SOURCE_FILE} ${SOURCE_FILE} COPYONLY)
-    separate_arguments(HARDWARE_LINK_FLAGS_LIST UNIX_COMMAND "${HARDWARE_LINK_FLAGS}")
-    separate_arguments(CMAKE_CXX_FLAGS_LIST UNIX_COMMAND "${CMAKE_CXX_FLAGS}")
-    add_custom_command(OUTPUT ${DEVICE_OBJ_FILE} 
-                       COMMAND ${CMAKE_CXX_COMPILER} ${CMAKE_CXX_FLAGS_LIST} ${HARDWARE_LINK_FLAGS_LIST} -fsycl-link ${SOURCE_FILE} -o ${CMAKE_BINARY_DIR}/${DEVICE_OBJ_FILE}
-                       DEPENDS ${SOURCE_FILE})
-endif()
+###############################################################################
+### FPGA Hardware
+###############################################################################
+# To compile in a single command:
+#   dpcpp -fintelfpga -Xshardware -Xsboard=<FPGA_BOARD> max_interleaving.cpp -o max_interleaving.fpga
+# CMake executes:
+#   [compile] dpcpp -fintelfpga -o max_interleaving.cpp.o -c max_interleaving.cpp
+#   [link]    dpcpp -fintelfpga -Xshardware -Xsboard=<FPGA_BOARD> max_interleaving.cpp.o -o max_interleaving.fpga
+add_executable(${FPGA_TARGET} EXCLUDE_FROM_ALL ${SOURCE_FILE})
+add_custom_target(fpga DEPENDS ${FPGA_TARGET})
+set_target_properties(${FPGA_TARGET} PROPERTIES COMPILE_FLAGS "${HARDWARE_COMPILE_FLAGS}")
+set_target_properties(${FPGA_TARGET} PROPERTIES LINK_FLAGS "${HARDWARE_LINK_FLAGS} -reuse-exe=${CMAKE_BINARY_DIR}/${FPGA_TARGET}")
+
+# The -reuse-exe flag enables rapid recompilation of host-only code changes.
+# See DPC++FPGA/GettingStarted/fast_recompile for details.

--- a/DirectProgramming/DPC++FPGA/Tutorials/Features/memory_attributes/CMakeLists.txt
+++ b/DirectProgramming/DPC++FPGA/Tutorials/Features/memory_attributes/CMakeLists.txt
@@ -1,11 +1,17 @@
-set(CMAKE_CXX_COMPILER "dpcpp")
-if(WIN32)
-    set(CMAKE_C_COMPILER "clang-cl")
+if(UNIX)
+    # Direct CMake to use dpcpp rather than the default C++ compiler/linker
+    set(CMAKE_CXX_COMPILER dpcpp)
+else() # Windows
+    # Force CMake to use dpcpp rather than the default C++ compiler/linker 
+    # (needed on Windows only)
+    include (CMakeForceCompiler)
+    CMAKE_FORCE_CXX_COMPILER (dpcpp IntelDPCPP)
+    include (Platform/Windows-Clang)
 endif()
 
-cmake_minimum_required (VERSION 2.8)
+cmake_minimum_required (VERSION 3.4)
 
-project(MemoryAttributesOverview)
+project(MemoryAttributesOverview CXX)
 
 set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})
 set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})

--- a/DirectProgramming/DPC++FPGA/Tutorials/Features/memory_attributes/src/CMakeLists.txt
+++ b/DirectProgramming/DPC++FPGA/Tutorials/Features/memory_attributes/src/CMakeLists.txt
@@ -1,71 +1,73 @@
+# To see a Makefile equivalent of this build system:
+# https://github.com/oneapi-src/oneAPI-samples/blob/master/DirectProgramming/DPC++/ProjectTemplates/makefile-fpga
+
 set(SOURCE_FILE memory_attributes.cpp)
 set(TARGET_NAME memory_attributes)
 set(EMULATOR_TARGET ${TARGET_NAME}.fpga_emu)
 set(FPGA_TARGET ${TARGET_NAME}.fpga)
 
 # FPGA board selection
-set(A10_PAC_BOARD_NAME "intel_a10gx_pac:pac_a10")
-set(S10_PAC_BOARD_NAME "intel_s10sx_pac:pac_s10")
-set(SELECTED_BOARD ${A10_PAC_BOARD_NAME})
-if (NOT DEFINED FPGA_BOARD)
-    message(STATUS "\tFPGA_BOARD was not specified. Configuring the design to run on the Intel(R) Programmable Acceleration Card (PAC) with Intel Arria(R) 10 GX FPGA. Please refer to the README for information on board selection.")
-elseif(FPGA_BOARD STREQUAL ${A10_PAC_BOARD_NAME})
-    message(STATUS "\tConfiguring the design to run on the Intel(R) Programmable Acceleration Card (PAC) with Intel Arria(R) 10 GX FPGA.")
-elseif(FPGA_BOARD STREQUAL ${S10_PAC_BOARD_NAME})
-    message(STATUS "\tConfiguring the design to run on the Intel(R) Programmable Acceleration Card (PAC) D5005 (with Intel Stratix(R) 10 SX FPGA).")
-    set(SELECTED_BOARD ${S10_PAC_BOARD_NAME})
+if(NOT DEFINED FPGA_BOARD)
+    set(FPGA_BOARD "intel_a10gx_pac:pac_a10")
+    message(STATUS "FPGA_BOARD was not specified.\
+                    \nConfiguring the design to run on the default FPGA board ${FPGA_BOARD} (Intel(R) PAC with Intel Arria(R) 10 GX FPGA). \
+                    \nPlease refer to the README for information on board selection.")
 else()
-    message(STATUS "\tAn invalid board name was passed in using the FPGA_BOARD flag. Configuring the design to run on the Intel(R) Programmable Acceleration Card (PAC) with Intel Arria(R) 10 GX FPGA. Please refer to the README for the list of valid board names.")
+    message(STATUS "Configuring the design to run on FPGA board ${FPGA_BOARD}")
 endif()
 
-# Flags
-set(EMULATOR_COMPILE_FLAGS "-fintelfpga -DFPGA_EMULATOR")
+# This is a Windows-specific flag that enables exception handling in host code
+if(WIN32)
+    set(WIN_FLAG "/EHsc")
+endif()
+
+# A DPC++ ahead-of-time (AoT) compile processes the device code in two stages.
+# 1. The "compile" stage compiles the device code to an intermediate representation (SPIR-V).
+# 2. The "link" stage invokes the compiler's FPGA backend before linking.
+#    For this reason, FPGA backend flags must be passed as link flags in CMake.
+set(EMULATOR_COMPILE_FLAGS "${WIN_FLAG} -fintelfpga -DFPGA_EMULATOR")
 set(EMULATOR_LINK_FLAGS "-fintelfpga")
-set(HARDWARE_COMPILE_FLAGS "-fintelfpga")
-set(HARDWARE_LINK_FLAGS "-fintelfpga -Xshardware -Xsboard=${SELECTED_BOARD} ${USER_HARDWARE_FLAGS}")
+set(HARDWARE_COMPILE_FLAGS "${WIN_FLAG} -fintelfpga")
+set(HARDWARE_LINK_FLAGS "-fintelfpga -Xshardware -Xsboard=${FPGA_BOARD} ${USER_HARDWARE_FLAGS}")
 # use cmake -D USER_HARDWARE_FLAGS=<flags> to set extra flags for FPGA backend compilation
 
+###############################################################################
+### FPGA Emulator
+###############################################################################
+# To compile in a single command:
+#    dpcpp -fintelfpga -DFPGA_EMULATOR memory_attributes.cpp -o memory_attributes.fpga_emu
+# CMake executes:
+#    [compile] dpcpp -fintelfpga -DFPGA_EMULATOR -o memory_attributes.cpp.o -c memory_attributes.cpp
+#    [link]    dpcpp -fintelfpga memory_attributes.cpp.o -o memory_attributes.fpga_emu
+add_executable(${EMULATOR_TARGET} ${SOURCE_FILE})
+set_target_properties(${EMULATOR_TARGET} PROPERTIES COMPILE_FLAGS "${EMULATOR_COMPILE_FLAGS}")
+set_target_properties(${EMULATOR_TARGET} PROPERTIES LINK_FLAGS "${EMULATOR_LINK_FLAGS}")
+add_custom_target(fpga_emu DEPENDS ${EMULATOR_TARGET})
 
-# FPGA emulator
-if(WIN32)
-    set(WIN_EMULATOR_TARGET ${EMULATOR_TARGET}.exe)
-    add_custom_target(fpga_emu DEPENDS ${WIN_EMULATOR_TARGET})
-    separate_arguments(WIN_EMULATOR_COMPILE_FLAGS WINDOWS_COMMAND "${EMULATOR_COMPILE_FLAGS}")
-    add_custom_command(OUTPUT ${WIN_EMULATOR_TARGET} 
-                       COMMAND ${CMAKE_CXX_COMPILER} /EHsc ${WIN_EMULATOR_COMPILE_FLAGS} ${CMAKE_CURRENT_SOURCE_DIR}/${SOURCE_FILE} -o ${CMAKE_BINARY_DIR}/${WIN_EMULATOR_TARGET}
-                       DEPENDS ${SOURCE_FILE})
-else()
-    add_executable(${EMULATOR_TARGET} ${SOURCE_FILE})
-    add_custom_target(fpga_emu DEPENDS ${EMULATOR_TARGET})
-    set_target_properties(${EMULATOR_TARGET} PROPERTIES COMPILE_FLAGS ${EMULATOR_COMPILE_FLAGS})
-    set_target_properties(${EMULATOR_TARGET} PROPERTIES LINK_FLAGS ${EMULATOR_LINK_FLAGS})
-endif()
+###############################################################################
+### Generate Report
+###############################################################################
+# To compile manually:
+#   dpcpp -fintelfpga -Xshardware -Xsboard=<FPGA_BOARD> -fsycl-link=early memory_attributes.cpp -o memory_attributes_report.a
+set(FPGA_EARLY_IMAGE ${TARGET_NAME}_report.a)
+# The compile output is not an executable, but an intermediate compilation result unique to DPC++.
+add_executable(${FPGA_EARLY_IMAGE} ${SOURCE_FILE})
+add_custom_target(report DEPENDS ${FPGA_EARLY_IMAGE})
+set_target_properties(${FPGA_EARLY_IMAGE} PROPERTIES COMPILE_FLAGS "${HARDWARE_COMPILE_FLAGS}")
+set_target_properties(${FPGA_EARLY_IMAGE} PROPERTIES LINK_FLAGS "${HARDWARE_LINK_FLAGS} -fsycl-link=early")
+# fsycl-link=early stops the compiler after RTL generation, before invoking Quartus
 
-# FPGA hardware
-if(WIN32)
-    add_custom_target(fpga COMMAND echo "An FPGA hardware target is not provided on Windows. See README for details.")
-else()
-    add_executable(${FPGA_TARGET} EXCLUDE_FROM_ALL ${SOURCE_FILE})
-    add_custom_target(fpga DEPENDS ${FPGA_TARGET})
-    set_target_properties(${FPGA_TARGET} PROPERTIES COMPILE_FLAGS ${HARDWARE_COMPILE_FLAGS})
-    set_target_properties(${FPGA_TARGET} PROPERTIES LINK_FLAGS ${HARDWARE_LINK_FLAGS})
-endif()
-
-# Generate report
-if(WIN32)
-    set(DEVICE_OBJ_FILE ${TARGET_NAME}_report.a)
-    add_custom_target(report DEPENDS ${DEVICE_OBJ_FILE})
-    separate_arguments(HARDWARE_LINK_FLAGS_LIST WINDOWS_COMMAND "${HARDWARE_LINK_FLAGS}")
-    add_custom_command(OUTPUT ${DEVICE_OBJ_FILE} 
-                       COMMAND ${CMAKE_CXX_COMPILER} /EHsc ${HARDWARE_LINK_FLAGS_LIST} -fsycl-link ${CMAKE_CURRENT_SOURCE_DIR}/${SOURCE_FILE} -o ${CMAKE_BINARY_DIR}/${DEVICE_OBJ_FILE}
-                       DEPENDS ${SOURCE_FILE})
-else()
-    set(DEVICE_OBJ_FILE ${TARGET_NAME}_report.a)
-    add_custom_target(report DEPENDS ${DEVICE_OBJ_FILE})
-    configure_file(${CMAKE_CURRENT_SOURCE_DIR}/${SOURCE_FILE} ${SOURCE_FILE} COPYONLY)
-    separate_arguments(HARDWARE_LINK_FLAGS_LIST UNIX_COMMAND "${HARDWARE_LINK_FLAGS}")
-    separate_arguments(CMAKE_CXX_FLAGS_LIST UNIX_COMMAND "${CMAKE_CXX_FLAGS}")
-    add_custom_command(OUTPUT ${DEVICE_OBJ_FILE} 
-                       COMMAND ${CMAKE_CXX_COMPILER} ${CMAKE_CXX_FLAGS_LIST} ${HARDWARE_LINK_FLAGS_LIST} -fsycl-link ${SOURCE_FILE} -o ${CMAKE_BINARY_DIR}/${DEVICE_OBJ_FILE}
-                       DEPENDS ${SOURCE_FILE})
-endif()
+###############################################################################
+### FPGA Hardware
+###############################################################################
+# To compile in a single command:
+#   dpcpp -fintelfpga -Xshardware -Xsboard=<FPGA_BOARD> memory_attributes.cpp -o memory_attributes.fpga
+# CMake executes:
+#   [compile] dpcpp -fintelfpga -o memory_attributes.cpp.o -c memory_attributes.cpp
+#   [link]    dpcpp -fintelfpga -Xshardware -Xsboard=<FPGA_BOARD> memory_attributes.cpp.o -o memory_attributes.fpga
+add_executable(${FPGA_TARGET} EXCLUDE_FROM_ALL ${SOURCE_FILE})
+add_custom_target(fpga DEPENDS ${FPGA_TARGET})
+set_target_properties(${FPGA_TARGET} PROPERTIES COMPILE_FLAGS "${HARDWARE_COMPILE_FLAGS}")
+set_target_properties(${FPGA_TARGET} PROPERTIES LINK_FLAGS "${HARDWARE_LINK_FLAGS} -reuse-exe=${CMAKE_BINARY_DIR}/${FPGA_TARGET}")
+# The -reuse-exe flag enables rapid recompilation of host-only code changes.
+# See DPC++FPGA/GettingStarted/fast_recompile for details.

--- a/DirectProgramming/DPC++FPGA/Tutorials/Features/pipes/CMakeLists.txt
+++ b/DirectProgramming/DPC++FPGA/Tutorials/Features/pipes/CMakeLists.txt
@@ -1,11 +1,17 @@
-set(CMAKE_CXX_COMPILER "dpcpp")
-if(WIN32)
-    set(CMAKE_C_COMPILER "clang-cl")
+if(UNIX)
+    # Direct CMake to use dpcpp rather than the default C++ compiler/linker
+    set(CMAKE_CXX_COMPILER dpcpp)
+else() # Windows
+    # Force CMake to use dpcpp rather than the default C++ compiler/linker 
+    # (needed on Windows only)
+    include (CMakeForceCompiler)
+    CMAKE_FORCE_CXX_COMPILER (dpcpp IntelDPCPP)
+    include (Platform/Windows-Clang)
 endif()
 
-cmake_minimum_required (VERSION 2.8)
+cmake_minimum_required (VERSION 3.4)
 
-project(Pipes)
+project(Pipes CXX)
 
 set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})
 set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})

--- a/DirectProgramming/DPC++FPGA/Tutorials/Features/pipes/src/CMakeLists.txt
+++ b/DirectProgramming/DPC++FPGA/Tutorials/Features/pipes/src/CMakeLists.txt
@@ -1,72 +1,73 @@
+# To see a Makefile equivalent of this build system:
+# https://github.com/oneapi-src/oneAPI-samples/blob/master/DirectProgramming/DPC++/ProjectTemplates/makefile-fpga
+
 set(SOURCE_FILE pipes.cpp)
 set(TARGET_NAME pipes)
 set(EMULATOR_TARGET ${TARGET_NAME}.fpga_emu)
 set(FPGA_TARGET ${TARGET_NAME}.fpga)
 
-
 # FPGA board selection
-set(A10_PAC_BOARD_NAME "intel_a10gx_pac:pac_a10")
-set(S10_PAC_BOARD_NAME "intel_s10sx_pac:pac_s10")
-set(SELECTED_BOARD ${A10_PAC_BOARD_NAME})
-if (NOT DEFINED FPGA_BOARD)
-    message(STATUS "\tFPGA_BOARD was not specified. Configuring the design to run on the Intel(R) Programmable Acceleration Card (PAC) with Intel Arria(R) 10 GX FPGA. Please refer to the README for information on board selection.")
-elseif(FPGA_BOARD STREQUAL ${A10_PAC_BOARD_NAME})
-    message(STATUS "\tConfiguring the design to run on the Intel(R) Programmable Acceleration Card (PAC) with Intel Arria(R) 10 GX FPGA.")
-elseif(FPGA_BOARD STREQUAL ${S10_PAC_BOARD_NAME})
-    message(STATUS "\tConfiguring the design to run on the Intel(R) Programmable Acceleration Card (PAC) D5005 (with Intel Stratix(R) 10 SX FPGA).")
-    set(SELECTED_BOARD ${S10_PAC_BOARD_NAME})
+if(NOT DEFINED FPGA_BOARD)
+    set(FPGA_BOARD "intel_a10gx_pac:pac_a10")
+    message(STATUS "FPGA_BOARD was not specified.\
+                    \nConfiguring the design to run on the default FPGA board ${FPGA_BOARD} (Intel(R) PAC with Intel Arria(R) 10 GX FPGA). \
+                    \nPlease refer to the README for information on board selection.")
 else()
-    message(STATUS "\tAn invalid board name was passed in using the FPGA_BOARD flag. Configuring the design to run on the Intel(R) Programmable Acceleration Card (PAC) with Intel Arria(R) 10 GX FPGA. Please refer to the README for the list of valid board names.")
+    message(STATUS "Configuring the design to run on FPGA board ${FPGA_BOARD}")
 endif()
 
-# Flags
-set(EMULATOR_COMPILE_FLAGS "-fintelfpga -DFPGA_EMULATOR")
+# This is a Windows-specific flag that enables exception handling in host code
+if(WIN32)
+    set(WIN_FLAG "/EHsc")
+endif()
+
+# A DPC++ ahead-of-time (AoT) compile processes the device code in two stages.
+# 1. The "compile" stage compiles the device code to an intermediate representation (SPIR-V).
+# 2. The "link" stage invokes the compiler's FPGA backend before linking.
+#    For this reason, FPGA backend flags must be passed as link flags in CMake.
+set(EMULATOR_COMPILE_FLAGS "${WIN_FLAG} -fintelfpga -DFPGA_EMULATOR")
 set(EMULATOR_LINK_FLAGS "-fintelfpga")
-set(HARDWARE_COMPILE_FLAGS "-fintelfpga")
-set(HARDWARE_LINK_FLAGS "-fintelfpga -Xshardware -Xsboard=${SELECTED_BOARD} ${USER_HARDWARE_FLAGS}")
+set(HARDWARE_COMPILE_FLAGS "${WIN_FLAG} -fintelfpga")
+set(HARDWARE_LINK_FLAGS "-fintelfpga -Xshardware -Xsboard=${FPGA_BOARD} ${USER_HARDWARE_FLAGS}")
 # use cmake -D USER_HARDWARE_FLAGS=<flags> to set extra flags for FPGA backend compilation
 
+###############################################################################
+### FPGA Emulator
+###############################################################################
+# To compile in a single command:
+#    dpcpp -fintelfpga -DFPGA_EMULATOR pipes.cpp -o pipes.fpga_emu
+# CMake executes:
+#    [compile] dpcpp -fintelfpga -DFPGA_EMULATOR -o pipes.cpp.o -c pipes.cpp
+#    [link]    dpcpp -fintelfpga pipes.cpp.o -o pipes.fpga_emu
+add_executable(${EMULATOR_TARGET} ${SOURCE_FILE})
+set_target_properties(${EMULATOR_TARGET} PROPERTIES COMPILE_FLAGS "${EMULATOR_COMPILE_FLAGS}")
+set_target_properties(${EMULATOR_TARGET} PROPERTIES LINK_FLAGS "${EMULATOR_LINK_FLAGS}")
+add_custom_target(fpga_emu DEPENDS ${EMULATOR_TARGET})
 
-# FPGA emulator
-if(WIN32)
-    set(WIN_EMULATOR_TARGET ${EMULATOR_TARGET}.exe)
-    add_custom_target(fpga_emu DEPENDS ${WIN_EMULATOR_TARGET})
-    separate_arguments(WIN_EMULATOR_COMPILE_FLAGS WINDOWS_COMMAND "${EMULATOR_COMPILE_FLAGS}")
-    add_custom_command(OUTPUT ${WIN_EMULATOR_TARGET} 
-                       COMMAND ${CMAKE_CXX_COMPILER} /EHsc ${WIN_EMULATOR_COMPILE_FLAGS} ${CMAKE_CURRENT_SOURCE_DIR}/${SOURCE_FILE} -o ${CMAKE_BINARY_DIR}/${WIN_EMULATOR_TARGET}
-                       DEPENDS ${SOURCE_FILE})
-else()
-    add_executable(${EMULATOR_TARGET} ${SOURCE_FILE})
-    add_custom_target(fpga_emu DEPENDS ${EMULATOR_TARGET})
-    set_target_properties(${EMULATOR_TARGET} PROPERTIES COMPILE_FLAGS ${EMULATOR_COMPILE_FLAGS})
-    set_target_properties(${EMULATOR_TARGET} PROPERTIES LINK_FLAGS ${EMULATOR_LINK_FLAGS})
-endif()
+###############################################################################
+### Generate Report
+###############################################################################
+# To compile manually:
+#   dpcpp -fintelfpga -Xshardware -Xsboard=<FPGA_BOARD> -fsycl-link=early pipes.cpp -o pipes_report.a
+set(FPGA_EARLY_IMAGE ${TARGET_NAME}_report.a)
+# The compile output is not an executable, but an intermediate compilation result unique to DPC++.
+add_executable(${FPGA_EARLY_IMAGE} ${SOURCE_FILE})
+add_custom_target(report DEPENDS ${FPGA_EARLY_IMAGE})
+set_target_properties(${FPGA_EARLY_IMAGE} PROPERTIES COMPILE_FLAGS "${HARDWARE_COMPILE_FLAGS}")
+set_target_properties(${FPGA_EARLY_IMAGE} PROPERTIES LINK_FLAGS "${HARDWARE_LINK_FLAGS} -fsycl-link=early")
+# fsycl-link=early stops the compiler after RTL generation, before invoking Quartus
 
-# FPGA hardware
-if(WIN32)
-    add_custom_target(fpga COMMAND echo "An FPGA hardware target is not provided on Windows. See README for details.")
-else()
-    add_executable(${FPGA_TARGET} EXCLUDE_FROM_ALL ${SOURCE_FILE})
-    add_custom_target(fpga DEPENDS ${FPGA_TARGET})
-    set_target_properties(${FPGA_TARGET} PROPERTIES COMPILE_FLAGS ${HARDWARE_COMPILE_FLAGS})
-    set_target_properties(${FPGA_TARGET} PROPERTIES LINK_FLAGS ${HARDWARE_LINK_FLAGS})
-endif()
-
-# Generate report
-if(WIN32)
-    set(DEVICE_OBJ_FILE ${TARGET_NAME}_report.a)
-    add_custom_target(report DEPENDS ${DEVICE_OBJ_FILE})
-    separate_arguments(HARDWARE_LINK_FLAGS_LIST WINDOWS_COMMAND "${HARDWARE_LINK_FLAGS}")
-    add_custom_command(OUTPUT ${DEVICE_OBJ_FILE} 
-                       COMMAND ${CMAKE_CXX_COMPILER} /EHsc ${HARDWARE_LINK_FLAGS_LIST} -fsycl-link ${CMAKE_CURRENT_SOURCE_DIR}/${SOURCE_FILE} -o ${CMAKE_BINARY_DIR}/${DEVICE_OBJ_FILE}
-                       DEPENDS ${SOURCE_FILE})
-else()
-    set(DEVICE_OBJ_FILE ${TARGET_NAME}_report.a)
-    add_custom_target(report DEPENDS ${DEVICE_OBJ_FILE})
-    configure_file(${CMAKE_CURRENT_SOURCE_DIR}/${SOURCE_FILE} ${SOURCE_FILE} COPYONLY)
-    separate_arguments(HARDWARE_LINK_FLAGS_LIST UNIX_COMMAND "${HARDWARE_LINK_FLAGS}")
-    separate_arguments(CMAKE_CXX_FLAGS_LIST UNIX_COMMAND "${CMAKE_CXX_FLAGS}")
-    add_custom_command(OUTPUT ${DEVICE_OBJ_FILE} 
-                       COMMAND ${CMAKE_CXX_COMPILER} ${CMAKE_CXX_FLAGS_LIST} ${HARDWARE_LINK_FLAGS_LIST} -fsycl-link ${SOURCE_FILE} -o ${CMAKE_BINARY_DIR}/${DEVICE_OBJ_FILE}
-                       DEPENDS ${SOURCE_FILE})
-endif()
+###############################################################################
+### FPGA Hardware
+###############################################################################
+# To compile in a single command:
+#   dpcpp -fintelfpga -Xshardware -Xsboard=<FPGA_BOARD> pipes.cpp -o pipes.fpga
+# CMake executes:
+#   [compile] dpcpp -fintelfpga -o pipes.cpp.o -c pipes.cpp
+#   [link]    dpcpp -fintelfpga -Xshardware -Xsboard=<FPGA_BOARD> pipes.cpp.o -o pipes.fpga
+add_executable(${FPGA_TARGET} EXCLUDE_FROM_ALL ${SOURCE_FILE})
+add_custom_target(fpga DEPENDS ${FPGA_TARGET})
+set_target_properties(${FPGA_TARGET} PROPERTIES COMPILE_FLAGS "${HARDWARE_COMPILE_FLAGS}")
+set_target_properties(${FPGA_TARGET} PROPERTIES LINK_FLAGS "${HARDWARE_LINK_FLAGS} -reuse-exe=${CMAKE_BINARY_DIR}/${FPGA_TARGET}")
+# The -reuse-exe flag enables rapid recompilation of host-only code changes.
+# See DPC++FPGA/GettingStarted/fast_recompile for details.

--- a/DirectProgramming/DPC++FPGA/Tutorials/Features/speculated_iterations/CMakeLists.txt
+++ b/DirectProgramming/DPC++FPGA/Tutorials/Features/speculated_iterations/CMakeLists.txt
@@ -1,11 +1,17 @@
-set(CMAKE_CXX_COMPILER "dpcpp")
-if(WIN32)
-    set(CMAKE_C_COMPILER "clang-cl")
+if(UNIX)
+    # Direct CMake to use dpcpp rather than the default C++ compiler/linker
+    set(CMAKE_CXX_COMPILER dpcpp)
+else() # Windows
+    # Force CMake to use dpcpp rather than the default C++ compiler/linker 
+    # (needed on Windows only)
+    include (CMakeForceCompiler)
+    CMAKE_FORCE_CXX_COMPILER (dpcpp IntelDPCPP)
+    include (Platform/Windows-Clang)
 endif()
 
-cmake_minimum_required (VERSION 2.8)
+cmake_minimum_required (VERSION 3.4)
 
-project(SpeculatedIterations)
+project(SpeculatedIterations CXX)
 
 set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})
 set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})

--- a/DirectProgramming/DPC++FPGA/Tutorials/Features/speculated_iterations/speculated_iterations_a10.vcxproj
+++ b/DirectProgramming/DPC++FPGA/Tutorials/Features/speculated_iterations/speculated_iterations_a10.vcxproj
@@ -93,7 +93,6 @@
     <Link>
       <SubSystem>Console</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <SpecifyDevCmplAdditionalOptions>-Xsboard=intel_a10gx_pac:pac_a10</SpecifyDevCmplAdditionalOptions>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
@@ -113,7 +112,6 @@
     <Link>
       <SubSystem>Console</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <SpecifyDevCmplAdditionalOptions>-Xsboard=intel_a10gx_pac:pac_a10</SpecifyDevCmplAdditionalOptions>
     </Link>
     <Manifest />
   </ItemDefinitionGroup>
@@ -134,7 +132,6 @@
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <SpecifyDevCmplAdditionalOptions>-Xsboard=intel_a10gx_pac:pac_a10</SpecifyDevCmplAdditionalOptions>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
@@ -158,7 +155,6 @@
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <SpecifyDevCmplAdditionalOptions>-Xsboard=intel_a10gx_pac:pac_a10</SpecifyDevCmplAdditionalOptions>
     </Link>
   </ItemDefinitionGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />

--- a/DirectProgramming/DPC++FPGA/Tutorials/Features/speculated_iterations/speculated_iterations_agilex.vcxproj
+++ b/DirectProgramming/DPC++FPGA/Tutorials/Features/speculated_iterations/speculated_iterations_agilex.vcxproj
@@ -11,17 +11,14 @@
     </ProjectConfiguration>
   </ItemGroup>
   <ItemGroup>
-    <ClCompile Include="src\speculated_iterations.cpp">
-      <PreprocessorDefinitions Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">S10;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <PreprocessorDefinitions Condition="'$(Configuration)|$(Platform)'=='Release|x64'">S10;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-    </ClCompile>
+    <ClCompile Include="src\speculated_iterations.cpp" />
   </ItemGroup>
   <ItemGroup>
     <None Include="README.md" />
   </ItemGroup>
   <PropertyGroup Label="Globals">
     <VCProjectVersion>15.0</VCProjectVersion>
-    <ProjectGuid>{cf6a576b-665d-4f24-bb62-0dae7a7b3c65}</ProjectGuid>
+    <ProjectGuid>{cf6a576b-665d-4f24-bb62-0dae7a7b3c64}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>speculated_iterations</RootNamespace>
     <WindowsTargetPlatformVersion>$(WindowsSDKVersion.Replace("\",""))</WindowsTargetPlatformVersion>
@@ -110,7 +107,7 @@
       <AdditionalOptions>-DFPGA_EMULATOR %(AdditionalOptions)</AdditionalOptions>
       <ObjectFileName>$(IntDir)speculated_iterations.obj</ObjectFileName>
       <AdditionalIncludeDirectories>$(ONEAPI_ROOT)dev-utilities\latest\include</AdditionalIncludeDirectories>
-      <PreprocessorDefinitions>S10;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>Agilex;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -151,7 +148,7 @@
       <AdditionalOptions>-DFPGA_EMULATOR %(AdditionalOptions)</AdditionalOptions>
       <ObjectFileName>$(IntDir)speculated_iterations.obj</ObjectFileName>
       <AdditionalIncludeDirectories>$(ONEAPI_ROOT)dev-utilities\latest\include</AdditionalIncludeDirectories>
-      <PreprocessorDefinitions>S10;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>Agilex;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>

--- a/DirectProgramming/DPC++FPGA/Tutorials/Features/speculated_iterations/src/CMakeLists.txt
+++ b/DirectProgramming/DPC++FPGA/Tutorials/Features/speculated_iterations/src/CMakeLists.txt
@@ -1,80 +1,86 @@
+# To see a Makefile equivalent of this build system:
+# https://github.com/oneapi-src/oneAPI-samples/blob/master/DirectProgramming/DPC++/ProjectTemplates/makefile-fpga
+
 set(SOURCE_FILE speculated_iterations.cpp)
 set(TARGET_NAME speculated_iterations)
 set(EMULATOR_TARGET ${TARGET_NAME}.fpga_emu)
 set(FPGA_TARGET ${TARGET_NAME}.fpga)
+set(REPORTS_TARGET ${TARGET_NAME}_report)
 
 # FPGA board selection
-set(A10_PAC_BOARD_NAME "intel_a10gx_pac:pac_a10")
-set(S10_PAC_BOARD_NAME "intel_s10sx_pac:pac_s10")
-set(SELECTED_BOARD ${A10_PAC_BOARD_NAME})
-if (NOT DEFINED FPGA_BOARD)
-    message(STATUS "\tFPGA_BOARD was not specified. Configuring the design to run on the Intel(R) Programmable Acceleration Card (PAC) with Intel Arria(R) 10 GX FPGA. Please refer to the README for information on board selection.")
-elseif(FPGA_BOARD STREQUAL ${A10_PAC_BOARD_NAME})
-    message(STATUS "\tConfiguring the design to run on the Intel(R) Programmable Acceleration Card (PAC) with Intel Arria(R) 10 GX FPGA.")
-elseif(FPGA_BOARD STREQUAL ${S10_PAC_BOARD_NAME})
-    message(STATUS "\tConfiguring the design to run on the Intel(R) Programmable Acceleration Card (PAC) D5005 (with Intel Stratix(R) 10 SX FPGA).")
-    set(SELECTED_BOARD ${S10_PAC_BOARD_NAME})
+if(NOT DEFINED FPGA_BOARD)
+    set(FPGA_BOARD "intel_a10gx_pac:pac_a10")
+    set(DEVICE_FLAG "-DA10")
+    message(STATUS "FPGA_BOARD was not specified.\
+                    \nConfiguring the design to run on the default FPGA board ${FPGA_BOARD} (Intel(R) PAC with Intel Arria(R) 10 GX FPGA). \
+                    \nPlease refer to the README for information on board selection.")
 else()
-    message(STATUS "\tAn invalid board name was passed in using the FPGA_BOARD flag. Configuring the design to run on the Intel(R) Programmable Acceleration Card (PAC) with Intel Arria(R) 10 GX FPGA. Please refer to the README for the list of valid board names.")
+    if(FPGA_BOARD STREQUAL "intel_a10gx_pac:pac_a10")
+        set(DEVICE_FLAG "-DA10")
+    elseif(FPGA_BOARD STREQUAL "intel_s10sx_pac:pac_s10" OR FPGA_BOARD STREQUAL "intel_s10sx_pac:pac_s10_usm")
+        set(DEVICE_FLAG "-DS10")
+    endif()
+    message(STATUS "Configuring the design to run on FPGA board ${FPGA_BOARD}")
 endif()
 
-# This tutorial needs to know which FPGA we are targeting to decide how many speculated iterations to use
-if(SELECTED_BOARD STREQUAL ${A10_PAC_BOARD_NAME})
-    set(FPGA_BOARD_MACRO "-DA10")
-elseif(SELECTED_BOARD STREQUAL ${S10_PAC_BOARD_NAME})
-    set(FPGA_BOARD_MACRO "-DS10")
-else()
-    message(FATAL_ERROR "Unknown board!")
+if(NOT DEFINED DEVICE_FLAG)
+    message(FATAL_ERROR "An unrecognized or custom board was passed, but DEVICE_FLAG was not specified. \
+                         Please make sure you have set -DDEVICE_FLAG=-DA10, -DDEVICE_FLAG=-DS10 or \
+                         -DDEVICE_FLAG=-DAgilex.")
 endif()
 
-# Flags
-set(EMULATOR_COMPILE_FLAGS "-fintelfpga -DFPGA_EMULATOR ${FPGA_BOARD_MACRO}")
+# This is a Windows-specific flag that enables exception handling in host code
+if(WIN32)
+    set(WIN_FLAG "/EHsc")
+endif()
+
+# A DPC++ ahead-of-time (AoT) compile processes the device code in two stages.
+# 1. The "compile" stage compiles the device code to an intermediate representation (SPIR-V).
+# 2. The "link" stage invokes the compiler's FPGA backend before linking.
+#    For this reason, FPGA backend flags must be passed as link flags in CMake.
+set(EMULATOR_COMPILE_FLAGS "${WIN_FLAG} -fintelfpga -DFPGA_EMULATOR ${DEVICE_FLAG}")
 set(EMULATOR_LINK_FLAGS "-fintelfpga")
-set(HARDWARE_COMPILE_FLAGS "-fintelfpga ${FPGA_BOARD_MACRO}")
-set(HARDWARE_LINK_FLAGS "-fintelfpga -Xshardware -Xsboard=${SELECTED_BOARD} ${FPGA_BOARD_MACRO} ${USER_HARDWARE_FLAGS}")
+set(HARDWARE_COMPILE_FLAGS "${WIN_FLAG} -fintelfpga ${DEVICE_FLAG}")
+set(HARDWARE_LINK_FLAGS "-fintelfpga -Xshardware -Xsboard=${FPGA_BOARD} ${DEVICE_FLAG} ${USER_HARDWARE_FLAGS}")
 # use cmake -D USER_HARDWARE_FLAGS=<flags> to set extra flags for FPGA backend compilation
 
+###############################################################################
+### FPGA Emulator
+###############################################################################
+# To compile in a single command:
+#    dpcpp -fintelfpga -DFPGA_EMULATOR -DA10 speculated_iterations.cpp -o speculated_iterations.fpga_emu
+# CMake executes:
+#    [compile] dpcpp -fintelfpga -DFPGA_EMULATOR -DA10 -o speculated_iterations.cpp.o -c speculated_iterations.cpp
+#    [link]    dpcpp -fintelfpga speculated_iterations.cpp.o -o speculated_iterations.fpga_emu
+add_executable(${EMULATOR_TARGET} ${SOURCE_FILE}) # CMake automatically adds #include'd headers to the dependency list
+set_target_properties(${EMULATOR_TARGET} PROPERTIES COMPILE_FLAGS "${EMULATOR_COMPILE_FLAGS}")
+set_target_properties(${EMULATOR_TARGET} PROPERTIES LINK_FLAGS "${EMULATOR_LINK_FLAGS}")
+add_custom_target(fpga_emu DEPENDS ${EMULATOR_TARGET})
 
-# FPGA emulator
-if(WIN32)
-    set(WIN_EMULATOR_TARGET ${EMULATOR_TARGET}.exe)
-    add_custom_target(fpga_emu DEPENDS ${WIN_EMULATOR_TARGET})
-    separate_arguments(WIN_EMULATOR_COMPILE_FLAGS WINDOWS_COMMAND "${EMULATOR_COMPILE_FLAGS}")
-    add_custom_command(OUTPUT ${WIN_EMULATOR_TARGET} 
-                       COMMAND ${CMAKE_CXX_COMPILER} /EHsc ${WIN_EMULATOR_COMPILE_FLAGS} ${CMAKE_CURRENT_SOURCE_DIR}/${SOURCE_FILE} -o ${CMAKE_BINARY_DIR}/${WIN_EMULATOR_TARGET}
-                       DEPENDS ${SOURCE_FILE})
-else()
-    add_executable(${EMULATOR_TARGET} ${SOURCE_FILE})
-    add_custom_target(fpga_emu DEPENDS ${EMULATOR_TARGET})
-    set_target_properties(${EMULATOR_TARGET} PROPERTIES COMPILE_FLAGS ${EMULATOR_COMPILE_FLAGS})
-    set_target_properties(${EMULATOR_TARGET} PROPERTIES LINK_FLAGS ${EMULATOR_LINK_FLAGS})
-endif()
+###############################################################################
+### Generate Report
+###############################################################################
+# To compile manually:
+#   dpcpp -fintelfpga -Xshardware -Xsboard=<FPGA_BOARD> -DA10 -fsycl-link=early speculated_iterations.cpp -o speculated_iterations_report.a
+set(FPGA_EARLY_IMAGE ${TARGET_NAME}_report.a)
+# The compile output is not an executable, but an intermediate compilation result unique to DPC++.
+add_executable(${FPGA_EARLY_IMAGE} ${SOURCE_FILE})
+add_custom_target(report DEPENDS ${FPGA_EARLY_IMAGE})
+set_target_properties(${FPGA_EARLY_IMAGE} PROPERTIES COMPILE_FLAGS "${HARDWARE_COMPILE_FLAGS}")
+set_target_properties(${FPGA_EARLY_IMAGE} PROPERTIES LINK_FLAGS "${HARDWARE_LINK_FLAGS} -fsycl-link=early")
+# fsycl-link=early stops the compiler after RTL generation, before invoking Quartus
 
-# FPGA hardware
-if(WIN32)
-    add_custom_target(fpga COMMAND echo "An FPGA hardware target is not provided on Windows. See README for details.")
-else()
-    add_executable(${FPGA_TARGET} EXCLUDE_FROM_ALL ${SOURCE_FILE})
-    add_custom_target(fpga DEPENDS ${FPGA_TARGET})
-    set_target_properties(${FPGA_TARGET} PROPERTIES COMPILE_FLAGS ${HARDWARE_COMPILE_FLAGS})
-    set_target_properties(${FPGA_TARGET} PROPERTIES LINK_FLAGS ${HARDWARE_LINK_FLAGS})
-endif()
-
-# Generate report
-if(WIN32)
-    set(DEVICE_OBJ_FILE ${TARGET_NAME}_report.a)
-    add_custom_target(report DEPENDS ${DEVICE_OBJ_FILE})
-    separate_arguments(HARDWARE_LINK_FLAGS_LIST WINDOWS_COMMAND "${HARDWARE_LINK_FLAGS}")
-    add_custom_command(OUTPUT ${DEVICE_OBJ_FILE} 
-                       COMMAND ${CMAKE_CXX_COMPILER} /EHsc ${HARDWARE_LINK_FLAGS_LIST} -fsycl-link ${CMAKE_CURRENT_SOURCE_DIR}/${SOURCE_FILE} -o ${CMAKE_BINARY_DIR}/${DEVICE_OBJ_FILE}
-                       DEPENDS ${SOURCE_FILE})
-else()
-    set(DEVICE_OBJ_FILE ${TARGET_NAME}_report.a)
-    add_custom_target(report DEPENDS ${DEVICE_OBJ_FILE})
-    configure_file(${CMAKE_CURRENT_SOURCE_DIR}/${SOURCE_FILE} ${SOURCE_FILE} COPYONLY)
-    separate_arguments(HARDWARE_LINK_FLAGS_LIST UNIX_COMMAND "${HARDWARE_LINK_FLAGS}")
-    separate_arguments(CMAKE_CXX_FLAGS_LIST UNIX_COMMAND "${CMAKE_CXX_FLAGS}")
-    add_custom_command(OUTPUT ${DEVICE_OBJ_FILE} 
-                       COMMAND ${CMAKE_CXX_COMPILER} ${CMAKE_CXX_FLAGS_LIST} ${HARDWARE_LINK_FLAGS_LIST} -fsycl-link ${SOURCE_FILE} -o ${CMAKE_BINARY_DIR}/${DEVICE_OBJ_FILE}
-                       DEPENDS ${SOURCE_FILE})
-endif()
+###############################################################################
+### FPGA Hardware
+###############################################################################
+# To compile in a single command:
+#   dpcpp -fintelfpga -Xshardware -Xsboard=<FPGA_BOARD> -DA10 speculated_iterations.cpp -o speculated_iterations.fpga
+# CMake executes:
+#   [compile] dpcpp -fintelfpga -DA10 -o speculated_iterations.cpp.o -c speculated_iterations.cpp
+#   [link]    dpcpp -fintelfpga -Xshardware -Xsboard=<FPGA_BOARD> -DA10 speculated_iterations.cpp.o -o speculated_iterations.fpga
+add_executable(${FPGA_TARGET} EXCLUDE_FROM_ALL ${SOURCE_FILE})
+add_custom_target(fpga DEPENDS ${FPGA_TARGET})
+set_target_properties(${FPGA_TARGET} PROPERTIES COMPILE_FLAGS "${HARDWARE_COMPILE_FLAGS}")
+set_target_properties(${FPGA_TARGET} PROPERTIES LINK_FLAGS "${HARDWARE_LINK_FLAGS} -reuse-exe=${CMAKE_BINARY_DIR}/${FPGA_TARGET}")
+# The -reuse-exe flag enables rapid recompilation of host-only code changes.
+# See DPC++FPGA/GettingStarted/fast_recompile for details.

--- a/DirectProgramming/DPC++FPGA/Tutorials/Features/speculated_iterations/src/speculated_iterations.cpp
+++ b/DirectProgramming/DPC++FPGA/Tutorials/Features/speculated_iterations/src/speculated_iterations.cpp
@@ -112,8 +112,8 @@ int main(int argc, char *argv[]) {
   int r0, r1, r2;
 
 // Choose the number of speculated iterations based on the FPGA board selected.
-// This reflects compute latency differences on different hardware architectures,
-// and is a low-level optimization.
+// This reflects compute latency differences on different hardware
+// architectures, and is a low-level optimization.
 #if defined(A10)
   ComplexExit<0>(selector, bound, r0);
   ComplexExit<10>(selector, bound, r1);
@@ -122,6 +122,10 @@ int main(int argc, char *argv[]) {
   ComplexExit<0>(selector, bound, r0);
   ComplexExit<10>(selector, bound, r1);
   ComplexExit<54>(selector, bound, r2);
+#elif defined(Agilex)
+  ComplexExit<0>(selector, bound, r0);
+  ComplexExit<10>(selector, bound, r1);
+  ComplexExit<50>(selector, bound, r2);
 #else
   std::static_assert(false, "Invalid FPGA board macro");
 #endif
@@ -146,9 +150,7 @@ int main(int argc, char *argv[]) {
     passed = false;
   }
 
-
   std::cout << (passed ? "PASSED: The results are correct" : "FAILED") << "\n";
 
   return passed ? 0 : -1;
 }
-

--- a/DirectProgramming/DPC++FPGA/Tutorials/GettingStarted/fast_recompile/CMakeLists.txt
+++ b/DirectProgramming/DPC++FPGA/Tutorials/GettingStarted/fast_recompile/CMakeLists.txt
@@ -1,11 +1,17 @@
-set(CMAKE_CXX_COMPILER "dpcpp")
-if(WIN32)
-    set(CMAKE_C_COMPILER "clang-cl")
+if(UNIX)
+    # Direct CMake to use dpcpp rather than the default C++ compiler/linker
+    set(CMAKE_CXX_COMPILER dpcpp)
+else() # Windows
+    # Force CMake to use dpcpp rather than the default C++ compiler/linker 
+    # (needed on Windows only)
+    include (CMakeForceCompiler)
+    CMAKE_FORCE_CXX_COMPILER (dpcpp IntelDPCPP)
+    include (Platform/Windows-Clang)
 endif()
 
-cmake_minimum_required (VERSION 2.8)
+cmake_minimum_required (VERSION 3.4)
 
-project(FastRecompile)
+project(FastRecompile CXX)
 
 set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})
 set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})

--- a/DirectProgramming/DPC++FPGA/Tutorials/GettingStarted/fast_recompile/src/CMakeLists.txt
+++ b/DirectProgramming/DPC++FPGA/Tutorials/GettingStarted/fast_recompile/src/CMakeLists.txt
@@ -5,110 +5,93 @@ set(TARGET_NAME fast_recompile)
 set(EMULATOR_TARGET ${TARGET_NAME}.fpga_emu)
 set(FPGA_TARGET ${TARGET_NAME}.fpga)
 
-
 # FPGA board selection
-set(A10_PAC_BOARD_NAME "intel_a10gx_pac:pac_a10")
-set(S10_PAC_BOARD_NAME "intel_s10sx_pac:pac_s10")
-set(SELECTED_BOARD ${A10_PAC_BOARD_NAME})
-if (NOT DEFINED FPGA_BOARD)
-    message(STATUS "\tFPGA_BOARD was not specified. Configuring the design to run on the Intel(R) Programmable Acceleration Card (PAC) with Intel Arria(R) 10 GX FPGA. Please refer to the README for information on board selection.")
-elseif(FPGA_BOARD STREQUAL ${A10_PAC_BOARD_NAME})
-    message(STATUS "\tConfiguring the design to run on the Intel(R) Programmable Acceleration Card (PAC) with Intel Arria(R) 10 GX FPGA.")
-elseif(FPGA_BOARD STREQUAL ${S10_PAC_BOARD_NAME})
-    message(STATUS "\tConfiguring the design to run on the Intel(R) Programmable Acceleration Card (PAC) D5005 (with Intel Stratix(R) 10 SX FPGA).")
-    set(SELECTED_BOARD ${S10_PAC_BOARD_NAME})
+if(NOT DEFINED FPGA_BOARD)
+    set(FPGA_BOARD "intel_a10gx_pac:pac_a10")
+    message(STATUS "FPGA_BOARD was not specified.\
+                    \nConfiguring the design to run on the default FPGA board ${FPGA_BOARD} (Intel(R) PAC with Intel Arria(R) 10 GX FPGA). \
+                    \nPlease refer to the README for information on board selection.")
 else()
-    message(STATUS "\tAn invalid board name was passed in using the FPGA_BOARD flag. Configuring the design to run on the Intel(R) Programmable Acceleration Card (PAC) with Intel Arria(R) 10 GX FPGA. Please refer to the README for the list of valid board names.")
+    message(STATUS "Configuring the design to run on FPGA board ${FPGA_BOARD}")
 endif()
 
+# This is a Windows-specific flag that enables exception handling in host code
+if(WIN32)
+    set(WIN_FLAG "/EHsc")
+endif()
 
-# Flags
-set(EMULATOR_COMPILE_FLAGS -fintelfpga -DFPGA_EMULATOR -c)
+set(EMULATOR_COMPILE_FLAGS ${WIN_FLAG} -fintelfpga -DFPGA_EMULATOR -c)
 set(EMULATOR_LINK_FLAGS -fintelfpga)
-set(HARDWARE_COMPILE_FLAGS -fintelfpga -c)
-set(HARDWARE_LINK_FLAGS "-fintelfpga -Xshardware -Xsboard=${SELECTED_BOARD} ${USER_HARDWARE_FLAGS}")
+set(HARDWARE_COMPILE_FLAGS ${WIN_FLAG} -fintelfpga -c)
+set(HARDWARE_LINK_FLAGS -fintelfpga -Xshardware -Xsboard=${FPGA_BOARD} ${USER_HARDWARE_FLAGS})
 # use cmake -D USER_HARDWARE_FLAGS=<flags> to set extra flags for FPGA backend compilation
 
-String(STRIP "${CMAKE_EXE_LINKER_FLAGS}" CMAKE_EXE_LINKER_FLAGS)
+###############################################################################
+### FPGA Emulator
+###############################################################################
+# To compile manually:
+#   dpcpp -fintelfpga -DFPGA_EMULATOR -c host.cpp -o host_emu.o
+#   dpcpp -fintelfpga -DFPGA_EMULATOR -c kernel.cpp -o dev_emu.o
+#   dpcpp -fintelfpga -fsycl-link=image dev_emu.o -o dev_image_emu.a
+#   dpcpp -fintelfpga host_emu.o dev_image_emu.a -o fast_recompile.fpga
 
-
-# FPGA emulator
 if(WIN32)
-    set(WIN_EMULATOR_TARGET ${EMULATOR_TARGET}.exe)
-    add_custom_target(fpga_emu DEPENDS ${WIN_EMULATOR_TARGET})
-    set(HOST_EMU_OBJ "host_emu.o")
-    set(DEVICE_EMU_OBJ "dev_emu.o")
-    set(DEVICE_IMAGE_EMU_OBJ "dev_image_emu.a")
-
-    add_custom_command(OUTPUT ${HOST_EMU_OBJ} 
-                 COMMAND dpcpp /EHsc ${EMULATOR_COMPILE_FLAGS}
-                 ${CMAKE_CURRENT_SOURCE_DIR}/${HOST_SOURCE_FILE} -o ${HOST_EMU_OBJ} 
-                 DEPENDS ${HOST_SOURCE_FILE} ${KERNEL_HEADER_FILE})
-
-    add_custom_command(OUTPUT ${DEVICE_EMU_OBJ} 
-                 COMMAND dpcpp /EHsc ${EMULATOR_COMPILE_FLAGS} ${CMAKE_CURRENT_SOURCE_DIR}/${DEVICE_SOURCE_FILE} -o ${DEVICE_EMU_OBJ}
-                 DEPENDS ${DEVICE_SOURCE_FILE} ${KERNEL_HEADER_FILE})
-
-    add_custom_command(OUTPUT ${DEVICE_IMAGE_EMU_OBJ} 
-                 COMMAND dpcpp ${EMULATOR_LINK_FLAGS} -fsycl-link=image ${DEVICE_EMU_OBJ} -o ${DEVICE_IMAGE_EMU_OBJ} 
-                 DEPENDS ${DEVICE_EMU_OBJ})
-
-    add_custom_command(OUTPUT ${WIN_EMULATOR_TARGET}
-                 COMMAND dpcpp -fintelfpga ${HOST_EMU_OBJ} ${DEVICE_IMAGE_EMU_OBJ} -o ${CMAKE_BINARY_DIR}/${WIN_EMULATOR_TARGET} 
-                 DEPENDS ${HOST_EMU_OBJ} ${DEVICE_IMAGE_EMU_OBJ})
-                 
-else()
-    add_custom_target(fpga_emu DEPENDS ${EMULATOR_TARGET})
-    set(HOST_EMU_OBJ "host_emu.o")
-    set(DEVICE_EMU_OBJ "dev_emu.o")
-    set(DEVICE_IMAGE_EMU_OBJ "dev_image_emu.a")
-
-    separate_arguments(CMAKE_CXX_FLAGS_LIST UNIX_COMMAND "${CMAKE_CXX_FLAGS}")
-
-    add_custom_command(OUTPUT ${HOST_EMU_OBJ} 
-                 COMMAND ${CMAKE_CXX_COMPILER} ${CMAKE_CXX_FLAGS_LIST} ${EMULATOR_COMPILE_FLAGS}
-                 ${CMAKE_CURRENT_SOURCE_DIR}/${HOST_SOURCE_FILE} -o ${HOST_EMU_OBJ} 
-                 DEPENDS ${HOST_SOURCE_FILE} ${KERNEL_HEADER_FILE})
-
-    add_custom_command(OUTPUT ${DEVICE_EMU_OBJ} 
-                 COMMAND ${CMAKE_CXX_COMPILER} ${CMAKE_CXX_FLAGS_LIST} ${EMULATOR_COMPILE_FLAGS} ${CMAKE_CURRENT_SOURCE_DIR}/${DEVICE_SOURCE_FILE} -o ${DEVICE_EMU_OBJ}
-                 DEPENDS ${DEVICE_SOURCE_FILE} ${KERNEL_HEADER_FILE})
-
-    add_custom_command(OUTPUT ${DEVICE_IMAGE_EMU_OBJ} 
-                 COMMAND ${CMAKE_CXX_COMPILER} ${CMAKE_CXX_FLAGS_LIST} ${EMULATOR_LINK_FLAGS} -fsycl-link=image ${DEVICE_EMU_OBJ} -o ${DEVICE_IMAGE_EMU_OBJ} 
-                 DEPENDS ${DEVICE_EMU_OBJ})
-
-    add_custom_command(OUTPUT ${EMULATOR_TARGET}
-                 COMMAND ${CMAKE_CXX_COMPILER} ${CMAKE_CXX_FLAGS_LIST} -fintelfpga ${HOST_EMU_OBJ} ${DEVICE_IMAGE_EMU_OBJ} -o ${CMAKE_BINARY_DIR}/${EMULATOR_TARGET} 
-                 DEPENDS ${HOST_EMU_OBJ} ${DEVICE_IMAGE_EMU_OBJ})
+    set(EMULATOR_TARGET ${EMULATOR_TARGET}.exe)
 endif()
+add_custom_target(fpga_emu DEPENDS ${EMULATOR_TARGET})
+set(HOST_EMU_OBJ "host_emu.o")
+set(DEVICE_EMU_OBJ "dev_emu.o")
+set(DEVICE_IMAGE_EMU_OBJ "dev_image_emu.a")
 
-# FPGA hardware
+set(CMAKE_CXX_FLAGS_LIST ${CMAKE_CXX_FLAGS_LIST})
+separate_arguments(CMAKE_CXX_FLAGS_LIST)
+
+add_custom_command(OUTPUT ${HOST_EMU_OBJ}
+                   COMMAND ${CMAKE_CXX_COMPILER} ${CMAKE_CXX_FLAGS_LIST} ${EMULATOR_COMPILE_FLAGS}
+                   ${CMAKE_CURRENT_SOURCE_DIR}/${HOST_SOURCE_FILE} -o ${HOST_EMU_OBJ}
+                   DEPENDS ${HOST_SOURCE_FILE} ${KERNEL_HEADER_FILE})
+
+add_custom_command(OUTPUT ${DEVICE_EMU_OBJ}
+                   COMMAND ${CMAKE_CXX_COMPILER} ${CMAKE_CXX_FLAGS_LIST} ${EMULATOR_COMPILE_FLAGS} ${CMAKE_CURRENT_SOURCE_DIR}/${DEVICE_SOURCE_FILE} -o ${DEVICE_EMU_OBJ}
+                   DEPENDS ${DEVICE_SOURCE_FILE} ${KERNEL_HEADER_FILE})
+
+add_custom_command(OUTPUT ${DEVICE_IMAGE_EMU_OBJ}
+                   COMMAND ${CMAKE_CXX_COMPILER} ${CMAKE_CXX_FLAGS_LIST} ${EMULATOR_LINK_FLAGS} -fsycl-link=image ${DEVICE_EMU_OBJ} -o ${DEVICE_IMAGE_EMU_OBJ}
+                   DEPENDS ${DEVICE_EMU_OBJ})
+
+add_custom_command(OUTPUT ${EMULATOR_TARGET}
+                   COMMAND ${CMAKE_CXX_COMPILER} ${CMAKE_CXX_FLAGS_LIST} -fintelfpga ${HOST_EMU_OBJ} ${DEVICE_IMAGE_EMU_OBJ} -o ${CMAKE_BINARY_DIR}/${EMULATOR_TARGET}
+                   DEPENDS ${HOST_EMU_OBJ} ${DEVICE_IMAGE_EMU_OBJ})
+
+###############################################################################
+### FPGA Hardware
+###############################################################################
+# To compile manually:
+#   dpcpp -fintelfpga -c host.cpp -o host.o
+#   dpcpp -fintelfpga -Xshardware -Xsboard=<FPGA_BOARD> -fsycl-link=image kernel.cpp -o dev_image.a
+#   dpcpp -fintelfpga host.o dev_image.a -o fast_recompile.fpga
+
 if(WIN32)
-    add_custom_target(fpga COMMAND echo "An FPGA hardware target is not provided on Windows. See README for details.")
-else()
-    add_custom_target(fpga DEPENDS ${FPGA_TARGET})
-    set(HOST_OBJ "host.o")
-    set(DEVICE_OBJ "dev.o")
-    set(DEVICE_IMAGE_OBJ "dev_image.a")
-
-    separate_arguments(CMAKE_CXX_FLAGS_LIST UNIX_COMMAND "${CMAKE_CXX_FLAGS}")
-    separate_arguments(HARDWARE_LINK_FLAGS_LIST UNIX_COMMAND "${HARDWARE_LINK_FLAGS}")
-
-    add_custom_command(OUTPUT ${HOST_OBJ} 
-                 COMMAND ${CMAKE_CXX_COMPILER} ${CMAKE_CXX_FLAGS_LIST} ${HARDWARE_COMPILE_FLAGS} ${CMAKE_CURRENT_SOURCE_DIR}/${HOST_SOURCE_FILE} -o ${HOST_OBJ} 
-                 DEPENDS ${HOST_SOURCE_FILE} ${KERNEL_HEADER_FILE})
-
-    add_custom_command(OUTPUT ${DEVICE_OBJ} 
-                 COMMAND ${CMAKE_CXX_COMPILER} ${CMAKE_CXX_FLAGS_LIST} ${HARDWARE_COMPILE_FLAGS} ${CMAKE_CURRENT_SOURCE_DIR}/${DEVICE_SOURCE_FILE} -o ${DEVICE_OBJ} 
-                 DEPENDS ${DEVICE_SOURCE_FILE} ${KERNEL_HEADER_FILE})
-
-    add_custom_command(OUTPUT ${DEVICE_IMAGE_OBJ} 
-                 COMMAND ${CMAKE_CXX_COMPILER} ${CMAKE_CXX_FLAGS_LIST} ${HARDWARE_LINK_FLAGS_LIST} -fsycl-link=image ${DEVICE_OBJ} -o ${DEVICE_IMAGE_OBJ} 
-                 DEPENDS ${DEVICE_OBJ})
-
-    add_custom_command(OUTPUT ${FPGA_TARGET} 
-                 COMMAND ${CMAKE_CXX_COMPILER} ${CMAKE_CXX_FLAGS_LIST} ${CMAKE_EXE_LINKER_FLAGS} -fintelfpga ${HOST_OBJ} ${DEVICE_IMAGE_OBJ} -o ${CMAKE_BINARY_DIR}/${FPGA_TARGET} 
-                 DEPENDS ${HOST_OBJ} ${DEVICE_IMAGE_OBJ})
+    set(FPGA_TARGET ${FPGA_TARGET}.exe)
 endif()
+add_custom_target(fpga DEPENDS ${FPGA_TARGET})
+set(HOST_OBJ "host.o")
+set(DEVICE_OBJ "dev.o")
+set(DEVICE_IMAGE_OBJ "dev_image.a")
 
+set(CMAKE_CXX_FLAGS_LIST "${CMAKE_CXX_FLAGS}")
+separate_arguments(CMAKE_CXX_FLAGS_LIST)
+set(HARDWARE_LINK_FLAGS_LIST "${HARDWARE_LINK_FLAGS}")
+separate_arguments(HARDWARE_LINK_FLAGS_LIST)
+
+add_custom_command(OUTPUT ${HOST_OBJ}
+                   COMMAND ${CMAKE_CXX_COMPILER} ${CMAKE_CXX_FLAGS_LIST} ${HARDWARE_COMPILE_FLAGS} ${CMAKE_CURRENT_SOURCE_DIR}/${HOST_SOURCE_FILE} -o ${HOST_OBJ}
+                   DEPENDS ${HOST_SOURCE_FILE} ${KERNEL_HEADER_FILE})
+
+add_custom_command(OUTPUT ${DEVICE_IMAGE_OBJ}
+                   COMMAND ${CMAKE_CXX_COMPILER} ${CMAKE_CXX_FLAGS_LIST} ${HARDWARE_LINK_FLAGS_LIST} -fsycl-link=image ${CMAKE_CURRENT_SOURCE_DIR}/${DEVICE_SOURCE_FILE} -o ${DEVICE_IMAGE_OBJ}
+                   DEPENDS ${DEVICE_SOURCE_FILE} ${KERNEL_HEADER_FILE})
+
+add_custom_command(OUTPUT ${FPGA_TARGET}
+                   COMMAND ${CMAKE_CXX_COMPILER} ${CMAKE_CXX_FLAGS_LIST} -fintelfpga ${HOST_OBJ} ${DEVICE_IMAGE_OBJ} -o ${CMAKE_BINARY_DIR}/${FPGA_TARGET}
+                   DEPENDS ${HOST_OBJ} ${DEVICE_IMAGE_OBJ})

--- a/DirectProgramming/DPC++FPGA/Tutorials/GettingStarted/fpga_compile/CMakeLists.txt
+++ b/DirectProgramming/DPC++FPGA/Tutorials/GettingStarted/fpga_compile/CMakeLists.txt
@@ -1,16 +1,20 @@
-set(CMAKE_CXX_COMPILER "dpcpp")
-if(WIN32)
-    set(CMAKE_C_COMPILER "clang-cl")
+if(UNIX)
+    # Direct CMake to use dpcpp rather than the default C++ compiler/linker
+    set(CMAKE_CXX_COMPILER dpcpp)
+else() # Windows
+    # Force CMake to use dpcpp rather than the default C++ compiler/linker 
+    # (needed on Windows only)
+    include (CMakeForceCompiler)
+    CMAKE_FORCE_CXX_COMPILER (dpcpp IntelDPCPP)
+    include (Platform/Windows-Clang)
 endif()
 
+cmake_minimum_required (VERSION 3.4)
 
-cmake_minimum_required (VERSION 2.8)
-
-project(FPGACompile)
+project(FPGACompile CXX)
 
 set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})
 set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})
 
 add_subdirectory (src)
-

--- a/DirectProgramming/DPC++FPGA/Tutorials/GettingStarted/fpga_compile/src/CMakeLists.txt
+++ b/DirectProgramming/DPC++FPGA/Tutorials/GettingStarted/fpga_compile/src/CMakeLists.txt
@@ -1,73 +1,73 @@
+# To see a Makefile equivalent of this build system:
+# https://github.com/oneapi-src/oneAPI-samples/blob/master/DirectProgramming/DPC++/ProjectTemplates/makefile-fpga
+
 set(SOURCE_FILE fpga_compile.cpp)
 set(TARGET_NAME fpga_compile)
 set(EMULATOR_TARGET ${TARGET_NAME}.fpga_emu)
 set(FPGA_TARGET ${TARGET_NAME}.fpga)
 
 # FPGA board selection
-set(A10_PAC_BOARD_NAME "intel_a10gx_pac:pac_a10")
-set(S10_PAC_BOARD_NAME "intel_s10sx_pac:pac_s10")
-set(SELECTED_BOARD ${A10_PAC_BOARD_NAME})
 if(NOT DEFINED FPGA_BOARD)
-    message(STATUS "\tFPGA_BOARD was not specified. Configuring the design to run on the Intel(R) Programmable Acceleration Card (PAC) with Intel Arria(R) 10 GX FPGA. Please refer to the README for information on board selection.")
-elseif(FPGA_BOARD STREQUAL ${A10_PAC_BOARD_NAME})
-    message(STATUS "\tConfiguring the design to run on the Intel(R) Programmable Acceleration Card (PAC) with Intel Arria(R) 10 GX FPGA.")
-elseif(FPGA_BOARD STREQUAL ${S10_PAC_BOARD_NAME})
-    message(STATUS "\tConfiguring the design to run on the Intel(R) Programmable Acceleration Card (PAC) D5005 (with Intel Stratix(R) 10 SX FPGA).")
-    set(SELECTED_BOARD ${S10_PAC_BOARD_NAME})
+    set(FPGA_BOARD "intel_a10gx_pac:pac_a10")
+    message(STATUS "FPGA_BOARD was not specified.\
+                    \nConfiguring the design to run on the default FPGA board ${FPGA_BOARD} (Intel(R) PAC with Intel Arria(R) 10 GX FPGA). \
+                    \nPlease refer to the README for information on board selection.")
 else()
-    message(STATUS "\tAn invalid board name was passed in using the FPGA_BOARD flag. Configuring the design to run on the Intel(R) Programmable Acceleration Card (PAC) with Intel Arria(R) 10 GX FPGA. Please refer to the README for the list of valid board names.")
+    message(STATUS "Configuring the design to run on FPGA board ${FPGA_BOARD}")
 endif()
 
-# Flags
-set(EMULATOR_COMPILE_FLAGS "-fintelfpga -DFPGA_EMULATOR ")
-set(EMULATOR_LINK_FLAGS "-fintelfpga ")
-set(HARDWARE_COMPILE_FLAGS "-fintelfpga")
-set(HARDWARE_LINK_FLAGS "-fintelfpga -Xshardware -Xsboard=${SELECTED_BOARD} ${USER_HARDWARE_FLAGS}")
+# This is a Windows-specific flag that enables exception handling in host code
+if(WIN32)
+    set(WIN_FLAG "/EHsc")
+endif()
+
+# A DPC++ ahead-of-time (AoT) compile processes the device code in two stages.
+# 1. The "compile" stage compiles the device code to an intermediate representation (SPIR-V).
+# 2. The "link" stage invokes the compiler's FPGA backend before linking.
+#    For this reason, FPGA backend flags must be passed as link flags in CMake.
+set(EMULATOR_COMPILE_FLAGS "${WIN_FLAG} -fintelfpga -DFPGA_EMULATOR")
+set(EMULATOR_LINK_FLAGS "-fintelfpga")
+set(HARDWARE_COMPILE_FLAGS "${WIN_FLAG} -fintelfpga")
+set(HARDWARE_LINK_FLAGS "-fintelfpga -Xshardware -Xsboard=${FPGA_BOARD} ${USER_HARDWARE_FLAGS}")
 # use cmake -D USER_HARDWARE_FLAGS=<flags> to set extra flags for FPGA backend compilation
 
+###############################################################################
+### FPGA Emulator
+###############################################################################
+# To compile in a single command:
+#    dpcpp -fintelfpga -DFPGA_EMULATOR fpga_compile.cpp -o fpga_compile.fpga_emu
+# CMake executes:
+#    [compile] dpcpp -fintelfpga -DFPGA_EMULATOR -o fpga_compile.cpp.o -c fpga_compile.cpp
+#    [link]    dpcpp -fintelfpga fpga_compile.cpp.o -o fpga_compile.fpga_emu
+add_executable(${EMULATOR_TARGET} ${SOURCE_FILE})
+set_target_properties(${EMULATOR_TARGET} PROPERTIES COMPILE_FLAGS "${EMULATOR_COMPILE_FLAGS}")
+set_target_properties(${EMULATOR_TARGET} PROPERTIES LINK_FLAGS "${EMULATOR_LINK_FLAGS}")
+add_custom_target(fpga_emu DEPENDS ${EMULATOR_TARGET})
 
-# FPGA emulator
-if(WIN32)
-    set(WIN_EMULATOR_TARGET ${EMULATOR_TARGET}.exe)
-    add_custom_target(fpga_emu DEPENDS ${WIN_EMULATOR_TARGET})
-    separate_arguments(WIN_EMULATOR_COMPILE_FLAGS WINDOWS_COMMAND "${EMULATOR_COMPILE_FLAGS}")
-    add_custom_command(OUTPUT ${WIN_EMULATOR_TARGET} 
-                       COMMAND ${CMAKE_CXX_COMPILER} /EHsc ${WIN_EMULATOR_COMPILE_FLAGS} ${CMAKE_CURRENT_SOURCE_DIR}/${SOURCE_FILE} -o ${CMAKE_BINARY_DIR}/${WIN_EMULATOR_TARGET}
-                       DEPENDS ${SOURCE_FILE})
-else()
-    add_executable(${EMULATOR_TARGET} ${SOURCE_FILE})
-    add_custom_target(fpga_emu DEPENDS ${EMULATOR_TARGET})
-    set_target_properties(${EMULATOR_TARGET} PROPERTIES COMPILE_FLAGS ${EMULATOR_COMPILE_FLAGS})
-    set_target_properties(${EMULATOR_TARGET} PROPERTIES LINK_FLAGS ${EMULATOR_LINK_FLAGS})
-endif()
+###############################################################################
+### Generate Report
+###############################################################################
+# To compile manually:
+#   dpcpp -fintelfpga -Xshardware -Xsboard=<FPGA_BOARD> -fsycl-link=early fpga_compile.cpp -o fpga_compile_report.a
+set(FPGA_EARLY_IMAGE ${TARGET_NAME}_report.a)
+# The compile output is not an executable, but an intermediate compilation result unique to DPC++.
+add_executable(${FPGA_EARLY_IMAGE} ${SOURCE_FILE})
+add_custom_target(report DEPENDS ${FPGA_EARLY_IMAGE})
+set_target_properties(${FPGA_EARLY_IMAGE} PROPERTIES COMPILE_FLAGS "${HARDWARE_COMPILE_FLAGS}")
+set_target_properties(${FPGA_EARLY_IMAGE} PROPERTIES LINK_FLAGS "${HARDWARE_LINK_FLAGS} -fsycl-link=early")
+# fsycl-link=early stops the compiler after RTL generation, before invoking Quartus
 
-# FPGA hardware
-if(WIN32)
-    add_custom_target(fpga COMMAND echo "An FPGA hardware target is not provided on Windows. See README for details.")
-else()
-    add_executable(${FPGA_TARGET} EXCLUDE_FROM_ALL ${SOURCE_FILE})
-    add_custom_target(fpga DEPENDS ${FPGA_TARGET})
-    set_target_properties(${FPGA_TARGET} PROPERTIES COMPILE_FLAGS ${HARDWARE_COMPILE_FLAGS})
-    set_target_properties(${FPGA_TARGET} PROPERTIES LINK_FLAGS ${HARDWARE_LINK_FLAGS})
-endif()
+###############################################################################
+### FPGA Hardware
+###############################################################################
+# To compile in a single command:
+#   dpcpp -fintelfpga -Xshardware -Xsboard=<FPGA_BOARD> fpga_compile.cpp -o fpga_compile.fpga
+# CMake executes:
+#   [compile] dpcpp -fintelfpga -o fpga_compile.cpp.o -c fpga_compile.cpp
+#   [link]    dpcpp -fintelfpga -Xshardware -Xsboard=<FPGA_BOARD> fpga_compile.cpp.o -o fpga_compile.fpga
+add_executable(${FPGA_TARGET} EXCLUDE_FROM_ALL ${SOURCE_FILE})
+add_custom_target(fpga DEPENDS ${FPGA_TARGET})
+set_target_properties(${FPGA_TARGET} PROPERTIES COMPILE_FLAGS "${HARDWARE_COMPILE_FLAGS}")
+set_target_properties(${FPGA_TARGET} PROPERTIES LINK_FLAGS "${HARDWARE_LINK_FLAGS}")
 
-# Generate report
-if(WIN32)
-    set(DEVICE_OBJ_FILE ${TARGET_NAME}_report.a)
-    add_custom_target(report DEPENDS ${DEVICE_OBJ_FILE})
-    separate_arguments(HARDWARE_LINK_FLAGS_LIST WINDOWS_COMMAND "${HARDWARE_LINK_FLAGS}")
-    separate_arguments(CMAKE_CXX_FLAGS_LIST WINDOWS_COMMAND "${CMAKE_CXX_FLAGS}")
-    add_custom_command(OUTPUT ${DEVICE_OBJ_FILE} 
-                       COMMAND ${CMAKE_CXX_COMPILER} /EHsc ${CMAKE_CXX_FLAGS_LIST} ${HARDWARE_LINK_FLAGS_LIST} -fsycl-link ${CMAKE_CURRENT_SOURCE_DIR}/${SOURCE_FILE} -o ${CMAKE_BINARY_DIR}/${DEVICE_OBJ_FILE}
-                       DEPENDS ${SOURCE_FILE})
-else()
-    set(DEVICE_OBJ_FILE ${TARGET_NAME}_report.a)
-    add_custom_target(report DEPENDS ${DEVICE_OBJ_FILE})
-    configure_file(${CMAKE_CURRENT_SOURCE_DIR}/${SOURCE_FILE} ${SOURCE_FILE} COPYONLY)
-    separate_arguments(HARDWARE_LINK_FLAGS_LIST UNIX_COMMAND "${HARDWARE_LINK_FLAGS}")
-    separate_arguments(HARDWARE_LINK_FLAGS_LIST UNIX_COMMAND "${HARDWARE_LINK_FLAGS}")
-    add_custom_command(OUTPUT ${DEVICE_OBJ_FILE} 
-                       COMMAND ${CMAKE_CXX_COMPILER} ${CMAKE_CXX_FLAGS_LIST} ${HARDWARE_LINK_FLAGS_LIST} -fsycl-link ${SOURCE_FILE} -o ${CMAKE_BINARY_DIR}/${DEVICE_OBJ_FILE}
-                       DEPENDS ${SOURCE_FILE})
-endif()
 

--- a/DirectProgramming/DPC++FPGA/Tutorials/Tools/dynamic_profiler/CMakeLists.txt
+++ b/DirectProgramming/DPC++FPGA/Tutorials/Tools/dynamic_profiler/CMakeLists.txt
@@ -1,11 +1,17 @@
-set(CMAKE_CXX_COMPILER "dpcpp")
-if(WIN32)
-    set(CMAKE_C_COMPILER "clang-cl")
+if(UNIX)
+    # Direct CMake to use dpcpp rather than the default C++ compiler/linker
+    set(CMAKE_CXX_COMPILER dpcpp)
+else() # Windows
+    # Force CMake to use dpcpp rather than the default C++ compiler/linker 
+    # (needed on Windows only)
+    include (CMakeForceCompiler)
+    CMAKE_FORCE_CXX_COMPILER (dpcpp IntelDPCPP)
+    include (Platform/Windows-Clang)
 endif()
 
-cmake_minimum_required (VERSION 2.8)
+cmake_minimum_required (VERSION 3.4)
 
-project(DynamicProfiler)
+project(DynamicProfiler CXX)
 
 set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})
 set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})

--- a/DirectProgramming/DPC++FPGA/Tutorials/Tools/dynamic_profiler/src/CMakeLists.txt
+++ b/DirectProgramming/DPC++FPGA/Tutorials/Tools/dynamic_profiler/src/CMakeLists.txt
@@ -1,42 +1,56 @@
+# To see a Makefile equivalent of this build system:
+# https://github.com/oneapi-src/oneAPI-samples/blob/master/DirectProgramming/DPC++/ProjectTemplates/makefile-fpga
+
 set(SOURCE_FILE dynamic_profiler.cpp)
 set(TARGET_NAME dynamic_profiler)
 set(EMULATOR_TARGET ${TARGET_NAME}.fpga_emu)
 set(FPGA_TARGET ${TARGET_NAME}.fpga)
 
 # FPGA board selection
-set(A10_PAC_BOARD_NAME "intel_a10gx_pac:pac_a10")
-set(S10_PAC_BOARD_NAME "intel_s10sx_pac:pac_s10")
-set(SELECTED_BOARD ${A10_PAC_BOARD_NAME})
-if (NOT DEFINED FPGA_BOARD)
-    message(STATUS "\tFPGA_BOARD was not specified. Configuring the design to run on the Intel(R) Programmable Acceleration Card (PAC) with Intel Arria(R) 10 GX FPGA. Please refer to the README for information on board selection.")
-elseif(FPGA_BOARD STREQUAL ${A10_PAC_BOARD_NAME})
-    message(STATUS "\tConfiguring the design to run on the Intel(R) Programmable Acceleration Card (PAC) with Intel Arria(R) 10 GX FPGA.")
-elseif(FPGA_BOARD STREQUAL ${S10_PAC_BOARD_NAME})
-    message(STATUS "\tConfiguring the design to run on the Intel(R) Programmable Acceleration Card (PAC) D5005 (with Intel Stratix(R) 10 SX FPGA).")
-    set(SELECTED_BOARD ${S10_PAC_BOARD_NAME})
+if(NOT DEFINED FPGA_BOARD)
+    set(FPGA_BOARD "intel_a10gx_pac:pac_a10")
+    message(STATUS "FPGA_BOARD was not specified.\
+                    \nConfiguring the design to run on the default FPGA board ${FPGA_BOARD} (Intel(R) PAC with Intel Arria(R) 10 GX FPGA). \
+                    \nPlease refer to the README for information on board selection.")
 else()
-    message(STATUS "\tAn invalid board name was passed in using the FPGA_BOARD flag. Configuring the design to run on the Intel(R) Programmable Acceleration Card (PAC) with Intel Arria(R) 10 GX FPGA. Please refer to the README for the list of valid board names.")
+    message(STATUS "Configuring the design to run on FPGA board ${FPGA_BOARD}")
 endif()
 
-# Flags
-set(EMULATOR_COMPILE_FLAGS "-fintelfpga -DFPGA_EMULATOR -fp-model=precise -ffp-contract=off")
-set(EMULATOR_LINK_FLAGS "-fintelfpga -fp-model=precise -ffp-contract=off")
-set(HARDWARE_COMPILE_FLAGS "-fintelfpga -fp-model=precise -ffp-contract=off")
-set(HARDWARE_LINK_FLAGS "-fintelfpga -Xshardware -Xsboard=${SELECTED_BOARD} -Xsprofile ${USER_HARDWARE_FLAGS}")
+# A DPC++ ahead-of-time (AoT) compile processes the device code in two stages.
+# 1. The "compile" stage compiles the device code to an intermediate representation (SPIR-V).
+# 2. The "link" stage invokes the compiler's FPGA backend before linking.
+#    For this reason, FPGA backend flags must be passed as link flags in CMake.
+set(EMULATOR_COMPILE_FLAGS "-fintelfpga -DFPGA_EMULATOR")
+set(EMULATOR_LINK_FLAGS "-fintelfpga")
+set(HARDWARE_COMPILE_FLAGS "-fintelfpga")
+set(HARDWARE_LINK_FLAGS "-fintelfpga -Xshardware -Xsboard=${FPGA_BOARD} -Xsprofile ${USER_HARDWARE_FLAGS}")
 # use cmake -D USER_HARDWARE_FLAGS=<flags> to set extra flags for FPGA backend compilation
 
-
-# FPGA emulator
+###############################################################################
+### FPGA Emulator
+###############################################################################
+# To compile in a single command:
+#    dpcpp -fintelfpga -DFPGA_EMULATOR dynamic_profiler.cpp -o dynamic_profiler.fpga_emu
+# CMake executes:
+#    [compile] dpcpp -fintelfpga -DFPGA_EMULATOR -o dynamic_profiler.cpp.o -c dynamic_profiler.cpp
+#    [link]    dpcpp -fintelfpga dynamic_profiler.cpp.o -o dynamic_profiler.fpga_emu
 add_executable(${EMULATOR_TARGET} ${SOURCE_FILE})
 add_custom_target(fpga_emu DEPENDS ${EMULATOR_TARGET})
-set_target_properties(${EMULATOR_TARGET} PROPERTIES COMPILE_FLAGS ${EMULATOR_COMPILE_FLAGS})
-set_target_properties(${EMULATOR_TARGET} PROPERTIES LINK_FLAGS ${EMULATOR_LINK_FLAGS})
+set_target_properties(${EMULATOR_TARGET} PROPERTIES COMPILE_FLAGS "${EMULATOR_COMPILE_FLAGS}")
+set_target_properties(${EMULATOR_TARGET} PROPERTIES LINK_FLAGS "${EMULATOR_LINK_FLAGS}")
 
-# FPGA hardware
+###############################################################################
+### FPGA Hardware
+###############################################################################
+# To compile in a single command:
+#   dpcpp -fintelfpga -Xshardware -Xsboard=<FPGA_BOARD> dynamic_profiler.cpp -o dynamic_profiler.fpga
+# CMake executes:
+#   [compile] dpcpp -fintelfpga -o dynamic_profiler.cpp.o -c dynamic_profiler.cpp
+#   [link]    dpcpp -fintelfpga -Xshardware -Xsboard=<FPGA_BOARD> dynamic_profiler.cpp.o -o dynamic_profiler.fpga
 add_executable(${FPGA_TARGET} EXCLUDE_FROM_ALL ${SOURCE_FILE})
 add_custom_target(fpga DEPENDS ${FPGA_TARGET})
-set_target_properties(${FPGA_TARGET} PROPERTIES COMPILE_FLAGS ${HARDWARE_COMPILE_FLAGS})
-set_target_properties(${FPGA_TARGET} PROPERTIES LINK_FLAGS ${HARDWARE_LINK_FLAGS})
+set_target_properties(${FPGA_TARGET} PROPERTIES COMPILE_FLAGS "${HARDWARE_COMPILE_FLAGS}")
+set_target_properties(${FPGA_TARGET} PROPERTIES LINK_FLAGS "${HARDWARE_LINK_FLAGS}")
 
 # Run
 add_custom_target(run

--- a/DirectProgramming/DPC++FPGA/Tutorials/Tools/dynamic_profiler/src/dynamic_profiler.cpp
+++ b/DirectProgramming/DPC++FPGA/Tutorials/Tools/dynamic_profiler/src/dynamic_profiler.cpp
@@ -1,15 +1,15 @@
 /*
   Please refer to the README file for information on how and why the
-  Intel(r) Dynamic Profiler for DPC++ should be used. This code sample 
+  Intel(r) Dynamic Profiler for DPC++ should be used. This code sample
   does not explain the tool, rather it is an artificial example that
   demonstates the sort of code changes the profiler data can guide.
   The main content of this sample is in the README file.
 */
 
-#include <numeric>
-
 #include <CL/sycl.hpp>
 #include <CL/sycl/INTEL/fpga_extensions.hpp>
+#include <cmath>
+#include <numeric>
 
 // dpc_common.hpp can be found in the dev-utilities include folder.
 // e.g., $ONEAPI_ROOT/dev-utilities//include/dpc_common.hpp
@@ -48,7 +48,7 @@ constexpr int kComplexity = 2000;
 // Perform two stages of processing on the input data.
 // The output of ConsumerWork1 needs to go to the input
 // of ConsumerWork2, so they cannot be done concurrently.
-// These functions are currently doing pointless work, but 
+// These functions are currently doing pointless work, but
 // can be replaced with more useful operations.
 float ConsumerWork1(float f) {
   float output = f;
@@ -75,7 +75,7 @@ float ConsumerWork2(float f) {
 // The Consumer kernel reads data from the pipe, performs the two ConsumerWork
 // operations on the data, and writes the results to the output buffer.
 
-void ProducerBefore(queue &q, buffer<float, 1>& buffer_a) {
+void ProducerBefore(queue &q, buffer<float, 1> &buffer_a) {
   auto e = q.submit([&](handler &h) {
     // Get kernel access to the buffers
     accessor a(buffer_a, h, read_only);
@@ -88,7 +88,7 @@ void ProducerBefore(queue &q, buffer<float, 1>& buffer_a) {
   });
 }
 
-void ConsumerBefore(queue &q, buffer<float, 1>& buffer_a) {
+void ConsumerBefore(queue &q, buffer<float, 1> &buffer_a) {
   auto e = q.submit([&](handler &h) {
     // Get kernel access to the buffers
     accessor a(buffer_a, h, write_only, noinit);
@@ -111,10 +111,10 @@ void ConsumerBefore(queue &q, buffer<float, 1>& buffer_a) {
 // ConsumerWork1 on it before giving it to the concurrently
 // running Consumer kernel.
 // The Consumer kernel reads data from the pipe, performs the rest
-// of the work (ConsumerWork2), and writes the results 
+// of the work (ConsumerWork2), and writes the results
 // to the output buffer.
 
-void ProducerAfter(queue &q, buffer<float, 1>& buffer_a) {
+void ProducerAfter(queue &q, buffer<float, 1> &buffer_a) {
   auto e = q.submit([&](handler &h) {
     // Get kernel access to the buffers
     accessor a(buffer_a, h, read_only);
@@ -129,7 +129,7 @@ void ProducerAfter(queue &q, buffer<float, 1>& buffer_a) {
   });
 }
 
-void ConsumerAfter(queue &q, buffer<float, 1>& buffer_a) {
+void ConsumerAfter(queue &q, buffer<float, 1> &buffer_a) {
   auto e = q.submit([&](handler &h) {
     // Get kernel access to the buffers
     accessor a(buffer_a, h, write_only, noinit);
@@ -150,18 +150,23 @@ void ConsumerAfter(queue &q, buffer<float, 1>& buffer_a) {
 // output so that this method completes quickly. This is done
 // intentionally/artificially to keep host-processing time shorter than kernel
 // execution time. Grabs kernel output data from its SYCL buffers.
-bool ProcessOutput(buffer<float, 1>& input_buf, buffer<float, 1>& output_buf) {
+bool ProcessOutput(buffer<float, 1> &input_buf, buffer<float, 1> &output_buf) {
   host_accessor input_buf_acc(input_buf, read_only);
   host_accessor output_buf_acc(output_buf, read_only);
   int num_errors = 0;
   int num_errors_to_print = 5;
   bool pass = true;
 
+  // Max fractional difference between FPGA result and CPU result
+  // Anything greater than this will be considered an error
+  constexpr double epsilon = 0.01;
+
   for (int i = 0; i < kSize / 8; i++) {
     auto step1 = ConsumerWork1(input_buf_acc[i]);
     auto valid_result = ConsumerWork2(step1);
 
-    const bool out_invalid = (valid_result != output_buf_acc[i]);
+    const bool out_invalid =
+        std::abs((output_buf_acc[i] - valid_result) / valid_result) > epsilon;
     if ((num_errors < num_errors_to_print) && out_invalid) {
       if (num_errors == 0) {
         pass = false;
@@ -182,8 +187,8 @@ int main() {
 #if defined(FPGA_EMULATOR)
   INTEL::fpga_emulator_selector device_selector;
   std::cout << "\nThe Dynamic Profiler cannot be used in the emulator "
-                "flow. Please compile to FPGA hardware to collect "
-                "dynamic profiling data. \n\n";
+               "flow. Please compile to FPGA hardware to collect "
+               "dynamic profiling data. \n\n";
 #else
   INTEL::fpga_selector device_selector;
 #endif

--- a/DirectProgramming/DPC++FPGA/Tutorials/Tools/system_profiling/CMakeLists.txt
+++ b/DirectProgramming/DPC++FPGA/Tutorials/Tools/system_profiling/CMakeLists.txt
@@ -1,11 +1,17 @@
-set(CMAKE_CXX_COMPILER "dpcpp")
-if(WIN32)
-    set(CMAKE_C_COMPILER "clang-cl")
+if(UNIX)
+    # Direct CMake to use dpcpp rather than the default C++ compiler/linker
+    set(CMAKE_CXX_COMPILER dpcpp)
+else() # Windows
+    # Force CMake to use dpcpp rather than the default C++ compiler/linker 
+    # (needed on Windows only)
+    include (CMakeForceCompiler)
+    CMAKE_FORCE_CXX_COMPILER (dpcpp IntelDPCPP)
+    include (Platform/Windows-Clang)
 endif()
 
-cmake_minimum_required (VERSION 2.8)
+cmake_minimum_required (VERSION 3.4)
 
-project(SystemProfiling)
+project(SystemProfiling CXX)
 
 set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})
 set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})

--- a/DirectProgramming/DPC++FPGA/Tutorials/Tools/system_profiling/src/CMakeLists.txt
+++ b/DirectProgramming/DPC++FPGA/Tutorials/Tools/system_profiling/src/CMakeLists.txt
@@ -1,40 +1,55 @@
+# To see a Makefile equivalent of this build system:
+# https://github.com/oneapi-src/oneAPI-samples/blob/master/DirectProgramming/DPC++/ProjectTemplates/makefile-fpga
+
 set(SOURCE_FILE double_buffering.cpp)
 set(TARGET_NAME double_buffering)
 set(EMULATOR_TARGET ${TARGET_NAME}.fpga_emu)
 set(FPGA_TARGET ${TARGET_NAME}.fpga)
 
 # FPGA board selection
-set(A10_PAC_BOARD_NAME "intel_a10gx_pac:pac_a10")
-set(S10_PAC_BOARD_NAME "intel_s10sx_pac:pac_s10")
-set(SELECTED_BOARD ${A10_PAC_BOARD_NAME})
-if (NOT DEFINED FPGA_BOARD)
-    message(STATUS "\tFPGA_BOARD was not specified. Configuring the design to run on the Intel(R) Programmable Acceleration Card (PAC) with Intel Arria(R) 10 GX FPGA. Please refer to the README for information on board selection.")
-elseif(FPGA_BOARD STREQUAL ${A10_PAC_BOARD_NAME})
-    message(STATUS "\tConfiguring the design to run on the Intel(R) Programmable Acceleration Card (PAC) with Intel Arria(R) 10 GX FPGA.")
-elseif(FPGA_BOARD STREQUAL ${S10_PAC_BOARD_NAME})
-    message(STATUS "\tConfiguring the design to run on the Intel(R) Programmable Acceleration Card (PAC) D5005 (with Intel Stratix(R) 10 SX FPGA).")
-    set(SELECTED_BOARD ${S10_PAC_BOARD_NAME})
+if(NOT DEFINED FPGA_BOARD)
+    set(FPGA_BOARD "intel_a10gx_pac:pac_a10")
+    message(STATUS "FPGA_BOARD was not specified.\
+                    \nConfiguring the design to run on the default FPGA board ${FPGA_BOARD} (Intel(R) PAC with Intel Arria(R) 10 GX FPGA). \
+                    \nPlease refer to the README for information on board selection.")
 else()
-    message(STATUS "\tAn invalid board name was passed in using the FPGA_BOARD flag. Configuring the design to run on the Intel(R) Programmable Acceleration Card (PAC) with Intel Arria(R) 10 GX FPGA. Please refer to the README for the list of valid board names.")
+    message(STATUS "Configuring the design to run on FPGA board ${FPGA_BOARD}")
 endif()
 
-# Flags
+# A DPC++ ahead-of-time (AoT) compile processes the device code in two stages.
+# 1. The "compile" stage compiles the device code to an intermediate representation (SPIR-V).
+# 2. The "link" stage invokes the compiler's FPGA backend before linking.
+#    For this reason, FPGA backend flags must be passed as link flags in CMake.
 set(EMULATOR_COMPILE_FLAGS "-fintelfpga -DFPGA_EMULATOR")
 set(EMULATOR_LINK_FLAGS "-fintelfpga")
 set(HARDWARE_COMPILE_FLAGS "-fintelfpga")
-set(HARDWARE_LINK_FLAGS "-fintelfpga -Xshardware -Xsboard=${SELECTED_BOARD} ${USER_HARDWARE_FLAGS}")
+set(HARDWARE_LINK_FLAGS "-fintelfpga -Xshardware -Xsboard=${FPGA_BOARD} ${USER_HARDWARE_FLAGS}")
 # use cmake -D USER_HARDWARE_FLAGS=<flags> to set extra flags for FPGA backend compilation
 
-
-# FPGA emulator
+###############################################################################
+### FPGA Emulator
+###############################################################################
+# To compile in a single command:
+#    dpcpp -fintelfpga -DFPGA_EMULATOR double_buffering.cpp -o double_buffering.fpga_emu
+# CMake executes:
+#    [compile] dpcpp -fintelfpga -DFPGA_EMULATOR -o double_buffering.cpp.o -c double_buffering.cpp
+#    [link]    dpcpp -fintelfpga double_buffering.cpp.o -o double_buffering.fpga_emu
 add_executable(${EMULATOR_TARGET} ${SOURCE_FILE})
+set_target_properties(${EMULATOR_TARGET} PROPERTIES COMPILE_FLAGS "${EMULATOR_COMPILE_FLAGS}")
+set_target_properties(${EMULATOR_TARGET} PROPERTIES LINK_FLAGS "${EMULATOR_LINK_FLAGS}")
 add_custom_target(fpga_emu DEPENDS ${EMULATOR_TARGET})
-set_target_properties(${EMULATOR_TARGET} PROPERTIES COMPILE_FLAGS ${EMULATOR_COMPILE_FLAGS})
-set_target_properties(${EMULATOR_TARGET} PROPERTIES LINK_FLAGS ${EMULATOR_LINK_FLAGS})
 
-# FPGA hardware
+###############################################################################
+### FPGA Hardware
+###############################################################################
+# To compile in a single command:
+#   dpcpp -fintelfpga -Xshardware -Xsboard=<FPGA_BOARD> double_buffering.cpp -o double_buffering.fpga
+# CMake executes:
+#   [compile] dpcpp -fintelfpga -o double_buffering.cpp.o -c double_buffering.cpp
+#   [link]    dpcpp -fintelfpga -Xshardware -Xsboard=<FPGA_BOARD> double_buffering.cpp.o -o double_buffering.fpga
 add_executable(${FPGA_TARGET} EXCLUDE_FROM_ALL ${SOURCE_FILE})
 add_custom_target(fpga DEPENDS ${FPGA_TARGET})
-set_target_properties(${FPGA_TARGET} PROPERTIES COMPILE_FLAGS ${HARDWARE_COMPILE_FLAGS})
-set_target_properties(${FPGA_TARGET} PROPERTIES LINK_FLAGS ${HARDWARE_LINK_FLAGS})
-
+set_target_properties(${FPGA_TARGET} PROPERTIES COMPILE_FLAGS "${HARDWARE_COMPILE_FLAGS}")
+set_target_properties(${FPGA_TARGET} PROPERTIES LINK_FLAGS "${HARDWARE_LINK_FLAGS} -reuse-exe=${CMAKE_BINARY_DIR}/${FPGA_TARGET}")
+# The -reuse-exe flag enables rapid recompilation of host-only code changes.
+# See DPC++FPGA/GettingStarted/fast_recompile for details.

--- a/DirectProgramming/DPC++FPGA/Tutorials/Tools/use_library/CMakeLists.txt
+++ b/DirectProgramming/DPC++FPGA/Tutorials/Tools/use_library/CMakeLists.txt
@@ -1,11 +1,9 @@
-set(CMAKE_CXX_COMPILER "dpcpp")
-if(WIN32)
-    set(CMAKE_C_COMPILER "clang-cl")
-endif()
+# Direct CMake to use dpcpp rather than the default C++ compiler/linker
+set(CMAKE_CXX_COMPILER dpcpp)
 
-cmake_minimum_required (VERSION 2.8)
+cmake_minimum_required (VERSION 3.4)
 
-project(UseLibrary)
+project(UseLibrary CXX)
 
 set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})
 set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})

--- a/DirectProgramming/DPC++FPGA/Tutorials/Tools/use_library/src/CMakeLists.txt
+++ b/DirectProgramming/DPC++FPGA/Tutorials/Tools/use_library/src/CMakeLists.txt
@@ -7,116 +7,120 @@ set(FPGA_TARGET ${TARGET_NAME}.fpga)
 set(REPORT_TARGET ${TARGET_NAME}_report.a)
 
 # FPGA board selection
-set(A10_PAC_BOARD_NAME "intel_a10gx_pac:pac_a10")
-set(S10_PAC_BOARD_NAME "intel_s10sx_pac:pac_s10")
-set(SELECTED_BOARD ${A10_PAC_BOARD_NAME})
-if (NOT DEFINED FPGA_BOARD)
-    message(STATUS "\tFPGA_BOARD was not specified. Configuring the design to run on the Intel(R) Programmable Acceleration Card (PAC) with Intel Arria(R) 10 GX FPGA. Please refer to the README for information on board selection.")
-elseif(FPGA_BOARD STREQUAL ${A10_PAC_BOARD_NAME})
-    message(STATUS "\tConfiguring the design to run on the Intel(R) Programmable Acceleration Card (PAC) with Intel Arria(R) 10 GX FPGA.")
-elseif(FPGA_BOARD STREQUAL ${S10_PAC_BOARD_NAME})
-    message(STATUS "\tConfiguring the design to run on the Intel(R) Programmable Acceleration Card (PAC) D5005 (with Intel Stratix(R) 10 SX FPGA).")
-    set(SELECTED_BOARD ${S10_PAC_BOARD_NAME})
+if(NOT DEFINED FPGA_BOARD)
+    set(FPGA_BOARD "intel_a10gx_pac:pac_a10")
+    message(STATUS "FPGA_BOARD was not specified.\
+                    \nConfiguring the design to run on the default FPGA board ${FPGA_BOARD} (Intel(R) PAC with Intel Arria(R) 10 GX FPGA). \
+                    \nPlease refer to the README for information on board selection.")
 else()
-    message(STATUS "\tAn invalid board name was passed in using the FPGA_BOARD flag. Configuring the design to run on the Intel(R) Programmable Acceleration Card (PAC) with Intel Arria(R) 10 GX FPGA. Please refer to the README for the list of valid board names.")
+    message(STATUS "Configuring the design to run on FPGA board ${FPGA_BOARD}")
 endif()
 
 # Library source files
-set(HLS_SOURCE lib_hls.cpp) 
+set(HLS_SOURCE lib_hls.cpp)
 set(HLS_SOURCE_OBJECT lib_hls.o)
-set(OCL_SOURCE lib_ocl.cl) 
+set(OCL_SOURCE lib_ocl.cl)
 set(OCL_SOURCE_OBJECT lib_ocl.o)
-set(SYCL_SOURCE lib_sycl.cpp) 
+set(SYCL_SOURCE lib_sycl.cpp)
 set(SYCL_SOURCE_OBJECT lib_sycl.o)
 set(RTL_C_MODEL lib_rtl_model.cpp)
-set(RTL_SPEC lib_rtl_spec.xml) 
-set(RTL_V lib_rtl.v) 
+set(RTL_SPEC lib_rtl_spec.xml)
+set(RTL_V lib_rtl.v)
 set(RTL_SOURCE_OBJECT lib_rtl.o)
 
 # Flags
-set(LIBRARY_DEVICE_LINK_FLAGS "${LIBRARY_ARCHIVE}")
-set(LIBRARY_HOST_LINK_FLAGS "${HLS_SOURCE_OBJECT} ${OCL_SOURCE_OBJECT} ${SYCL_SOURCE_OBJECT} ${RTL_SOURCE_OBJECT}")
 set(EMULATOR_COMPILE_FLAGS "-fintelfpga -DFPGA_EMULATOR")
-set(EMULATOR_LINK_FLAGS "-fintelfpga ${LIBRARY_DEVICE_LINK_FLAGS}")
+set(EMULATOR_LINK_FLAGS "-fintelfpga")
 set(HARDWARE_COMPILE_FLAGS "-fintelfpga")
-set(HARDWARE_LINK_FLAGS "-fintelfpga -Xshardware -Xsboard=${SELECTED_BOARD} ${LIBRARY_DEVICE_LINK_FLAGS} ${USER_HARDWARE_FLAGS}")
+set(HARDWARE_LINK_FLAGS "-fintelfpga -Xshardware -Xsboard=${FPGA_BOARD} ${USER_HARDWARE_FLAGS}")
 # use cmake -D USER_HARDWARE_FLAGS=<flags> to set extra flags for FPGA backend compilation
 
 # Flag lists for custom commands
 separate_arguments(CMAKE_CXX_FLAGS_LIST UNIX_COMMAND "${CMAKE_CXX_FLAGS}")
-separate_arguments(EMULATOR_COMPILE_FLAGS_LIST UNIX_COMMAND "${EMULATOR_COMPILE_FLAGS}")
-separate_arguments(EMULATOR_LINK_FLAGS_LIST UNIX_COMMAND "${EMULATOR_LINK_FLAGS}")
-separate_arguments(HARDWARE_COMPILE_FLAGS_LIST UNIX_COMMAND "${HARDWARE_COMPILE_FLAGS}")
 separate_arguments(HARDWARE_LINK_FLAGS_LIST UNIX_COMMAND "${HARDWARE_LINK_FLAGS}")
+
+###############################################################################
+### Generate Library
+###############################################################################
+
+# The RTL file (specified in lib_rtl_spec.xml) must be copied to the CMake working directory for the final stage of FPGA hardware compilation
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/${RTL_V} ${RTL_V} COPYONLY)
 
 # Create HLS source object
 add_custom_target(
-    create_hls_source_object 
-    COMMAND fpga_crossgen ${HLS_SOURCE} --source hls --target sycl -o ${HLS_SOURCE_OBJECT} ${CMAKE_CXX_FLAGS_LIST}
+    create_hls_source_object
+    COMMAND fpga_crossgen ${CMAKE_CURRENT_SOURCE_DIR}/${HLS_SOURCE} --source hls --target sycl -o ${HLS_SOURCE_OBJECT} ${CMAKE_CXX_FLAGS_LIST}
 )
 
 # Create OCL source object
 add_custom_target(
     create_ocl_source_object
-    COMMAND fpga_crossgen ${OCL_SOURCE} --source ocl --target sycl -o ${OCL_SOURCE_OBJECT}
+    COMMAND fpga_crossgen ${CMAKE_CURRENT_SOURCE_DIR}/${OCL_SOURCE} --source ocl --target sycl -o ${OCL_SOURCE_OBJECT}
 )
 
 # Create SYCL source object
 add_custom_target(
-    create_sycl_source_object 
-    COMMAND fpga_crossgen ${SYCL_SOURCE} --source sycl --target sycl -o ${SYCL_SOURCE_OBJECT} ${CMAKE_CXX_FLAGS_LIST}
+    create_sycl_source_object
+    COMMAND fpga_crossgen ${CMAKE_CURRENT_SOURCE_DIR}/${SYCL_SOURCE} --source sycl --target sycl -o ${SYCL_SOURCE_OBJECT} ${CMAKE_CXX_FLAGS_LIST}
 )
 
 # Create RTL source object
 add_custom_target(
     create_rtl_source_object
-    COMMAND fpga_crossgen ${RTL_SPEC} --emulation_model ${RTL_C_MODEL} --target sycl -o ${RTL_SOURCE_OBJECT}
+    COMMAND fpga_crossgen ${CMAKE_CURRENT_SOURCE_DIR}/${RTL_SPEC} --emulation_model ${CMAKE_CURRENT_SOURCE_DIR}/${RTL_C_MODEL} --target sycl -o ${RTL_SOURCE_OBJECT}
 )
 
 # Create library archive
-add_custom_target(
-    create_library_archive 
-    COMMAND fpga_libtool ${HLS_SOURCE_OBJECT} ${OCL_SOURCE_OBJECT} ${SYCL_SOURCE_OBJECT} ${RTL_SOURCE_OBJECT} --target sycl --create ${LIBRARY_ARCHIVE} 
-    DEPENDS create_hls_source_object create_ocl_source_object create_sycl_source_object create_rtl_source_object
-)
+# This executes:
+# fpga_libtool lib_hls.o lib_ocl.o lib_sycl.o lib_rtl.o --target sycl --create lib.a
+add_custom_target(create_library_archive DEPENDS ${CMAKE_ARCHIVE_OUTPUT_DIRECTORY}/${LIBRARY_ARCHIVE})
+add_custom_command(OUTPUT ${CMAKE_ARCHIVE_OUTPUT_DIRECTORY}/${LIBRARY_ARCHIVE}
+                   COMMAND fpga_libtool ${HLS_SOURCE_OBJECT} ${OCL_SOURCE_OBJECT} ${SYCL_SOURCE_OBJECT} ${RTL_SOURCE_OBJECT} --target sycl --create ${CMAKE_ARCHIVE_OUTPUT_DIRECTORY}/${LIBRARY_ARCHIVE}
+                   DEPENDS create_hls_source_object create_ocl_source_object create_sycl_source_object create_rtl_source_object)
 
-# FPGA emulator
-set(SOURCE_OBJ_FILE_EMU ${SOURCE_FILE}.emu.o)
+# Tell CMake to recognize our custom library
+add_library(library_archive STATIC IMPORTED GLOBAL)
+add_dependencies(library_archive create_library_archive)
+set_target_properties(library_archive PROPERTIES IMPORTED_LOCATION ${CMAKE_ARCHIVE_OUTPUT_DIRECTORY}/${LIBRARY_ARCHIVE})
+
+###############################################################################
+### FPGA Emulator
+###############################################################################
+# To compile in a single command:
+#    dpcpp -fintelfpga -DFPGA_EMULATOR use_library.cpp lib.a -o use_library.fpga_emu
+# CMake executes:
+#    [compile] dpcpp -fintelfpga -DFPGA_EMULATOR -o use_library.cpp.o -c use_library.cpp
+#    [link]    dpcpp -fintelfpga use_library.cpp.o -o use_library.fpga_emu lib.a 
+add_executable(${EMULATOR_TARGET} ${SOURCE_FILE})
 add_custom_target(fpga_emu DEPENDS ${EMULATOR_TARGET})
-add_custom_command(OUTPUT ${SOURCE_OBJ_FILE_EMU}
-                   COMMAND ${CMAKE_CXX_COMPILER} ${CMAKE_CXX_FLAGS_LIST} ${SOURCE_FILE} ${EMULATOR_COMPILE_FLAGS_LIST} -c -o ${SOURCE_OBJ_FILE_EMU}
-                   DEPENDS ${SOURCE_FILE} ${HEADER_FILE})
-add_custom_command(OUTPUT ${EMULATOR_TARGET}
-                   COMMAND ${CMAKE_CXX_COMPILER} ${CMAKE_CXX_FLAGS_LIST} ${SOURCE_OBJ_FILE_EMU} ${EMULATOR_LINK_FLAGS_LIST} -o ${CMAKE_BINARY_DIR}/${EMULATOR_TARGET}
-                   DEPENDS ${SOURCE_OBJ_FILE_EMU} create_library_archive)
+target_link_libraries(${EMULATOR_TARGET} library_archive)
+set_target_properties(${EMULATOR_TARGET} PROPERTIES COMPILE_FLAGS "${EMULATOR_COMPILE_FLAGS}")
+set_target_properties(${EMULATOR_TARGET} PROPERTIES LINK_FLAGS "${EMULATOR_LINK_FLAGS}")
 
-# FPGA hardware
-set(SOURCE_OBJ_FILE_FPGA ${SOURCE_FILE}.fpga.o)
+###############################################################################
+### Generate Report
+###############################################################################
+# To compile manually:
+#   dpcpp -fintelfpga -Xshardware -Xsboard=<FPGA_BOARD> -fsycl-link=early use_library.cpp lib.a -o use_library_report.a
+set(FPGA_EARLY_IMAGE ${TARGET_NAME}_report.a)
+# The compile output is not an executable, but an intermediate compilation result unique to DPC++.
+add_executable(${FPGA_EARLY_IMAGE} ${SOURCE_FILE})
+target_link_libraries(${FPGA_EARLY_IMAGE} library_archive)
+add_custom_target(report DEPENDS ${FPGA_EARLY_IMAGE})
+set_target_properties(${FPGA_EARLY_IMAGE} PROPERTIES COMPILE_FLAGS "${HARDWARE_COMPILE_FLAGS}")
+set_target_properties(${FPGA_EARLY_IMAGE} PROPERTIES LINK_FLAGS "${HARDWARE_LINK_FLAGS} -fsycl-link=early")
+# fsycl-link=early stops the compiler after RTL generation, before invoking Quartus
+
+###############################################################################
+### FPGA Hardware
+###############################################################################
+# To compile in a single command:
+#   dpcpp -fintelfpga -Xshardware -Xsboard=<FPGA_BOARD> use_library.cpp lib.a -o use_library.fpga
+# CMake executes:
+#   [compile] dpcpp -fintelfpga -o use_library.cpp.o -c use_library.cpp
+#   [link]    dpcpp -fintelfpga -Xshardware -Xsboard=<FPGA_BOARD> use_library.cpp.o -o use_library.fpga lib.a 
+add_executable(${FPGA_TARGET} ${SOURCE_FILE})
 add_custom_target(fpga DEPENDS ${FPGA_TARGET})
-add_custom_command(OUTPUT ${SOURCE_OBJ_FILE_FPGA}
-                   COMMAND ${CMAKE_CXX_COMPILER} ${CMAKE_CXX_FLAGS_LIST} ${SOURCE_FILE} ${HARDWARE_COMPILE_FLAGS_LIST} -c -o ${SOURCE_OBJ_FILE_FPGA}
-                   DEPENDS ${SOURCE_FILE} ${HEADER_FILE})
-add_custom_command(OUTPUT ${FPGA_TARGET}
-                   COMMAND ${CMAKE_CXX_COMPILER} ${CMAKE_CXX_FLAGS_LIST} ${SOURCE_OBJ_FILE_FPGA} ${HARDWARE_LINK_FLAGS_LIST} -o ${CMAKE_BINARY_DIR}/${FPGA_TARGET}
-                   DEPENDS ${SOURCE_OBJ_FILE_FPGA} create_library_archive)
-
-# Generate report
-set(SOURCE_OBJ_FILE_REPORT ${SOURCE_FILE}.report.o)
-add_custom_target(report DEPENDS ${REPORT_TARGET})
-add_custom_command(OUTPUT ${SOURCE_OBJ_FILE_REPORT}
-                   COMMAND ${CMAKE_CXX_COMPILER} ${CMAKE_CXX_FLAGS_LIST} ${SOURCE_FILE} ${HARDWARE_COMPILE_FLAGS_LIST} -c -o ${SOURCE_OBJ_FILE_REPORT}
-                   DEPENDS ${SOURCE_FILE} ${HEADER_FILE})
-add_custom_command(OUTPUT ${REPORT_TARGET} 
-                   COMMAND ${CMAKE_CXX_COMPILER} ${CMAKE_CXX_FLAGS_LIST} ${SOURCE_OBJ_FILE_REPORT} ${HARDWARE_LINK_FLAGS_LIST} -fsycl-link -o ${CMAKE_BINARY_DIR}/${REPORT_TARGET}
-                   DEPENDS ${SOURCE_OBJ_FILE_REPORT} create_library_archive)
-
-# Copy files
-configure_file(${CMAKE_CURRENT_SOURCE_DIR}/${SOURCE_FILE} ${SOURCE_FILE} COPYONLY)
-configure_file(${CMAKE_CURRENT_SOURCE_DIR}/${HEADER_FILE} ${HEADER_FILE} COPYONLY)
-configure_file(${CMAKE_CURRENT_SOURCE_DIR}/${HLS_SOURCE} ${HLS_SOURCE} COPYONLY)
-configure_file(${CMAKE_CURRENT_SOURCE_DIR}/${OCL_SOURCE} ${OCL_SOURCE} COPYONLY)
-configure_file(${CMAKE_CURRENT_SOURCE_DIR}/${SYCL_SOURCE} ${SYCL_SOURCE} COPYONLY)
-configure_file(${CMAKE_CURRENT_SOURCE_DIR}/${RTL_SPEC} ${RTL_SPEC} COPYONLY)
-configure_file(${CMAKE_CURRENT_SOURCE_DIR}/${RTL_C_MODEL} ${RTL_C_MODEL} COPYONLY)
-configure_file(${CMAKE_CURRENT_SOURCE_DIR}/${RTL_V} ${RTL_V} COPYONLY)
-
+target_link_libraries(${FPGA_TARGET} library_archive)
+set_target_properties(${FPGA_TARGET} PROPERTIES COMPILE_FLAGS "${HARDWARE_COMPILE_FLAGS}")
+set_target_properties(${FPGA_TARGET} PROPERTIES LINK_FLAGS "${HARDWARE_LINK_FLAGS} -reuse-exe=${CMAKE_BINARY_DIR}/${FPGA_TARGET}")


### PR DESCRIPTION
# Description

All of the CMake files for FPGA tutorial code samples are revised in this change. The key changes are:
 - Restructure the CMake files for better readability, making it easier for readers to understand the dpcpp commands being called
 - Remove the special cases required for CMake Windows support
 - Add support for 3rd party and custom FPGA boards to samples, including support for Agilex

Some non-CMake files are also modified to enable these goals:
 - Changes necessary for Agilex support (e.g. cpp changes in samples with device-dependency)
 - Improve CMake readability by removing unnecessary  "disable fast math" compile flags from certain samples (use fuzzy floating point equality checks instead)

## Type of change

- [X] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

All of the samples were tested on Windows and Linux on local machines. Hardware tests were also run on Arria 10 PAC, Stratix 10 PAC, and a custom Agilex reference board.

- [X] Command Line
- [X] Visual Studio