### PR TITLE
Fix for FPGA io_streaming design breaking due to non-forward declarable kernel name

### DIFF
--- a/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/io_streaming/src/LoopbackTest.hpp
+++ b/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/io_streaming/src/LoopbackTest.hpp
@@ -16,10 +16,9 @@ using namespace sycl;
 
 // declare the kernel and pipe ID stucts globally to reduce name mangling
 struct LoopBackMainKernel;
-struct LoopBackIOPipes {
-  struct ReadIOPipeID { static constexpr unsigned id = 0; };
-  struct WriteIOPipeID { static constexpr unsigned id = 1; };
-};
+struct LoopBackReadIOPipeID { static constexpr unsigned id = 0; };
+struct LoopBackWriteIOPipeID { static constexpr unsigned id = 1; };
+
 
 //
 // The simplest processing kernel. Streams data in 'IOPipeIn' and streams
@@ -54,9 +53,9 @@ bool RunLoopbackSystem(queue& q, size_t count) {
   constexpr size_t kIOPipeDepth = 4;
 #ifndef USE_REAL_IO_PIPES
   // these are FAKE IO pipes (and their producer/consumer)
-  using FakeIOPipeInProducer = Producer<LoopBackIOPipes::ReadIOPipeID,
+  using FakeIOPipeInProducer = Producer<LoopBackReadIOPipeID,
                                 T, use_usm_host_alloc, kIOPipeDepth>;
-  using FakeIOPipeOutConsumer = Consumer<LoopBackIOPipes::WriteIOPipeID,
+  using FakeIOPipeOutConsumer = Consumer<LoopBackWriteIOPipeID,
                                  T, use_usm_host_alloc, kIOPipeDepth>;
   using ReadIOPipe = typename FakeIOPipeInProducer::Pipe;
   using WriteIOPipe = typename FakeIOPipeOutConsumer::Pipe;
@@ -67,10 +66,10 @@ bool RunLoopbackSystem(queue& q, size_t count) {
 #else
   // these are REAL IO pipes
   using ReadIOPipe = 
-    ext::intel::kernel_readable_io_pipe<LoopBackIOPipes::ReadIOPipeID,
+    ext::intel::kernel_readable_io_pipe<LoopBackReadIOPipeID,
                                    T, kIOPipeDepth>;
   using WriteIOPipe =
-    ext::intel::kernel_writeable_io_pipe<LoopBackIOPipes::WriteIOPipeID,
+    ext::intel::kernel_writeable_io_pipe<LoopBackWriteIOPipeID,
                                     T, kIOPipeDepth>;
 #endif
   //////////////////////////////////////////////////////////////////////////////

--- a/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/io_streaming/src/SideChannelTest.hpp
+++ b/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/io_streaming/src/SideChannelTest.hpp
@@ -12,15 +12,11 @@ using namespace std::chrono_literals;
 
 // declare the kernel and pipe ID stucts globally to reduce name mangling
 struct SideChannelMainKernel;
-struct SideChannelIOPipes {
-  struct ReadIOPipeID { static constexpr unsigned id = 0; };
-  struct WriteIOPipeID { static constexpr unsigned id = 1; };
-};
-struct SideChannelPipes {
-  struct HostToDeviceSideChannelID;
-  struct DeviceToHostSideChannelID;
-  struct HostToDeviceTermSideChannelID;
-};
+struct SideChannelReadIOPipeID { static constexpr unsigned id = 0; };
+struct SideChannelWriteIOPipeID { static constexpr unsigned id = 1; };
+struct HostToDeviceSideChannelID;
+struct DeviceToHostSideChannelID;
+struct HostToDeviceTermSideChannelID;
 
 //
 // Submit the main processing kernel (or kernels, in general).
@@ -115,9 +111,9 @@ bool RunSideChannelsSystem(queue& q, size_t count) {
   //////////////////////////////////////////////////////////////////////////////
   // IO pipes
   // these are the FAKE IO pipes
-  using FakeIOPipeInProducer = Producer<SideChannelIOPipes::ReadIOPipeID,
+  using FakeIOPipeInProducer = Producer<SideChannelReadIOPipeID,
                                 T, use_usm_host_alloc>;
-  using FakeIOPipeOutConsumer = Consumer<SideChannelIOPipes::WriteIOPipeID,
+  using FakeIOPipeOutConsumer = Consumer<SideChannelWriteIOPipeID,
                                  T, use_usm_host_alloc>;
   using ReadIOPipe = typename FakeIOPipeInProducer::Pipe;
   using WriteIOPipe = typename FakeIOPipeOutConsumer::Pipe;
@@ -130,10 +126,10 @@ bool RunSideChannelsSystem(queue& q, size_t count) {
   //////////////////////////////////////////////////////////////////////////////
   // the side channels
   using MyHostToDeviceSideChannel = 
-    HostToDeviceSideChannel<SideChannelPipes::HostToDeviceSideChannelID,
+    HostToDeviceSideChannel<HostToDeviceSideChannelID,
                             int, use_usm_host_alloc, 1>;
   using MyHostToDeviceTermSideChannel = 
-    HostToDeviceSideChannel<SideChannelPipes::HostToDeviceTermSideChannelID,
+    HostToDeviceSideChannel<HostToDeviceTermSideChannelID,
                             char, use_usm_host_alloc, 1>;
   
   // This side channel is used to sent updates from the device to the host.
@@ -144,7 +140,7 @@ bool RunSideChannelsSystem(queue& q, size_t count) {
   // frequency of updates from the device is so low that this channel can be
   // shallow.
   using MyDeviceToHostSideChannel = 
-    DeviceToHostSideChannel<SideChannelPipes::DeviceToHostSideChannelID,
+    DeviceToHostSideChannel<DeviceToHostSideChannelID,
                             int, use_usm_host_alloc, 8>;
 
 


### PR DESCRIPTION

# Existing Sample Changes
## Description
SYCL kernel names need to be forward declarable. The kernels in this tutorial were being falsely compiled until a recent change. This PR fixes the compile error.

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
- [X] Command Line
Built emulation and reports.