### PR TITLE
node and mode update for daal4py readme

### DIFF
--- a/AI-and-Analytics/Getting-Started-Samples/IntelPython_daal4py_GettingStarted/README.md
+++ b/AI-and-Analytics/Getting-Started-Samples/IntelPython_daal4py_GettingStarted/README.md
@@ -172,6 +172,6 @@ In order to run on the DevCloud, you need to request a compute node using node p
 | Node              | Command                                                 |
 | ----------------- | ------------------------------------------------------- |
 | GPU               | qsub -l nodes=1:gpu:ppn=2 -d . hello-world.sh           |
-| CPU               | qsub -l nodes=1:xeon:ppn=2 -d . hello-world.sh          |
+| __CPU               | qsub -l nodes=1:xeon:ppn=2 -d . hello-world.sh__          |
 | FPGA Compile Time | qsub -l nodes=1:fpga\_compile:ppn=2 -d . hello-world.sh |
 | FPGA Runtime      | qsub -l nodes=1:fpga\_runtime:ppn=2 -d . hello-world.sh |

--- a/AI-and-Analytics/Getting-Started-Samples/IntelPython_daal4py_GettingStarted/README.md
+++ b/AI-and-Analytics/Getting-Started-Samples/IntelPython_daal4py_GettingStarted/README.md
@@ -124,7 +124,30 @@ Run the Program
 
 `python IntelPython_daal4py_GettingStarted.py`
 
-The output files of the script will be saved in the included models and result directories. 
+The output files of the script will be saved in the included models and result directories.
+
+### Running Samples on the Intel&reg; DevCloud (Optional)<a name="run-samples-on-devcloud"></a>
+
+<!---Include the next paragraph ONLY if the sample runs in batch mode-->
+### Run in Batch Mode
+This sample runs in batch mode, so you must have a script for batch processing. Once you have a script set up, refer to [Running the Sample](#running-the-sample).
+
+<!---Include the next paragraph ONLY if the sample DOES NOT RUN in batch mode-->
+### Run in Interactive Mode
+This sample runs in interactive mode. For more information, see [Run as Juypter Notebook](#run-as-jupyter-notebook).
+
+### Request a Compute Node
+In order to run on the DevCloud, you need to request a compute node using node properties such as: `gpu`, `xeon`, `fpga_compile`, `fpga_runtime` and others. For more information about the node properties, execute the `pbsnodes` command.
+ This node information must be provided when submitting a job to run your sample in batch mode using the qsub command. When you see the qsub command in the Run section of the [Hello World instructions](https://devcloud.intel.com/oneapi/get_started/aiAnalyticsToolkitSamples/), change the command to fit the node you are using. Nodes which are in bold indicate they are compatible with this sample:
+
+<!---Mark each compatible Node in BOLD-->
+| Node              | Command                                                 |
+| ----------------- | ------------------------------------------------------- |
+| GPU               | qsub -l nodes=1:gpu:ppn=2 -d . hello-world.sh           |
+| __CPU__           | __qsub -l nodes=1:xeon:ppn=2 -d . hello-world.sh__      |
+| FPGA Compile Time | qsub -l nodes=1:fpga\_compile:ppn=2 -d . hello-world.sh |
+| FPGA Runtime      | qsub -l nodes=1:fpga\_runtime:ppn=2 -d . hello-world.sh |
+
 
 ##### Expected Printed Output (with similar numbers):
 ```
@@ -154,24 +177,3 @@ Here is one of our loaded model's features:
    1.58423529e-02 -4.57542900e-01]]
 [CODE_SAMPLE_COMPLETED_SUCCESFULLY]
 ```
-### Running Samples on the Intel&reg; DevCloud (Optional)<a name="run-samples-on-devcloud"></a>
-
-<!---Include the next paragraph ONLY if the sample runs in batch mode-->
-### Run in Batch Mode
-This sample runs in batch mode, so you must have a script for batch processing. Once you have a script set up, refer to [Running the Sample](#running-the-sample).
-
-<!---Include the next paragraph ONLY if the sample DOES NOT RUN in batch mode-->
-### Run in Interactive Mode
-This sample runs in interactive mode. For more information, see [Run as Juypter Notebook](#run-as-jupyter-notebook).
-
-### Request a Compute Node
-In order to run on the DevCloud, you need to request a compute node using node properties such as: `gpu`, `xeon`, `fpga_compile`, `fpga_runtime` and others. For more information about the node properties, execute the `pbsnodes` command.
- This node information must be provided when submitting a job to run your sample in batch mode using the qsub command. When you see the qsub command in the Run section of the [Hello World instructions](https://devcloud.intel.com/oneapi/get_started/aiAnalyticsToolkitSamples/), change the command to fit the node you are using. Nodes which are in bold indicate they are compatible with this sample:
-
-<!---Mark each compatible Node in BOLD-->
-| Node              | Command                                                 |
-| ----------------- | ------------------------------------------------------- |
-| GPU               | qsub -l nodes=1:gpu:ppn=2 -d . hello-world.sh           |
-| __CPU__               | __qsub -l nodes=1:xeon:ppn=2 -d . hello-world.sh__          |
-| FPGA Compile Time | qsub -l nodes=1:fpga\_compile:ppn=2 -d . hello-world.sh |
-| FPGA Runtime      | qsub -l nodes=1:fpga\_runtime:ppn=2 -d . hello-world.sh |

--- a/AI-and-Analytics/Getting-Started-Samples/IntelPython_daal4py_GettingStarted/README.md
+++ b/AI-and-Analytics/Getting-Started-Samples/IntelPython_daal4py_GettingStarted/README.md
@@ -80,7 +80,7 @@ jupyter notebook
 
 ### Running the Sample as a Jupyter Notebook<a name="run-as-jupyter-notebook"></a>
 
-Open .pynb file and run cells in Jupyter Notebook using the "Run" button (see image)
+Open .ipynb file and run cells in Jupyter Notebook using the "Run" button (see image)
 
 ![Click the Run Button in the Jupyter Notebook](Jupyter_Run.jpg "Run Button on Jupyter Notebook")
 

--- a/AI-and-Analytics/Getting-Started-Samples/IntelPython_daal4py_GettingStarted/README.md
+++ b/AI-and-Analytics/Getting-Started-Samples/IntelPython_daal4py_GettingStarted/README.md
@@ -172,6 +172,6 @@ In order to run on the DevCloud, you need to request a compute node using node p
 | Node              | Command                                                 |
 | ----------------- | ------------------------------------------------------- |
 | GPU               | qsub -l nodes=1:gpu:ppn=2 -d . hello-world.sh           |
-| __CPU               | qsub -l nodes=1:xeon:ppn=2 -d . hello-world.sh__          |
+| __CPU__               | __qsub -l nodes=1:xeon:ppn=2 -d . hello-world.sh__          |
 | FPGA Compile Time | qsub -l nodes=1:fpga\_compile:ppn=2 -d . hello-world.sh |
 | FPGA Runtime      | qsub -l nodes=1:fpga\_runtime:ppn=2 -d . hello-world.sh |

--- a/AI-and-Analytics/Getting-Started-Samples/IntelPython_daal4py_GettingStarted/README.md
+++ b/AI-and-Analytics/Getting-Started-Samples/IntelPython_daal4py_GettingStarted/README.md
@@ -24,6 +24,9 @@ Code samples are licensed under the MIT license. See
 
 Third party program Licenses can be found here: [third-party-programs.txt](https://github.com/oneapi-src/oneAPI-samples/blob/master/third-party-programs.txt)
 
+## Running Samples on the Intel&reg; DevCloud
+If you are running this sample on the DevCloud, see [Running Samples on the Intel&reg; DevCloud](#run-samples-on-devcloud)
+
 ## Building daal4py for CPU
 
 oneAPI Data Analytics Library is ready for use once you finish the Intel® oneAPI AI Analytics Toolkit installation and have run the post installation script.
@@ -73,9 +76,9 @@ Launch Jupyter Notebook in the directory housing the code example
 ```
 jupyter notebook
 ```
-## Running the Sample
+## Running the Sample<a name="running-the-sample"></a>
 
-### Running the Sample as a Jupyter Notebook
+### Running the Sample as a Jupyter Notebook<a name="run-as-jupyter-notebook"></a>
 
 Open .pynb file and run cells in Jupyter Notebook using the "Run" button (see image)
 
@@ -151,4 +154,24 @@ Here is one of our loaded model's features:
    1.58423529e-02 -4.57542900e-01]]
 [CODE_SAMPLE_COMPLETED_SUCCESFULLY]
 ```
+### Running Samples on the Intel&reg; DevCloud (Optional)<a name="run-samples-on-devcloud"></a>
 
+<!---Include the next paragraph ONLY if the sample runs in batch mode-->
+### Run in Batch Mode
+This sample runs in batch mode, so you must have a script for batch processing. Once you have a script set up, refer to [Running the Sample](#running-the-sample).
+
+<!---Include the next paragraph ONLY if the sample DOES NOT RUN in batch mode-->
+### Run in Interactive Mode
+This sample runs in interactive mode. For more information, see [Run as Juypter Notebook](#run-as-jupyter-notebook).
+
+### Request a Compute Node
+In order to run on the DevCloud, you need to request a compute node using node properties such as: `gpu`, `xeon`, `fpga_compile`, `fpga_runtime` and others. For more information about the node properties, execute the `pbsnodes` command.
+ This node information must be provided when submitting a job to run your sample in batch mode using the qsub command. When you see the qsub command in the Run section of the [Hello World instructions](https://devcloud.intel.com/oneapi/get_started/aiAnalyticsToolkitSamples/), change the command to fit the node you are using. Nodes which are in bold indicate they are compatible with this sample:
+
+<!---Mark each compatible Node in BOLD-->
+| Node              | Command                                                 |
+| ----------------- | ------------------------------------------------------- |
+| GPU               | qsub -l nodes=1:gpu:ppn=2 -d . hello-world.sh           |
+| CPU               | qsub -l nodes=1:xeon:ppn=2 -d . hello-world.sh          |
+| FPGA Compile Time | qsub -l nodes=1:fpga\_compile:ppn=2 -d . hello-world.sh |
+| FPGA Runtime      | qsub -l nodes=1:fpga\_runtime:ppn=2 -d . hello-world.sh |


### PR DESCRIPTION
# Introduction
This template serves 2 purposes and will need to be edited accordingly prior to submitting the PR
- Changes to existing samples
- Submission of new Samples

# Existing Sample Changes
## Description

Made edits to the Running Samples in Devcloud section to enable users to select the correct mode and node to run their sample.
I added a jump link at the top to skip to the DevCloud directions. I am not sure if there are steps required before running a sample on the devcloud. For example, does the user need to build daal4py for CPU or activate conda before using the DevCloud? If the answer is yes, then the jump link to the DevCloud directions need to move down below the required steps.

**NOTE**: Prior to accepting pull request, please review the commented sections in the README.md:

1. If your sample runs in batch mode, please delete the section on how to run in interactive mode. Joe Oster requested this because interactive mode can be troublesome so we would rather have users use batch mode when possible.
2. In the node table, if a node is applicable to this sample, please change the node name to **BOLD** so users can easily identify which nodes are available.

Fixes Issue# 

## External Dependencies

None.

## Type of change

Please delete options that are not relevant. Add a 'X' to the one that is applicable. 

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Implement fixes for ONSAM Jiras
- [ x] Documentation

## How Has This Been Tested?

Text was reviewed and approved by Dan Petre, Donna Boyer, and Joe Oster.

- [ ] Command Line
- [ ] oneapi-cli
- [ ] Visual Studio
- [ ] Eclipse IDE
- [x ] VSCode
- [ ] When compiling the compliler flag "-Wall -Wformat-security -Werror=format-security" was used

