### PR TITLE
Fixing intermittent segfaults in gzip design

### DIFF
--- a/DirectProgramming/DPC++FPGA/ReferenceDesigns/gzip/src/CMakeLists.txt
+++ b/DirectProgramming/DPC++FPGA/ReferenceDesigns/gzip/src/CMakeLists.txt
@@ -41,8 +41,8 @@ if(FPGA_BOARD MATCHES ".*a10.*")
 elseif(FPGA_BOARD MATCHES ".*s10.*")
     # S10 parameters
     set(NUM_ENGINES 2)
-    set(LL_SEED "-Xsseed=1")
-    set(HIGH_BW_SEED "-Xsseed=6")
+    set(LL_SEED "-Xsseed=2")
+    set(HIGH_BW_SEED "-Xsseed=2")
     set(NUM_REORDER "-Xsnum-reorder=6")
 elseif(FPGA_BOARD MATCHES ".*agilex.*")
     # Agilex™

--- a/DirectProgramming/DPC++FPGA/ReferenceDesigns/gzip/src/gzipkernel.cpp
+++ b/DirectProgramming/DPC++FPGA/ReferenceDesigns/gzip/src/gzipkernel.cpp
@@ -2052,7 +2052,7 @@ void SubmitGzipTasksSingleEngine(
       // we compare to
       unsigned int insize_compare = (accessor_isz) / kVec;
 
-      int ctr = insize_compare = insize_compare - 1;
+      int ctr = insize_compare - 1;
 
       char first_valid_pos = 0;
 
@@ -2063,7 +2063,10 @@ void SubmitGzipTasksSingleEngine(
 
       // load in new data
       struct LzInput in;
-      Unroller<0, kVec>::step([&](int i) { in.data[i] = acc_pibuf[inpos++]; });
+      Unroller<0, kVec>::step([&](int i) {
+        // prevent out-of-bounds reads
+        in.data[i] = (inpos < accessor_isz) ? acc_pibuf[inpos++] : 0;
+      });
 
       Unroller<0, kVec>::step(
           [&](int i) { current_window[i + kVec] = in.data[i]; });

--- a/DirectProgramming/DPC++FPGA/ReferenceDesigns/gzip/src/gzipkernel_ll.cpp
+++ b/DirectProgramming/DPC++FPGA/ReferenceDesigns/gzip/src/gzipkernel_ll.cpp
@@ -2157,7 +2157,7 @@ event SubmitLZReduction(queue &q, size_t block_size, bool last_block,
         // what we compare to
         unsigned int insize_compare = (accessor_isz) / kVec;
 
-        int ctr = insize_compare = insize_compare - 1;
+        int ctr = insize_compare - 1;
 
         char first_valid_pos = 0;
 
@@ -2193,7 +2193,8 @@ event SubmitLZReduction(queue &q, size_t block_size, bool last_block,
 
           // load in new data
           Unroller<0, kVec>::step([&](int i) {
-            in.data[i] = acc_pibuf[inpos++];
+            // guarding against out-of-bounds accesses
+            in.data[i] = (inpos < accessor_isz) ? acc_pibuf[inpos++] : 0;
             input_data.arr[16 * (int)crc_ch_load_upper + i] = in.data[i];
           });
 


### PR DESCRIPTION
# Existing Sample Changes
## Description
We were overrunning reads to a pointer in one of the kernels that caused an intermittent segfault in emulation. In theory, this segfault could occur in hardware too, but didn't seem to happen. We also didn't see segfaults in emulation or hardware for regular gzip, but we were overrunning the pointer, so I fixed that too.

## Type of change

Please delete options that are not relevant. Add a 'X' to the one that is applicable. 

- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [X] Command Line
- [X] Hardware