### PR TITLE
Removed recursive function from kernel in FPGA Reference Design mvdr_beamforming

### DIFF
--- a/DirectProgramming/DPC++FPGA/ReferenceDesigns/mvdr_beamforming/src/StreamingQRD.hpp
+++ b/DirectProgramming/DPC++FPGA/ReferenceDesigns/mvdr_beamforming/src/StreamingQRD.hpp
@@ -21,7 +21,13 @@ static constexpr T Pow2(T n) {
 // base-2 logarithm
 template <typename T>
 static constexpr T Log2(T n) {
-  return ((n < 2) ? T(0) : T(1) + Log2(n / 2));
+  T ret = T(0);
+  T val = n;
+  while (val > T(1)) {
+    val >>= 1;
+    ret++;
+  }
+  return ret;
 }
 // round up Log2
 template <typename T>


### PR DESCRIPTION
Signed-off-by: mtucker <mike.d.b.tucker@intel.com>

## Description

The dpcpp front-end is adding a check in 2021.3 that disallows recursive functions inside kernels.  The check is currently overly restrictive, and disallows static compile-time recursive functions.  This code change converts a static compile time function to a loop instead of a recursive implementation to avoid this issue.

Fixes Issue# CMPLRLLVM-27921

## External Dependencies

None

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Implement fixes for ONSAM Jiras

## How Has This Been Tested?

- [X] Command Line
