### PR TITLE
Change intel::ii attribute to intel::initiation_interval in all FPGA code samples

### DIFF
--- a/DirectProgramming/DPC++FPGA/ReferenceDesigns/db/src/db_utils/fifo_sort.hpp
+++ b/DirectProgramming/DPC++FPGA/ReferenceDesigns/db/src/db_utils/fifo_sort.hpp
@@ -769,7 +769,7 @@ void sort(Compare compare) {
   constexpr int kTotalIter = kOutputStartLastStage + sort_size;
 
   // Sort
-  //[[intel::ii(1)]]
+  //[[intel::initiation_interval(1)]]
   for (int i = 0; i < kTotalIter; i++) {
 #ifdef DEBUG
     std::cout << "I: " << i << std::endl;

--- a/DirectProgramming/DPC++FPGA/ReferenceDesigns/db/src/query1/query1_kernel.cpp
+++ b/DirectProgramming/DPC++FPGA/ReferenceDesigns/db/src/query1/query1_kernel.cpp
@@ -112,7 +112,7 @@ bool SubmitQuery1(queue& q, Database& dbinfo, DBDate low_date,
       count_local.Init();
 
       // stream each row in the DB (kElementsPerCycle rows at a time)
-      [[intel::ii(1)]]
+      [[intel::initiation_interval(1)]]
       for (size_t r = 0; r < rows; r += kElementsPerCycle) {
         // locals
         DBDecimal qty[kElementsPerCycle];

--- a/DirectProgramming/DPC++FPGA/ReferenceDesigns/mvdr_beamforming/src/StreamingQRD.hpp
+++ b/DirectProgramming/DPC++FPGA/ReferenceDesigns/mvdr_beamforming/src/StreamingQRD.hpp
@@ -188,7 +188,7 @@ event SubmitStreamingQRDKernel(queue& q) {
 
         // Calculate Q and R by iterating over A
         // NO-FORMAT comments are for clang-format
-        [[intel::ii(1)]]                               // NO-FORMAT: Attribute
+        [[intel::initiation_interval(1)]]              // NO-FORMAT: Attribute
         [[intel::ivdep(k_min_inner_loop_iterations)]]  // NO-FORMAT: Attribute
         for (int s = 0; s < kNumIterations; s++) {
           AColumn vector_t;

--- a/DirectProgramming/DPC++FPGA/ReferenceDesigns/qrd/src/qrd.cpp
+++ b/DirectProgramming/DPC++FPGA/ReferenceDesigns/qrd/src/qrd.cpp
@@ -175,7 +175,7 @@ void QRDecomposition(vector<float> &in_matrix, vector<float> &out_matrix,
                           : 0;
             int qr_idx = l * kOutputMatrixSize / 2;
 
-            [[intel::ii(1)]] [[intel::ivdep(
+            [[intel::initiation_interval(1)]] [[intel::ivdep(
                 FIXED_ITERATIONS)]] for (int s = 0; s < ITERATIONS; s++) {
               MyComplex vector_t[ROWS_COMPONENT];
               MyComplex sori[kNumBanks];

--- a/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/shannonization/src/IntersectionKernel.hpp
+++ b/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/shannonization/src/IntersectionKernel.hpp
@@ -49,7 +49,7 @@ struct IntersectionKernel<0, II, APipe, BPipe> {
     int b_count = 1;
     int n = 0;
 
-    [[intel::ii(II)]]
+    [[intel::initiation_interval(II)]]
     while (a_count < a_size || b_count < b_size) {
       // increment the intersection counter if the table elements match
       if (a == b) {
@@ -99,7 +99,7 @@ struct IntersectionKernel<1, II, APipe, BPipe> {
     int b_count_next = 2;
     int n = 0;
 
-    [[intel::ii(II)]]
+    [[intel::initiation_interval(II)]]
     while (a_count < a_size || b_count < b_size) {
       // increment the intersection counter if the table elements match
       if (a == b) {
@@ -161,7 +161,7 @@ struct IntersectionKernel<2, II, APipe, BPipe> {
     bool b_count_next_inrange = true;
     bool keep_going = true;
 
-    [[intel::ii(II)]]
+    [[intel::initiation_interval(II)]]
     while (keep_going) {
       // increment the intersection counter if the table elements match
       if (a == b) {
@@ -252,7 +252,7 @@ struct IntersectionKernel<3, II, APipe, BPipe> {
     bool num_compares_in_range = num_compares < total_compares;
     bool num_compares_next_in_range = num_compares_next < total_compares;
 
-    [[intel::ii(II)]]
+    [[intel::initiation_interval(II)]]
     while (keep_going) {
       if (!a_valid || !b_valid) {
         if (!a_valid) {


### PR DESCRIPTION
## Description
Change [[intel::ii]] to [[intel::initiation_interval]] since the former syntax is deprecated and produces a warning as of (upcoming) release 2021.3. 

## External Dependencies
None

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration: 

Ran the original and changed example designs with 2021.3. The original versions will emit a deprecation warning for ii, whereas 2021.3 will accept them without any warnings. I observed the impact of this attribute and verified that the compiler is behaving in the way that is expected (validated using the HTML reports). 

- [x] Command Line
- [x] oneapi-cli
- [ ] Visual Studio
- [ ] Eclipse IDE
- [ ] VSCode

