### PR TITLE
Added in activate tensorflow step

### DIFF
--- a/AI-and-Analytics/Getting-Started-Samples/IntelTensorFlow_GettingStarted/README.md
+++ b/AI-and-Analytics/Getting-Started-Samples/IntelTensorFlow_GettingStarted/README.md
@@ -121,8 +121,8 @@ dnnl_verbose,exec,cpu,convolution,jit:avx512_common,forward_training,src_f32::bl
 ```
 Please see the [DNNL Developer's Guide](https://intel.github.io/mkl-dnn/dev_guide_verbose.html) for more details on the verbose log. 
 
-### Running Samples In DevCloud (Optional)
-#### Run TensorFlow_HelloWorld in Jupyter Lab
+## Running Samples In DevCloud (Optional)
+### Run TensorFlow_HelloWorld in Jupyter Lab
 1.	Open [Intel DevCloud](https://software.intel.com/content/www/us/en/develop/tools/devcloud.html).
 2.	In the upper right corner, click Sign In.
 3.	Log in with your Intel account username and password.


### PR DESCRIPTION
The ''source activate tensorflow'' step was missing from the instructions to "run from a local terminal."

# Existing Sample Changes
## Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes Issue# 

## External Dependencies

None
## Type of change

Please delete options that are not relevant. Add a 'X' to the one that is applicable. 


## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x ] Command Line
- [ ] oneapi-cli
- [ ] Visual Studio
- [ ] Eclipse IDE
- [ ] VSCode
- [ ] When compiling the compliler flag "-Wall -Wformat-security -Werror=format-security" was used

**_Delete this line and everything below if this is not a PR for a new code sample_**
