### PR TITLE
Add ID field back to ProducerConsumerBaseImpl in FakeIOPipes.hpp

### DIFF
--- a/DirectProgramming/DPC++FPGA/ReferenceDesigns/mvdr_beamforming/src/FakeIOPipes.hpp
+++ b/DirectProgramming/DPC++FPGA/ReferenceDesigns/mvdr_beamforming/src/FakeIOPipes.hpp
@@ -18,7 +18,7 @@ namespace detail {
 
 using namespace sycl;
 
-template <typename T, bool use_host_alloc>
+template <typename ID, typename T, bool use_host_alloc>
 class ProducerConsumerBaseImpl {
  protected:
   // private members
@@ -134,10 +134,10 @@ class ProducerConsumerBaseImpl {
 ////////////////////////////////////////////////////////////////////////////////
 // Producer implementation
 template <typename Id, typename T, bool use_host_alloc, size_t min_capacity>
-class ProducerImpl : public ProducerConsumerBaseImpl<T, use_host_alloc> {
+class ProducerImpl : public ProducerConsumerBaseImpl<Id, T, use_host_alloc> {
  private:
   // base implementation alias
-  using BaseImpl = ProducerConsumerBaseImpl<T, use_host_alloc>;
+  using BaseImpl = ProducerConsumerBaseImpl<Id, T, use_host_alloc>;
   using kernel_ptr_type = typename BaseImpl::kernel_ptr_type;
 
   // IDs for the pipe and kernel
@@ -204,10 +204,10 @@ class ProducerImpl : public ProducerConsumerBaseImpl<T, use_host_alloc> {
 ////////////////////////////////////////////////////////////////////////////////
 // Consumer implementation
 template <typename Id, typename T, bool use_host_alloc, size_t min_capacity>
-class ConsumerImpl : public ProducerConsumerBaseImpl<T, use_host_alloc> {
+class ConsumerImpl : public ProducerConsumerBaseImpl<Id, T, use_host_alloc> {
  private:
   // base implementation alias
-  using BaseImpl = ProducerConsumerBaseImpl<T, use_host_alloc>;
+  using BaseImpl = ProducerConsumerBaseImpl<Id, T, use_host_alloc>;
   using kernel_ptr_type = typename BaseImpl::kernel_ptr_type;
 
   // IDs for the pipe and kernel

--- a/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/io_streaming/src/FakeIOPipes.hpp
+++ b/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/io_streaming/src/FakeIOPipes.hpp
@@ -18,7 +18,7 @@ namespace detail {
 
 using namespace sycl;
 
-template <typename T, bool use_host_alloc>
+template <typename ID, typename T, bool use_host_alloc>
 class ProducerConsumerBaseImpl {
  protected:
   // private members
@@ -134,10 +134,10 @@ class ProducerConsumerBaseImpl {
 ////////////////////////////////////////////////////////////////////////////////
 // Producer implementation
 template <typename Id, typename T, bool use_host_alloc, size_t min_capacity>
-class ProducerImpl : public ProducerConsumerBaseImpl<T, use_host_alloc> {
+class ProducerImpl : public ProducerConsumerBaseImpl<Id, T, use_host_alloc> {
  private:
   // base implementation alias
-  using BaseImpl = ProducerConsumerBaseImpl<T, use_host_alloc>;
+  using BaseImpl = ProducerConsumerBaseImpl<Id, T, use_host_alloc>;
   using kernel_ptr_type = typename BaseImpl::kernel_ptr_type;
 
   // IDs for the pipe and kernel
@@ -204,10 +204,10 @@ class ProducerImpl : public ProducerConsumerBaseImpl<T, use_host_alloc> {
 ////////////////////////////////////////////////////////////////////////////////
 // Consumer implementation
 template <typename Id, typename T, bool use_host_alloc, size_t min_capacity>
-class ConsumerImpl : public ProducerConsumerBaseImpl<T, use_host_alloc> {
+class ConsumerImpl : public ProducerConsumerBaseImpl<Id, T, use_host_alloc> {
  private:
   // base implementation alias
-  using BaseImpl = ProducerConsumerBaseImpl<T, use_host_alloc>;
+  using BaseImpl = ProducerConsumerBaseImpl<Id, T, use_host_alloc>;
   using kernel_ptr_type = typename BaseImpl::kernel_ptr_type;
 
   // IDs for the pipe and kernel


### PR DESCRIPTION
## Description

In FakeIOPipes.hpp, when two Producers or Consumers that use the same type are used in the same scope, their underlying base classes alias to each other and cause a runtime error when trying to initialize the second instance.  That error does not occur in the two samples that use FakeIOPipes, but it does happen in a new design (not yet comitted) that uses them.  This bug fix is for anyone who wants to reuse the FakeIOPipes in their own designs.

Also converted all line endings to UNIX style, so recommend ignoring whitespace changes when reviewing.


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] Command Line
