### PR TITLE
Pull request for adding VisualComputing tutorial section to respository

### DIFF
--- a/VisualComputing/README.md
+++ b/VisualComputing/README.md
@@ -1,0 +1,30 @@
+# Visual Computing Tutorials
+
+Source code area for learning about visual computing development from Intel
+
+## **hellodxtriangle**
+
+ - Additional source code for a technical introduction article to development with the Intel® OSPRay API and the Intel® OSPRay Studio showcase application.
+ - Targeted for those familiar with Microsoft* DirectX* and the DirectX* 11 introductory source code.
+ - Generates the DirectX* version of comparable scenes to *ospTutorial* and Intel OSPRay Studio scene graph test sources.
+- Article Link: TBD
+
+**Try it:**
+ - Requirements: 
+	 - Windows 10, Microsoft Visual Studio 2019
+	 - Windows SDK 10.0.19041.0 (or higher)
+	 - DirectX* 11 Toolkit
+		 - The toolkit libraries are automatically downloaded through the CMakeLists.txt file with vcpkg.
+		 - 600MB on disk.
+ - Clone and build with *x64 Native Tools Command Prompt for VS 2019*:
+	 - `git clone https://github.com/oneapi-src/oneAPI-samples oneAPI-samples`
+	 - `cd oneAPI-samples\VisualComputing\hellodxtriangle`
+	 - `mkdir build`
+	 - `cd build`
+	 - If you have a proxy set it: `set HTTPS_PROXY=http://your.proxy.com:port`
+	 - `cmake -G "Visual Studio 16 2019" -A x64 ..`
+	 - `cmake --build . --config Release`
+ - Run program and open the result image
+	 - `cd Release`
+	 - `hellodxtriangle.exe`
+	 - `explorer hellodxtriangle.png`

--- a/VisualComputing/hellodxtriangle/CMakeLists.txt
+++ b/VisualComputing/hellodxtriangle/CMakeLists.txt
@@ -1,0 +1,71 @@
+cmake_minimum_required(VERSION 3.19)
+project(studyTutorial
+	DESCRIPTION "Study hello world program for drawing ospTutorial with DirectX"
+  LANGUAGES CXX)
+
+#Download and install directxtk from vcpkg (approx 600MB)
+#If you see:
+#  status: [4;"A requested feature, protocol or option was not found built-in in this libcurl due to a build-time decision."] OR
+#  status: [5;"Couldn't resolve proxy name"]
+#  Make sure you set HTTPS_PROXY to the proxy server for your organization as needed: set HTTPS_PROXY=http://your.proxy.com:###
+set(VCPKG_URL "https://github.com/microsoft/vcpkg/archive/refs/tags/2021.05.12.zip")
+set(VCPKG_MD5 "a81b4205c3ab1c53ba879cfa3386b1bf")
+set(VCPKG_DIR "${CMAKE_BINARY_DIR}/vcpkg-2021.05.12")
+if(NOT EXISTS "${VCPKG_DIR}/bootstrap-vcpkg.bat")
+
+  message("Downloading ${VCPKG_URL} to vcpkg.zip... if you see a hang here try configuiring your proxy (HTTPS_PROXY HTTP_PROXY)")
+
+  file(DOWNLOAD ${VCPKG_URL} ${CMAKE_BINARY_DIR}/vcpkg.zip EXPECTED_MD5 ${VCPKG_MD5} STATUS VCPKG_DOWNLOAD_STATUS SHOW_PROGRESS)
+  message("vcpkg download status: ${VCPKG_DOWNLOAD_STATUS}")
+
+  file(ARCHIVE_EXTRACT INPUT ${CMAKE_BINARY_DIR}/vcpkg.zip DESTINATION ${CMAKE_BINARY_DIR})
+  message("vcpkg extracted")
+else()
+
+
+  message("vcpkg already downloaded")
+endif()
+
+set(VCPKG_INSTALL_OUTPUT "")
+set(VCPKG_RESULT_OUTPUT "")
+if(NOT EXISTS "${VCPKG_DIR}/installed/x64-windows/share/directxtk/directxtk-config.cmake")
+  message("vcpkg bootstrapping and installing directxtk:x64-windows directxmath:x64-windows")
+  set(BOOTSTRAP_BAT ${VCPKG_DIR}\\bootstrap-vcpkg.bat)
+  execute_process(
+    COMMAND ${BOOTSTRAP_BAT} 
+    WORKING_DIRECTORY ${VCPKG_DIR}
+    ECHO_OUTPUT_VARIABLE
+    ECHO_ERROR_VARIABLE
+  )
+
+  set(VCPKG_EXE ${VCPKG_DIR}\\vcpkg.exe)
+  set(VCPKG_ARGS install directxtk:x64-windows directxmath:x64-windows)
+  execute_process(
+    COMMAND ${VCPKG_EXE} ${VCPKG_ARGS}
+    ECHO_OUTPUT_VARIABLE
+    ECHO_ERROR_VARIABLE
+  )
+
+else()
+
+  message("directxtoolkit from vcpkg already installed")
+endif()
+
+message("vcpkg bootstrapped")
+
+add_executable(hellodxtriangle
+  hellodxtriangle.cpp
+)
+
+#Configure the target/project
+target_compile_definitions(hellodxtriangle PRIVATE "$<$<CONFIG:DEBUG>:_DEBUG>" "$<$<CONFIG:RELEASE>:NDEBUG>")
+
+set(directxtk_DIR ${VCPKG_DIR}/installed/x64-windows/share/directxtk)
+set(directxmath_DIR ${VCPKG_DIR}/installed/x64-windows/share/directxmath)
+find_package(directxtk CONFIG REQUIRED)
+find_package(directxmath CONFIG REQUIRED)
+target_link_libraries(hellodxtriangle PRIVATE
+  d3d11.lib
+  Microsoft::DirectXTK)
+target_compile_options(hellodxtriangle PRIVATE /Zc:__cplusplus)
+set_property(DIRECTORY PROPERTY VS_STARTUP_PROJECT hellodxtriangle)

--- a/VisualComputing/hellodxtriangle/hellodxtriangle.cpp
+++ b/VisualComputing/hellodxtriangle/hellodxtriangle.cpp
@@ -1,0 +1,248 @@
+
+//D3D11
+#include <d3d11_1.h>
+#include <dxgi1_2.h>
+#include <DirectXMath.h>
+#include <DirectXColors.h>
+
+//D3D11 TK
+
+#include "SimpleMath.h"
+#include "VertexTypes.h"
+#include "PrimitiveBatch.h"
+#include "Effects.h"
+#include "CommonStates.h"
+#include "ScreenGrab.h"
+#include "DirectXHelpers.h"
+#include "Model.h"
+#include "GeometricPrimitive.h"
+
+
+
+// stl
+#include <vector>
+#include <memory>
+#include <algorithm>
+#include <stdexcept>
+
+//Debug
+#include <iostream>
+
+
+//Windows
+#include <wrl/client.h>
+#include "wincodec.h"
+
+
+//Namespaces and convenience aliasing
+
+using Microsoft::WRL::ComPtr;
+using VertexType = DirectX::VertexPositionColor;
+
+//Exception from tutorial
+
+namespace DX
+{
+	inline void ThrowIfFailed(HRESULT hr)
+	{
+		if (FAILED(hr))
+		{
+			// Set a breakpoint on this line to catch DirectX API errors
+			throw std::exception();
+		}
+	}
+}
+
+int main(int argc, const char* argv[])
+{
+	int ret = 0;
+
+	//Context and device Setup variables
+	ComPtr<ID3D11Device> device;
+	ComPtr<ID3D11DeviceContext> context;
+	//derived functionality containers
+	ComPtr<ID3D11Device1> d3dDevice;
+	ComPtr<ID3D11DeviceContext1> d3dContext;
+
+	ComPtr<ID3D11RenderTargetView>  renderTargetView;
+	ComPtr<ID3D11DepthStencilView>  depthStencilView;
+	ComPtr<ID3D11InputLayout> inputLayout;
+	ComPtr<ID3D11Texture2D>  textureRenderTarget;
+
+	std::unique_ptr<DirectX::CommonStates> states;
+	std::unique_ptr<DirectX::BasicEffect> effect;
+
+	std::unique_ptr< DirectX::PrimitiveBatch<VertexType >> batch;
+
+	//Needed for COM capabilities or else exceptions
+	DX::ThrowIfFailed(CoInitialize(nullptr));
+
+	std::cout << "Running lean hello world program" << std::endl;
+
+	std::cout << "Initialize" << std::endl;
+	int width = 1024;
+	int height = 768;
+	int outputWidth = (std::max)(width, 1);
+	int outputHeight = (std::max)(height, 1);
+
+
+	std::cout << "Device" << std::endl;
+	static const D3D_FEATURE_LEVEL featureLevels[] =
+	{
+		D3D_FEATURE_LEVEL_11_1,
+		D3D_FEATURE_LEVEL_11_0,
+		D3D_FEATURE_LEVEL_10_1,
+		D3D_FEATURE_LEVEL_10_0,
+		D3D_FEATURE_LEVEL_9_3,
+		D3D_FEATURE_LEVEL_9_2,
+		D3D_FEATURE_LEVEL_9_1,
+	};
+	UINT creationFlags = 0;
+	D3D_FEATURE_LEVEL deviceLevel;
+
+	
+	DX::ThrowIfFailed(D3D11CreateDevice(
+		nullptr,                            // specify nullptr to use the default adapter
+		D3D_DRIVER_TYPE_HARDWARE,
+		nullptr,
+		creationFlags,
+		featureLevels,
+		static_cast<UINT>(std::size(featureLevels)),
+		D3D11_SDK_VERSION,
+		device.ReleaseAndGetAddressOf(),    // returns the Direct3D device created
+		&deviceLevel,                    // returns feature level of device created
+		context.ReleaseAndGetAddressOf()    // returns the device immediate context
+	));
+
+	device.As(&d3dDevice);
+	context.As(&d3dContext);
+
+	states = std::make_unique<DirectX::CommonStates>(d3dDevice.Get());
+
+	effect = std::make_unique<DirectX::BasicEffect>(d3dDevice.Get());
+	effect->SetVertexColorEnabled(true);
+
+	DX::ThrowIfFailed(
+		DirectX::CreateInputLayoutFromEffect<VertexType>(d3dDevice.Get(), effect.get(),
+			inputLayout.ReleaseAndGetAddressOf()
+			));
+
+	batch = std::make_unique<DirectX::PrimitiveBatch<VertexType>>(d3dContext.Get());
+
+
+
+	std::cout << "Resources" << std::endl;
+	ID3D11RenderTargetView* nullViews[] = { nullptr };
+	d3dContext->OMSetRenderTargets(static_cast<UINT>(std::size(nullViews)), nullViews, nullptr);
+	renderTargetView.Reset();
+	depthStencilView.Reset();
+	d3dContext->Flush();
+
+	//Texture setup to later feed render target
+	const UINT textureBufferWidth = 1024U;
+	const UINT textureBufferHeight = 768U;
+	D3D11_TEXTURE2D_DESC desc;
+	std::memset(&desc, 0, sizeof(desc));
+	desc.Width = textureBufferWidth;
+	desc.Height = textureBufferHeight;
+	desc.ArraySize = 1;
+	desc.Format = DXGI_FORMAT_R8G8B8A8_UNORM;
+	desc.MipLevels = 1;
+	desc.SampleDesc.Count = 1;
+	desc.SampleDesc.Quality = 0;
+	desc.BindFlags = D3D11_BIND_RENDER_TARGET;
+	desc.CPUAccessFlags = 0;
+	desc.Usage = D3D11_USAGE_DEFAULT;
+
+
+	DX::ThrowIfFailed(d3dDevice->CreateTexture2D(&desc, nullptr, textureRenderTarget.GetAddressOf()));
+
+
+	const DXGI_FORMAT depthBufferFormat = DXGI_FORMAT_D24_UNORM_S8_UINT;
+	D3D11_RENDER_TARGET_VIEW_DESC rtvDesc;
+	std::memset(&rtvDesc, 0, sizeof(rtvDesc));
+	rtvDesc.Format = desc.Format;
+	rtvDesc.ViewDimension = D3D11_RTV_DIMENSION_TEXTURE2D;
+	rtvDesc.Texture2D.MipSlice = 0;
+
+	DX::ThrowIfFailed(d3dDevice->CreateRenderTargetView(textureRenderTarget.Get(), &rtvDesc, renderTargetView.ReleaseAndGetAddressOf()));
+
+	CD3D11_TEXTURE2D_DESC depthStencilDesc(depthBufferFormat, textureBufferWidth, textureBufferHeight, 1, 1, D3D11_BIND_DEPTH_STENCIL);
+	ComPtr<ID3D11Texture2D> depthStencil;
+	DX::ThrowIfFailed(d3dDevice->CreateTexture2D(&depthStencilDesc, nullptr, depthStencil.GetAddressOf()));
+
+	CD3D11_DEPTH_STENCIL_VIEW_DESC depthStencilViewDesc(D3D11_DSV_DIMENSION_TEXTURE2D);
+	DX::ThrowIfFailed(d3dDevice->CreateDepthStencilView(depthStencil.Get(), &depthStencilViewDesc, depthStencilView.ReleaseAndGetAddressOf()));
+
+
+	std::cout << "Render" << std::endl;
+
+	// camera
+	DirectX::SimpleMath::Vector3 cam_pos{ 0.f, 0.f, 0.f };
+	DirectX::SimpleMath::Vector3 cam_up{ 0.f, 1.f, 0.f };
+	DirectX::SimpleMath::Vector3 cam_view{ 0.1f, 0.f, 1.f };
+	using DirectX::SimpleMath::Matrix;
+	float aspect = outputWidth / (float) outputHeight;
+	float fov = DirectX::XM_PI / 3.f;
+	DirectX::SimpleMath::Matrix world, view, projection;
+	world = DirectX::SimpleMath::Matrix::Identity;
+	view = DirectX::SimpleMath::Matrix::CreateLookAt(cam_pos, cam_view, cam_up);
+
+	//Note that the far plane in the OSPRay render operation assumes infinite far plane.
+	projection = Matrix::CreatePerspectiveFieldOfView(fov,
+		aspect, 1.e-6f, 10.f);
+	//change to grey
+	d3dContext->ClearRenderTargetView(renderTargetView.Get(), DirectX::Colors::CornflowerBlue);
+	d3dContext->ClearDepthStencilView(depthStencilView.Get(), D3D11_CLEAR_DEPTH | D3D11_CLEAR_STENCIL, 1.0f, 0);
+
+	d3dContext->OMSetRenderTargets(1, renderTargetView.GetAddressOf(), depthStencilView.Get());
+
+	// Set the viewport.
+	CD3D11_VIEWPORT viewport(0.0f, 0.0f, static_cast<float>(outputWidth), static_cast<float>(outputHeight));
+
+	d3dContext->RSSetViewports(1, &viewport);
+
+
+	d3dContext->OMSetBlendState(states->Opaque(), nullptr, 0xFFFFFFFF);
+	d3dContext->OMSetDepthStencilState(states->DepthNone(), 0);
+	d3dContext->RSSetState(states->CullNone());
+
+	//transformations for camera control
+	effect->SetProjection(projection);
+	effect->SetView(view);
+	effect->SetWorld(world);
+
+
+	effect->Apply(d3dContext.Get());
+	
+	d3dContext->IASetInputLayout(inputLayout.Get());
+	
+	//Use batch to draw... 
+	batch->Begin();
+
+	
+	std::vector<DirectX::VertexPositionColor> vertsColors = { { DirectX::SimpleMath::Vector3{-1.0f, -1.0f, 3.0f}, DirectX::XMFLOAT4{0.9f, 0.5f, 0.5f, 1.0f} } ,
+		{ DirectX::SimpleMath::Vector3{-1.0f, 1.0f, 3.0f}, DirectX::XMFLOAT4{0.8f, 0.8f, 0.8f, 1.0f} },
+		{ DirectX::SimpleMath::Vector3{1.0f, -1.0f, 3.0f}, DirectX::XMFLOAT4{0.8f, 0.8f, 0.8f, 1.0f} },
+		{ DirectX::SimpleMath::Vector3{0.1f, 0.1f, 0.3f}, DirectX::XMFLOAT4{0.5f, 0.9f, 0.5f, 1.0f} }
+	};
+	std::vector<uint16_t> index = { 0, 1, 2, 1, 2, 3 };
+	
+	batch->DrawIndexed(D3D11_PRIMITIVE_TOPOLOGY::D3D11_PRIMITIVE_TOPOLOGY_TRIANGLELIST, 
+		index.data(),
+		index.size(),
+		vertsColors.data(),
+		vertsColors.size());
+		
+
+
+	batch->End();
+	
+	std::cout << "Write" << std::endl;
+	DX::ThrowIfFailed(DirectX::SaveWICTextureToFile(d3dContext.Get(), textureRenderTarget.Get(), GUID_ContainerFormatPng, L"hellodxtriangle.png"));
+
+	//COM Tear down
+	CoUninitialize();
+
+	return ret;
+}


### PR DESCRIPTION
Signed-off-by: Michael R Carroll <michael.carroll@alumni.usc.edu>

# Adding a New Sample(s)

## Description

Technical consultants are staging code for learning to use these Visual Computing Developer products: Render Kit, GPA, and oneVPL
We are starting with an apples to apples comparison article between Intel OSPRay and Microsoft DirectX11 (Direct3D11). Many rendering developers have familiarity with DirectX and could benefit from feature capability and library intent comparisons between OSPray and DirectX. This should help those familiar with a rasterization API to try OSPRay with confidence.


The initial proposed code presents a DirectX11 ToolKit based application in line with how developers are introduced to DirectX (Direct3D) 11 or 12, the application outputs the same output graphic as two RenderKit onboarding applications:
1) OSPRay: ospTutorial 
2) OSPRay Studio: test_sgTutorial - https://github.com/ospray/ospray_studio/blob/master/sg/tests/test_sgTutorial.cpp
The proposed code requires Windows 10 SDK 10, DirectX11TK (vpkg:  directxtk:x64-windows directxmath:x64-windows)  These are build time libraries Windows rasterization developers will go to as pretty standard. The code uses stripped code from the directx11 'd3d11game_win32' microsoft template. https://github.com/walbourn/directx-vs-templates/tree/master/d3d11game_win32

Future possibilities: There are interesting use cases beyond this one where
developers would ingest output from a ray tracing (RenderKit)
into a game engine built with DirectX.

## Checklist
Administrative
- [ ] Review sample design with the appropriate [Domain Expert](https://github.com/oneapi-src/oneAPI-samples/wiki/Reviewers-and-Domain-Experts): None listed yet for Domain?
- [* ] If you have any new dependencies/binaries, inform the oneAPI Code Samples Project Manager: @JoeOster
	- We began discussion with @JoeOster last week... info:
	- DirectX11 (Direct3D11 Programs) require Windows SDK.
	- The sample uses Directx11TK and DirectXMath per DirectX development  onboarding instruction. It currently deploys it by acquiring them from VCPKG per the CMakeLists.txt generation step.

Code Development
- [ ] Implement coding guidelines and ensure code quality. [see wiki for details](https://github.com/oneapi-src/oneAPI-samples/wiki/General-Code-Guidelines)
- [ ] Adhere to readme template 
- [ ] Enforce format via clang-format config file
- [ ] Adhere to sample.json specification. https://github.com/oneapi-src/oneAPI-samples/wiki/sample-json-specification
- [ ] Ensure/create CI test configurations for sample (ciTests field) https://github.com/oneapi-src/oneAPI-samples/wiki/sample-json-ci-test-object
- [ ] Run jsonlint on sample.json to verify json syntax. www.jsonlint.com

Security and Legal
- [ ] OSPDT Approval (see @JoeOster for assistance)
- [ ] Compile using the following compiler flags and fix any warnings, the falgs are: "/Wall -Wformat-security -Werror=format-security"
- [ ] Bandit Scans (Python only)
- [ ] Virus scan

Review
- [ ] Review DPC++ code with Paul Peterseon. (GitHub User: pmpeter1)
- [ ] Review readme with Tom Lenth(@tomlenth) and/or Joe Oster(@JoeOster)
- [ ] Tested using Dev Cloud when applicable


