### PR TITLE
vector-add: use dpcpp-cl for Windows version of the sample

### DIFF
--- a/DirectProgramming/DPC++/DenseLinearAlgebra/vector-add/Makefile.win
+++ b/DirectProgramming/DPC++/DenseLinearAlgebra/vector-add/Makefile.win
@@ -1,5 +1,5 @@
-CXX = dpcpp
-CXXFLAGS = -O2 -EHsc -Zi
+CXX = dpcpp-cl
+CXXFLAGS = /O2 /EHsc /Zi
 LDFLAGS = 
 EXE_NAME = vector-add-buffers.exe
 SOURCES = src/vector-add-buffers.cpp


### PR DESCRIPTION
Signed-off-by: Khalik Kasimov <khalik.kasimov@intel.com>

# Existing Sample Changes
## Description

This change includes update for vector-add sample to use dpcpp-cl for Windows instead of dpcpp for upcoming release.
The change is introduced as the Windows version of the sample uses Windows specific options.
Note: this PR does not include changes for FPGA Makefile for Windows.

## Type of change

- [X] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Tested as described in a sample README.md

- [X] Command Line
- [X] When compiling the compiler flag "-Wall -Wformat-security -Werror=format-security" was used