### PR TITLE
Nbody Readme fix typo

### DIFF
--- a/DirectProgramming/DPC++/N-BodyMethods/Nbody/README.md
+++ b/DirectProgramming/DPC++/N-BodyMethods/Nbody/README.md
@@ -96,7 +96,7 @@ Below are the default parameters:
     ===============================
     Built target run
 
-### Running the Hidden Markov Model sample in the DevCloud<a name="run-nbody-on-devcloud"></a>
+### Running the Nbody sample in the DevCloud<a name="run-nbody-on-devcloud"></a>
 1.  Open a terminal on your Linux system.
 2.	Log in to DevCloud.
 ```
@@ -107,7 +107,7 @@ ssh devcloud
 git clone https://github.com/oneapi-src/oneAPI-samples.git
 ```
 
-4. Change directories to the  Hidden Markov Model sample directory.
+4. Change directories to the Nbody sample directory.
 ```
 cd ~/oneAPI-samples/DirectProgramming/DPC++/N-bodyMethods/Nbody
 ```


### PR DESCRIPTION
Fixed two typos in the Nbody readme.

# Existing Sample Changes
## Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes Issue# 

## External Dependencies

List any external dependencies created as a result of this change.

## Type of change

Please delete options that are not relevant. Add a 'X' to the one that is applicable. 

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Implement fixes for ONSAM Jiras
- [x ] Documentation

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Command Line
- [ ] oneapi-cli
- [ ] Visual Studio
- [ ] Eclipse IDE
- [ x] VSCode
- [ ] When compiling the compliler flag "-Wall -Wformat-security -Werror=format-security" was used

