### PR TITLE
Fixed the namespace issue repported in ONSAM-1433

### DIFF
--- a/DirectProgramming/DPC++/N-BodyMethods/Nbody/src/GSimulation.cpp
+++ b/DirectProgramming/DPC++/N-BodyMethods/Nbody/src/GSimulation.cpp
@@ -164,7 +164,7 @@ void GSimulation::Start() {
        #if(__SYCL_COMPILER_VERSION <= 20200827)
        h.parallel_for(ndrange, intel::reduction(energy, 0.f, std::plus<RealType>()), [=](nd_item<1> it, auto& energy) {
        #else
-       h.parallel_for(ndrange, ONEAPI::reduction(energy, 0.f, std::plus<RealType>()), [=](nd_item<1> it, auto& energy) {
+       h.parallel_for(ndrange, ext::oneapi::reduction(energy, 0.f, std::plus<RealType>()), [=](nd_item<1> it, auto& energy) {
        #endif
 	 auto i = it.get_global_id();
          p[i].vel[0] += p[i].acc[0] * dt;  // 2flops


### PR DESCRIPTION
# Existing Sample Changes
## Description

Namespace change from ONEAPI to ext::oneapi for Nbody sample

Fixes Issue# ONSAM-1433

## External Dependencies

No external dependencies

## Type of change

Please delete options that are not relevant. Add a 'X' to the one that is applicable. 

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Implement fixes for ONSAM Jiras

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [X] Command Line
- [ ] oneapi-cli
- [ ] Visual Studio
- [ ] Eclipse IDE
- [ ] VSCode
- [ ] When compiling the compliler flag "-Wall -Wformat-security -Werror=format-security" was used

