### PR TITLE
Declare kernel name in global namespace and update deprecated syntax in ProjectTemplates samples.

### DIFF
--- a/DirectProgramming/DPC++/ProjectTemplates/cmake-fpga/src/main.cpp
+++ b/DirectProgramming/DPC++/ProjectTemplates/cmake-fpga/src/main.cpp
@@ -6,21 +6,24 @@
 
 // located in $ONEAPI_ROOT/compiler/latest/linux/include/sycl/
 #include <CL/sycl.hpp>
-#include <CL/sycl/INTEL/fpga_extensions.hpp>
+#include <sycl/ext/intel/fpga_extensions.hpp>
 #include <cstdlib>
 #include <iostream>
 
 using namespace cl::sycl;
+
+// declare the kernel name as a global to reduce name mangling
+class ExampleKernel;
 
 int main() {
   // create device selector for the device of your interest
   // FPGA_EMULATOR defined in cmake-fpga/src/CMakeLists.txt
 #if defined(FPGA_EMULATOR)
   // DPC++ extension: FPGA emulator selector on systems without FPGA card
-  INTEL::fpga_emulator_selector device_selector;
+  ext::intel::fpga_emulator_selector device_selector;
 #else
   // DPC++ extension: FPGA selector on systems with FPGA card
-  INTEL::fpga_selector device_selector;
+  ext::intel::fpga_selector device_selector;
 #endif
 
   // create a buffer
@@ -29,7 +32,6 @@ int main() {
   buffer A(out_data);
 
   // create a kernel
-  class ExampleKernel;
   queue q{device_selector };
   q.submit([&](handler& h) {
     auto out = A.get_access<access::mode::write>(h);

--- a/DirectProgramming/DPC++/ProjectTemplates/cmake-gpu/src/main.cpp
+++ b/DirectProgramming/DPC++/ProjectTemplates/cmake-gpu/src/main.cpp
@@ -11,6 +11,9 @@
 
 using namespace cl::sycl;
 
+// declare the kernel name as a global to reduce name mangling
+class ExampleKernel;
+
 int main() {
   // create GPU device selector
   gpu_selector device_selector;
@@ -21,7 +24,6 @@ int main() {
   buffer<int> A{ R };
 
   // create a kernel
-  class ExampleKernel;
   queue q{device_selector };
   q.submit([&](handler& h) {
     auto out = A.get_access<access::mode::write>(h);

--- a/DirectProgramming/DPC++/ProjectTemplates/makefile-fpga/src/main.cpp
+++ b/DirectProgramming/DPC++/ProjectTemplates/makefile-fpga/src/main.cpp
@@ -6,21 +6,24 @@
 
 // located in $ONEAPI_ROOT/compiler/latest/linux/include/sycl/
 #include <CL/sycl.hpp>
-#include <CL/sycl/INTEL/fpga_extensions.hpp>
+#include <sycl/ext/intel/fpga_extensions.hpp>
 #include <cstdlib>
 #include <iostream>
 
 using namespace cl::sycl;
+
+// declare the kernel name as a global to reduce name mangling
+class ExampleKernel;
 
 int main() {
   // create device selector for the device of your interest
   // FPGA_EMULATOR defined in makefile-fpga/Makefile
 #if defined(FPGA_EMULATOR)
   // DPC++ extension: FPGA emulator selector on systems without FPGA card
-  INTEL::fpga_emulator_selector device_selector;
+  ext::intel::fpga_emulator_selector device_selector;
 #else
   // DPC++ extension: FPGA selector on systems with FPGA card
-  INTEL::fpga_selector device_selector;
+  ext::intel::fpga_selector device_selector;
 #endif
 
   // create a buffer
@@ -29,7 +32,6 @@ int main() {
   buffer<int,1> A(out_data);
 
   // create a kernel
-  class ExampleKernel;
   queue q{device_selector };
   q.submit([&](handler& h) {
     auto out = A.get_access<access::mode::write>(h);

--- a/DirectProgramming/DPC++/ProjectTemplates/makefile-gpu/src/main.cpp
+++ b/DirectProgramming/DPC++/ProjectTemplates/makefile-gpu/src/main.cpp
@@ -11,6 +11,9 @@
 
 using namespace cl::sycl;
 
+// declare the kernel name as a global to reduce name mangling
+class ExampleKernel;
+
 int main() {
   // create GPU device selector
   gpu_selector device_selector;
@@ -21,7 +24,6 @@ int main() {
   buffer<int> A{ R };
 
   // create a kernel
-  class ExampleKernel;
   queue q{device_selector };
   q.submit([&](handler& h) {
     auto out = A.get_access<access::mode::write>(h);


### PR DESCRIPTION
## Description

The ProjectTemplates samples were failing at runtime with 2021.4 compiler.  Moved the declaration of the kernel name class to be global to fix the issue.

Also cleaned up depricated syntax for the FPGA versions of the templates.

## Type of change

Please delete options that are not relevant. Add a 'X' to the one that is applicable. 

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

 - ran cmake (when present) and make on all updated samples, compiles all passed with no syntax warnings in 2021.4
 - executed the emulator targets for the fpga samples, they now work

- [x] Command Line

