### PR TITLE
Update compute_units to use Linux-style flags

### DIFF
--- a/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/compute_units/src/CMakeLists.txt
+++ b/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/compute_units/src/CMakeLists.txt
@@ -18,7 +18,7 @@ endif()
 
 # This is a Windows-specific flag that enables exception handling in host code
 if(WIN32)
-    set(WIN_FLAG "/EHsc")
+    set(WIN_FLAG "-EHsc")
 endif()
 
 # A DPC++ ahead-of-time (AoT) compile processes the device code in two stages.


### PR DESCRIPTION
## Description

Update the compute_units FPGA tutorial to use Linux-style flags on Windows.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- [x] Command Line

