### PR TITLE
Switch to icpx compiler; Add -ipo flag to the linker

### DIFF
--- a/DirectProgramming/C++/CombinationalLogic/MandelbrotOMP/Makefile
+++ b/DirectProgramming/C++/CombinationalLogic/MandelbrotOMP/Makefile
@@ -23,7 +23,7 @@ endif
 
 TARGET := $(BUILDDIR)/Mandelbrot
 
-icpc: $(TARGET)
+icpx: $(TARGET)
 
 SOURCES := $(wildcard $(SRCDIR)/*.cpp)
 OBJECTS := $(patsubst $(SRCDIR)/%,$(BUILDDIR)/%,$(SOURCES:.cpp=.o))

--- a/DirectProgramming/C++/CombinationalLogic/MandelbrotOMP/Makefile
+++ b/DirectProgramming/C++/CombinationalLogic/MandelbrotOMP/Makefile
@@ -10,12 +10,12 @@
 # PURPOSE, NON-INFRINGEMENT OF INTELLECTUAL PROPERTY RIGHTS.
 #
 # =============================================================
-CXX := icpc
+CXX := icpx
 SRCDIR := src
 BUILDDIR := release
 CFLAGS := -O3 -ipo -qopenmp -std=c++11
 EXTRA_CFLAGS :=
-LIBFLAGS := -qopenmp
+LIBFLAGS := -ipo -qopenmp
 
 ifdef perf_num
 	EXTRA_CFLAGS += -D PERF_NUM

--- a/DirectProgramming/C++/GraphTraversal/MergesortOMP/Makefile
+++ b/DirectProgramming/C++/GraphTraversal/MergesortOMP/Makefile
@@ -23,7 +23,7 @@ endif
 
 TARGET := $(BUILDDIR)/MergeSort
 
-icpc: $(TARGET)
+icpx: $(TARGET)
 
 SOURCES := $(wildcard $(SRCDIR)/*.cpp)
 OBJECTS := $(patsubst $(SRCDIR)/%,$(BUILDDIR)/%,$(SOURCES:.cpp=.o))

--- a/DirectProgramming/C++/GraphTraversal/MergesortOMP/Makefile
+++ b/DirectProgramming/C++/GraphTraversal/MergesortOMP/Makefile
@@ -10,12 +10,12 @@
 # PURPOSE, NON-INFRINGEMENT OF INTELLECTUAL PROPERTY RIGHTS.
 #
 # =============================================================
-CXX := icpc
+CXX := icpx
 SRCDIR := src
 BUILDDIR := release
 CFLAGS := -O3 -ipo -qopenmp -std=c++11
 EXTRA_CFLAGS :=
-LIBFLAGS := -qopenmp
+LIBFLAGS := -ipo -qopenmp
 
 ifdef perf_num
 	EXTRA_CFLAGS += -D PERF_NUM


### PR DESCRIPTION
Signed-off-by: Sergey Kiselev <sergey.kiselev@intel.com>

# Existing Sample Changes
## Description

Modify Makefile to work with oneAPI 2021.3:
* Switch from icpc compiler to icpx
* Add -ipo flag to the linker to match the compiler interprocedural optimization settings

Fixes Issue# 

## External Dependencies

List any external dependencies created as a result of this change.

## Type of change

Please delete options that are not relevant. Add a 'X' to the one that is applicable. 

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Implement fixes for ONSAM Jiras

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Command Line
- [ ] oneapi-cli
- [ ] Visual Studio
- [ ] Eclipse IDE
- [ ] VSCode
- [ ] When compiling the compiler flag "-Wall -Wformat-security -Werror=format-security" was used
