### PR TITLE
[FPGA] Fix gzip buffer alloc sizes

### DIFF
--- a/DirectProgramming/DPC++FPGA/ReferenceDesigns/gzip/src/gzip.cpp
+++ b/DirectProgramming/DPC++FPGA/ReferenceDesigns/gzip/src/gzip.cpp
@@ -170,7 +170,7 @@ int main(int argc, char *argv[]) {
     std::cerr << "Caught a SYCL host exception:\n" << e.what() << "\n";
 
     // Most likely the runtime couldn't find FPGA hardware!
-    if (e.get_cl_code() == CL_DEVICE_NOT_FOUND) {
+    if (e.code().value() == CL_DEVICE_NOT_FOUND) {
       std::cerr << "If you are targeting an FPGA, please ensure that your "
                    "system has a correctly configured FPGA board.\n";
       std::cerr << "Run sys_check in the oneAPI root directory to verify.\n";

--- a/DirectProgramming/DPC++FPGA/ReferenceDesigns/gzip/src/gzip_ll.cpp
+++ b/DirectProgramming/DPC++FPGA/ReferenceDesigns/gzip/src/gzip_ll.cpp
@@ -176,7 +176,7 @@ int main(int argc, char *argv[]) {
     std::cerr << "Caught a SYCL host exception:\n" << e.what() << "\n";
 
     // Most likely the runtime couldn't find FPGA hardware!
-    if (e.get_cl_code() == CL_DEVICE_NOT_FOUND) {
+    if (e.code().value() == CL_DEVICE_NOT_FOUND) {
       std::cerr << "If you are targeting an FPGA, please ensure that your "
                    "system has a correctly configured FPGA board.\n";
       std::cerr << "Run sys_check in the oneAPI root directory to verify.\n";


### PR DESCRIPTION
# Existing Sample Changes
## Description

This fix addresses the problem identified in JIRA CMPLRLLVM-32151.
The Windows emulator was hanging. The issue was root caused to an improper buffer allocation (which interestingly has not been a problem for a very long time). This change matches the source buffer size to the destination buffer size.

## Type of change

- [X ] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
Ran Windows emulator manually
Ran A10/S10 regtests on Linux and Windows, emulator, hardware, gzip and gzip_ll.
