### PR TITLE
Changed FakeIOPipes for MVDR and IO streaming samples

### DIFF
--- a/DirectProgramming/DPC++FPGA/ReferenceDesigns/mvdr_beamforming/src/FakeIOPipes.hpp
+++ b/DirectProgramming/DPC++FPGA/ReferenceDesigns/mvdr_beamforming/src/FakeIOPipes.hpp
@@ -8,6 +8,12 @@
 #include <CL/sycl.hpp>
 #include <CL/sycl/INTEL/fpga_extensions.hpp>
 
+// the "detail" namespace is commonly used in C++ as an internal namespace
+// (to a file) that is not meant to be visible to the public and should be
+// ignored by external users. That is to say, you should never have the line:
+// "using namespace detail;" in your code!
+//
+// "internal" is another common name for a namespace like this.
 namespace detail {
 
 using namespace sycl;


### PR DESCRIPTION
Signed-off-by: tyoungsc <tanner.young-schultz@intel.com>

## Description
FakeIOPipes no return a pair of events: the DMA event (a noop for USM host allocations) and the
kernel event. This allows the user of the FakeIOPipe to be more fine
grain on what they wait for. Used this in MVDR to not include the DMA
events in the throughput calculation for non-USM boards.

## External Dependencies

None

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
- [X] Command Line
Tested both changed tests in emulation for USM and non-USM boards.
