### PR TITLE
Update FPGA mvdr_beamforming design README with more typical output from a run on the FPGA.

### DIFF
--- a/DirectProgramming/DPC++FPGA/ReferenceDesigns/mvdr_beamforming/README.md
+++ b/DirectProgramming/DPC++FPGA/ReferenceDesigns/mvdr_beamforming/README.md
@@ -157,7 +157,7 @@ You can compile and run this Reference Design in the Eclipse* IDE (in Linux*) an
 | 2                     | The output directory (default=`.`)
 
 ### Example of Output
-You should see the following output in the console:
+You should see the following typical output in the console:
 
 ```
 Matrices:         1024
@@ -166,17 +166,19 @@ Output Directory: '.'
 
 Reading training data from '../data/A_real.txt and ../data/A_imag.txt
 Reading input data from ../data/X_real.txt and ../data/X_imag.txt
+Launched MVDR kernels
 
 *** Launching throughput test of 1024 matrices ***
 Sensor inputs                 : 16
 Training matrix rows          : 48
 Data rows per training matrix : 48
 Steering vectors              : 25
-Throughput: 34.6133 matrices/second
-Throughput: 82.5219 matrices/second
+Streaming pipe width          : 4
+Throughput: 233793 matrices/second
 Checking output data against ../data/small_expected_out_real.txt and ../data/small_expected_out_imag.txt
 Output data check succeeded
 PASSED
+
 ```
 
 ## Additional Design Information


### PR DESCRIPTION
## Description

Update README file to fix a duplicate line, and provide output that matches the current code and gives a throughput number from a run on the FPGA instead of on the emulator.

## Type of change

Please delete options that are not relevant. Add a 'X' to the one that is applicable. 

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

No testing, README update only.