### PR TITLE
Update non FPGA samples no_init

### DIFF
--- a/DirectProgramming/DPC++/DenseLinearAlgebra/simple-add/README.md
+++ b/DirectProgramming/DPC++/DenseLinearAlgebra/simple-add/README.md
@@ -29,6 +29,12 @@ Code samples are licensed under the MIT license. See
 
 Third party program Licenses can be found here: [third-party-programs.txt](https://github.com/oneapi-src/oneAPI-samples/blob/master/third-party-programs.txt)
 
+## Known Issues
+With oneAPI 2021.4 the argument for accessors was changed from 'noinit' to 'no_init'. The change was derived from a change between the SYCL 2020 provisional spec and that of the 2020Rev3 spec
+
+If running this sample and it fails, do one of the following
+- Update the oneAPI base toolkit to 2021.4
+- Change the 'no_init' argument  to 'noinit'
 ## Building the `simple add DPC++` Program for CPU and GPU 
 
 ### Include Files

--- a/DirectProgramming/DPC++/DenseLinearAlgebra/simple-add/src/simple-add-buffers.cpp
+++ b/DirectProgramming/DPC++/DenseLinearAlgebra/simple-add/src/simple-add-buffers.cpp
@@ -53,7 +53,7 @@ void IotaParallel(queue &q, IntArray &a_array, int value) {
   // data access permission and device computation (kernel).
   q.submit([&](auto &h) {
     // Create an accessor with write permission.
-    accessor a(a_buf, h, write_only, noinit);
+    accessor a(a_buf, h, write_only, no_init);
 
     // Use parallel_for to populate consecutive numbers starting with a
     // specified value in parallel on device. This executes the kernel.

--- a/DirectProgramming/DPC++/DenseLinearAlgebra/vector-add/README.md
+++ b/DirectProgramming/DPC++/DenseLinearAlgebra/vector-add/README.md
@@ -31,6 +31,12 @@ Code samples are licensed under the MIT license. See
 
 Third party program Licenses can be found here: [third-party-programs.txt](https://github.com/oneapi-src/oneAPI-samples/blob/master/third-party-programs.txt)
 
+## Known Issues
+With oneAPI 2021.4 the argument for accessors was changed from 'noinit' to 'no_init'. The change was derived from a change between the SYCL 2020 provisional spec and that of the 2020Rev3 spec
+
+If running this sample and it fails, do one of the following
+- Update the oneAPI base toolkit to 2021.4
+- Change the 'no_init' argument  to 'noinit'
 ## Building the `vector-add` Program for CPU and GPU 
 
 > Note: if you have not already done so, set up your CLI 

--- a/DirectProgramming/DPC++/DenseLinearAlgebra/vector-add/src/vector-add-buffers.cpp
+++ b/DirectProgramming/DPC++/DenseLinearAlgebra/vector-add/src/vector-add-buffers.cpp
@@ -71,7 +71,7 @@ void VectorAdd(queue &q, const IntVector &a_vector, const IntVector &b_vector,
     accessor b(b_buf, h, read_only);
 
     // The sum_accessor is used to store (with write permission) the sum data.
-    accessor sum(sum_buf, h, write_only, noinit);
+    accessor sum(sum_buf, h, write_only, no_init);
 
     // Use parallel_for to run vector addition in parallel on device. This
     // executes the kernel.


### PR DESCRIPTION
# Existing Sample Changes
## Description

With oneAPI 2021.4 the argument for accessors was changed from 'noinit' to 'no_init'. The change was derived from a change between the SYCL 2020 provisional spec and that of the 2020Rev3 spec

