### PR TITLE
FPGA db Reference Design cmake update to eliminate warning

### DIFF
--- a/DirectProgramming/DPC++FPGA/ReferenceDesigns/db/src/CMakeLists.txt
+++ b/DirectProgramming/DPC++FPGA/ReferenceDesigns/db/src/CMakeLists.txt
@@ -97,7 +97,7 @@ if(NOT DEFINED QUARTUS_CORES)
 endif()
 
 # check if they want to use the small database
-if(DEFINED SF_SMALL)
+if(SF_SMALL)
     message(STATUS "\tManual override for database size - building for small database (SF=0.01)")
     set(SF_SMALL_ARG -DSF_SMALL)
 else()


### PR DESCRIPTION
Signed-off-by: mtucker <mike.d.b.tucker@intel.com>

## Description

Update cmake file to check value of SF_SMALL instead of whether it is defined, to avoid cmake warning when using that variable

Fixes Issue# 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] Command Line
