### PR TITLE
Updating FPGA design DB to wait on ALL events

### DIFF
--- a/DirectProgramming/DPC++FPGA/ReferenceDesigns/db/src/query11/query11_kernel.cpp
+++ b/DirectProgramming/DPC++FPGA/ReferenceDesigns/db/src/query11/query11_kernel.cpp
@@ -291,6 +291,10 @@ bool SubmitQuery11(queue& q, Database& dbinfo, std::string& nation,
   ///////////////////////////////////////////////////////////////////////////
 
   // wait for kernels to finish
+  produce_ps_event.wait();
+  join_event.wait();
+  compute_event.wait();
+  sort_event.wait();
   consume_sort_event.wait();
 
   high_resolution_clock::time_point host_end = high_resolution_clock::now();

--- a/DirectProgramming/DPC++FPGA/ReferenceDesigns/db/src/query12/query12_kernel.cpp
+++ b/DirectProgramming/DPC++FPGA/ReferenceDesigns/db/src/query12/query12_kernel.cpp
@@ -271,6 +271,9 @@ bool SubmitQuery12(queue& q, Database& dbinfo, DBDate low_date,
   /////////////////////////////////////////////////////////////////////////////
 
   // wait for the Compute kernel to finish
+  produce_lineitem_event.wait();
+  produce_orders_event.wait();
+  join_event.wait();
   compute_event.wait();
 
   // stop timer

--- a/DirectProgramming/DPC++FPGA/ReferenceDesigns/db/src/query9/query9_kernel.cpp
+++ b/DirectProgramming/DPC++FPGA/ReferenceDesigns/db/src/query9/query9_kernel.cpp
@@ -699,6 +699,14 @@ bool SubmitQuery9(queue& q, Database& dbinfo, std::string colour,
   // wait for kernel to finish
   filter_parts_event.wait();
   computation_kernel_event.wait();
+  join_li_o_s_ps_event.wait();
+  sort_event.wait();
+  consume_sort_event.wait();
+  feed_sort_event.wait();
+  produce_part_supplier_event.wait();
+  join_partsupplier_supplier_event.wait();
+  join_lineitem_orders_event.wait();
+  producer_orders_event.wait();
 
   high_resolution_clock::time_point host_end = high_resolution_clock::now();
   duration<double, std::milli> diff = host_end - host_start;


### PR DESCRIPTION
# Existing Sample Changes
## Description
To align with other designs, I explicitly wait on all events. None of the kernels are intended to run forever, so this change should do nothing but make sure no kernels are hanging.

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
- [X] Command Line