### PR TITLE
Use C++17 for LiDAR-Object-Detection Sample

### DIFF
--- a/AI-and-Analytics/End-to-end-Workloads/LidarObjectDetection-PointPillars/CMakeLists.txt
+++ b/AI-and-Analytics/End-to-end-Workloads/LidarObjectDetection-PointPillars/CMakeLists.txt
@@ -3,11 +3,11 @@ cmake_minimum_required(VERSION 3.5)
 include(GNUInstallDirs)
 include(CMakePackageConfigHelpers)
 
-project(LidarObjectDetection-PointPillars VERSION 1.0.0)
-
 set(CXX_STANDARD_REQUIRED ON)
-set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_COMPILER dpcpp)
+
+project(LidarObjectDetection-PointPillars VERSION 1.0.0)
 
 ############################################################
 # gather all dependencies

--- a/AI-and-Analytics/End-to-end-Workloads/LidarObjectDetection-PointPillars/src/pointpillars/nms.cpp
+++ b/AI-and-Analytics/End-to-end-Workloads/LidarObjectDetection-PointPillars/src/pointpillars/nms.cpp
@@ -14,6 +14,7 @@
 #include "pointpillars/nms.hpp"
 #include <CL/sycl.hpp>
 #include <algorithm>
+#include <numeric>
 #include <set>
 #include <vector>
 #include "devicemanager/devicemanager.hpp"

--- a/AI-and-Analytics/End-to-end-Workloads/LidarObjectDetection-PointPillars/src/pointpillars/postprocess.cpp
+++ b/AI-and-Analytics/End-to-end-Workloads/LidarObjectDetection-PointPillars/src/pointpillars/postprocess.cpp
@@ -15,12 +15,12 @@
  * limitations under the License.
  */
 
-#include "pointpillars/postprocess.hpp"
-#include <CL/sycl.hpp>
-#include <algorithm>
 #include <oneapi/dpl/algorithm>
 #include <oneapi/dpl/execution>
 #include <oneapi/dpl/iterator>
+#include <CL/sycl.hpp>
+#include <algorithm>
+#include "pointpillars/postprocess.hpp"   // the oneapi headers have to be included at first here!
 #include "devicemanager/devicemanager.hpp"
 
 namespace pointpillars {


### PR DESCRIPTION
- include missing <numeric> header in NMS
- tested with oneAPI 2021.2
- changed include order in postprocess.cpp to ensure proper TBB
  handling with C++17