### PR TITLE
Small change to MVDR to wrap stuff correctly in if-defs for real vs fake IO pipes

### DIFF
--- a/DirectProgramming/DPC++FPGA/ReferenceDesigns/mvdr_beamforming/src/mvdr_beamforming.cpp
+++ b/DirectProgramming/DPC++FPGA/ReferenceDesigns/mvdr_beamforming/src/mvdr_beamforming.cpp
@@ -391,9 +391,11 @@ int main(int argc, char *argv[]) {
 
     auto end_time = high_resolution_clock::now();
 
+#if not defined(REAL_IO_PIPES)
     // Stop the timer before performing the DMA from the consumer. Again,
     // if USM host allocations are used then this is a noop.
     consume_dma_event.wait();
+#endif
 
     // compute latency and throughput
     duration<double, std::milli> process_time(end_time - start_time);


### PR DESCRIPTION
# Existing Sample Changes
## Description
We .wait() on an event that is declared inside an if-def, but didn't wrap the wait in an if-def.

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
- [X] Command Line