### PR TITLE
Removing old compile flag from GZIP CMakeLists.txt

### DIFF
--- a/DirectProgramming/DPC++FPGA/ReferenceDesigns/gzip/src/CMakeLists.txt
+++ b/DirectProgramming/DPC++FPGA/ReferenceDesigns/gzip/src/CMakeLists.txt
@@ -77,7 +77,7 @@ message(STATUS "NUM_REORDER_LL=${NUM_REORDER_LL}")
 #    For this reason, FPGA backend flags must be passed as link flags in CMake.
 set(EMULATOR_COMPILE_FLAGS "-Wall ${WIN_FLAG} -fintelfpga -g0 -DNUM_ENGINES=${NUM_ENGINES} -DFPGA_EMULATOR")
 set(EMULATOR_LINK_FLAGS "-fintelfpga -DNUM_ENGINES=${NUM_ENGINES}")
-set(HARDWARE_COMPILE_FLAGS "-Wall ${WIN_FLAG} -MMD -fintelfpga -DNUM_ENGINES=${NUM_ENGINES}")
+set(HARDWARE_COMPILE_FLAGS "-Wall ${WIN_FLAG} -fintelfpga -DNUM_ENGINES=${NUM_ENGINES}")
 set(HARDWARE_LINK_FLAGS "-fintelfpga -Xshardware -Xsparallel=2 -Xsopt-arg=\"-nocaching\" -Xsboard=${FPGA_BOARD} -DNUM_ENGINES=${NUM_ENGINES} ${USER_HARDWARE_FLAGS}")
 # use cmake -D USER_HARDWARE_FLAGS=<flags> to set extra flags for FPGA backend compilation
 


### PR DESCRIPTION
# Existing Sample Changes
## Description
Removing old compile flag from GZIP CMakeLists.txt that was causing build errors on some machines.

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [X] Command Line
- [X] On machine where it was previously failing.