### PR TITLE
Small update to FPGA DB design

### DIFF
--- a/DirectProgramming/DPC++FPGA/ReferenceDesigns/db/src/query12/query12_kernel.cpp
+++ b/DirectProgramming/DPC++FPGA/ReferenceDesigns/db/src/query12/query12_kernel.cpp
@@ -78,6 +78,7 @@ bool SubmitQuery12(queue& q, Database& dbinfo, DBDate low_date,
     accessor l_receiptdate_accessor(l_receiptdate_buf, h, read_only);
 
     h.single_task<LineItemProducer>([=]() [[intel::kernel_args_restrict]] {
+      [[intel::initiation_interval(1)]]
       for (size_t i = 0; i < l_rows; i += kLineItemJoinWindowSize) {
         // bulk read of data from global memory
         NTuple<kLineItemJoinWindowSize, LineItemRow> data;
@@ -113,6 +114,7 @@ bool SubmitQuery12(queue& q, Database& dbinfo, DBDate low_date,
     accessor o_orderpriority_accessor(o_orderpriority_buf, h, read_only);
 
     h.single_task<OrdersProducer>([=]() [[intel::kernel_args_restrict]] {
+      [[intel::initiation_interval(1)]]
       for (size_t i = 0; i < o_rows; i += kOrderJoinWindowSize) {
         // bulk read of data from global memory
         NTuple<kOrderJoinWindowSize, OrdersRow> data;
@@ -185,6 +187,7 @@ bool SubmitQuery12(queue& q, Database& dbinfo, DBDate low_date,
       DBDecimal low_line_count1_local = 0, low_line_count2_local = 0;
       bool done;
 
+      [[intel::initiation_interval(1)]]
       do {
         // get joined row from pipe
         bool pipe_valid;

--- a/DirectProgramming/DPC++FPGA/ReferenceDesigns/db/src/query9/query9_kernel.cpp
+++ b/DirectProgramming/DPC++FPGA/ReferenceDesigns/db/src/query9/query9_kernel.cpp
@@ -559,7 +559,7 @@ bool SubmitQuery9(queue& q, Database& dbinfo, std::string colour,
           //    A) Apply the [[intel::speculated_iterations(0)]] attribute
           //    B) Explicitly bound the loop iterations
           // For an explanation why, see the optimize_inner_loops tutorial.
-          [[intel::speculated_iterations(0)]]
+          [[intel::initiation_interval(1), intel::speculated_iterations(0)]]
           for (char i = 0; i < valid_count && 
                 i < kLineItemOrdersJoinWinSize; i++) {
             UnrolledLoop<0, kLineItemOrdersJoinWinSize>([&](auto j) {

--- a/DirectProgramming/DPC++FPGA/ReferenceDesigns/db/src/query9/query9_kernel.cpp
+++ b/DirectProgramming/DPC++FPGA/ReferenceDesigns/db/src/query9/query9_kernel.cpp
@@ -513,6 +513,7 @@ bool SubmitQuery9(queue& q, Database& dbinfo, std::string colour,
       bool done = false;
       size_t num_rows = 0;
 
+      [[intel::initiation_interval(1)]]
       do {
         // get data from upstream
         bool valid;


### PR DESCRIPTION
# Existing Sample Changes
## Description
Small change that forces II=1 to all main processing loops. This works around a regression from a recent xmain integration AND is more clear since we know we want II=1 on all of these loops.

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
- [X] Command Line

