### PR TITLE
MandelbrotOMP: fix in executable name

### DIFF
--- a/DirectProgramming/C++/CombinationalLogic/MandelbrotOMP/Makefile
+++ b/DirectProgramming/C++/CombinationalLogic/MandelbrotOMP/Makefile
@@ -21,7 +21,7 @@ ifdef perf_num
 	EXTRA_CFLAGS += -D PERF_NUM
 endif
 
-TARGET := $(BUILDDIR)/MergeSort
+TARGET := $(BUILDDIR)/Mandelbrot
 
 icpc: $(TARGET)
 


### PR DESCRIPTION
# Description
Makefile for MandelbrotOMP sample contains the executable name of another sample: MergeSort instead of Mandelbrot.
Makefile for Mandelbrot is updated to product the executable with Mandelbrot name.
The logic of sample is not changed. Just renaming the output executable.

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
- [X] Command Line