### PR TITLE
Update Cmake file to build either high bandwidth or low latency varia…

### DIFF
--- a/DirectProgramming/DPC++FPGA/ReferenceDesigns/gzip/src/CMakeLists.txt
+++ b/DirectProgramming/DPC++FPGA/ReferenceDesigns/gzip/src/CMakeLists.txt
@@ -1,20 +1,22 @@
 set(TARGET_NAME gzip)
 
-# High bandwidth variant
-set(SOURCE_FILE gzip.cpp crc32.cpp WriteGzip.cpp CompareGzip.cpp)
+
+if(LOW_LATENCY)
+    # Compile the low latency version of the design
+    message(STATUS "Compiling the Low Latency variant of the design")
+    set(SOURCE_FILE gzip_ll.cpp crc32.cpp WriteGzip.cpp CompareGzip.cpp)
+    set(DEVICE_SOURCE_FILE gzipkernel_ll.cpp)
+    set(DEVICE_HEADER_FILE gzipkernel_ll.hpp)
+else()
+    # Compile the high bandwidth version of the design
+    message(STATUS "Compiling the High Bandwidth variation of the design")
+    set(SOURCE_FILE gzip.cpp crc32.cpp WriteGzip.cpp CompareGzip.cpp)
+    set(DEVICE_SOURCE_FILE gzipkernel.cpp)
+    set(DEVICE_HEADER_FILE gzipkernel.hpp)
+endif()
+
 set(EMULATOR_TARGET ${TARGET_NAME}.fpga_emu)
 set(FPGA_TARGET ${TARGET_NAME}.fpga)
-set(DEVICE_SOURCE_FILE gzipkernel.cpp)
-set(DEVICE_HEADER_FILE gzipkernel.hpp)
-set(HIGH_BW_SEED "-Xsseed=8")
-
-# Low latency variant
-set(SOURCE_FILE_LL gzip_ll.cpp crc32.cpp WriteGzip.cpp CompareGzip.cpp)
-set(EMULATOR_TARGET_LL ${TARGET_NAME}_ll.fpga_emu)
-set(FPGA_TARGET_LL ${TARGET_NAME}_ll.fpga)
-set(DEVICE_SOURCE_FILE_LL gzipkernel_ll.cpp)
-set(DEVICE_HEADER_FILE_LL gzipkernel_ll.hpp)
-set(LL_SEED "-Xsseed=1")
 
 # FPGA board selection
 if(NOT DEFINED FPGA_BOARD)
@@ -35,41 +37,53 @@ endif()
 if(FPGA_BOARD MATCHES ".*a10.*")
     # A10 parameters
     set(NUM_ENGINES 1)
-    set(LL_SEED "-Xsseed=4")
-    set(HIGH_BW_SEED "-Xsseed=4")
-    set(NUM_REORDER "")
+    if(DEFINED LOW_LATENCY)
+        set(SEED "-Xsseed=4")
+        set(NUM_REORDER "")
+    else()
+        set(SEED "-Xsseed=4")
+        set(NUM_REORDER "")
+    endif()
 elseif(FPGA_BOARD MATCHES ".*s10.*")
     # S10 parameters
     set(NUM_ENGINES 2)
-    set(LL_SEED "-Xsseed=2")
-    set(HIGH_BW_SEED "-Xsseed=2")
-    set(NUM_REORDER "-Xsnum-reorder=6")
+    if(DEFINED LOW_LATENCY)
+        set(SEED "-Xsseed=2")
+        set(NUM_REORDER "")
+    else()
+        set(SEED "-Xsseed=2")
+        # For the High Bandwidth variant, specify 6 reordering units to improve global memory read bandwidth across 4 channels of DDR.
+        # For Low Latency variant this is not necessary since only one channel of global memory is used (host memory).
+        set(NUM_REORDER "-Xsnum-reorder=6")
+    endif()
 elseif(FPGA_BOARD MATCHES ".*agilex.*")
     # Agilex™
     set(NUM_ENGINES 2)
-    set(LL_SEED "-Xsseed=1")
-    set(HIGH_BW_SEED "-Xsseed=8")
-    # For the High Bandwidth variant, specify 6 reordering units to improve global memory read bandwidth across 4 channels of DDR.
-    # For Low Latency variant this is not necessary since only one channel of global memory is used (host memory).
-    set(NUM_REORDER "-Xsnum-reorder=6")
+    if(DEFINED LOW_LATENCY)
+        set(SEED "-Xsseed=1")
+        set(NUM_REORDER "")
+    else()
+        set(SEED "-Xsseed=8")
+        # For the High Bandwidth variant, specify 6 reordering units to improve global memory read bandwidth across 4 channels of DDR.
+        # For Low Latency variant this is not necessary since only one channel of global memory is used (host memory).
+        set(NUM_REORDER "-Xsnum-reorder=6")
+    endif()
 else()
-    message(FATAL_ERROR "Unknown board!")
+    set(NUM_ENGINES 1)
+    set(SEED "-Xsseed=1")
+    set(NUM_REORDER "")
 endif()
 
-# Enable low-latency variant
 # Presence of USM host allocations (and whether to turn on enable the low-latency target) is detected automatically by
 # looking at the name of the BSP, or manually by the user when running CMake.
 # E.g., cmake .. -DUSER_ENABLE_USM=1
 if(FPGA_BOARD MATCHES ".*usm.*" OR DEFINED USER_ENABLE_USM)
     set(USM_ENABLED 1)
-    set(NUM_REORDER_LL "")
 endif()
 
 message(STATUS "NUM_ENGINES=${NUM_ENGINES}")
-message(STATUS "LL_SEED=${LL_SEED}")
-message(STATUS "HIGH_BW_SEED=${HIGH_BW_SEED}")
+message(STATUS "SEED=${SEED}")
 message(STATUS "NUM_REORDER=${NUM_REORDER}")
-message(STATUS "NUM_REORDER_LL=${NUM_REORDER_LL}")
 
 # A DPC++ ahead-of-time (AoT) compile processes the device code in two stages.
 # 1. The "compile" stage compiles the device code to an intermediate representation (SPIR-V).
@@ -81,11 +95,6 @@ set(HARDWARE_COMPILE_FLAGS "-Wall ${WIN_FLAG} -fintelfpga -DNUM_ENGINES=${NUM_EN
 set(HARDWARE_LINK_FLAGS "-fintelfpga -Xshardware -Xsparallel=2 -Xsopt-arg=\"-nocaching\" -Xsboard=${FPGA_BOARD} -DNUM_ENGINES=${NUM_ENGINES} ${USER_HARDWARE_FLAGS}")
 # use cmake -D USER_HARDWARE_FLAGS=<flags> to set extra flags for FPGA backend compilation
 
-#//////////////////////////////////////////////////////////////////////////////#
-#//////////////////////////////////////////////////////////////////////////////#
-#                           High Bandwidth Variant                             #
-#//////////////////////////////////////////////////////////////////////////////#
-#//////////////////////////////////////////////////////////////////////////////#
 ###############################################################################
 ### FPGA Emulator
 ###############################################################################
@@ -102,7 +111,7 @@ set(FPGA_EARLY_IMAGE ${TARGET_NAME}_report.a)
 add_executable(${FPGA_EARLY_IMAGE} ${SOURCE_FILE} ${DEVICE_SOURCE_FILE})
 add_custom_target(report DEPENDS ${FPGA_EARLY_IMAGE})
 set_target_properties(${FPGA_EARLY_IMAGE} PROPERTIES COMPILE_FLAGS "${HARDWARE_COMPILE_FLAGS}")
-set_target_properties(${FPGA_EARLY_IMAGE} PROPERTIES LINK_FLAGS "${HARDWARE_LINK_FLAGS} ${NUM_REORDER} ${HIGH_BW_SEED} -fsycl-link=early")
+set_target_properties(${FPGA_EARLY_IMAGE} PROPERTIES LINK_FLAGS "${HARDWARE_LINK_FLAGS} ${NUM_REORDER} ${SEED} -fsycl-link=early")
 # fsycl-link=early stops the compiler after RTL generation, before invoking Quartus
 
 ###############################################################################
@@ -111,52 +120,9 @@ set_target_properties(${FPGA_EARLY_IMAGE} PROPERTIES LINK_FLAGS "${HARDWARE_LINK
 add_executable(${FPGA_TARGET} EXCLUDE_FROM_ALL ${SOURCE_FILE} ${DEVICE_SOURCE_FILE})
 add_custom_target(fpga DEPENDS ${FPGA_TARGET})
 set_target_properties(${FPGA_TARGET} PROPERTIES COMPILE_FLAGS "${HARDWARE_COMPILE_FLAGS}")
-set_target_properties(${FPGA_TARGET} PROPERTIES LINK_FLAGS "${HARDWARE_LINK_FLAGS} ${NUM_REORDER} ${HIGH_BW_SEED} -reuse-exe=${CMAKE_BINARY_DIR}/${FPGA_TARGET}")
+set_target_properties(${FPGA_TARGET} PROPERTIES LINK_FLAGS "${HARDWARE_LINK_FLAGS} ${NUM_REORDER} ${SEED} -reuse-exe=${CMAKE_BINARY_DIR}/${FPGA_TARGET}")
 # The -reuse-exe flag enables rapid recompilation of host-only code changes.
 # See DPC++FPGA/GettingStarted/fast_recompile for details.
-#//////////////////////////////////////////////////////////////////////////////#
-#//////////////////////////////////////////////////////////////////////////////#
-#//////////////////////////////////////////////////////////////////////////////#
-#//////////////////////////////////////////////////////////////////////////////#
 
 
 
-#//////////////////////////////////////////////////////////////////////////////#
-#//////////////////////////////////////////////////////////////////////////////#
-#                            Low Latency Variant                               #
-#//////////////////////////////////////////////////////////////////////////////#
-#//////////////////////////////////////////////////////////////////////////////#
-if (${USM_ENABLED})
-###############################################################################
-### FPGA Emulator
-###############################################################################
-add_executable(${EMULATOR_TARGET_LL} ${SOURCE_FILE_LL} ${DEVICE_SOURCE_FILE_LL})
-set_target_properties(${EMULATOR_TARGET_LL} PROPERTIES COMPILE_FLAGS "${EMULATOR_COMPILE_FLAGS}")
-set_target_properties(${EMULATOR_TARGET_LL} PROPERTIES LINK_FLAGS "${EMULATOR_LINK_FLAGS}")
-add_custom_target(fpga_emu_ll DEPENDS ${EMULATOR_TARGET_LL})
-
-###############################################################################
-### Generate Report
-###############################################################################
-set(FPGA_EARLY_IMAGE_LL ${TARGET_NAME}_ll_report.a)
-# The compile output is not an executable, but an intermediate compilation result unique to DPC++.
-add_executable(${FPGA_EARLY_IMAGE_LL} ${SOURCE_FILE_LL} ${DEVICE_SOURCE_FILE_LL})
-add_custom_target(report_ll DEPENDS ${FPGA_EARLY_IMAGE_LL})
-set_target_properties(${FPGA_EARLY_IMAGE_LL} PROPERTIES COMPILE_FLAGS "${HARDWARE_COMPILE_FLAGS}")
-set_target_properties(${FPGA_EARLY_IMAGE_LL} PROPERTIES LINK_FLAGS "${HARDWARE_LINK_FLAGS} ${NUM_REORDER_LL} ${LL_SEED} -fsycl-link=early")
-# fsycl-link=early stops the compiler after RTL generation, before invoking Quartus
-
-###############################################################################
-### FPGA Hardware
-###############################################################################
-add_executable(${FPGA_TARGET_LL} EXCLUDE_FROM_ALL ${SOURCE_FILE_LL} ${DEVICE_SOURCE_FILE_LL})
-add_custom_target(fpga_ll DEPENDS ${FPGA_TARGET_LL})
-set_target_properties(${FPGA_TARGET_LL} PROPERTIES COMPILE_FLAGS "${HARDWARE_COMPILE_FLAGS}")
-set_target_properties(${FPGA_TARGET_LL} PROPERTIES LINK_FLAGS "${HARDWARE_LINK_FLAGS} ${NUM_REORDER_LL} ${LL_SEED} -reuse-exe=${CMAKE_BINARY_DIR}/${FPGA_TARGET_LL}")
-# The -reuse-exe flag enables rapid recompilation of host-only code changes.
-# See DPC++FPGA/GettingStarted/fast_recompile for details.
-endif()
-#//////////////////////////////////////////////////////////////////////////////#
-#//////////////////////////////////////////////////////////////////////////////#
-#//////////////////////////////////////////////////////////////////////////////#
-#//////////////////////////////////////////////////////////////////////////////#


### PR DESCRIPTION
…nt based on a flag passed in to CMAKE, instead of making separate Makefile targets for the Low Latency version.

Signed-off-by: mtucker <mike.d.b.tucker@intel.com>

# Existing Sample Changes
## Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes Issue# 

## External Dependencies

List any external dependencies created as a result of this change.

## Type of change

Please delete options that are not relevant. Add a 'X' to the one that is applicable. 

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Implement fixes for ONSAM Jiras

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Command Line
- [ ] oneapi-cli
- [ ] Visual Studio
- [ ] Eclipse IDE
- [ ] VSCode
- [ ] When compiling the compliler flag "-Wall -Wformat-security -Werror=format-security" was used

**_Delete this line and everything below if this is not a PR for a new code sample_**

**_Delete this line and all above it if this PR is for a new code sample_**
# Adding a New Sample(s)

## Description

Please include a description of the sample

## Checklist
Administrative
- [ ] Review sample design with the appropriate [Domain Expert](https://github.com/oneapi-src/oneAPI-samples/wiki/Reviewers-and-Domain-Experts): <insert Name Here>
- [ ] If you have any new dependencies/binaries, inform the oneAPI Code Samples Project Manager

Code Development
- [ ] Implement coding guidelines and ensure code quality. [see wiki for details](https://github.com/oneapi-src/oneAPI-samples/wiki/General-Code-Guidelines)
- [ ] Adhere to readme template 
- [ ] Enforce format via clang-format config file
- [ ] Adhere to sample.json specification. https://github.com/oneapi-src/oneAPI-samples/wiki/sample-json-specification
- [ ] Ensure/create CI test configurations for sample (ciTests field) https://github.com/oneapi-src/oneAPI-samples/wiki/sample-json-ci-test-object
- [ ] Run jsonlint on sample.json to verify json syntax. www.jsonlint.com

Security and Legal
- [ ] OSPDT Approval (see Project Manager for assistance)
- [ ] Compile using the following compiler flags and fix any warnings, the falgs are: "/Wall -Wformat-security -Werror=format-security"
- [ ] Bandit Scans (Python only)
- [ ] Virus scan

Review
- [ ] Review DPC++ code with Paul Peterseon. (GitHub User: pmpeter1)
- [ ] Review readme with Tom Lenth(@tomlenth) and/or Project Manager
- [ ] Tested using Dev Cloud when applicable
