### PR TITLE
Update openOMP to compile for Linux

### DIFF
--- a/.github/ISSUE_TEMPLATE/new_sample.md
+++ b/.github/ISSUE_TEMPLATE/new_sample.md
@@ -3,7 +3,7 @@ name: Request to add a oneAPI Sample
 about: Use this template to request to add a new Code Sample
 title: 'Request to Add a oneAPI Sample <YourSampleName>'
 labels: 'enhancement'
-assignees: '@JoeOster, @srdontha'
+assignees: '@JoeOster'
 ---
 
 ## Summary
@@ -21,10 +21,11 @@ Please supply what [Domain](https://github.com/oneapi-src/oneAPI-samples/wiki/Re
 Include a short Description of what the sample while Demonstrate and why it is important to the ecosystem.
 
 ## Dependencies
-Please list any dependencies, libraries and images, etc and urls to the download locations using the following [form](https://teams.microsoft.com/l/file/576476E2-256A-4AF9-A1A9-9619A3DB9EB2?tenantId=46c98d88-e344-4ed4-8496-4ed7712e255d&fileType=pptx&objectUrl=https%3A%2F%2Fintel.sharepoint.com%2Fsites%2FOneAPICodeSamplesCommittee%2FShared%20Documents%2FGeneral%2FNewSample_Approval_Template_v0.7.pptx&baseUrl=https%3A%2F%2Fintel.sharepoint.com%2Fsites%2FOneAPICodeSamplesCommittee&serviceName=teams&threadId=19:d29358239f3343f2b26f0c13a47a478d@thread.skype&groupId=1bc67a43-c3a0-4246-98e2-21f851672b78)
+Please list any dependencies, libraries and images, etc and urls of the download locations
 
 ## Proposed folder Location
 Please include the proposed folder location for your sample to reside
 
 ## Checklist
 [ ] Samples Working Group Permission accepted on <Insert Date>
+

--- a/.github/ISSUE_TEMPLATE/new_sample.md
+++ b/.github/ISSUE_TEMPLATE/new_sample.md
@@ -21,9 +21,10 @@ Please supply what [Domain](https://github.com/oneapi-src/oneAPI-samples/wiki/Re
 Include a short Description of what the sample while Demonstrate and why it is important to the ecosystem.
 
 ## Dependencies
-Please list any dependencies, libraries and images, etc and urls to the download locations
+Please list any dependencies, libraries and images, etc and urls to the download locations using the following [form](https://teams.microsoft.com/l/file/576476E2-256A-4AF9-A1A9-9619A3DB9EB2?tenantId=46c98d88-e344-4ed4-8496-4ed7712e255d&fileType=pptx&objectUrl=https%3A%2F%2Fintel.sharepoint.com%2Fsites%2FOneAPICodeSamplesCommittee%2FShared%20Documents%2FGeneral%2FNewSample_Approval_Template_v0.7.pptx&baseUrl=https%3A%2F%2Fintel.sharepoint.com%2Fsites%2FOneAPICodeSamplesCommittee&serviceName=teams&threadId=19:d29358239f3343f2b26f0c13a47a478d@thread.skype&groupId=1bc67a43-c3a0-4246-98e2-21f851672b78)
 
 ## Proposed folder Location
 Please include the proposed folder location for your sample to reside
 
-
+## Checklist
+[ ] Samples Working Group Permission accepted on <Insert Date>

--- a/DirectProgramming/C++/CombinationalLogic/MandelbrotOMP/README.md
+++ b/DirectProgramming/C++/CombinationalLogic/MandelbrotOMP/README.md
@@ -5,7 +5,7 @@ Mandelbrot is an infinitely complex fractal patterning that is derived from a si
 
 | Optimized for                     | Description
 |:---                               |:---
-| OS                                | MacOS Catalina or newer;
+| OS                                | Linux. MacOS Catalina or newer;
 | Hardware                          | Skylake with GEN9 or newer
 | Software                          | Intel&reg; oneAPI C++ Compiler Classic
 | What you will learn               | How to optimize a scalar implementation using OpenMP pragmas

--- a/DirectProgramming/C++/CombinationalLogic/MandelbrotOMP/sample.json
+++ b/DirectProgramming/C++/CombinationalLogic/MandelbrotOMP/sample.json
@@ -3,7 +3,7 @@
     "categories": ["Toolkit/oneAPI Direct Programming/C++/Combinational Logic", "Toolkit/oneAPI Tools/Advisor"],
     "description": "Calculates the Mandelbrot Set and outputs a BMP image representation using OpenMP* (OMP)",
     "os": ["darwin", "linux"],
-    "builder": ["make", "cmake"],
+    "builder": ["make"],
     "languages": [{"cpp":{}}],
     "toolchain": ["icc"],
     "guid": "DD113F58-4D91-41BB-B46E-6CF2C0D9F6F9",
@@ -12,14 +12,9 @@
             { "id": "standard", "steps": [ "make", "make run", "make clean" ] },
             { "id": "perf_num", "env": [ "export perf_num=1" ], "steps": [ "make", "make run", "make clean" ] }
         ],
-        "linux": [{
-		"id": "mandelbrot_omp",
-		"steps": [
-		    	"mkdir build",
-			"cd build",
-                	"cmake ..",
-                	"make",
-                	"make run"
-		 ]
+	    "linux": [ 
+            { "id": "standard", "steps": [ "make", "make run", "make clean" ] },
+            { "id": "perf_num", "env": [ "export perf_num=1" ], "steps": [ "make", "make run", "make clean" ] }
+        ],
     }
 }

--- a/DirectProgramming/C++/CombinationalLogic/MandelbrotOMP/sample.json
+++ b/DirectProgramming/C++/CombinationalLogic/MandelbrotOMP/sample.json
@@ -2,8 +2,8 @@
     "name": "Mandelbrot OMP",
     "categories": ["Toolkit/oneAPI Direct Programming/C++/Combinational Logic", "Toolkit/oneAPI Tools/Advisor"],
     "description": "Calculates the Mandelbrot Set and outputs a BMP image representation using OpenMP* (OMP)",
-    "os": ["darwin"],
-    "builder": ["make"],
+    "os": ["darwin", "linux"],
+    "builder": ["make", "cmake"],
     "languages": [{"cpp":{}}],
     "toolchain": ["icc"],
     "guid": "DD113F58-4D91-41BB-B46E-6CF2C0D9F6F9",
@@ -11,6 +11,14 @@
         "darwin": [ 
             { "id": "standard", "steps": [ "make", "make run", "make clean" ] },
             { "id": "perf_num", "env": [ "export perf_num=1" ], "steps": [ "make", "make run", "make clean" ] }
-        ]
+        ],
+        "linux": [{
+		    "steps": [
+			    "mkdir build",
+                "cd build",
+                "cmake ..",
+                "make",
+                "make run"
+		 ]
     }
 }

--- a/DirectProgramming/C++/CombinationalLogic/MandelbrotOMP/sample.json
+++ b/DirectProgramming/C++/CombinationalLogic/MandelbrotOMP/sample.json
@@ -13,12 +13,13 @@
             { "id": "perf_num", "env": [ "export perf_num=1" ], "steps": [ "make", "make run", "make clean" ] }
         ],
         "linux": [{
-		    "steps": [
-			    "mkdir build",
-                "cd build",
-                "cmake ..",
-                "make",
-                "make run"
+		"id": "mandelbrot_omp",
+		"steps": [
+		    	"mkdir build",
+			"cd build",
+                	"cmake ..",
+                	"make",
+                	"make run"
 		 ]
     }
 }

--- a/DirectProgramming/C++/CombinationalLogic/MandelbrotOMP/sample.json
+++ b/DirectProgramming/C++/CombinationalLogic/MandelbrotOMP/sample.json
@@ -15,6 +15,6 @@
 	    "linux": [ 
             { "id": "standard", "steps": [ "make", "make run", "make clean" ] },
             { "id": "perf_num", "env": [ "export perf_num=1" ], "steps": [ "make", "make run", "make clean" ] }
-        ],
+        ]
     }
 }


### PR DESCRIPTION
# Existing Sample Changes
## Description

This is a change to original sample. Originally it was written for Mac only, I am extending the sample.json so that it will work for Linux as well.

Also fixing a template

Fixes Issue# 

## External Dependencies

N/A

## Type of change

Please delete options that are not relevant. Add a 'X' to the one that is applicable. 

- [x] New feature (non-breaking change which adds functionality)


## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] When compiling the compiler flag "-Wall -Wformat-security -Werror=format-security" was used
