### PR TITLE
FPGA: memory_attributes README fix

### DIFF
--- a/DirectProgramming/DPC++FPGA/Tutorials/Features/memory_attributes/README.md
+++ b/DirectProgramming/DPC++FPGA/Tutorials/Features/memory_attributes/README.md
@@ -39,7 +39,7 @@ Memory attributes can be applied to any variable or array defined within the ker
 | `intel::private_copies(N)`       | Specifies that a maximum of N private copies should be created to enable concurrent execution of N pipelined threads.
 | `intel::simple_dual_port`        | Specifies that the memory implementing the variable or array should have no port that services both reads and writes.
 | `intel::merge("key", "type")`    | Merge two or more variables or arrays in the same scope width-wise or depth-wise. All variables with the same `key` string are merged into the same memory system. The string `type` can be either `width` or `depth`. 
-| `intel::bank_bits(b0, b1,..., bn)`  | Specifies that the local memory addresses should use bits (b0, b1,..., bn) for bank-selection, where (b0, b1,..., bn) are indicated in terms of word-addressing. The bits of the local memory address not included in (b0, b1,..., bn) will be used for word-selection in each bank. 
+| `intel::bank_bits(b0, b1,..., bn)`  | Specifies that the local memory addresses should use bits `(b0, b1,..., bn)` for bank-selection, where `(b0, b1,..., bn)` are indicated in terms of word-addressing. The bits of the local memory address not included in `(b0, b1,..., bn)` will be used for word-selection in each bank. 
 
 
 #### Example 1: Applying memory attributes to private arrays

--- a/DirectProgramming/DPC++FPGA/Tutorials/Features/memory_attributes/README.md
+++ b/DirectProgramming/DPC++FPGA/Tutorials/Features/memory_attributes/README.md
@@ -29,17 +29,17 @@ Memory attributes can be applied to any variable or array defined within the ker
 
 | Memory Attribute                 | Description
 ---                                |---
-| intelfpga::register              | Forces a variable or array to be carried through the pipeline in registers.
-| intelfpga::memory("`impl_type`") | Forces a variable or array to be implemented as embedded memory. The optional string parameter `impl_type` can be `BLOCK_RAM` or `MLAB`.
-| intelfpga::numbanks(N)           | Specifies that the memory implementing the variable or array must have N memory banks. 
-| intelfpga::bankwidth(W)          | Specifies that the memory implementing the variable or array must be W bytes wide.
-| intelfpga::singlepump            | Specifies that the memory implementing the variable or array should be clocked at the same rate as the accesses to it.
-| intelfpga::doublepump            | Specifies that the memory implementing the variable or array should be clocked at twice the rate as the accesses to it.
-| intelfpga::max_replicates(N)     | Specifies that a maximum of N replicates should be created to enable simultaneous reads from the datapath.
-| intelfpga::private_copies(N)     | Specifies that a maximum of N private copies should be created to enable concurrent execution of N pipelined threads.
-| intelfpga::simple_dual_port      | Specifies that the memory implementing the variable or array should have no port that services both reads and writes.
-| intelfpga::merge("`key`", "`type`")  | Merge two or more variables or arrays in the same scope width-wise or depth-wise. All variables with the same `key` string are merged into the same memory system. The string `type` can be either `width` or `depth`. 
-| intelfpga::bank_bits(b<sub>0</sub>,b<sub>1</sub>,...,b<sub>n</sub>)  | Specifies that the local memory addresses should use bits (b<sub>0</sub>,b<sub>1</sub>,...,b<sub>n</sub>) for bank-selection, where (b<sub>0</sub>,b<sub>1</sub>,...,b<sub>n</sub>) are indicated in terms of word-addressing. The bits of the local memory address not included in (b<sub>0</sub>,b<sub>1</sub>,...,b<sub>n</sub>) will be used for word-selection in each bank. 
+| `intel::fpga_register`           | Forces a variable or array to be carried through the pipeline in registers.
+| `intel::memory("impl_type")`     | Forces a variable or array to be implemented as embedded memory. The optional string parameter `impl_type` can be `BLOCK_RAM` or `MLAB`.
+| `intel::numbanks(N)`             | Specifies that the memory implementing the variable or array must have N memory banks. 
+| `intel::bankwidth(W)`            | Specifies that the memory implementing the variable or array must be W bytes wide.
+| `intel::singlepump`              | Specifies that the memory implementing the variable or array should be clocked at the same rate as the accesses to it.
+| `intel::doublepump`              | Specifies that the memory implementing the variable or array should be clocked at twice the rate as the accesses to it.
+| `intel::max_replicates(N)`       | Specifies that a maximum of N replicates should be created to enable simultaneous reads from the datapath.
+| `intel::private_copies(N)`       | Specifies that a maximum of N private copies should be created to enable concurrent execution of N pipelined threads.
+| `intel::simple_dual_port`        | Specifies that the memory implementing the variable or array should have no port that services both reads and writes.
+| `intel::merge("key", "type")`    | Merge two or more variables or arrays in the same scope width-wise or depth-wise. All variables with the same `key` string are merged into the same memory system. The string `type` can be either `width` or `depth`. 
+| `intel::bank_bits(b<sub>0</sub>,b<sub>1</sub>,...,b<sub>n</sub>)`  | Specifies that the local memory addresses should use bits (b<sub>0</sub>,b<sub>1</sub>,...,b<sub>n</sub>) for bank-selection, where (b<sub>0</sub>,b<sub>1</sub>,...,b<sub>n</sub>) are indicated in terms of word-addressing. The bits of the local memory address not included in (b<sub>0</sub>,b<sub>1</sub>,...,b<sub>n</sub>) will be used for word-selection in each bank. 
 
 
 #### Example 1: Applying memory attributes to private arrays
@@ -49,16 +49,16 @@ q.submit([&](handler &h) {
     // Create a kernel memory 8 bytes wide (2 integers per memory word)
     // and split the contents into 2 banks (each bank will contain 32
     // integers in 16 memory words). 
-    [[intelfpga::bankwidth(8), intelfpga::numbanks(2)]] int a[64];
+    [[intel::bankwidth(8), intel::numbanks(2)]] int a[64];
     
     // Force array 'b' to be carried live in the data path using
     // registers. 
-    [[intelfpga::register]] int b[64];
+    [[intel::fpga_register]] int b[64];
 
     // Merge 'mem_A' and 'mem_B' width-wise so that they are mapped
     // to the same kernel memory system,
-    [[intelfpga::merge("mem", "width")]] unsigned short mem_A[64];
-    [[intelfpga::merge("mem", "width")]] unsigned short mem_B[64];
+    [[intel::merge("mem", "width")]] unsigned short mem_A[64];
+    [[intel::merge("mem", "width")]] unsigned short mem_B[64];
     
     // ...
   });
@@ -71,8 +71,8 @@ q.submit([&](handler &h) {
 // Memory attributes can be specified for struct data members
 // within the struct declaration.
 struct State {
-  [[intelfpga::numbanks(2)]] int mem[64];
-  [[intelfpga::register]]    int reg[8];
+  [[intel::numbanks(2)]] int mem[64];
+  [[intel::fpga_register]]    int reg[8];
 };
 
 q.submit([&](handler &h) {
@@ -87,7 +87,7 @@ q.submit([&](handler &h) {
     // level attribute takes precedence. Here, the compiler will
     // generate a single memory system for S2, which will have 4
     // banks.  
-    [[intelfpga::numbanks(4)]] State S2;
+    [[intel::numbanks(4)]] State S2;
 
     // ...
   });
@@ -96,7 +96,7 @@ q.submit([&](handler &h) {
 ```
 
 ### Tutorial Code Overview
-This tutorial demonstrates the trade-offs between choosing a single-pumped and double-pumped memory system for your kernel. We will apply the attributes `[[intelfpga::singlepump]]` and `[[intelfpga::doublepump]]` to the two dimensional array `dict_offset`. 
+This tutorial demonstrates the trade-offs between choosing a single-pumped and double-pumped memory system for your kernel. We will apply the attributes `[[intel::singlepump]]` and `[[intel::doublepump]]` to the two dimensional array `dict_offset`. 
 
 The tutorial enqueues three versions of the same kernel:
 * `dict_offset` is single-pumped
@@ -283,6 +283,6 @@ PASSED: all kernel results are correct.
 ### Discussion
 
 Feel free to experiment further with the tutorial code. You can:
- - Change the memory implementation type to block RAMs (using `[[intelfpga::memory("BLOCK_RAM")]]`) or registers (using `[[intelfpga::register]]`) to see how it affects the area and f<sub>MAX</sub> of the tutorial design.
+ - Change the memory implementation type to block RAMs (using `[[intel::memory("BLOCK_RAM")]]`) or registers (using `[[intel::fpga_register]]`) to see how it affects the area and f<sub>MAX</sub> of the tutorial design.
  - Vary `kRows` and/or `kVec` (both in powers of 2) see how it affects the trade-off between single-pumped and double-pumped memories.
 

--- a/DirectProgramming/DPC++FPGA/Tutorials/Features/memory_attributes/README.md
+++ b/DirectProgramming/DPC++FPGA/Tutorials/Features/memory_attributes/README.md
@@ -39,7 +39,7 @@ Memory attributes can be applied to any variable or array defined within the ker
 | `intel::private_copies(N)`       | Specifies that a maximum of N private copies should be created to enable concurrent execution of N pipelined threads.
 | `intel::simple_dual_port`        | Specifies that the memory implementing the variable or array should have no port that services both reads and writes.
 | `intel::merge("key", "type")`    | Merge two or more variables or arrays in the same scope width-wise or depth-wise. All variables with the same `key` string are merged into the same memory system. The string `type` can be either `width` or `depth`. 
-| `intel::bank_bits(b<sub>0</sub>,b<sub>1</sub>,...,b<sub>n</sub>)`  | Specifies that the local memory addresses should use bits (b<sub>0</sub>,b<sub>1</sub>,...,b<sub>n</sub>) for bank-selection, where (b<sub>0</sub>,b<sub>1</sub>,...,b<sub>n</sub>) are indicated in terms of word-addressing. The bits of the local memory address not included in (b<sub>0</sub>,b<sub>1</sub>,...,b<sub>n</sub>) will be used for word-selection in each bank. 
+| `intel::bank_bits`(b<sub>0</sub>,b<sub>1</sub>,...,b<sub>n</sub>)  | Specifies that the local memory addresses should use bits (b<sub>0</sub>,b<sub>1</sub>,...,b<sub>n</sub>) for bank-selection, where (b<sub>0</sub>,b<sub>1</sub>,...,b<sub>n</sub>) are indicated in terms of word-addressing. The bits of the local memory address not included in (b<sub>0</sub>,b<sub>1</sub>,...,b<sub>n</sub>) will be used for word-selection in each bank. 
 
 
 #### Example 1: Applying memory attributes to private arrays

--- a/DirectProgramming/DPC++FPGA/Tutorials/Features/memory_attributes/README.md
+++ b/DirectProgramming/DPC++FPGA/Tutorials/Features/memory_attributes/README.md
@@ -30,7 +30,7 @@ Memory attributes can be applied to any variable or array defined within the ker
 | Memory Attribute                 | Description
 ---                                |---
 | `intel::fpga_register`           | Forces a variable or array to be carried through the pipeline in registers.
-| `intel::memory("impl_type")`     | Forces a variable or array to be implemented as embedded memory. The optional string parameter `impl_type` can be `BLOCK_RAM` or `MLAB`.
+| `intel::fpga_memory("impl_type")`| Forces a variable or array to be implemented as embedded memory. The optional string parameter `impl_type` can be `BLOCK_RAM` or `MLAB`.
 | `intel::numbanks(N)`             | Specifies that the memory implementing the variable or array must have N memory banks. 
 | `intel::bankwidth(W)`            | Specifies that the memory implementing the variable or array must be W bytes wide.
 | `intel::singlepump`              | Specifies that the memory implementing the variable or array should be clocked at the same rate as the accesses to it.
@@ -39,7 +39,7 @@ Memory attributes can be applied to any variable or array defined within the ker
 | `intel::private_copies(N)`       | Specifies that a maximum of N private copies should be created to enable concurrent execution of N pipelined threads.
 | `intel::simple_dual_port`        | Specifies that the memory implementing the variable or array should have no port that services both reads and writes.
 | `intel::merge("key", "type")`    | Merge two or more variables or arrays in the same scope width-wise or depth-wise. All variables with the same `key` string are merged into the same memory system. The string `type` can be either `width` or `depth`. 
-| `intel::bank_bits`(b<sub>0</sub>,b<sub>1</sub>,...,b<sub>n</sub>)  | Specifies that the local memory addresses should use bits (b<sub>0</sub>,b<sub>1</sub>,...,b<sub>n</sub>) for bank-selection, where (b<sub>0</sub>,b<sub>1</sub>,...,b<sub>n</sub>) are indicated in terms of word-addressing. The bits of the local memory address not included in (b<sub>0</sub>,b<sub>1</sub>,...,b<sub>n</sub>) will be used for word-selection in each bank. 
+| `intel::bank_bits(b0, b1,..., bn)`  | Specifies that the local memory addresses should use bits (b0, b1,..., bn) for bank-selection, where (b0, b1,..., bn) are indicated in terms of word-addressing. The bits of the local memory address not included in (b0, b1,..., bn) will be used for word-selection in each bank. 
 
 
 #### Example 1: Applying memory attributes to private arrays
@@ -71,7 +71,7 @@ q.submit([&](handler &h) {
 // Memory attributes can be specified for struct data members
 // within the struct declaration.
 struct State {
-  [[intel::numbanks(2)]] int mem[64];
+  [[intel::numbanks(2)]]      int mem[64];
   [[intel::fpga_register]]    int reg[8];
 };
 
@@ -283,6 +283,6 @@ PASSED: all kernel results are correct.
 ### Discussion
 
 Feel free to experiment further with the tutorial code. You can:
- - Change the memory implementation type to block RAMs (using `[[intel::memory("BLOCK_RAM")]]`) or registers (using `[[intel::fpga_register]]`) to see how it affects the area and f<sub>MAX</sub> of the tutorial design.
+ - Change the memory implementation type to block RAMs (using `[[intel::fpga_memory("BLOCK_RAM")]]`) or registers (using `[[intel::fpga_register]]`) to see how it affects the area and f<sub>MAX</sub> of the tutorial design.
  - Vary `kRows` and/or `kVec` (both in powers of 2) see how it affects the trade-off between single-pumped and double-pumped memories.
 


### PR DESCRIPTION
# Existing Sample Changes
## Description

This change accomplishes four small formatting issues with the memory_attributes README:
- Updated instances of `intelfpga::` to `intel::`
- Updated instances of `register` to `fpga_register`
- Updated instances of `memory` to `fpga_memory`
- Updated the table of memory attributes so that the attributes are in code font instead of just the normal font

Fixes Issue# 

## External Dependencies

N/A

## Type of change

Please delete options that are not relevant. Add a 'X' to the one that is applicable. 

- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

I've verified that the README file produced looks as expected.


