### PR TITLE
ONSAM-1414 Broken Link in Headers

### DIFF
--- a/DirectProgramming/C++/CombinationalLogic/MandelbrotOMP/Makefile
+++ b/DirectProgramming/C++/CombinationalLogic/MandelbrotOMP/Makefile
@@ -1,15 +1,3 @@
-#==============================================================
-#
-# SAMPLE SOURCE CODE - SUBJECT TO THE TERMS OF SAMPLE CODE LICENSE AGREEMENT,
-# http://software.intel.com/en-us/articles/intel-sample-source-code-license-agreement/
-#
-# Copyright Intel Corporation
-#
-# THIS FILE IS PROVIDED "AS IS" WITH NO WARRANTIES, EXPRESS OR IMPLIED, INCLUDING BUT
-# NOT LIMITED TO ANY IMPLIED WARRANTY OF MERCHANTABILITY, FITNESS FOR A PARTICULAR
-# PURPOSE, NON-INFRINGEMENT OF INTELLECTUAL PROPERTY RIGHTS.
-#
-# =============================================================
 CXX := icpc
 SRCDIR := src
 BUILDDIR := release

--- a/DirectProgramming/C++/CompilerInfrastructure/Intrinsics/Makefile
+++ b/DirectProgramming/C++/CompilerInfrastructure/Intrinsics/Makefile
@@ -1,15 +1,3 @@
-#==============================================================
-#
-# SAMPLE SOURCE CODE - SUBJECT TO THE TERMS OF SAMPLE CODE LICENSE AGREEMENT,
-# http://software.intel.com/en-us/articles/intel-sample-source-code-license-agreement/
-#
-# Copyright Intel Corporation
-#
-# THIS FILE IS PROVIDED "AS IS" WITH NO WARRANTIES, EXPRESS OR IMPLIED, INCLUDING BUT
-# NOT LIMITED TO ANY IMPLIED WARRANTY OF MERCHANTABILITY, FITNESS FOR A PARTICULAR
-# PURPOSE, NON-INFRINGEMENT OF INTELLECTUAL PROPERTY RIGHTS.
-#
-# =============================================================
 CC = icc
 EXECS=intrin_dot_sample.exe intrin_double_sample.exe intrin_ftz_sample.exe
 DBG_EXECS=intrin_dot_sample_dbg.exe intrin_double_sample_dbg.exe intrin_ftz_sample_dbg.exe

--- a/DirectProgramming/C++/CompilerInfrastructure/Intrinsics/src/intrin_dot_sample.cpp
+++ b/DirectProgramming/C++/CompilerInfrastructure/Intrinsics/src/intrin_dot_sample.cpp
@@ -1,15 +1,3 @@
-//==============================================================
-//
-// SAMPLE SOURCE CODE - SUBJECT TO THE TERMS OF SAMPLE CODE LICENSE AGREEMENT,
-// http://software.intel.com/en-us/articles/intel-sample-source-code-license-agreement/
-//
-// Copyright 2016 Intel Corporation
-//
-// THIS FILE IS PROVIDED "AS IS" WITH NO WARRANTIES, EXPRESS OR IMPLIED,
-// INCLUDING BUT NOT LIMITED TO ANY IMPLIED WARRANTY OF MERCHANTABILITY, FITNESS
-// FOR A PARTICULAR PURPOSE, NON-INFRINGEMENT OF INTELLECTUAL PROPERTY RIGHTS.
-//
-// =============================================================
 /* [DESCRIPTION]
  * This C code sample demonstrates how to use C, Intel(R) MMX(TM),
  * Intel(R) Streaming SIMD Extensions 3 (Intel(R) SSE3),

--- a/DirectProgramming/C++/CompilerInfrastructure/Intrinsics/src/intrin_double_sample.cpp
+++ b/DirectProgramming/C++/CompilerInfrastructure/Intrinsics/src/intrin_double_sample.cpp
@@ -1,15 +1,3 @@
-//==============================================================
-//
-// SAMPLE SOURCE CODE - SUBJECT TO THE TERMS OF SAMPLE CODE LICENSE AGREEMENT,
-// http://software.intel.com/en-us/articles/intel-sample-source-code-license-agreement/
-//
-// Copyright 2016 Intel Corporation
-//
-// THIS FILE IS PROVIDED "AS IS" WITH NO WARRANTIES, EXPRESS OR IMPLIED,
-// INCLUDING BUT NOT LIMITED TO ANY IMPLIED WARRANTY OF MERCHANTABILITY, FITNESS
-// FOR A PARTICULAR PURPOSE, NON-INFRINGEMENT OF INTELLECTUAL PROPERTY RIGHTS.
-//
-// =============================================================
 /* [DESCRIPTION]
  * This C code sample demonstrates how to use C in
  * comparison with

--- a/DirectProgramming/C++/CompilerInfrastructure/Intrinsics/src/intrin_ftz_sample.cpp
+++ b/DirectProgramming/C++/CompilerInfrastructure/Intrinsics/src/intrin_ftz_sample.cpp
@@ -1,15 +1,3 @@
-//==============================================================
-//
-// SAMPLE SOURCE CODE - SUBJECT TO THE TERMS OF SAMPLE CODE LICENSE AGREEMENT,
-// http://software.intel.com/en-us/articles/intel-sample-source-code-license-agreement/
-//
-// Copyright 2017 Intel Corporation
-//
-// THIS FILE IS PROVIDED "AS IS" WITH NO WARRANTIES, EXPRESS OR IMPLIED,
-// INCLUDING BUT NOT LIMITED TO ANY IMPLIED WARRANTY OF MERCHANTABILITY, FITNESS
-// FOR A PARTICULAR PURPOSE, NON-INFRINGEMENT OF INTELLECTUAL PROPERTY RIGHTS.
-//
-// =============================================================
 /* [DESCRIPTION]
  * This code sample demonstrates how to use the
  * _MM_GET_FLUSH_ZERO_MODE() and _MM_GET_DENORMALS_ZERO_MODE()

--- a/DirectProgramming/C++/GraphTraversal/MergesortOMP/Makefile
+++ b/DirectProgramming/C++/GraphTraversal/MergesortOMP/Makefile
@@ -1,15 +1,3 @@
-#==============================================================
-#
-# SAMPLE SOURCE CODE - SUBJECT TO THE TERMS OF SAMPLE CODE LICENSE AGREEMENT,
-# http://software.intel.com/en-us/articles/intel-sample-source-code-license-agreement/
-#
-# Copyright Intel Corporation
-#
-# THIS FILE IS PROVIDED "AS IS" WITH NO WARRANTIES, EXPRESS OR IMPLIED, INCLUDING BUT
-# NOT LIMITED TO ANY IMPLIED WARRANTY OF MERCHANTABILITY, FITNESS FOR A PARTICULAR
-# PURPOSE, NON-INFRINGEMENT OF INTELLECTUAL PROPERTY RIGHTS.
-#
-# =============================================================
 CXX := icpc
 SRCDIR := src
 BUILDDIR := release

--- a/DirectProgramming/C++/GraphTraversal/MergesortOMP/src/merge_sort.cpp
+++ b/DirectProgramming/C++/GraphTraversal/MergesortOMP/src/merge_sort.cpp
@@ -1,15 +1,3 @@
-//==============================================================
-//
-// SAMPLE SOURCE CODE - SUBJECT TO THE TERMS OF SAMPLE CODE LICENSE AGREEMENT,
-// http://software.intel.com/en-us/articles/intel-sample-source-code-license-agreement/
-//
-// Copyright Intel Corporation
-//
-// THIS FILE IS PROVIDED "AS IS" WITH NO WARRANTIES, EXPRESS OR IMPLIED,
-// INCLUDING BUT NOT LIMITED TO ANY IMPLIED WARRANTY OF MERCHANTABILITY, FITNESS
-// FOR A PARTICULAR PURPOSE, NON-INFRINGEMENT OF INTELLECTUAL PROPERTY RIGHTS.
-//
-// =============================================================
 #define _CRT_SECURE_NO_DEPRECATE
 #include <omp.h>
 

--- a/DirectProgramming/DPC++/SpectralMethods/DiscreteCosineTransform/src/DCT.cpp
+++ b/DirectProgramming/DPC++/SpectralMethods/DiscreteCosineTransform/src/DCT.cpp
@@ -1,16 +1,3 @@
-//=======================================================================================
-//
-// SAMPLE SOURCE CODE - SUBJECT TO THE TERMS OF SAMPLE CODE LICENSE AGREEMENT,
-// http://software.intel.com/en-us/articles/intel-sample-source-code-license-agreement/
-//
-// Copyright Intel Corporation
-//
-// THIS FILE IS PROVIDED "AS IS" WITH NO WARRANTIES, EXPRESS OR IMPLIED,
-// INCLUDING BUT NOT LIMITED TO ANY IMPLIED WARRANTY OF MERCHANTABILITY, FITNESS
-// FOR A PARTICULAR PURPOSE, NON-INFRINGEMENT OF INTELLECTUAL PROPERTY RIGHTS.
-//
-// ======================================================================================
-
 #include "DCT.hpp"
 
 #include <CL/sycl.hpp>

--- a/DirectProgramming/DPC++/SpectralMethods/DiscreteCosineTransform/src/DCT.hpp
+++ b/DirectProgramming/DPC++/SpectralMethods/DiscreteCosineTransform/src/DCT.hpp
@@ -1,15 +1,3 @@
-//=======================================================================================
-//
-// SAMPLE SOURCE CODE - SUBJECT TO THE TERMS OF SAMPLE CODE LICENSE AGREEMENT,
-// http://software.intel.com/en-us/articles/intel-sample-source-code-license-agreement/
-//
-// Copyright Intel Corporation
-//
-// THIS FILE IS PROVIDED "AS IS" WITH NO WARRANTIES, EXPRESS OR IMPLIED,
-// INCLUDING BUT NOT LIMITED TO ANY IMPLIED WARRANTY OF MERCHANTABILITY, FITNESS
-// FOR A PARTICULAR PURPOSE, NON-INFRINGEMENT OF INTELLECTUAL PROPERTY RIGHTS.
-//
-// ======================================================================================
 #pragma pack(push, 1)
 
 // This is the data structure which is going to represent one pixel value in RGB


### PR DESCRIPTION
# Existing Sample Changes
## Description
Found links in several samples to be no longer valid, so I removed the license at the head of the affected files. 

The finding is that we don't need the headers, so long as each sample has a license.txt file, so removing is not going to cause issues
Fixes Issue# ONSAM-1414
