### PR TITLE
Change deprecated intel::ii to intel::initiation_interval in two files in FPGA mvdr_beamforming sample

### DIFF
--- a/DirectProgramming/DPC++FPGA/ReferenceDesigns/mvdr_beamforming/src/CMakeLists.txt
+++ b/DirectProgramming/DPC++FPGA/ReferenceDesigns/mvdr_beamforming/src/CMakeLists.txt
@@ -84,7 +84,7 @@ endif()
 # 1. The "compile" stage compiles the device code to an intermediate representation (SPIR-V).
 # 2. The "link" stage invokes the compiler's FPGA backend before linking.
 #    For this reason, FPGA backend flags must be passed as link flags in CMake.
-set(EMULATOR_COMPILE_FLAGS "-Wall ${WIN_FLAG} -fintelfpga -fbracket-depth=512 ${ENABLE_USM} ${SENSOR_SIZE_FLAG} ${NUM_SENSORS_FLAG} ${QRD_MIN_ITERATIONS_FLAG} ${STREAMING_PIPE_WIDTH_FLAG} -DFPGA_EMULATOR")
+set(EMULATOR_COMPILE_FLAGS "-Wall -Werror ${WIN_FLAG} -fintelfpga -fbracket-depth=512 ${ENABLE_USM} ${SENSOR_SIZE_FLAG} ${NUM_SENSORS_FLAG} ${QRD_MIN_ITERATIONS_FLAG} ${STREAMING_PIPE_WIDTH_FLAG} -DFPGA_EMULATOR")
 set(EMULATOR_LINK_FLAGS "-fintelfpga ${ENABLE_USM}")
 set(SIMULATOR_COMPILE_FLAGS "-Wall -fintelfpga -fbracket-depth=512 ${ENABLE_USM} ${SENSOR_SIZE_FLAG} ${NUM_SENSORS_FLAG} ${QRD_MIN_ITERATIONS_FLAG} ${STREAMING_PIPE_WIDTH_FLAG}")
 set(SIMULATOR_LINK_FLAGS "-fintelfpga -fbracket-depth=512 -Xssimulation -Xsghdl")

--- a/DirectProgramming/DPC++FPGA/ReferenceDesigns/mvdr_beamforming/src/InputDemux.hpp
+++ b/DirectProgramming/DPC++FPGA/ReferenceDesigns/mvdr_beamforming/src/InputDemux.hpp
@@ -103,7 +103,7 @@ event SubmitInputDemuxKernel(
       bool all_xrx_sent = false;
 
       // NO-FORMAT comments are for clang-format
-      [[intel::ii(1)]]  // NO-FORMAT: Attribute
+      [[intel::initiation_interval(1)]]  // NO-FORMAT: Attribute
       while (1) {
         // capture the current state of variables before they are modified
         // by this iteration of the loop

--- a/DirectProgramming/DPC++FPGA/ReferenceDesigns/mvdr_beamforming/src/Transpose.hpp
+++ b/DirectProgramming/DPC++FPGA/ReferenceDesigns/mvdr_beamforming/src/Transpose.hpp
@@ -99,7 +99,7 @@ struct Transposer {
     });
 
     // NO-FORMAT comments are for clang-format
-    [[intel::ii(1)]]  // NO-FORMAT: Attribute
+    [[intel::initiation_interval(1)]]  // NO-FORMAT: Attribute
     while (1) {
       // capture current value of all status variables as we begin each loop
       // iteration


### PR DESCRIPTION
Signed-off-by: mtucker <mike.d.b.tucker@intel.com>

## Description

Removed intel::ii which is deprecated as of 2021.3.  These files were missed in PR #482.
Add -Werror so that warnings can not slip in to this sample undetected in the future.

## External Dependencies

None

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Compiled fpga_emu target with latest 21.3 SYCL resource, no warnings generated.
