### PR TITLE
GUIDS repairs

### DIFF
--- a/DirectProgramming/C++/ParallelPatterns/openmp_reduction/sample.json
+++ b/DirectProgramming/C++/ParallelPatterns/openmp_reduction/sample.json
@@ -1,5 +1,5 @@
  {
- 	"guid": "ECF6C8EB-753B-4107-AF64-60662CE41726",
+ 	"guid": "c52eb5b5-5260-47d3-aded-15c5b27779d5",
  	"name": "OpenMP* Reduction",
  	"categories": ["Toolkit/oneAPI Direct Programming/C++/Parallel Patterns"],
  	"description": "This sample models OpenMP* (OMP) Reduction in different ways showing capability of Intel® oneAPI",

--- a/DirectProgramming/DPC++FPGA/ReferenceDesigns/crr/sample.json
+++ b/DirectProgramming/DPC++FPGA/ReferenceDesigns/crr/sample.json
@@ -1,5 +1,5 @@
 {
-  "guid": "D725E06E-0ECE-44F8-910D-AD1A8C89ED89",
+  "guid": "748eb906-309f-469b-95c9-5258006c7587",
   "name": "CRR",
   "categories": ["Toolkit/oneAPI Direct Programming/DPC++ FPGA/Reference Designs"],
   "description": "This sample shows a Binomial Tree Model for Option Pricing using a FPGA-optimized reference design of the Cox-Ross-Rubinstein (CRR) Binomial Tree Model with Greeks for American exercise options",

--- a/DirectProgramming/Fortran/CombinationalLogic/openmp-primes/sample.json
+++ b/DirectProgramming/Fortran/CombinationalLogic/openmp-primes/sample.json
@@ -1,4 +1,5 @@
 {
+  "guid": "6e0828c5-bed5-447a-bab6-7fa251626d54",
   "name": "OpenMP* Primes",
   "categories": ["Toolkit/oneAPI Direct Programming/Fortran/Combinational Logic"],
   "description": "Fortran Tutorial - Using OpenMP* (OMP)",

--- a/DirectProgramming/Fortran/DenseLinearAlgebra/optimize-integral/sample.json
+++ b/DirectProgramming/Fortran/DenseLinearAlgebra/optimize-integral/sample.json
@@ -1,4 +1,5 @@
 {
+  "guid": "5c6ee310-cb61-4f9f-80da-0c94a3cb53e7",
   "name": "Optimize Integral",
   "categories": ["Toolkit/oneAPI Direct Programming/Fortran/Dense Linear Algebra"],
   "description": "Fortran Sample - Simple Compiler Optimizations",

--- a/DirectProgramming/Fortran/DenseLinearAlgebra/vectorize-vecmatmult/sample.json
+++ b/DirectProgramming/Fortran/DenseLinearAlgebra/vectorize-vecmatmult/sample.json
@@ -1,4 +1,5 @@
 {
+  "guid": "f92e64c7-7a7c-4749-b421-9f7a9e120099",
   "name": "Vectorize VecMatMult",
   "categories": ["Toolkit/oneAPI Direct Programming/Fortran/Dense Linear Algebra"],
   "description": "Fortran Tutorial - Using Auto Vectorization",


### PR DESCRIPTION
# Existing Sample Changes
## Description

Several samples (Fortran) had missing GUIDs and found 2 GUIDs that were duplicated

Duplicate GUIDS were with samples:
- CRR and  Complex_Mult
- openMP Reduce and DPC Reduce