### PR TITLE
Update CMakeLists, minimum required version

### DIFF
--- a/Libraries/oneCCL/oneCCL_Getting_Started/CMakeLists.txt
+++ b/Libraries/oneCCL/oneCCL_Getting_Started/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.11)
+cmake_minimum_required(VERSION 3.4)
 if("${CMAKE_CXX_COMPILER}" STREQUAL "")
        set(CMAKE_C_COMPILER "clang")
        set(CMAKE_CXX_COMPILER "dpcpp")

--- a/Libraries/oneCCL/tutorials/oneCCL_Getting_Started.ipynb
+++ b/Libraries/oneCCL/tutorials/oneCCL_Getting_Started.ipynb
@@ -181,7 +181,7 @@
    "outputs": [],
    "source": [
     "%%writefile lab/CMakeLists.txt\n",
-    "#cmake_minimum_required (VERSION 2.8)\n",
+    "#cmake_minimum_required (VERSION 3.4)\n",
     "#project(CCL_SAMPLES)\n",
     "set(CCL_TEST_INCLUDE_DIR \"$ENV{PWD}/../include\")\n",
     "set(CMAKE_INSTALL_PREFIX \"$ENV{PWD}/_install\")\n",

--- a/Libraries/oneDNN/tutorials/CMakeLists.txt
+++ b/Libraries/oneDNN/tutorials/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.11)
+cmake_minimum_required(VERSION 3.4)
 if("${CMAKE_CXX_COMPILER}" STREQUAL "")
        set(CMAKE_C_COMPILER "clang")
        set(CMAKE_CXX_COMPILER "clang++")

--- a/Tools/Advisor/matrix_multiply_advisor/CMakeLists.txt
+++ b/Tools/Advisor/matrix_multiply_advisor/CMakeLists.txt
@@ -1,5 +1,5 @@
 set(CMAKE_CXX_COMPILER dpcpp)
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.4)
 project(matrix_multiply)
 set(CMAKE_CXX_FLAGS "-g -O3 -fsycl -Wno-write-strings -w -D_Linux")
 add_executable(matrix.dpcpp  src/matrix.cpp src/multiply.cpp)

--- a/Tools/IoTConnectionTools/azure-iothub-telemetry/cpp/CMakeLists.txt
+++ b/Tools/IoTConnectionTools/azure-iothub-telemetry/cpp/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.11)
+cmake_minimum_required(VERSION 3.4)
 project(azure-iothub-telemetry)
 
 # Use the Intel® C++ Compiler when available


### PR DESCRIPTION
# Existing Sample Changes
## Description

Update CMakeLists
Change minimum requaired versions to 3.4

Fixes Issue# 

## External Dependencies

None

## Type of change

Please delete options that are not relevant. Add a 'X' to the one that is applicable. 

- [X] Implement fixes for ONSAM Jiras

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Command Line
- [ ] oneapi-cli
- [ ] Visual Studio
- [ ] Eclipse IDE
- [ ] VSCode
- [ ] When compiling the compliler flag "-Wall -Wformat-security -Werror=format-security" was used
