### PR TITLE
Fixing FPGA merge sort design for non-power-of-2 data

### DIFF
--- a/DirectProgramming/DPC++FPGA/ReferenceDesigns/merge_sort/src/main.cpp
+++ b/DirectProgramming/DPC++FPGA/ReferenceDesigns/merge_sort/src/main.cpp
@@ -308,7 +308,7 @@ double FPGASort(queue &q, ValueT *in_ptr, ValueT *out_ptr, IndexT count) {
 
       for (IndexT i = 0; i < total_pipe_accesses; i++) {
         // read data from device memory
-        bool in_range = i < sorter_count;
+        bool in_range = i * kSortWidth < count;
 
         // build the input pipe data
         sycl::vec<ValueT, kSortWidth> data;
@@ -333,7 +333,7 @@ double FPGASort(queue &q, ValueT *in_ptr, ValueT *out_ptr, IndexT count) {
         auto data = SortOutPipe::read();
 
         // sorter_count is a multiple of kSortWidth
-        bool in_range = i < sorter_count;
+        bool in_range = i * kSortWidth < count;
 
         // only write out to device memory if the index is in range
         if (in_range) {


### PR DESCRIPTION
# Existing Sample Changes
## Description
Fixes bug for non-power-of-2 data. Previously we performed an incorrect check on the sorter vs the actual input size.

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [X] Command Line
- [X] regtest infra