### PR TITLE
Update depricated atomic_fence to sycl::ONEAPI::atomic_fence in mvdr_beamforming FPGA design

### DIFF
--- a/DirectProgramming/DPC++FPGA/ReferenceDesigns/mvdr_beamforming/src/SteeringVectorGenerator.hpp
+++ b/DirectProgramming/DPC++FPGA/ReferenceDesigns/mvdr_beamforming/src/SteeringVectorGenerator.hpp
@@ -72,8 +72,8 @@ event SubmitSteeringVectorGeneratorKernel(queue& q) {
         // The fence here ensures that all writes to the SteeringVectorsOutPipe
         // above will occur before the write to the pipe below.  Without the
         // fence, the compiler could re-order these pipe writes.
-        atomic_fence(sycl::ONEAPI::memory_order::acq_rel,
-                     sycl::ONEAPI::memory_scope::device);
+        sycl::ONEAPI::atomic_fence(sycl::ONEAPI::memory_order::acq_rel,
+                                   sycl::ONEAPI::memory_scope::device);
         UpdateSteeringOutPipe::write(true);
 
       }  // end of while( 1 )


### PR DESCRIPTION
## Description

replace atomic_fence with sycl::ONEAPI::atomic_fence

Fixes Issue# 
ONSAM-1396

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Implement fixes for ONSAM Jiras

## How Has This Been Tested?

- [x] Command Line
- [ ] oneapi-cli
- [ ] Visual Studio
- [ ] Eclipse IDE
- [ ] VSCode
- [ ] When compiling the compliler flag "-Wall -Wformat-security -Werror=format-security" was used

