### PR TITLE
ONSAM-1393: Correct "categories" attribute for proper display in the samples browsers.

### DIFF
--- a/AI-and-Analytics/End-to-end-Workloads/LidarObjectDetection-PointPillars/sample.json
+++ b/AI-and-Analytics/End-to-end-Workloads/LidarObjectDetection-PointPillars/sample.json
@@ -1,8 +1,8 @@
 {
     "guid" : "314B4C1D-07A0-4527-A9FA-9F87ED9622D7",
     "name": "Lidar Object Detection using PointPillars",
-    "categories": ["Toolkit/AI-and-Analytics/End-to-end-Workloads/LidarObjectDetection-PointPillars"],
-    "description": "This sample does object detection on LIDAR's point cloud provided as input. It is Intel® oneAPI implementation based on pape' PointPillars: Fast Encoders for Object Detection from Point Clouds'",
+    "categories": ["Toolkit/oneAPI Direct Programming/DPC++/Ai and Analytics"],
+    "description": "Object detection using a LIDAR point cloud as input. This implementation is based on the paper 'PointPillars: Fast Encoders for Object Detection from Point Clouds'",
     "toolchain": ["dpcpp"],
     "languages": [ { "cpp": {} } ],
     "targetDevice": ["CPU", "GPU"],

--- a/AI-and-Analytics/End-to-end-Workloads/README.md
+++ b/AI-and-Analytics/End-to-end-Workloads/README.md
@@ -1,29 +1,38 @@
 # End-to-end samples for Intel® oneAPI AI Analytics Toolkit (AI Kit)
 
-The Intel® oneAPI AI Analytics Toolkit (AI Kit) gives data scientists, AI developers, and researchers familiar Python* tools and frameworks to accelerate end-to-end data science and analytics pipelines on Intel® architectures. The components are built using oneAPI libraries for low-level compute optimizations. This toolkit maximizes performance from preprocessing through machine learning, and provides interoperability for efficient model development.
+The Intel® oneAPI AI Analytics Toolkit (AI Kit) gives data scientists, AI
+developers, and researchers familiar Python* tools and frameworks to
+accelerate end-to-end data science and analytics pipelines on Intel®
+architectures. The components are built using oneAPI libraries for low-level
+compute optimizations. This toolkit maximizes performance from preprocessing
+through machine learning, and provides interoperability for efficient model
+development.
 
-You can find more information at [ AI Kit](https://software.intel.com/content/www/us/en/develop/tools/oneapi/ai-analytics-toolkit.html).
-
-Users could learn how to make use of AI Kit for their end-to-end workloads.
+You can find more information at
+[AI Kit](https://software.intel.com/content/www/us/en/develop/tools/oneapi/ai-analytics-toolkit.html).
 
 ## License
 Code samples are licensed under the MIT license. See
-[License.txt](https://github.com/oneapi-src/oneAPI-samples/blob/master/License.txt) for details.
+[License.txt](https://github.com/oneapi-src/oneAPI-samples/blob/master/License.txt)
+for details.
 
-Third party program Licenses can be found here: [third-party-programs.txt](https://github.com/oneapi-src/oneAPI-samples/blob/master/third-party-programs.txt)
+Third party program Licenses can be found here:
+[third-party-programs.txt](https://github.com/oneapi-src/oneAPI-samples/blob/master/third-party-programs.txt)
 
 # End-to-end Samples
 
-| Components      | Folder                                             | Description
-| --------- | ------------------------------------------------ | -
-| Modin, oneDAL, IDP | [Census](Census)               | Use Intel® Distribution of Modin to ingest and process U.S. census data from 1970 to 2010 in order to build a ridge regression based model to find the relation between education and the total income earned in the US.
-| OpenVino | [LidarObjectDetection-PointPillars](LidarObjectDetection-PointPillars) | Performs 3D object detection and classification using data (point cloud) from a LIDAR sensor as input.
+| Components         | Folder                 | Description
+| ------------------ | ---------------------- | -----------
+| Modin, oneDAL, IDP | [Census](Census)       | Use Intel® Distribution of Modin to ingest and process U.S. census data from 1970 to 2010 in order to build a ridge regression based model to find the relation between education and the total income earned in the US.
+| OpenVino           | [LidarObjectDetection-PointPillars](LidarObjectDetection-PointPillars) | Performs 3D object detection and classification using point cloud data from a LIDAR sensor as input.
 
-# Using Samples in Intel oneAPI DevCloud
+# Using Samples in the Intel oneAPI DevCloud
 
-You can use AI Kit samples in
-the [Intel oneAPI DevCloud](https://devcloud.intel.com/oneapi/get-started/) environment in the following ways:
-* Log in to a DevCloud system via SSH and
-  * use `git clone` to get a full copy of samples repository, or
-  * use the `oneapi-cli` tool to download specific sample.
+You can use AI Kit samples in the
+[Intel oneAPI DevCloud](https://devcloud.intel.com/oneapi/get-started/)
+environment using the following methods:
+
+* Login to a DevCloud system using SSH
+* use `git clone` to get a full copy of the oneAPI samples repository
+* or use the `oneapi-cli` tool to download this specific sample
 * Launch a JupyterLab server and run Jupyter Notebooks from your web browser.

--- a/DirectProgramming/C++/Jupyter/OpenMP-offload-training/README.md
+++ b/DirectProgramming/C++/Jupyter/OpenMP-offload-training/README.md
@@ -1,4 +1,4 @@
-# oneAPI OpenMP Offload training Jupyter notebooks
+# oneAPI OpenMP Offload Training Jupyter Notebooks
 
 The the content of this repo is a collection of Jupyter notebooks that were
 developed to teach OpenMP Offload.

--- a/DirectProgramming/C++/Jupyter/OpenMP-offload-training/README.md
+++ b/DirectProgramming/C++/Jupyter/OpenMP-offload-training/README.md
@@ -1,25 +1,31 @@
-# oneAPI OpenMP Offload training Jupyter notebooks 
+# oneAPI OpenMP Offload training Jupyter notebooks
 
-The the content of this repo is a collection of Jupyter notebooks that were developed to teach OpenMP Offload.
+The the content of this repo is a collection of Jupyter notebooks that were
+developed to teach OpenMP Offload.
 
-The Jupyter notebooks are tested and can be run on Intel Devcloud.
-Below are the steps to access these Jupyter notebooks on Intel Devcloud
-1. Register to Intel devcloud 
-    https://intelsoftwaresites.secure.force.com/devcloud/oneapi
-2. Go to the "Terminal" in the Intel Devcloud
-3. Type in the below command to download the oneAPI-essentials series and OpenMP offload notebooks into your devcloud account
-    /data/oneapi_workshop/get_jupyter_notebooks.sh
+The Jupyter notebooks are tested and can be run on the Intel Devcloud. Below
+are the steps to access these Jupyter notebooks on the Intel Devcloud:
 
-| Optimized for                       | Description
-|:---                               |:---
-| OS                                | Linux*
-| Hardware                          | Skylake with GEN9 or newer
-| Software                          | Intel&reg; C++ Compiler
-| License                           | Samples licensed under MIT license.
-| What you will learn               | How to offload the computation to GPU using OpenMP with the Intel&reg; C++ Compiler
-| Time to complete                  | 2 Hours
+1. Register with the Intel Devcloud at
+   https://intelsoftwaresites.secure.force.com/devcloud/oneapi
+
+2. SSH into the Intel Devcloud "terminal"
+
+3. Type the following command to download the oneAPI-essentials series of
+   Jupyter notebooks and OpenMP offload notebooks into your devcloud account
+   `/data/oneapi_workshop/get_jupyter_notebooks.sh`
+
+| Optimized for         | Description
+|:---                   |:---
+| OS                    | Linux*
+| Hardware              | Skylake with GEN9 or newer
+| Software              | Intel&reg; C++ Compiler
+| License               | Samples licensed under MIT license.
+| What you will learn   | How to offload the computation to GPU using OpenMP with the Intel&reg; C++ Compiler
+| Time to complete      | 2 Hours
 
 ## Running the Jupyter Notebooks
+
 1. Open "OpenMP Welcome.ipynb" with JupyterLab
 2. Start the modules of interest
 3. Follow the instructions in each notebook and execute cells when instructed.

--- a/DirectProgramming/C++/Jupyter/OpenMP-offload-training/sample.json
+++ b/DirectProgramming/C++/Jupyter/OpenMP-offload-training/sample.json
@@ -1,7 +1,7 @@
 {
   "guid": "2D2AAD9B-29BF-4380-B5E7-575CDECCF686",
   "name": "OpenMP Offload C++ Tutorials",
-  "categories": [ "Toolkit/DirectProgramming/C++/Jupyter/OpenMP-offload-training/" ],
+  "categories": [ "Toolkit/oneAPI Direct Programming/C++/Tutorials Jupyter Notebooks" ],
   "description": "C++ OpenMP Offload Basics using Jupyter Notebooks",
   "toolchain": [ "dpcpp"],
   "languages": [{"cpp":{}}],

--- a/DirectProgramming/C++/Jupyter/OpenMP-offload-training/sample.json
+++ b/DirectProgramming/C++/Jupyter/OpenMP-offload-training/sample.json
@@ -3,7 +3,7 @@
   "name": "OpenMP Offload C++ Tutorials",
   "categories": [ "Toolkit/oneAPI Direct Programming/C++/Tutorials Jupyter Notebooks" ],
   "description": "C++ OpenMP Offload Basics using Jupyter Notebooks",
-  "toolchain": [ "dpcpp"],
+  "toolchain": [ "icx"],
   "languages": [{"cpp":{}}],
   "os": [ "linux" ],
   "builder": [ "make" ],

--- a/DirectProgramming/DPC++/Jupyter/oneapi-essentials-training/README.md
+++ b/DirectProgramming/DPC++/Jupyter/oneapi-essentials-training/README.md
@@ -1,29 +1,69 @@
-# oneAPI training Jupyter notebooks 
+# oneAPI training Jupyter notebooks
 
-The purpose of this repo is to be the central aggregation, curation, and distribution point for Juypter notebooks that are developed in support of oneAPI training programs (e.g., oneAPI Essentials Series). 
+The purpose of this repo is to be the central aggregation, curation, and
+distribution point for Juypter notebooks that are developed in support of
+oneAPI training programs (e.g., oneAPI Essentials Series).
 
-The Jupyter notebooks are tested and can be run on Intel Devcloud.
-Below are the steps to access these Jupyter notebooks on Intel Devcloud
-1. Register on [Intel Devcloud](https://intelsoftwaresites.secure.force.com/devcloud/oneapi)
-2. Go to the "Terminal" in the Intel Devcloud
-3. Type in the below command to download the oneAPI-essentials series notebooks into your Devcloud account
-    /data/oneapi_workshop/get_jupyter_notebooks.sh
-    
-## License  
-Code samples are licensed under the MIT license. See [License.txt](https://github.com/oneapi-src/oneAPI-samples/blob/master/License.txt) for details.
+The Jupyter notebooks are tested and can be run on the Intel Devcloud. Below
+are the steps to access these Jupyter notebooks on the Intel Devcloud:
 
-Third party program Licenses can be found here: [third-party-programs.txt](https://github.com/oneapi-src/oneAPI-samples/blob/master/third-party-programs.txt)
+1. Register with the Intel Devcloud at
+   https://intelsoftwaresites.secure.force.com/devcloud/oneapi
 
-# The organization of the Jupyter notebook directories is a follows:
+2. SSH into the Intel Devcloud "terminal"
 
-| Notebook Name | Owner | Description |
-|---|---|---|
-|[oneAPI_Intro](01_oneAPI_Intro)|Praveen.K.Kundurthy@intel.com| + Introduction and Motivation for oneAPI and DPC++.<br>+ DPC++ __Hello World__<br>+ Compiling DPC++ and __DevCloud__ Usage<br>+ ___Lab Excercise___: Vector Increment to Vector Add |
-|[DPCPP_Program_Structure](02_DPCPP_Program_Structure)|Praveen.K.Kundurthy@intel.com| + __Classes__ - device, device_selector, queue, basic kernels and ND-Range kernels, Buffers-Accessor memory model<br>+ DPC++ __Code Anotomy__<br>+ Implicit __Dependency__ with Accessors, __Synchronization__ with Host Accessor and Buffer Destruction<br>+ Creating __Custom__ Device Selector<br>+ ___Lab Exercise___: Complex Multiplication |
-|[DPCPP_Unified_Shared_Memory](03_DPCPP_Unified_Shared_Memory)|Rakshith.Krishnappa@intel.com| + What is Unified Shared Memory(USM) and Motivation<br>+ __Implicit and Explicit USM__ code example<br>+ Handling __data dependency__ using depends_on() and ordered queues<br>+ ___Lab Exercise___: Solving data dependency with USM |
-|[DPCPP_Sub_Groups](04_DPCPP_Sub_Groups)|Rakshith.Krishnappa@intel.com| + What is Sub-Goups and Motivation<br>+ Quering for __sub-group info__<br>+ Sub-group __collectives__<br>+ Sub-group __shuffle operations__ |
-|[Intel_Advisor](05_Intel_Advisor)|Praveen.K.Kundurthy@intel.com| + __Offload Advisor__ Tool usage and command-line options<br>+ __Roofline Analysis__ and command-line options |
-|[Intel_VTune_Profiler](06_Intel_VTune_Profiler)|Rakshith.Krishnappa@intel.com| + Intel VTune Profiler usage __in Intel DevCloud__ environment using command-line options<br>+ ___Lab Excercise___: VTune Profiling by collecting __gpu_hotspots__ for [iso3dfd](https://github.com/intel/HPCKit-code-samples/tree/master/Compiler/iso3dfd_dpcpp) sample application. |
-|[Intel oneAPI DPC++ Library (oneDPL)](07_DPCPP_Library)|Praveen.K.Kundurthy@intel.com| + Introduction to DPC++ Library<br>+ ___Lab Excercise___: Gamma Correction with oneDPL |
+3. Type the following command to download the oneAPI-essentials series of
+   Jupyter notebooks and OpenMP offload notebooks into your devcloud account
+   `/data/oneapi_workshop/get_jupyter_notebooks.sh`
 
+## License
 
+Code samples are licensed under the MIT license. See
+[License.txt](https://github.com/oneapi-src/oneAPI-samples/blob/master/License.txt)
+for details.
+
+Third party program Licenses can be found here:
+[third-party-programs.txt](https://github.com/oneapi-src/oneAPI-samples/blob/master/third-party-programs.txt)
+
+# Organization of the Jupyter Notebook Directories
+
+Notebook Name: Owner
+* Descriptions
+*
+
+[oneAPI_Intro](01_oneAPI_Intro): Praveen.K.Kundurthy@intel.com
+* Introduction and Motivation for oneAPI and DPC++
+* DPC++ __Hello World__
+* Compiling DPC++ and __DevCloud__ Usage
+* _Lab Excercise_: Vector Increment to Vector Add
+
+[DPCPP_Program_Structure](02_DPCPP_Program_Structure): Praveen.K.Kundurthy@intel.com
+* __Classes__ - device, device_selector, queue, basic kernels and ND-Range kernels, Buffers-Accessor memory model
+* DPC++ __Code Anotomy__
+* Implicit __Dependency__ with Accessors, __Synchronization__ with Host Accessor and Buffer Destruction
+* Creating __Custom__ Device Selector
+* _Lab Exercise_: Complex Multiplication
+
+[DPCPP_Unified_Shared_Memory](03_DPCPP_Unified_Shared_Memory): Rakshith.Krishnappa@intel.com
+* What is Unified Shared Memory(USM) and Motivation
+* __Implicit and Explicit USM__ code example
+* Handling __data dependency__ using depends_on() and ordered queues
+* _Lab Exercise_: Solving data dependency with USM
+
+[DPCPP_Sub_Groups](04_DPCPP_Sub_Groups): Rakshith.Krishnappa@intel.com
+* What is Sub-Goups and Motivation
+* Quering for __sub-group info__
+* Sub-group __collectives__
+* Sub-group __shuffle operations__
+
+[Intel_Advisor](05_Intel_Advisor): Praveen.K.Kundurthy@intel.com
+* __Offload Advisor__ Tool usage and command-line options
+* __Roofline Analysis__ and command-line options
+
+[Intel_VTune_Profiler](06_Intel_VTune_Profiler): Rakshith.Krishnappa@intel.com
+* Intel VTune Profiler usage __in Intel DevCloud__ environment using command-line options
+* _Lab Excercise_: VTune Profiling by collecting __gpu_hotspots__ for [iso3dfd](https://github.com/intel/HPCKit-code-samples/tree/master/Compiler/iso3dfd_dpcpp) sample application
+
+[Intel oneAPI DPC++ Library (oneDPL)](07_DPCPP_Library): Praveen.K.Kundurthy@intel.com
+* Introduction to DPC++ Library
+* _Lab Excercise_: Gamma Correction with oneDPL

--- a/DirectProgramming/DPC++/Jupyter/oneapi-essentials-training/sample.json
+++ b/DirectProgramming/DPC++/Jupyter/oneapi-essentials-training/sample.json
@@ -1,7 +1,7 @@
 {
   "guid": "f51eea84-5732-4425-a530-113448519667",
   "name": "DPC++ Essentials Tutorials",
-  "categories": [ "Toolkit/DirectProgramming/DPC++/Jupyter/oneapi-essentials-training/" ],
+  "categories": [ "Toolkit/oneAPI Direct Programming/DPC++/Tutorials Jupyter Notebooks" ],
   "description": "DPC++ Essentials Tutorials using Jupyter Notebooks",
   "toolchain": [ "dpcpp" ],
   "languages": [ { "cpp": { "properties": { "projectOptions": [ { "projectType": "makefile" } ] } } } ],

--- a/DirectProgramming/DPC++/OpenCLInterop/README.md
+++ b/DirectProgramming/DPC++/OpenCLInterop/README.md
@@ -1,47 +1,69 @@
 # DPC++ OpenCL&trade; Interoperability Example
 
-This examples demonstrate how DPC++ can interact with OpenCL&trade;. This code shample will show  programmers to incrementally migrate from
-OpenCL to DPC++. Two usage scenarios are shown. First is a DPC++ program that compiles and runs an OpenCL kernel. The second program converts OpenCL objects to DPC++.
+This examples demonstrate how DPC++ can interact with OpenCL&trade;. This code
+sample illustrates how to incrementally migrate from OpenCL to DPC++. Two
+usage scenarios are shown: the first is a DPC++ program that compiles and runs
+an OpenCL kernel; the second program converts OpenCL objects to DPC++.
 
-For more information on migrating from OpenCL to DPC++, see [Migrating OpenCL Designs to DPC++](https://software.intel.com/content/www/us/en/develop/articles/migrating-opencl-designs-to-dpcpp.html).
+For more information on migrating from OpenCL to DPC++, see
+[Migrating OpenCL Designs to DPC++](https://software.intel.com/content/www/us/en/develop/articles/migrating-opencl-designs-to-dpcpp.html).
 
-| Optimized for                       | Description
-|:---                               |:---
-| OS                                | Linux* Ubuntu* 18.04, 20
-| Hardware                          | Skylake or newer
-| Software                          | Intel&reg; oneAPI DPC++/C++ Compiler, Intel Devcloud
-| What you will learn               | How OpenCL code can interact with DPC++ with the Intel&reg; oneAPI DPC++/C++ Compiler
-| Time to complete                  | 10 minutes
+| Optimized for        | Description
+|:---                  |:---
+| OS                   | Linux* Ubuntu* 18.04, 20
+| Hardware             | Skylake or newer
+| Software             | Intel&reg; oneAPI DPC++/C++ Compiler, Intel Devcloud
+| What you will learn  | How OpenCL code can interact with DPC++ with the Intel&reg; oneAPI DPC++/C++ Compiler
+| Time to complete     | 10 minutes
 
 ## Purpose
-For users migrating from OpenCL to DPC++, interoperability allows the migration to take place piecemeal so that the migration of all kernels does not have to occur simultaneously.
- 
+
+For users migrating from OpenCL to DPC++, interoperability allows the
+migration to take place piecemeal. It is not necessary for migration of all
+existing OpenCL kernels occur simultaneously.
+
 ## Key Implementation Details
-The common OpenCL to DPC++ conversion scenarios are covered.
-1. In dpcpp_with_opencl_kernel.dp.cpp, the DPC++ program compiles and runs an OpenCL kernel. (For this, OpenCL must be set as the backend and not Level 0, the environment variable SYCL_DEVICE_FILTER=OPENCL is used)
-2. In dpcpp_with_opencl_objects.dp.cpp, the program converts OpenCL objects (Memory Objects, Platform, Context, Program, Kernel) to DPC++ and execute the program. 
 
-## License  
+Two common OpenCL to DPC++ conversion scenarios are demonstrated.
+
+1. In `dpcpp_with_opencl_kernel.dp.cpp`, the DPC++ program compiles and runs
+   an OpenCL kernel. (For this, OpenCL must be set as the backend and not Level
+   0, the environment variable SYCL_DEVICE_FILTER=OPENCL is used).
+
+2. In `dpcpp_with_opencl_objects.dp.cpp`, the program converts OpenCL objects
+   (Memory Objects, Platform, Context, Program, Kernel) to DPC++ and execute the
+   program.
+
+## License
+
 Code samples are licensed under the MIT license. See
-[License.txt](https://github.com/oneapi-src/oneAPI-samples/blob/master/License.txt) for details.
+[License.txt](https://github.com/oneapi-src/oneAPI-samples/blob/master/License.txt)
+for details.
 
-Third party program Licenses can be found here: [third-party-programs.txt](https://github.com/oneapi-src/oneAPI-samples/blob/master/third-party-programs.txt)
+Third party program Licenses can be found here:
+[third-party-programs.txt](https://github.com/oneapi-src/oneAPI-samples/blob/master/third-party-programs.txt)
 
 ## Building the Program
 
-> Note: if you have not already done so, set up your CLI 
-> environment by sourcing  the setvars script located in 
-> the root of your oneAPI installation. 
+> Note: if you have not already done so, set up your CLI
+> environment by sourcing  the setvars script located in
+> the root of your oneAPI installation.
 >
-> Linux Sudo: . /opt/intel/oneapi/setvars.sh  
-> Linux User: . ~/intel/oneapi/setvars.sh  
+> Linux sudo: . /opt/intel/oneapi/setvars.sh
+> Linux user: . ~/intel/oneapi/setvars.sh
 > Windows: C:\Program Files(x86)\Intel\oneAPI\setvars.bat
 
 ### Running Samples In DevCloud
-If running a sample in the Intel DevCloud, remember that you must specify the compute node (CPU, GPU, FPGA) and whether to run in batch or interactive mode. For more information, see the Intel® oneAPI Base Toolkit Get Started Guide (https://devcloud.intel.com/oneapi/get_started/baseToolkitSamples/)
+
+If running a sample in the Intel DevCloud, remember that you must specify the
+compute node (CPU, GPU, FPGA) and whether to run in batch or interactive mode.
+For more information, see the Intel® oneAPI Base Toolkit Get Started Guide
+(https://devcloud.intel.com/oneapi/get_started/baseToolkitSamples/)
 
 ### On a Linux* System
+
 Perform the following steps:
+
 1. Build the program
 	```
     $ mkdir build
@@ -61,7 +83,7 @@ Perform the following steps:
     make clean
     ```
 
-### Example of Output
+### Output Example
 ```
 Device: Intel(R) HD Graphics 630 [0x5912]
 PASSED!

--- a/DirectProgramming/DPC++/OpenCLInterop/sample.json
+++ b/DirectProgramming/DPC++/OpenCLInterop/sample.json
@@ -1,8 +1,8 @@
 {
   "guid": "E3DE34BF-E5B6-44AF-8722-B2A5A6BE8D57",
   "name": "DPC++ OpenCL Interoperability Samples",
-  "categories": [ "Toolkit/DirectProgramming/DPC++/opencl_interop/" ],
-  "description": "Samples showing DPC++ OpenCL Interoperability",
+  "categories": [ "Toolkit/oneAPI Direct Programming/DPC++/OpenCL Interoperability" ],
+  "description": "Samples showing DPC++ and OpenCL Interoperability",
   "toolchain": [ "dpcpp" ],
   "languages": [ { "cpp": { "properties": { "projectOptions": [ { "projectType": "makefile" } ] } } } ],
   "os": [ "linux" ],

--- a/DirectProgramming/Fortran/Jupyter/OpenMP-offload-training/README.md
+++ b/DirectProgramming/Fortran/Jupyter/OpenMP-offload-training/README.md
@@ -1,25 +1,31 @@
-# oneAPI OpenMP Offload training Jupyter notebooks 
+# oneAPI OpenMP Offload Training Jupyter Notebooks
 
-The the content of this repo is a collection of Jupyter notebooks that were developed to teach OpenMP Offload.
+The the content of this repo is a collection of Jupyter notebooks that were
+developed to teach OpenMP Offload.
 
-The Jupyter notebooks are tested and can be run on Intel Devcloud.
-Below are the steps to access these Jupyter notebooks on Intel Devcloud
-1. Register to Intel devcloud 
-    https://intelsoftwaresites.secure.force.com/devcloud/oneapi
-2. Go to the "Terminal" in the Intel Devcloud
-3. Type in the below command to download the oneAPI-essentials series and OpenMP offload notebooks into your devcloud account
-    /data/oneapi_workshop/get_jupyter_notebooks.sh
+The Jupyter notebooks are tested and can be run on the Intel Devcloud. Below
+are the steps to access these Jupyter notebooks on the Intel Devcloud:
 
-| Optimized for                       | Description
-|:---                               |:---
-| OS                                | Linux*
-| Hardware                          | Skylake with GEN9 or newer
-| Software                          | Intel&reg; Fortran Compiler
-| License                           | Samples licensed under MIT license.
-| What you will learn               | How to offload the computation to GPU using OpenMP with the Intel&reg; Fortran Compiler
-| Time to complete                  | 2 Hours
+1. Register with the Intel Devcloud at
+   https://intelsoftwaresites.secure.force.com/devcloud/oneapi
+
+2. SSH into the Intel Devcloud "terminal"
+
+3. Type the following command to download the oneAPI-essentials series of
+   Jupyter notebooks and OpenMP offload notebooks into your devcloud account
+   `/data/oneapi_workshop/get_jupyter_notebooks.sh`
+
+| Optimized for         | Description
+|:---                   |:---
+| OS                    | Linux*
+| Hardware              | Skylake with GEN9 or newer
+| Software              | Intel&reg; Fortran Compiler
+| License               | Samples licensed under MIT license.
+| What you will learn   | How to offload the computation to GPU using OpenMP with the Intel&reg; Fortran Compiler
+| Time to complete      | 2 Hours
 
 ## Running the Jupyter Notebooks
+
 1. Open "OpenMP Welcome.ipynb" with JupyterLab
 2. Start the modules of interest
 3. Follow the instructions in each notebook and execute cells when instructed.

--- a/DirectProgramming/Fortran/Jupyter/OpenMP-offload-training/sample.json
+++ b/DirectProgramming/Fortran/Jupyter/OpenMP-offload-training/sample.json
@@ -1,8 +1,9 @@
 {
   "guid": "D60DAB68-B9CC-4ECE-B10D-03F7B556171E",
   "name": "OpenMP Offload Fortran Tutorials",
-  "categories": [ "Toolkit/DirectProgramming/Fortran/Jupyter/OpenMP-offload-training/" ],
+  "categories": [ "oneAPI Direct Programming/Fortran/Tutorials Jupyter Notebooks" ],
   "description": "Fortran OpenMP Offload Basics using Jupyter Notebooks",
+  "toolchain": [ "ifx"],
   "languages": [ { "fortran": {} } ],
   "os": [ "linux" ],
   "builder": [ "make" ],

--- a/DirectProgramming/Fortran/Jupyter/OpenMP-offload-training/sample.json
+++ b/DirectProgramming/Fortran/Jupyter/OpenMP-offload-training/sample.json
@@ -1,7 +1,7 @@
 {
   "guid": "D60DAB68-B9CC-4ECE-B10D-03F7B556171E",
   "name": "OpenMP Offload Fortran Tutorials",
-  "categories": [ "oneAPI Direct Programming/Fortran/Tutorials Jupyter Notebooks" ],
+  "categories": [ "Toolkit/oneAPI Direct Programming/Fortran/Tutorials Jupyter Notebooks" ],
   "description": "Fortran OpenMP Offload Basics using Jupyter Notebooks",
   "toolchain": [ "ifx"],
   "languages": [ { "fortran": {} } ],


### PR DESCRIPTION
# Existing Sample Changes
## Description

The changes required are part of the `sample.json` file, and do not modify the actual samples in any way. Also cleaned up the associated README.md files for improved readability when being viewed as a text file, as opposed via a Markdown viewer.

Fixes Issue# ONSAM-1393

## External Dependencies

N/A

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] Implement fixes for ONSAM Jiras

## How Has This Been Tested?

View the sample tree in the `oneapi-cli` browser. Best to use `oneapi-cli --ignore-os` in order to see all available samples, regardless of your host OS.

- [NA] Command Line
- [X] oneapi-cli
- [ ] Visual Studio
- [ ] Eclipse IDE
- [X] VSCode
- [NA ] When compiling the compliler flag "-Wall -Wformat-security -Werror=format-security" was used