### PR TITLE
Update fig_7_10_accessors.cpp to use no_init instead of depricated noinit

### DIFF
--- a/Publications/DPC++/Ch07_buffers/fig_7_10_accessors.cpp
+++ b/Publications/DPC++/Ch07_buffers/fig_7_10_accessors.cpp
@@ -18,9 +18,9 @@ int main() {
   accessor pC{C};
 
   Q.submit([&](handler &h) {
-      accessor aA{A, h, write_only, noinit};
-      accessor aB{B, h, write_only, noinit};
-      accessor aC{C, h, write_only, noinit};
+      accessor aA{A, h, write_only, no_init};
+      accessor aB{B, h, write_only, no_init};
+      accessor aC{C, h, write_only, no_init};
       h.parallel_for(N, [=](id<1> i) {
           aA[i] = 1;
           aB[i] = 40;


### PR DESCRIPTION
# Existing Sample Changes
## Description

Changing a sample to reflect changes in 2021.4 noinit vs no_init


## External Dependencies

2021.4

## Type of change

Please delete options that are not relevant. Add a 'X' to the one that is applicable. 

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Implement fixes for ONSAM Jiras

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Command Line
- [ ] oneapi-cli
- [ ] Visual Studio
- [ ] Eclipse IDE
- [ ] VSCode
- [ ] When compiling the compliler flag "-Wall -Wformat-security -Werror=format-security" was used
