### PR TITLE
FPGA sample stall_free: Remove deprecated access::target::global_buffer

### DIFF
--- a/DirectProgramming/DPC++FPGA/Tutorials/Features/stall_enable/src/stall_enable.cpp
+++ b/DirectProgramming/DPC++FPGA/Tutorials/Features/stall_enable/src/stall_enable.cpp
@@ -36,9 +36,9 @@ static WorkType RealWork(WorkType a, WorkType b) {
 }
 
 using ReadAccessor =
-  accessor<WorkType, 1, access::mode::read, access::target::global_buffer>;
+  accessor<WorkType, 1, access::mode::read, access::target::device>;
 using WriteAccessor =
-  accessor<WorkType, 1, access::mode::write, access::target::global_buffer>;
+  accessor<WorkType, 1, access::mode::write, access::target::device>;
 
 static void Work(const ReadAccessor &vec_a, const ReadAccessor &vec_b,
                  const WriteAccessor &vec_res) {


### PR DESCRIPTION
## Remove deprecated access::target::global_buffer

Fix a deprecated message that will cause problems later when we die if there are any warnings.  Replace access::target::global_buffer with access::target::device

## Type of change
- [ X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Ran locally:

- [X] Command Line
- [X] When compiling the compliler flag "-Wall -Wformat-security -Werror=format-security" was used
