### PR TITLE
change cpu_icc to cpu for 2021.5 release

### DIFF
--- a/Libraries/oneCCL/oneCCL_Getting_Started/README.md
+++ b/Libraries/oneCCL/oneCCL_Getting_Started/README.md
@@ -71,7 +71,7 @@ You can refer to this page [oneAPI](https://software.intel.com/en-us/oneapi) for
   ex : /opt/intel/oneapi \
   Don't need to replace {DPCPP_CMPLR_ROOT} 
   ```
-  source ${ONEAPI_ROOT}/setvars.sh --ccl-configuration=cpu_icc
+  source ${ONEAPI_ROOT}/setvars.sh --ccl-configuration=cpu
 
   cd oneapi-toolkit/oneCCL/oneCCL_Getting_Started   
   mkdir build  

--- a/Libraries/oneCCL/tutorials/oneCCL_Getting_Started.ipynb
+++ b/Libraries/oneCCL/tutorials/oneCCL_Getting_Started.ipynb
@@ -188,8 +188,8 @@
     "if(${CMAKE_CXX_COMPILER_ID} STREQUAL \"GNU\")\n",
     "    file(GLOB sources \"cpu_*.c\" \"cpu_*.cpp\")\n",
     "    set(CMAKE_CXX_FLAGS \"${CMAKE_CXX_FLAGS} ${CMAKE_CLANG_FLAGS} -std=c++11\")\n",
-    "    set(CCL_INCLUDE_DIR \"$ENV{CCL_ROOT}/include/cpu_icc\")\n",
-    "    set(CCL_LIB_DIR \"$ENV{CCL_ROOT}/lib/cpu_icc\")\n",
+    "    set(CCL_INCLUDE_DIR \"$ENV{CCL_ROOT}/include/cpu\")\n",
+    "    set(CCL_LIB_DIR \"$ENV{CCL_ROOT}/lib/cpu\")\n",
     "    foreach(src ${sources})\n",
     "        include_directories(${CCL_INCLUDE_DIR})\n",
     "        include_directories(${CCL_TEST_INCLUDE_DIR})\n",
@@ -257,7 +257,7 @@
    "source": [
     "%%writefile build.sh\n",
     "#!/bin/bash\n",
-    "source $ONEAPI_INSTALL/setvars.sh --ccl-configuration=cpu_icc --force > /dev/null 2>&1\n",
+    "source $ONEAPI_INSTALL/setvars.sh --ccl-configuration=cpu --force > /dev/null 2>&1\n",
     "export EXAMPLE_ROOT=./lab/\n",
     "mkdir cpu_gomp\n",
     "cd cpu_gomp\n",
@@ -274,7 +274,7 @@
     "\n",
     "#### Script - run.sh\n",
     "the script **run.sh** encapsulates the program for submission to the job queue for execution.\n",
-    "The user must switch to the g++ oneCCL configuration by inputting a custom configuration \"--ccl-configuration=cpu_icc\" when running \"source setvars.sh\".\n"
+    "The user must switch to the g++ oneCCL configuration by inputting a custom configuration \"--ccl-configuration=cpu\" when running \"source setvars.sh\".\n"
    ]
   },
   {
@@ -285,7 +285,7 @@
    "source": [
     "%%writefile run.sh\n",
     "#!/bin/bash\n",
-    "source $ONEAPI_INSTALL/setvars.sh --ccl-configuration=cpu_icc --force > /dev/null 2>&1\n",
+    "source $ONEAPI_INSTALL/setvars.sh --ccl-configuration=cpu --force > /dev/null 2>&1\n",
     "echo \"########## Executing the run\"\n",
     "./cpu_gomp/out/cpu_allreduce_cpp_test\n",
     "echo \"########## Done with the run\"\n",
@@ -337,7 +337,7 @@
    "source": [
     "%%writefile vtune_collect.sh\n",
     "#!/bin/bash\n",
-    "source $ONEAPI_INSTALL/setvars.sh --ccl-configuration=cpu_icc --force \n",
+    "source $ONEAPI_INSTALL/setvars.sh --ccl-configuration=cpu --force \n",
     "type=hotspots\n",
     "\n",
     "rm -r $(pwd)/vtune_data\n",
@@ -408,7 +408,7 @@
    "source": [
     "%%writefile vtune_collect.sh\n",
     "#!/bin/bash\n",
-    "source $ONEAPI_INSTALL/setvars.sh --ccl-configuration=cpu_icc --force \n",
+    "source $ONEAPI_INSTALL/setvars.sh --ccl-configuration=cpu --force \n",
     "type=gpu-hotspots\n",
     "\n",
     "rm -r $(pwd)/vtune_data\n",


### PR DESCRIPTION
# Existing Sample Changes
## Description

oneccl changes folder name from cpu_icc to cpu in 2021.5 release.
this PR addresses the necessary changes in oneccl samples for 2021.5 release.

Fixes Issue# 

## Type of change

Please delete options that are not relevant. Add a 'X' to the one that is applicable. 

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Implement fixes for ONSAM Jiras

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Command Line
- [ ] oneapi-cli
- [ ] Visual Studio
- [ ] Eclipse IDE
- [ ] VSCode
- [ ] When compiling the compliler flag "-Wall -Wformat-security -Werror=format-security" was used

