### PR TITLE
Mandelbrot, vector-add, Nbody samples are marked as Common+Advisor

### DIFF
--- a/DirectProgramming/C++/CombinationalLogic/MandelbrotOMP/sample.json
+++ b/DirectProgramming/C++/CombinationalLogic/MandelbrotOMP/sample.json
@@ -1,6 +1,6 @@
 {
     "name": "Mandelbrot OMP",
-    "categories": ["Toolkit/oneAPI Direct Programming/C++/Combinational Logic"],
+    "categories": ["Toolkit/oneAPI Direct Programming/C++/Combinational Logic", "Toolkit/oneAPI Tools/Advisor"],
     "description": "Calculates the Mandelbrot Set and outputs a BMP image representation using OpenMP* (OMP)",
     "os": ["darwin"],
     "builder": ["make"],

--- a/DirectProgramming/DPC++/CombinationalLogic/mandelbrot/sample.json
+++ b/DirectProgramming/DPC++/CombinationalLogic/mandelbrot/sample.json
@@ -1,7 +1,7 @@
 {
   "guid": "8572B85D-0B32-40B1-8112-538F480C8660",	
   "name": "Mandelbrot",
-  "categories": ["Toolkit/oneAPI Direct Programming/DPC++/Combinational Logic"],
+  "categories": ["Toolkit/oneAPI Direct Programming/DPC++/Combinational Logic", "Toolkit/oneAPI Tools/Advisor"],
   "description": "The Mandelbrot Set - a fractal example in mathematics",
   "toolchain": [ "dpcpp" ],
   "languages": [ { "cpp": {} } ],

--- a/DirectProgramming/DPC++/DenseLinearAlgebra/vector-add/sample.json
+++ b/DirectProgramming/DPC++/DenseLinearAlgebra/vector-add/sample.json
@@ -1,7 +1,7 @@
 {
   "guid":"b1b58be7-e22e-4ca2-ba59-6887b2f1be6c",
   "name": "Base: Vector Add",
-  "categories": ["Toolkit/Get Started", "Toolkit/oneAPI Direct Programming/DPC++/Dense Linear Algebra"],
+  "categories": ["Toolkit/Get Started", "Toolkit/oneAPI Direct Programming/DPC++/Dense Linear Algebra", "Toolkit/oneAPI Tools/Advisor"],
   "description": "This simple sample adds two large vectors in parallel. Provides a ‘Hello World!’ like sample to ensure your environment is setup correctly using simple Intel® oneAPI Data Parallel C++ (DPC++)",
   "toolchain": ["dpcpp"],
   "languages": [{"cpp": {"properties": {"projectOptions": [{"projectType": "makefile"}]}}}],

--- a/DirectProgramming/DPC++/N-BodyMethods/Nbody/sample.json
+++ b/DirectProgramming/DPC++/N-BodyMethods/Nbody/sample.json
@@ -1,7 +1,7 @@
 {
   "guid": "D5BFD7D5-737E-4CC9-84EE-FE94339B3DCA",
   "name": "N-Body",
-  "categories": ["Toolkit/oneAPI Direct Programming/DPC++/N-Body Methods"],
+  "categories": ["Toolkit/oneAPI Direct Programming/DPC++/N-Body Methods", "Toolkit/oneAPI Tools/Advisor"],
   "description": "An N-Body simulation is a simulation of a dynamical system of particles, usually under the influence of physical forces, such as gravity. This N-Body sample code is implemented using Intel® oneAPI Data Parallel C++ (DPC++) for CPU and GPU",
   "toolchain": ["dpcpp"],
   "languages": [{"cpp":{}}],


### PR DESCRIPTION
# Description
Mandelbrot, vector-add, Nbody samples are good for showcasing the features of Intel Advisor. The lists of categories for these samples are extended with "Toolkit/oneAPI Tools/Advisor". This change allows to show the mentioned samples in 2 places of the samples tree: in their actual location (see categories in sample.json before change) and in Advisor part of tree without source code duplication. The logic of samples is not changed.

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Sample Migration (Moving sample from old repository after completing checklist established)
- [X] sample.json update (categories)

# How Has This Been Tested?
- [X] Command Line
- [ ] oneapi-cli
- [ ] Visual Studio
- [ ] Eclipse IDE
- [ ] VSCode