### PR TITLE
fix deprecation notice

### DIFF
--- a/Libraries/oneMKL/black_scholes/black_scholes.cpp
+++ b/Libraries/oneMKL/black_scholes/black_scholes.cpp
@@ -27,6 +27,7 @@ using namespace oneapi;
 
 #include "input_generator.hpp"
 #include "black_scholes.hpp"
+#include "code_wrapper.tpp"
 
 namespace {
 
@@ -83,7 +84,7 @@ void async_sycl_error(sycl::exception_list el) {
         try {
             std::rethrow_exception(*l);
         } catch(const sycl::exception & e) {
-            std::cerr << "SYCL exception occured with code " << e.get_cl_code() << " with " << e.what() << std::endl;
+            std::cerr << "SYCL exception occured with code " << code_wrapper(e) << " with " << e.what() << std::endl;
         }
     }
 }
@@ -184,7 +185,7 @@ int sample_run(int64_t nopt) {
         }
     }
     catch (sycl::exception const & re) {
-        std::cerr << "SYCL exception occured with code " << re.get_cl_code() << " with " << re.what() << std::endl;
+        std::cerr << "SYCL exception occured with code " << code_wrapper(re) << " with " << re.what() << std::endl;
         return -1;
     }
 

--- a/Libraries/oneMKL/black_scholes/code_wrapper.tpp
+++ b/Libraries/oneMKL/black_scholes/code_wrapper.tpp
@@ -1,0 +1,28 @@
+//==============================================================
+// Copyright © 2020 Intel Corporation
+//
+// SPDX-License-Identifier: MIT
+// =============================================================
+
+/*******************************************************************************
+  !  Content:
+  !      Wrapper utility for backward compatibility with get_cl_code in SYCL 1.2.1
+  !******************************************************************************/
+
+#pragma once
+#include <utility>
+
+template <typename T, typename = void>
+struct has_member_code_meta : std::false_type {};
+
+template <typename T>
+struct has_member_code_meta<T, std::void_t<decltype( std::declval<T>().code() )> > : std::true_type {};
+
+template <typename T, typename std::enable_if<has_member_code_meta<T>::value>::type* = nullptr >
+auto code_wrapper (T x) {
+    return x.code();
+};
+template <typename T, typename std::enable_if<!has_member_code_meta<T>::value>::type* = nullptr >
+auto code_wrapper (T x) {
+    return x.get_cl_code();
+};


### PR DESCRIPTION
# Existing Sample Changes
## Description

Recent dpcpp compilers issue a deprecation notice for get_cl_code(). This patch calls new code() api when possible, falling back to get_cl_code() when not.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Implement fixes for ONSAM Jiras

## How Has This Been Tested?

- [ X ] Command Line (linux)
- [ ] oneapi-cli
- [ ] Visual Studio
- [ ] Eclipse IDE
- [ ] VSCode
- [ ] When compiling the compliler flag "-Wall -Wformat-security -Werror=format-security" was used
