### PR TITLE
Fixed for compile error in MVDR

### DIFF
--- a/DirectProgramming/DPC++FPGA/ReferenceDesigns/mvdr_beamforming/src/FakeIOPipes.hpp
+++ b/DirectProgramming/DPC++FPGA/ReferenceDesigns/mvdr_beamforming/src/FakeIOPipes.hpp
@@ -18,7 +18,7 @@ namespace detail {
 
 using namespace sycl;
 
-template <typename Id, typename T, bool use_host_alloc>
+template <typename T, bool use_host_alloc>
 class ProducerConsumerBaseImpl {
  protected:
   // private members
@@ -134,10 +134,10 @@ class ProducerConsumerBaseImpl {
 ////////////////////////////////////////////////////////////////////////////////
 // Producer implementation
 template <typename Id, typename T, bool use_host_alloc, size_t min_capacity>
-class ProducerImpl : public ProducerConsumerBaseImpl<Id, T, use_host_alloc> {
+class ProducerImpl : public ProducerConsumerBaseImpl<T, use_host_alloc> {
  private:
   // base implementation alias
-  using BaseImpl = ProducerConsumerBaseImpl<Id, T, use_host_alloc>;
+  using BaseImpl = ProducerConsumerBaseImpl<T, use_host_alloc>;
   using kernel_ptr_type = typename BaseImpl::kernel_ptr_type;
 
   // IDs for the pipe and kernel
@@ -186,7 +186,7 @@ class ProducerImpl : public ProducerConsumerBaseImpl<Id, T, use_host_alloc> {
 
       // the producing kernel
       // NO-FORMAT comments are for clang-format
-      h.single_task<KernelID>([=
+      h.single_task<Id>([=
       ]() [[intel::kernel_args_restrict]] {  // NO-FORMAT: Attribute
         kernel_ptr_type ptr(kernel_ptr);
         for (size_t i = 0; i < count; i++) {
@@ -204,10 +204,10 @@ class ProducerImpl : public ProducerConsumerBaseImpl<Id, T, use_host_alloc> {
 ////////////////////////////////////////////////////////////////////////////////
 // Consumer implementation
 template <typename Id, typename T, bool use_host_alloc, size_t min_capacity>
-class ConsumerImpl : public ProducerConsumerBaseImpl<Id, T, use_host_alloc> {
+class ConsumerImpl : public ProducerConsumerBaseImpl<T, use_host_alloc> {
  private:
   // base implementation alias
-  using BaseImpl = ProducerConsumerBaseImpl<Id, T, use_host_alloc>;
+  using BaseImpl = ProducerConsumerBaseImpl<T, use_host_alloc>;
   using kernel_ptr_type = typename BaseImpl::kernel_ptr_type;
 
   // IDs for the pipe and kernel
@@ -243,7 +243,7 @@ class ConsumerImpl : public ProducerConsumerBaseImpl<Id, T, use_host_alloc> {
     // launch the kernel to read the output into device side global memory
     auto kernel_event = q.submit([&](handler &h) {
       // NO-FORMAT comments are for clang-format
-      h.single_task<KernelID>([=
+      h.single_task<Id>([=
       ]() [[intel::kernel_args_restrict]] {  // NO-FORMAT: Attribute
         kernel_ptr_type ptr(kernel_ptr);
         for (size_t i = 0; i < count; i++) {


### PR DESCRIPTION
# Existing Sample Changes
## Description
Fixed a compile issue with MVDR. The compiler is generating a header file that was searching the global namespace for a KernelID that was a class member of a class. I changed the code to just used the passed in Id. This both fixes the compile and produces much nicer reports since the amount of name mangling in the kernel name is reduced. I also removed the Id parameter from the `ProducerConsumerBaseImpl` because it was unused.

## Type of change
Please delete options that are not relevant. Add a 'X' to the one that is applicable. 
- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
- [X] Command Line
I tested the functionality in emulation.