### PR TITLE
Dnn win

### DIFF
--- a/Libraries/oneDNN/getting_started/README.md
+++ b/Libraries/oneDNN/getting_started/README.md
@@ -102,7 +102,9 @@ C:\Program Files (x86)\Intel\oneAPI\setvars.bat
 cd C:\Program Files (x86)\Intel\oneAPI\dnnl\latest\cpu_dpcpp_gpu_dpcpp\examples\
 mkdir build
 cd build
-cmake -G Ninja ..
+set CC=clang
+set CXX=clang++
+cmake -G Ninja .. -DDNNL_CPU_RUNTIME=DPCPP -DDNNL_GPU_RUNTIME=DPCPP
 cmake --build .
 ```
 

--- a/Libraries/oneDNN/getting_started/README.md
+++ b/Libraries/oneDNN/getting_started/README.md
@@ -152,7 +152,6 @@ Example passed on CPU.
 
 When executed with `DNNL_VERBOSE=1`:
 ```
-dnnl_verbose,info,oneDNN v1.95.0 (commit ae08a30fff7f76759fd4c5093c01707d0ee12c4c)
 dnnl_verbose,info,cpu,runtime:DPC++
 dnnl_verbose,info,cpu,isa:Intel AVX2
 dnnl_verbose,info,gpu,runtime:DPC++

--- a/Libraries/oneDNN/getting_started/sample.json
+++ b/Libraries/oneDNN/getting_started/sample.json
@@ -29,7 +29,7 @@
 			"set CXX=clang++",
 			"mkdir build_cpu",
                         "cd build_cpu",
-                        "cmake -G Ninja ..",
+                        "cmake -G Ninja .. -DDNNL_CPU_RUNTIME=DPCPP -DDNNL_GPU_RUNTIME=DPCPP",
                         "cmake --build .",
                         "bin\\getting-started-cpp.exe"
 		 ]
@@ -41,7 +41,7 @@
 			"set CXX=clang++",
 			"mkdir build_gpu",
                         "cd build_gpu",
-                        "cmake -G Ninja ..",
+                        "cmake -G Ninja .. -DDNNL_CPU_RUNTIME=DPCPP -DDNNL_GPU_RUNTIME=DPCPP",
                         "cmake --build .",
                         "bin\\getting-started-cpp.exe gpu"
 		 ]

--- a/Libraries/oneDNN/simple_model/README.md
+++ b/Libraries/oneDNN/simple_model/README.md
@@ -99,7 +99,9 @@ C:\Program Files (x86)\Intel\oneAPI\setvars.bat
 cd C:\Program Files (x86)\Intel\oneAPI\dnnl\latest\cpu_dpcpp_gpu_dpcpp\examples\
 mkdir build
 cd build
-cmake -G Ninja ..
+set CC=clang
+set CXX=clang++
+cmake -G Ninja .. -DDNNL_CPU_RUNTIME=DPCPP -DDNNL_GPU_RUNTIME=DPCPP
 cmake --build .
 ```
 
@@ -150,7 +152,6 @@ Example passed on CPU.
 
 When executed with `DNNL_VERBOSE=1`:
 ```
-dnnl_verbose,info,oneDNN v1.95.0 (commit ae08a30fff7f76759fd4c5093c01707d0ee12c4c)
 dnnl_verbose,info,cpu,runtime:DPC++
 dnnl_verbose,info,cpu,isa:Intel AVX2
 dnnl_verbose,info,gpu,runtime:DPC++

--- a/Libraries/oneDNN/simple_model/sample.json
+++ b/Libraries/oneDNN/simple_model/sample.json
@@ -30,7 +30,7 @@
 			"set CXX=clang++",
 			"mkdir build_cpu",
                         "cd build_cpu",
-                        "cmake -G Ninja ..",
+                        "cmake -G Ninja .. -DDNNL_CPU_RUNTIME=DPCPP -DDNNL_GPU_RUNTIME=DPCPP",
                         "cmake --build .",
                         "bin\\cnn-inference-f32-cpp.exe"
 		 ]
@@ -42,7 +42,7 @@
 			"set CXX=clang++",
                         "mkdir build_gpu",
                         "cd build_gpu",
-                        "cmake -G Ninja ..",
+                        "cmake -G Ninja .. -DDNNL_CPU_RUNTIME=DPCPP -DDNNL_GPU_RUNTIME=DPCPP",
                         "cmake --build .",
                         "bin\\cnn-inference-f32-cpp.exe gpu"
 		 ]


### PR DESCRIPTION
# Existing Sample Changes
## Description

a fix for compiling oneDNN samples on Windows OS
Fixes Issue#  https://jira.devtools.intel.com/browse/ONSAM-1405



## Type of change

Please delete options that are not relevant. Add a 'X' to the one that is applicable. 

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Implement fixes for ONSAM Jiras

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Command Line
- [ ] oneapi-cli
- [ ] Visual Studio
- [ ] Eclipse IDE
- [ ] VSCode
- [ ] When compiling the compliler flag "-Wall -Wformat-security -Werror=format-security" was used

