### PR TITLE
FPGA samples: Fix long path issue that was causing Windows CI failures on some samples

### DIFF
--- a/DirectProgramming/DPC++FPGA/ReferenceDesigns/anr/sample.json
+++ b/DirectProgramming/DPC++FPGA/ReferenceDesigns/anr/sample.json
@@ -17,7 +17,7 @@
           "cd ../..",
           "mkdir build",
           "cd build",
-          "xcopy /E ..\\ReferenceDesigns\\anr\\test_data test_data\\",
+          "xcopy /E ..\\ReferenceDesigns\\anr\\test_data ..\\test_data\\",
           "cmake ../ReferenceDesigns/anr",
           "make fpga_emu",
           "./anr.fpga_emu"
@@ -30,7 +30,7 @@
           "cd ../..",
           "mkdir build",
           "cd build",
-          "xcopy /E ..\\ReferenceDesigns\\anr\\test_data test_data\\",
+          "xcopy /E ..\\ReferenceDesigns\\anr\\test_data ..\\test_data\\",
           "cmake ../ReferenceDesigns/anr",
           "make report"
         ]
@@ -44,7 +44,7 @@
           "cd ../..",
           "mkdir build",
           "cd build",
-          "xcopy /E ..\\ReferenceDesigns\\anr\\test_data test_data\\",
+          "xcopy /E ..\\ReferenceDesigns\\anr\\test_data ..\\test_data\\",
           "cmake -G \"NMake Makefiles\" ../ReferenceDesigns/anr",
           "nmake fpga_emu",
           "anr.fpga_emu.exe"
@@ -57,7 +57,7 @@
           "cd ../..",
           "mkdir build",
           "cd build",
-          "xcopy /E ..\\ReferenceDesigns\\anr\\test_data test_data\\",
+          "xcopy /E ..\\ReferenceDesigns\\anr\\test_data ..\\test_data\\",
           "cmake -G \"NMake Makefiles\" ../ReferenceDesigns/anr",
           "nmake report"
         ]

--- a/DirectProgramming/DPC++FPGA/ReferenceDesigns/anr/sample.json
+++ b/DirectProgramming/DPC++FPGA/ReferenceDesigns/anr/sample.json
@@ -13,9 +13,11 @@
       {
         "id": "fpga_emu",
         "steps": [
+          "dpcpp --version",
+          "cd ../..",
           "mkdir build",
           "cd build",
-          "cmake ..",
+          "cmake ../ReferenceDesigns/anr",
           "make fpga_emu",
           "./anr.fpga_emu"
         ]
@@ -23,9 +25,11 @@
       {
         "id": "report",
         "steps": [
+          "dpcpp --version",
+          "cd ../..",
           "mkdir build",
           "cd build",
-          "cmake ..",
+          "cmake ../ReferenceDesigns/anr",
           "make report"
         ]
       }
@@ -34,9 +38,11 @@
       {
         "id": "fpga_emu",
         "steps": [
+          "dpcpp --version",
+          "cd ../..",
           "mkdir build",
           "cd build",
-          "cmake -G \"NMake Makefiles\" ..",
+          "cmake -G \"NMake Makefiles\" ../ReferenceDesigns/anr",
           "nmake fpga_emu",
           "anr.fpga_emu.exe"
         ]
@@ -44,9 +50,11 @@
       {
         "id": "report",
         "steps": [
+          "dpcpp --version",
+          "cd ../..",
           "mkdir build",
           "cd build",
-          "cmake -G \"NMake Makefiles\" ..",
+          "cmake -G \"NMake Makefiles\" ../ReferenceDesigns/anr",
           "nmake report"
         ]
       }

--- a/DirectProgramming/DPC++FPGA/ReferenceDesigns/anr/sample.json
+++ b/DirectProgramming/DPC++FPGA/ReferenceDesigns/anr/sample.json
@@ -14,11 +14,9 @@
         "id": "fpga_emu",
         "steps": [
           "dpcpp --version",
-          "cd ../..",
           "mkdir build",
           "cd build",
-          "xcopy /E ..\\ReferenceDesigns\\anr\\test_data ..\\test_data\\",
-          "cmake ../ReferenceDesigns/anr",
+          "cmake ..",
           "make fpga_emu",
           "./anr.fpga_emu"
         ]
@@ -27,11 +25,9 @@
         "id": "report",
         "steps": [
           "dpcpp --version",
-          "cd ../..",
           "mkdir build",
           "cd build",
-          "xcopy /E ..\\ReferenceDesigns\\anr\\test_data ..\\test_data\\",
-          "cmake ../ReferenceDesigns/anr",
+          "cmake ..",
           "make report"
         ]
       }

--- a/DirectProgramming/DPC++FPGA/ReferenceDesigns/anr/sample.json
+++ b/DirectProgramming/DPC++FPGA/ReferenceDesigns/anr/sample.json
@@ -17,6 +17,7 @@
           "cd ../..",
           "mkdir build",
           "cd build",
+          "xcopy /E ..\\ReferenceDesigns\\anr\\test_data test_data\\",
           "cmake ../ReferenceDesigns/anr",
           "make fpga_emu",
           "./anr.fpga_emu"
@@ -29,6 +30,7 @@
           "cd ../..",
           "mkdir build",
           "cd build",
+          "xcopy /E ..\\ReferenceDesigns\\anr\\test_data test_data\\",
           "cmake ../ReferenceDesigns/anr",
           "make report"
         ]
@@ -42,6 +44,7 @@
           "cd ../..",
           "mkdir build",
           "cd build",
+          "xcopy /E ..\\ReferenceDesigns\\anr\\test_data test_data\\",
           "cmake -G \"NMake Makefiles\" ../ReferenceDesigns/anr",
           "nmake fpga_emu",
           "anr.fpga_emu.exe"
@@ -54,6 +57,7 @@
           "cd ../..",
           "mkdir build",
           "cd build",
+          "xcopy /E ..\\ReferenceDesigns\\anr\\test_data test_data\\",
           "cmake -G \"NMake Makefiles\" ../ReferenceDesigns/anr",
           "nmake report"
         ]

--- a/DirectProgramming/DPC++FPGA/ReferenceDesigns/anr/src/main.cpp
+++ b/DirectProgramming/DPC++FPGA/ReferenceDesigns/anr/src/main.cpp
@@ -43,7 +43,7 @@ bool Validate(PixelT* val, PixelT* ref, int rows, int cols,
 int main(int argc, char* argv[]) {
   /////////////////////////////////////////////////////////////
   // reading and validating the command line arguments
-  std::string data_dir = "../test_data";
+  std::string data_dir = "../ReferenceDesigns/anr/test_data";
   bool passed = true;
 #ifdef FPGA_EMULATOR
   int runs = 2;

--- a/DirectProgramming/DPC++FPGA/ReferenceDesigns/anr/src/main.cpp
+++ b/DirectProgramming/DPC++FPGA/ReferenceDesigns/anr/src/main.cpp
@@ -43,7 +43,7 @@ bool Validate(PixelT* val, PixelT* ref, int rows, int cols,
 int main(int argc, char* argv[]) {
   /////////////////////////////////////////////////////////////
   // reading and validating the command line arguments
-  std::string data_dir = "../ReferenceDesigns/anr/test_data";
+  std::string data_dir = "../test_data";
   bool passed = true;
 #ifdef FPGA_EMULATOR
   int runs = 2;

--- a/DirectProgramming/DPC++FPGA/ReferenceDesigns/crr/sample.json
+++ b/DirectProgramming/DPC++FPGA/ReferenceDesigns/crr/sample.json
@@ -14,10 +14,9 @@
         "id": "fpga_emu",
         "steps": [
           "dpcpp --version",
-          "cd ../..",
           "mkdir build",
           "cd build",
-          "cmake ../ReferenceDesigns/crr",
+          "cmake ..",
           "make fpga_emu",
           "./crr.fpga_emu ./src/data/ordered_inputs.csv -o=./src/data/ordered_outputs.csv"
         ]
@@ -26,10 +25,9 @@
         "id": "report",
         "steps": [
           "dpcpp --version",
-          "cd ../..",
           "mkdir build",
           "cd build",
-          "cmake ../ReferenceDesigns/crr",
+          "cmake ..",
           "make report"
         ]
       }

--- a/DirectProgramming/DPC++FPGA/ReferenceDesigns/crr/sample.json
+++ b/DirectProgramming/DPC++FPGA/ReferenceDesigns/crr/sample.json
@@ -18,7 +18,7 @@
           "cd build",
           "cmake ..",
           "make fpga_emu",
-          "./crr.fpga_emu ./src/data/ordered_inputs.csv -o=./src/data/ordered_outputs.csv"
+          "./crr.fpga_emu ./src/data/ordered_inputs.csv"
         ]
       },
       {
@@ -42,7 +42,7 @@
           "cd build",
           "cmake -G \"NMake Makefiles\" ../ReferenceDesigns/crr",
           "nmake fpga_emu",
-          "crr.fpga_emu.exe ../src/data/ordered_inputs.csv -o=../src/data/ordered_outputs.csv"
+          "crr.fpga_emu.exe ../src/data/ordered_inputs.csv"
         ]
       },
       {

--- a/DirectProgramming/DPC++FPGA/ReferenceDesigns/crr/sample.json
+++ b/DirectProgramming/DPC++FPGA/ReferenceDesigns/crr/sample.json
@@ -13,9 +13,11 @@
       {
         "id": "fpga_emu",
         "steps": [
+          "dpcpp --version",
+          "cd ../..",
           "mkdir build",
           "cd build",
-          "cmake ..",
+          "cmake ../ReferenceDesigns/crr",
           "make fpga_emu",
           "./crr.fpga_emu ./src/data/ordered_inputs.csv -o=./src/data/ordered_outputs.csv"
         ]
@@ -23,9 +25,11 @@
       {
         "id": "report",
         "steps": [
+          "dpcpp --version",
+          "cd ../..",
           "mkdir build",
           "cd build",
-          "cmake ..",
+          "cmake ../ReferenceDesigns/crr",
           "make report"
         ]
       }
@@ -34,9 +38,11 @@
       {
         "id": "fpga_emu",
         "steps": [
+          "dpcpp --version",
+          "cd ../..",
           "mkdir build",
           "cd build",
-          "cmake -G \"NMake Makefiles\" ..",
+          "cmake -G \"NMake Makefiles\" ../ReferenceDesigns/crr",
           "nmake fpga_emu",
           "crr.fpga_emu.exe ../src/data/ordered_inputs.csv -o=../src/data/ordered_outputs.csv"
         ]
@@ -44,9 +50,11 @@
       {
         "id": "report",
         "steps": [
+          "dpcpp --version",
+          "cd ../..",
           "mkdir build",
           "cd build",
-          "cmake -G \"NMake Makefiles\" ..",
+          "cmake -G \"NMake Makefiles\" ../ReferenceDesigns/crr",
           "nmake report"
         ]
       }

--- a/DirectProgramming/DPC++FPGA/ReferenceDesigns/crr/sample.json
+++ b/DirectProgramming/DPC++FPGA/ReferenceDesigns/crr/sample.json
@@ -18,7 +18,7 @@
           "cd build",
           "cmake ..",
           "make fpga_emu",
-          "./crr.fpga_emu ./src/data/ordered_inputs.csv"
+          "./crr.fpga_emu"
         ]
       },
       {
@@ -42,7 +42,7 @@
           "cd build",
           "cmake -G \"NMake Makefiles\" ../ReferenceDesigns/crr",
           "nmake fpga_emu",
-          "crr.fpga_emu.exe ../src/data/ordered_inputs.csv"
+          "crr.fpga_emu.exe"
         ]
       },
       {

--- a/DirectProgramming/DPC++FPGA/ReferenceDesigns/db/sample.json
+++ b/DirectProgramming/DPC++FPGA/ReferenceDesigns/db/sample.json
@@ -17,9 +17,10 @@
           "cd ../..",
           "mkdir build-q1",
           "cd build-q1",
+          "xcopy /E ..\\ReferenceDesigns\\db\\data data\\",
           "cmake ../ReferenceDesigns/db -DQUERY=1",
           "make fpga_emu",
-          "./db.fpga_emu --dbroot=../ReferenceDesigns/db/data/sf0.01 --test"
+          "./db.fpga_emu --dbroot=./data/sf0.01 --test"
         ]
       },
       {
@@ -29,9 +30,10 @@
           "cd ../..",
           "mkdir build-q9",
           "cd build-q9",
+          "xcopy /E ..\\ReferenceDesigns\\db\\data data\\",
           "cmake ../ReferenceDesigns/db -DQUERY=9",
           "make fpga_emu",
-          "./db.fpga_emu --dbroot=../ReferenceDesigns/db/data/sf0.01 --test"
+          "./db.fpga_emu --dbroot=./data/sf0.01 --test"
         ]
       },
       {
@@ -41,9 +43,10 @@
           "cd ../..",
           "mkdir build-q11",
           "cd build-q11",
+          "xcopy /E ..\\ReferenceDesigns\\db\\data data\\",
           "cmake ../ReferenceDesigns/db -DQUERY=11",
           "make fpga_emu",
-          "./db.fpga_emu --dbroot=../ReferenceDesigns/db/data/sf0.01 --test"
+          "./db.fpga_emu --dbroot=./data/sf0.01 --test"
         ]
       },
       {
@@ -53,9 +56,10 @@
           "cd ../..",
           "mkdir build-q12",
           "cd build-q12",
+          "xcopy /E ..\\ReferenceDesigns\\db\\data data\\",
           "cmake ../ReferenceDesigns/db -DQUERY=12",
           "make fpga_emu",
-          "./db.fpga_emu --dbroot=../ReferenceDesigns/db/data/sf0.01 --test"
+          "./db.fpga_emu --dbroot=./data/sf0.01 --test"
         ]
       },
       {
@@ -100,9 +104,10 @@
           "cd ../..",
           "mkdir build-q1",
           "cd build-q1",
+          "xcopy /E ..\\ReferenceDesigns\\db\\data data\\",
           "cmake -G \"NMake Makefiles\" ../ReferenceDesigns/db -DQUERY=1",
           "nmake fpga_emu",
-          "db.fpga_emu.exe --dbroot=../ReferenceDesigns/db/data/sf0.01 --test"
+          "db.fpga_emu.exe --dbroot=./data/sf0.01 --test"
         ]
       },
       {
@@ -112,9 +117,10 @@
           "cd ../..",
           "mkdir build-q9",
           "cd build-q9",
+          "xcopy /E ..\\ReferenceDesigns\\db\\data data\\",
           "cmake -G \"NMake Makefiles\" ../ReferenceDesigns/db -DQUERY=9",
           "nmake fpga_emu",
-          "db.fpga_emu.exe --dbroot=../ReferenceDesigns/db/data/sf0.01 --test"
+          "db.fpga_emu.exe --dbroot=./data/sf0.01 --test"
         ]
       },
       {
@@ -124,9 +130,10 @@
           "cd ../..",
           "mkdir build-q11",
           "cd build-q11",
+          "xcopy /E ..\\ReferenceDesigns\\db\\data data\\",
           "cmake -G \"NMake Makefiles\" ../ReferenceDesigns/db -DQUERY=11",
           "nmake fpga_emu",
-          "db.fpga_emu.exe --dbroot=../ReferenceDesigns/db/data/sf0.01 --test"
+          "db.fpga_emu.exe --dbroot=./data/sf0.01 --test"
         ]
       },
       {
@@ -136,9 +143,10 @@
           "cd ../..",
           "mkdir build-q12",
           "cd build-q12",
+          "xcopy /E ..\\ReferenceDesigns\\db\\data data\\",
           "cmake -G \"NMake Makefiles\" ../ReferenceDesigns/db -DQUERY=12",
           "nmake fpga_emu",
-          "db.fpga_emu.exe --dbroot=../ReferenceDesigns/db/data/sf0.01 --test"
+          "db.fpga_emu.exe --dbroot=./data/sf0.01 --test"
         ]
       },
       {

--- a/DirectProgramming/DPC++FPGA/ReferenceDesigns/db/sample.json
+++ b/DirectProgramming/DPC++FPGA/ReferenceDesigns/db/sample.json
@@ -13,9 +13,11 @@
       {
         "id": "fpga_emu_q1",
         "steps": [
+          "dpcpp --version",
+          "cd ../..",
           "mkdir build-q1",
           "cd build-q1",
-          "cmake .. -DQUERY=1",
+          "cmake ../ReferenceDesigns/db -DQUERY=1",
           "make fpga_emu",
           "./db.fpga_emu --dbroot=../data/sf0.01 --test"
         ]
@@ -23,9 +25,11 @@
       {
         "id": "fpga_emu_q9",
         "steps": [
+          "dpcpp --version",
+          "cd ../..",
           "mkdir build-q9",
           "cd build-q9",
-          "cmake .. -DQUERY=9",
+          "cmake ../ReferenceDesigns/db -DQUERY=9",
           "make fpga_emu",
           "./db.fpga_emu --dbroot=../data/sf0.01 --test"
         ]
@@ -33,9 +37,11 @@
       {
         "id": "fpga_emu_q11",
         "steps": [
+          "dpcpp --version",
+          "cd ../..",
           "mkdir build-q11",
           "cd build-q11",
-          "cmake .. -DQUERY=11",
+          "cmake ../ReferenceDesigns/db -DQUERY=11",
           "make fpga_emu",
           "./db.fpga_emu --dbroot=../data/sf0.01 --test"
         ]
@@ -43,9 +49,11 @@
       {
         "id": "fpga_emu_q12",
         "steps": [
+          "dpcpp --version",
+          "cd ../..",
           "mkdir build-q12",
           "cd build-q12",
-          "cmake .. -DQUERY=12",
+          "cmake ../ReferenceDesigns/db -DQUERY=12",
           "make fpga_emu",
           "./db.fpga_emu --dbroot=../data/sf0.01 --test"
         ]
@@ -53,27 +61,33 @@
       {
         "id": "report_q1",
         "steps": [
+          "dpcpp --version",
+          "cd ../..",
           "mkdir build-q1",
           "cd build-q1",
-          "cmake .. -DQUERY=1 -DSF_SMALL=1",
+          "cmake ../ReferenceDesigns/db -DQUERY=1 -DSF_SMALL=1",
           "make report"
         ]
       },
       {
         "id": "report_q11",
         "steps": [
+          "dpcpp --version",
+          "cd ../..",
           "mkdir build-q11",
           "cd build-q11",
-          "cmake .. -DQUERY=11 -DSF_SMALL=1",
+          "cmake ../ReferenceDesigns/db -DQUERY=11 -DSF_SMALL=1",
           "make report"
         ]
       },
       {
         "id": "report_q12",
         "steps": [
+          "dpcpp --version",
+          "cd ../..",
           "mkdir build-q12",
           "cd build-q12",
-          "cmake .. -DQUERY=12 -DSF_SMALL=1",
+          "cmake ../ReferenceDesigns/db -DQUERY=12 -DSF_SMALL=1",
           "make report"
         ]
       }
@@ -82,9 +96,11 @@
       {
         "id": "fpga_emu_q1",
         "steps": [
+          "dpcpp --version",
+          "cd ../..",
           "mkdir build-q1",
           "cd build-q1",
-          "cmake -G \"NMake Makefiles\" .. -DQUERY=1",
+          "cmake -G \"NMake Makefiles\" ../ReferenceDesigns/db -DQUERY=1",
           "nmake fpga_emu",
           "db.fpga_emu.exe --dbroot=../data/sf0.01 --test"
         ]
@@ -92,9 +108,11 @@
       {
         "id": "fpga_emu_q9",
         "steps": [
+          "dpcpp --version",
+          "cd ../..",
           "mkdir build-q9",
           "cd build-q9",
-          "cmake -G \"NMake Makefiles\" .. -DQUERY=9",
+          "cmake -G \"NMake Makefiles\" ../ReferenceDesigns/db -DQUERY=9",
           "nmake fpga_emu",
           "db.fpga_emu.exe --dbroot=../data/sf0.01 --test"
         ]
@@ -102,9 +120,11 @@
       {
         "id": "fpga_emu_q11",
         "steps": [
+          "dpcpp --version",
+          "cd ../..",
           "mkdir build-q11",
           "cd build-q11",
-          "cmake -G \"NMake Makefiles\" .. -DQUERY=11",
+          "cmake -G \"NMake Makefiles\" ../ReferenceDesigns/db -DQUERY=11",
           "nmake fpga_emu",
           "db.fpga_emu.exe --dbroot=../data/sf0.01 --test"
         ]
@@ -112,9 +132,11 @@
       {
         "id": "fpga_emu_q12",
         "steps": [
+          "dpcpp --version",
+          "cd ../..",
           "mkdir build-q12",
           "cd build-q12",
-          "cmake -G \"NMake Makefiles\" .. -DQUERY=12",
+          "cmake -G \"NMake Makefiles\" ../ReferenceDesigns/db -DQUERY=12",
           "nmake fpga_emu",
           "db.fpga_emu.exe --dbroot=../data/sf0.01 --test"
         ]
@@ -122,27 +144,33 @@
       {
         "id": "report_q1",
         "steps": [
+          "dpcpp --version",
+          "cd ../..",
           "mkdir build-q1",
           "cd build-q1",
-          "cmake -G \"NMake Makefiles\" .. -DQUERY=1",
+          "cmake -G \"NMake Makefiles\" ../ReferenceDesigns/db -DQUERY=1",
           "nmake report"
         ]
       },
       {
         "id": "report_q11",
         "steps": [
+          "dpcpp --version",
+          "cd ../..",
           "mkdir build-q11",
           "cd build-q11",
-          "cmake -G \"NMake Makefiles\" .. -DQUERY=11",
+          "cmake -G \"NMake Makefiles\" ../ReferenceDesigns/db -DQUERY=11",
           "nmake report"
         ]
       },
       {
         "id": "report_q12",
         "steps": [
+          "dpcpp --version",
+          "cd ../..",
           "mkdir build-q12",
           "cd build-q12",
-          "cmake -G \"NMake Makefiles\" .. -DQUERY=12",
+          "cmake -G \"NMake Makefiles\" ../ReferenceDesigns/db -DQUERY=12",
           "nmake report"
         ]
       }

--- a/DirectProgramming/DPC++FPGA/ReferenceDesigns/db/sample.json
+++ b/DirectProgramming/DPC++FPGA/ReferenceDesigns/db/sample.json
@@ -93,6 +93,7 @@
           "cd ../..",
           "mkdir build-q1",
           "cd build-q1",
+          "xcopy /E ..\\ReferenceDesigns\\db\\data ..\\data\\",
           "cmake -G \"NMake Makefiles\" ../ReferenceDesigns/db -DQUERY=1",
           "nmake fpga_emu",
           "db.fpga_emu.exe --dbroot=../data/sf0.01 --test"
@@ -105,6 +106,7 @@
           "cd ../..",
           "mkdir build-q9",
           "cd build-q9",
+          "xcopy /E ..\\ReferenceDesigns\\db\\data ..\\data\\",
           "cmake -G \"NMake Makefiles\" ../ReferenceDesigns/db -DQUERY=9",
           "nmake fpga_emu",
           "db.fpga_emu.exe --dbroot=../data/sf0.01 --test"
@@ -117,6 +119,7 @@
           "cd ../..",
           "mkdir build-q11",
           "cd build-q11",
+          "xcopy /E ..\\ReferenceDesigns\\db\\data ..\\data\\",
           "cmake -G \"NMake Makefiles\" ../ReferenceDesigns/db -DQUERY=11",
           "nmake fpga_emu",
           "db.fpga_emu.exe --dbroot=../data/sf0.01 --test"
@@ -129,6 +132,7 @@
           "cd ../..",
           "mkdir build-q12",
           "cd build-q12",
+          "xcopy /E ..\\ReferenceDesigns\\db\\data ..\\data\\",
           "cmake -G \"NMake Makefiles\" ../ReferenceDesigns/db -DQUERY=12",
           "nmake fpga_emu",
           "db.fpga_emu.exe --dbroot=../data/sf0.01 --test"

--- a/DirectProgramming/DPC++FPGA/ReferenceDesigns/db/sample.json
+++ b/DirectProgramming/DPC++FPGA/ReferenceDesigns/db/sample.json
@@ -17,10 +17,10 @@
           "cd ../..",
           "mkdir build-q1",
           "cd build-q1",
-          "xcopy /E ..\\ReferenceDesigns\\db\\data data\\",
+          "xcopy /E ..\\ReferenceDesigns\\db\\data ..\\data\\",
           "cmake ../ReferenceDesigns/db -DQUERY=1",
           "make fpga_emu",
-          "./db.fpga_emu --dbroot=./data/sf0.01 --test"
+          "./db.fpga_emu --dbroot=../data/sf0.01 --test"
         ]
       },
       {
@@ -30,10 +30,10 @@
           "cd ../..",
           "mkdir build-q9",
           "cd build-q9",
-          "xcopy /E ..\\ReferenceDesigns\\db\\data data\\",
+          "xcopy /E ..\\ReferenceDesigns\\db\\data ..\\data\\",
           "cmake ../ReferenceDesigns/db -DQUERY=9",
           "make fpga_emu",
-          "./db.fpga_emu --dbroot=./data/sf0.01 --test"
+          "./db.fpga_emu --dbroot=../data/sf0.01 --test"
         ]
       },
       {
@@ -43,10 +43,10 @@
           "cd ../..",
           "mkdir build-q11",
           "cd build-q11",
-          "xcopy /E ..\\ReferenceDesigns\\db\\data data\\",
+          "xcopy /E ..\\ReferenceDesigns\\db\\data ..\\data\\",
           "cmake ../ReferenceDesigns/db -DQUERY=11",
           "make fpga_emu",
-          "./db.fpga_emu --dbroot=./data/sf0.01 --test"
+          "./db.fpga_emu --dbroot=../data/sf0.01 --test"
         ]
       },
       {
@@ -56,10 +56,10 @@
           "cd ../..",
           "mkdir build-q12",
           "cd build-q12",
-          "xcopy /E ..\\ReferenceDesigns\\db\\data data\\",
+          "xcopy /E ..\\ReferenceDesigns\\db\\data ..\\data\\",
           "cmake ../ReferenceDesigns/db -DQUERY=12",
           "make fpga_emu",
-          "./db.fpga_emu --dbroot=./data/sf0.01 --test"
+          "./db.fpga_emu --dbroot=../data/sf0.01 --test"
         ]
       },
       {
@@ -104,10 +104,10 @@
           "cd ../..",
           "mkdir build-q1",
           "cd build-q1",
-          "xcopy /E ..\\ReferenceDesigns\\db\\data data\\",
+          "xcopy /E ..\\ReferenceDesigns\\db\\data ..\\data\\",
           "cmake -G \"NMake Makefiles\" ../ReferenceDesigns/db -DQUERY=1",
           "nmake fpga_emu",
-          "db.fpga_emu.exe --dbroot=./data/sf0.01 --test"
+          "db.fpga_emu.exe --dbroot=../data/sf0.01 --test"
         ]
       },
       {
@@ -117,10 +117,10 @@
           "cd ../..",
           "mkdir build-q9",
           "cd build-q9",
-          "xcopy /E ..\\ReferenceDesigns\\db\\data data\\",
+          "xcopy /E ..\\ReferenceDesigns\\db\\data ..\\data\\",
           "cmake -G \"NMake Makefiles\" ../ReferenceDesigns/db -DQUERY=9",
           "nmake fpga_emu",
-          "db.fpga_emu.exe --dbroot=./data/sf0.01 --test"
+          "db.fpga_emu.exe --dbroot=../data/sf0.01 --test"
         ]
       },
       {
@@ -130,10 +130,10 @@
           "cd ../..",
           "mkdir build-q11",
           "cd build-q11",
-          "xcopy /E ..\\ReferenceDesigns\\db\\data data\\",
+          "xcopy /E ..\\ReferenceDesigns\\db\\data ..\\data\\",
           "cmake -G \"NMake Makefiles\" ../ReferenceDesigns/db -DQUERY=11",
           "nmake fpga_emu",
-          "db.fpga_emu.exe --dbroot=./data/sf0.01 --test"
+          "db.fpga_emu.exe --dbroot=../data/sf0.01 --test"
         ]
       },
       {
@@ -143,10 +143,10 @@
           "cd ../..",
           "mkdir build-q12",
           "cd build-q12",
-          "xcopy /E ..\\ReferenceDesigns\\db\\data data\\",
+          "xcopy /E ..\\ReferenceDesigns\\db\\data ..\\data\\",
           "cmake -G \"NMake Makefiles\" ../ReferenceDesigns/db -DQUERY=12",
           "nmake fpga_emu",
-          "db.fpga_emu.exe --dbroot=./data/sf0.01 --test"
+          "db.fpga_emu.exe --dbroot=../data/sf0.01 --test"
         ]
       },
       {

--- a/DirectProgramming/DPC++FPGA/ReferenceDesigns/db/sample.json
+++ b/DirectProgramming/DPC++FPGA/ReferenceDesigns/db/sample.json
@@ -14,11 +14,9 @@
         "id": "fpga_emu_q1",
         "steps": [
           "dpcpp --version",
-          "cd ../..",
           "mkdir build-q1",
           "cd build-q1",
-          "xcopy /E ..\\ReferenceDesigns\\db\\data ..\\data\\",
-          "cmake ../ReferenceDesigns/db -DQUERY=1",
+          "cmake .. -DQUERY=1",
           "make fpga_emu",
           "./db.fpga_emu --dbroot=../data/sf0.01 --test"
         ]
@@ -27,11 +25,9 @@
         "id": "fpga_emu_q9",
         "steps": [
           "dpcpp --version",
-          "cd ../..",
           "mkdir build-q9",
           "cd build-q9",
-          "xcopy /E ..\\ReferenceDesigns\\db\\data ..\\data\\",
-          "cmake ../ReferenceDesigns/db -DQUERY=9",
+          "cmake .. -DQUERY=9",
           "make fpga_emu",
           "./db.fpga_emu --dbroot=../data/sf0.01 --test"
         ]
@@ -40,11 +36,9 @@
         "id": "fpga_emu_q11",
         "steps": [
           "dpcpp --version",
-          "cd ../..",
           "mkdir build-q11",
           "cd build-q11",
-          "xcopy /E ..\\ReferenceDesigns\\db\\data ..\\data\\",
-          "cmake ../ReferenceDesigns/db -DQUERY=11",
+          "cmake .. -DQUERY=11",
           "make fpga_emu",
           "./db.fpga_emu --dbroot=../data/sf0.01 --test"
         ]
@@ -53,11 +47,9 @@
         "id": "fpga_emu_q12",
         "steps": [
           "dpcpp --version",
-          "cd ../..",
           "mkdir build-q12",
           "cd build-q12",
-          "xcopy /E ..\\ReferenceDesigns\\db\\data ..\\data\\",
-          "cmake ../ReferenceDesigns/db -DQUERY=12",
+          "cmake .. -DQUERY=12",
           "make fpga_emu",
           "./db.fpga_emu --dbroot=../data/sf0.01 --test"
         ]
@@ -66,10 +58,9 @@
         "id": "report_q1",
         "steps": [
           "dpcpp --version",
-          "cd ../..",
           "mkdir build-q1",
           "cd build-q1",
-          "cmake ../ReferenceDesigns/db -DQUERY=1 -DSF_SMALL=1",
+          "cmake .. -DQUERY=1 -DSF_SMALL=1",
           "make report"
         ]
       },
@@ -77,10 +68,9 @@
         "id": "report_q11",
         "steps": [
           "dpcpp --version",
-          "cd ../..",
           "mkdir build-q11",
           "cd build-q11",
-          "cmake ../ReferenceDesigns/db -DQUERY=11 -DSF_SMALL=1",
+          "cmake .. -DQUERY=11 -DSF_SMALL=1",
           "make report"
         ]
       },
@@ -88,10 +78,9 @@
         "id": "report_q12",
         "steps": [
           "dpcpp --version",
-          "cd ../..",
           "mkdir build-q12",
           "cd build-q12",
-          "cmake ../ReferenceDesigns/db -DQUERY=12 -DSF_SMALL=1",
+          "cmake .. -DQUERY=12 -DSF_SMALL=1",
           "make report"
         ]
       }
@@ -104,7 +93,6 @@
           "cd ../..",
           "mkdir build-q1",
           "cd build-q1",
-          "xcopy /E ..\\ReferenceDesigns\\db\\data ..\\data\\",
           "cmake -G \"NMake Makefiles\" ../ReferenceDesigns/db -DQUERY=1",
           "nmake fpga_emu",
           "db.fpga_emu.exe --dbroot=../data/sf0.01 --test"
@@ -117,7 +105,6 @@
           "cd ../..",
           "mkdir build-q9",
           "cd build-q9",
-          "xcopy /E ..\\ReferenceDesigns\\db\\data ..\\data\\",
           "cmake -G \"NMake Makefiles\" ../ReferenceDesigns/db -DQUERY=9",
           "nmake fpga_emu",
           "db.fpga_emu.exe --dbroot=../data/sf0.01 --test"
@@ -130,7 +117,6 @@
           "cd ../..",
           "mkdir build-q11",
           "cd build-q11",
-          "xcopy /E ..\\ReferenceDesigns\\db\\data ..\\data\\",
           "cmake -G \"NMake Makefiles\" ../ReferenceDesigns/db -DQUERY=11",
           "nmake fpga_emu",
           "db.fpga_emu.exe --dbroot=../data/sf0.01 --test"
@@ -143,7 +129,6 @@
           "cd ../..",
           "mkdir build-q12",
           "cd build-q12",
-          "xcopy /E ..\\ReferenceDesigns\\db\\data ..\\data\\",
           "cmake -G \"NMake Makefiles\" ../ReferenceDesigns/db -DQUERY=12",
           "nmake fpga_emu",
           "db.fpga_emu.exe --dbroot=../data/sf0.01 --test"

--- a/DirectProgramming/DPC++FPGA/ReferenceDesigns/db/sample.json
+++ b/DirectProgramming/DPC++FPGA/ReferenceDesigns/db/sample.json
@@ -19,7 +19,7 @@
           "cd build-q1",
           "cmake ../ReferenceDesigns/db -DQUERY=1",
           "make fpga_emu",
-          "./db.fpga_emu --dbroot=../data/sf0.01 --test"
+          "./db.fpga_emu --dbroot=../ReferenceDesigns/db/data/sf0.01 --test"
         ]
       },
       {
@@ -31,7 +31,7 @@
           "cd build-q9",
           "cmake ../ReferenceDesigns/db -DQUERY=9",
           "make fpga_emu",
-          "./db.fpga_emu --dbroot=../data/sf0.01 --test"
+          "./db.fpga_emu --dbroot=../ReferenceDesigns/db/data/sf0.01 --test"
         ]
       },
       {
@@ -43,7 +43,7 @@
           "cd build-q11",
           "cmake ../ReferenceDesigns/db -DQUERY=11",
           "make fpga_emu",
-          "./db.fpga_emu --dbroot=../data/sf0.01 --test"
+          "./db.fpga_emu --dbroot=../ReferenceDesigns/db/data/sf0.01 --test"
         ]
       },
       {
@@ -55,7 +55,7 @@
           "cd build-q12",
           "cmake ../ReferenceDesigns/db -DQUERY=12",
           "make fpga_emu",
-          "./db.fpga_emu --dbroot=../data/sf0.01 --test"
+          "./db.fpga_emu --dbroot=../ReferenceDesigns/db/data/sf0.01 --test"
         ]
       },
       {
@@ -102,7 +102,7 @@
           "cd build-q1",
           "cmake -G \"NMake Makefiles\" ../ReferenceDesigns/db -DQUERY=1",
           "nmake fpga_emu",
-          "db.fpga_emu.exe --dbroot=../data/sf0.01 --test"
+          "db.fpga_emu.exe --dbroot=../ReferenceDesigns/db/data/sf0.01 --test"
         ]
       },
       {
@@ -114,7 +114,7 @@
           "cd build-q9",
           "cmake -G \"NMake Makefiles\" ../ReferenceDesigns/db -DQUERY=9",
           "nmake fpga_emu",
-          "db.fpga_emu.exe --dbroot=../data/sf0.01 --test"
+          "db.fpga_emu.exe --dbroot=../ReferenceDesigns/db/data/sf0.01 --test"
         ]
       },
       {
@@ -126,7 +126,7 @@
           "cd build-q11",
           "cmake -G \"NMake Makefiles\" ../ReferenceDesigns/db -DQUERY=11",
           "nmake fpga_emu",
-          "db.fpga_emu.exe --dbroot=../data/sf0.01 --test"
+          "db.fpga_emu.exe --dbroot=../ReferenceDesigns/db/data/sf0.01 --test"
         ]
       },
       {
@@ -138,7 +138,7 @@
           "cd build-q12",
           "cmake -G \"NMake Makefiles\" ../ReferenceDesigns/db -DQUERY=12",
           "nmake fpga_emu",
-          "db.fpga_emu.exe --dbroot=../data/sf0.01 --test"
+          "db.fpga_emu.exe --dbroot=../ReferenceDesigns/db/data/sf0.01 --test"
         ]
       },
       {

--- a/DirectProgramming/DPC++FPGA/ReferenceDesigns/gzip/sample.json
+++ b/DirectProgramming/DPC++FPGA/ReferenceDesigns/gzip/sample.json
@@ -14,10 +14,9 @@
         "id": "fpga_emu",
         "steps": [
           "dpcpp --version",
-          "cd ../..",
           "mkdir build",
           "cd build",
-          "cmake ../ReferenceDesigns/gzip",
+          "cmake ..",
           "make fpga_emu",
           "./gzip.fpga_emu ../src/gzip.cpp -o=test.gz"
         ]
@@ -26,10 +25,9 @@
         "id": "report",
         "steps": [
           "dpcpp --version",
-          "cd ../..",
           "mkdir build",
           "cd build",
-          "cmake ../ReferenceDesigns/gzip",
+          "cmake ..",
           "make report"
         ]
       }

--- a/DirectProgramming/DPC++FPGA/ReferenceDesigns/gzip/sample.json
+++ b/DirectProgramming/DPC++FPGA/ReferenceDesigns/gzip/sample.json
@@ -40,6 +40,7 @@
           "cd ../..",
           "mkdir build",
           "cd build",
+          "xcopy /E ..\\ReferenceDesigns\\gzip\\data ..\\data\\",
           "cmake -G \"NMake Makefiles\" ../ReferenceDesigns/gzip",
           "nmake fpga_emu",
           "gzip.fpga_emu.exe ../src/gzip.cpp -o=test.gz"

--- a/DirectProgramming/DPC++FPGA/ReferenceDesigns/gzip/sample.json
+++ b/DirectProgramming/DPC++FPGA/ReferenceDesigns/gzip/sample.json
@@ -13,9 +13,11 @@
       {
         "id": "fpga_emu",
         "steps": [
+          "dpcpp --version",
+          "cd ../..",
           "mkdir build",
           "cd build",
-          "cmake ..",
+          "cmake ../ReferenceDesigns/gzip",
           "make fpga_emu",
           "./gzip.fpga_emu ../src/gzip.cpp -o=test.gz"
         ]
@@ -23,9 +25,11 @@
       {
         "id": "report",
         "steps": [
+          "dpcpp --version",
+          "cd ../..",
           "mkdir build",
           "cd build",
-          "cmake ..",
+          "cmake ../ReferenceDesigns/gzip",
           "make report"
         ]
       }
@@ -34,9 +38,11 @@
       {
         "id": "fpga_emu",
         "steps": [
+          "dpcpp --version",
+          "cd ../..",
           "mkdir build",
           "cd build",
-          "cmake -G \"NMake Makefiles\" ..",
+          "cmake -G \"NMake Makefiles\" ../ReferenceDesigns/gzip",
           "nmake fpga_emu",
           "gzip.fpga_emu.exe ../src/gzip.cpp -o=test.gz"
         ]
@@ -44,9 +50,11 @@
       {
         "id": "report",
         "steps": [
+          "dpcpp --version",
+          "cd ../..",
           "mkdir build",
           "cd build",
-          "cmake -G \"NMake Makefiles\" ..",
+          "cmake -G \"NMake Makefiles\" ../ReferenceDesigns/gzip",
           "nmake report"
         ]
       }

--- a/DirectProgramming/DPC++FPGA/ReferenceDesigns/gzip/sample.json
+++ b/DirectProgramming/DPC++FPGA/ReferenceDesigns/gzip/sample.json
@@ -40,7 +40,7 @@
           "cd ../..",
           "mkdir build",
           "cd build",
-          "xcopy /E ..\\ReferenceDesigns\\gzip\\data ..\\data\\",
+          "xcopy /E ..\\ReferenceDesigns\\gzip\\src ..\\src\\",
           "cmake -G \"NMake Makefiles\" ../ReferenceDesigns/gzip",
           "nmake fpga_emu",
           "gzip.fpga_emu.exe ../src/gzip.cpp -o=test.gz"

--- a/DirectProgramming/DPC++FPGA/ReferenceDesigns/merge_sort/sample.json
+++ b/DirectProgramming/DPC++FPGA/ReferenceDesigns/merge_sort/sample.json
@@ -13,9 +13,11 @@
       {
         "id": "fpga_emu",
         "steps": [
+          "dpcpp --version",
+          "cd ../..",
           "mkdir build",
           "cd build",
-          "cmake ..",
+          "cmake ../ReferenceDesigns/merge_sort",
           "make fpga_emu",
           "./merge_sort.fpga_emu"
         ]
@@ -23,9 +25,11 @@
       {
         "id": "report",
         "steps": [
+          "dpcpp --version",
+          "cd ../..",
           "mkdir build",
           "cd build",
-          "cmake ..",
+          "cmake ../ReferenceDesigns/merge_sort",
           "make report"
         ]
       }
@@ -34,9 +38,11 @@
       {
         "id": "fpga_emu",
         "steps": [
+          "dpcpp --version",
+          "cd ../..",
           "mkdir build",
           "cd build",
-          "cmake -G \"NMake Makefiles\" ..",
+          "cmake -G \"NMake Makefiles\" ../ReferenceDesigns/merge_sort",
           "nmake fpga_emu",
           "merge_sort.fpga_emu.exe"
         ]
@@ -44,9 +50,11 @@
       {
         "id": "report",
         "steps": [
+          "dpcpp --version",
+          "cd ../..",
           "mkdir build",
           "cd build",
-          "cmake -G \"NMake Makefiles\" ..",
+          "cmake -G \"NMake Makefiles\" ../ReferenceDesigns/merge_sort",
           "nmake report"
         ]
       }

--- a/DirectProgramming/DPC++FPGA/ReferenceDesigns/merge_sort/sample.json
+++ b/DirectProgramming/DPC++FPGA/ReferenceDesigns/merge_sort/sample.json
@@ -14,10 +14,9 @@
         "id": "fpga_emu",
         "steps": [
           "dpcpp --version",
-          "cd ../..",
           "mkdir build",
           "cd build",
-          "cmake ../ReferenceDesigns/merge_sort",
+          "cmake ..",
           "make fpga_emu",
           "./merge_sort.fpga_emu"
         ]
@@ -26,10 +25,9 @@
         "id": "report",
         "steps": [
           "dpcpp --version",
-          "cd ../..",
           "mkdir build",
           "cd build",
-          "cmake ../ReferenceDesigns/merge_sort",
+          "cmake ..",
           "make report"
         ]
       }

--- a/DirectProgramming/DPC++FPGA/ReferenceDesigns/mvdr_beamforming/sample.json
+++ b/DirectProgramming/DPC++FPGA/ReferenceDesigns/mvdr_beamforming/sample.json
@@ -14,9 +14,11 @@
       {
         "id": "fpga_emu",
         "steps": [
+          "dpcpp --version",
+          "cd ../..",
           "mkdir build",
           "cd build",
-          "cmake ..",
+          "cmake ../ReferenceDesigns/mvdr_beamforming",
           "make fpga_emu",
           "./mvdr_beamforming.fpga_emu --in=../data"
         ]
@@ -24,9 +26,11 @@
       {
         "id": "report",
         "steps": [
+          "dpcpp --version",
+          "cd ../..",
           "mkdir build",
           "cd build",
-          "cmake ..",
+          "cmake ../ReferenceDesigns/mvdr_beamforming",
           "make report"
         ]
       }
@@ -35,9 +39,11 @@
       {
         "id": "fpga_emu",
         "steps": [
+          "dpcpp --version",
+          "cd ../..",
           "mkdir build",
           "cd build",
-          "cmake -G \"NMake Makefiles\" ..",
+          "cmake -G \"NMake Makefiles\" ../ReferenceDesigns/mvdr_beamforming",
           "nmake fpga_emu",
           "mvdr_beamforming.fpga_emu.exe --in=../data"
         ]
@@ -45,9 +51,11 @@
       {
         "id": "report",
         "steps": [
+          "dpcpp --version",
+          "cd ../..",
           "mkdir build",
           "cd build",
-          "cmake -G \"NMake Makefiles\" ..",
+          "cmake -G \"NMake Makefiles\" ../ReferenceDesigns/mvdr_beamforming",
           "nmake report"
         ]
       }

--- a/DirectProgramming/DPC++FPGA/ReferenceDesigns/mvdr_beamforming/sample.json
+++ b/DirectProgramming/DPC++FPGA/ReferenceDesigns/mvdr_beamforming/sample.json
@@ -18,10 +18,10 @@
           "cd ../..",
           "mkdir build",
           "cd build",
-          "xcopy /E ..\\ReferenceDesigns\\mvdr_beamforming\\data data\\",
+          "xcopy /E ..\\ReferenceDesigns\\mvdr_beamforming\\data ..\\data\\",
           "cmake ../ReferenceDesigns/mvdr_beamforming",
           "make fpga_emu",
-          "./mvdr_beamforming.fpga_emu --in=./data"
+          "./mvdr_beamforming.fpga_emu --in=../data"
         ]
       },
       {
@@ -44,10 +44,10 @@
           "cd ../..",
           "mkdir build",
           "cd build",
-          "xcopy /E ..\\ReferenceDesigns\\mvdr_beamforming\\data data\\",
+          "xcopy /E ..\\ReferenceDesigns\\mvdr_beamforming\\data ..\\data\\",
           "cmake -G \"NMake Makefiles\" ../ReferenceDesigns/mvdr_beamforming",
           "nmake fpga_emu",
-          "mvdr_beamforming.fpga_emu.exe --in=./data"
+          "mvdr_beamforming.fpga_emu.exe --in=../data"
         ]
       },
       {

--- a/DirectProgramming/DPC++FPGA/ReferenceDesigns/mvdr_beamforming/sample.json
+++ b/DirectProgramming/DPC++FPGA/ReferenceDesigns/mvdr_beamforming/sample.json
@@ -18,9 +18,10 @@
           "cd ../..",
           "mkdir build",
           "cd build",
+          "xcopy /E ..\\ReferenceDesigns\\mvdr_beamforming\\data data\\",
           "cmake ../ReferenceDesigns/mvdr_beamforming",
           "make fpga_emu",
-          "./mvdr_beamforming.fpga_emu --in=../ReferenceDesigns/mvdr_beamforming/data"
+          "./mvdr_beamforming.fpga_emu --in=./data"
         ]
       },
       {
@@ -43,9 +44,10 @@
           "cd ../..",
           "mkdir build",
           "cd build",
+          "xcopy /E ..\\ReferenceDesigns\\mvdr_beamforming\\data data\\",
           "cmake -G \"NMake Makefiles\" ../ReferenceDesigns/mvdr_beamforming",
           "nmake fpga_emu",
-          "mvdr_beamforming.fpga_emu.exe --in=../ReferenceDesigns/mvdr_beamforming/data"
+          "mvdr_beamforming.fpga_emu.exe --in=./data"
         ]
       },
       {

--- a/DirectProgramming/DPC++FPGA/ReferenceDesigns/mvdr_beamforming/sample.json
+++ b/DirectProgramming/DPC++FPGA/ReferenceDesigns/mvdr_beamforming/sample.json
@@ -20,7 +20,7 @@
           "cd build",
           "cmake ../ReferenceDesigns/mvdr_beamforming",
           "make fpga_emu",
-          "./mvdr_beamforming.fpga_emu --in=../data"
+          "./mvdr_beamforming.fpga_emu --in=../ReferenceDesigns/mvdr_beamforming/data"
         ]
       },
       {
@@ -45,7 +45,7 @@
           "cd build",
           "cmake -G \"NMake Makefiles\" ../ReferenceDesigns/mvdr_beamforming",
           "nmake fpga_emu",
-          "mvdr_beamforming.fpga_emu.exe --in=../data"
+          "mvdr_beamforming.fpga_emu.exe --in=../ReferenceDesigns/mvdr_beamforming/data"
         ]
       },
       {

--- a/DirectProgramming/DPC++FPGA/ReferenceDesigns/mvdr_beamforming/sample.json
+++ b/DirectProgramming/DPC++FPGA/ReferenceDesigns/mvdr_beamforming/sample.json
@@ -15,11 +15,9 @@
         "id": "fpga_emu",
         "steps": [
           "dpcpp --version",
-          "cd ../..",
           "mkdir build",
           "cd build",
-          "xcopy /E ..\\ReferenceDesigns\\mvdr_beamforming\\data ..\\data\\",
-          "cmake ../ReferenceDesigns/mvdr_beamforming",
+          "cmake ..",
           "make fpga_emu",
           "./mvdr_beamforming.fpga_emu --in=../data"
         ]
@@ -28,10 +26,9 @@
         "id": "report",
         "steps": [
           "dpcpp --version",
-          "cd ../..",
           "mkdir build",
           "cd build",
-          "cmake ../ReferenceDesigns/mvdr_beamforming",
+          "cmake ..",
           "make report"
         ]
       }

--- a/DirectProgramming/DPC++FPGA/ReferenceDesigns/qrd/sample.json
+++ b/DirectProgramming/DPC++FPGA/ReferenceDesigns/qrd/sample.json
@@ -17,10 +17,9 @@
         ],
         "steps": [
           "dpcpp --version",
-          "cd ../..",
           "mkdir build",
           "cd build",
-          "cmake ../ReferenceDesigns/qrd",
+          "cmake ..",
           "make fpga_emu",
           "./qrd.fpga_emu"
         ]
@@ -29,10 +28,9 @@
         "id": "report",
         "steps": [
           "dpcpp --version",
-          "cd ../..",
           "mkdir build",
           "cd build",
-          "cmake ../ReferenceDesigns/qrd",
+          "cmake ..",
           "make report"
         ]
       }

--- a/DirectProgramming/DPC++FPGA/ReferenceDesigns/qrd/sample.json
+++ b/DirectProgramming/DPC++FPGA/ReferenceDesigns/qrd/sample.json
@@ -16,9 +16,11 @@
           "export CL_CONFIG_CPU_FORCE_PRIVATE_MEM_SIZE=32MB"
         ],
         "steps": [
+          "dpcpp --version",
+          "cd ../..",
           "mkdir build",
           "cd build",
-          "cmake ..",
+          "cmake ../ReferenceDesigns/qrd",
           "make fpga_emu",
           "./qrd.fpga_emu"
         ]
@@ -26,9 +28,11 @@
       {
         "id": "report",
         "steps": [
+          "dpcpp --version",
+          "cd ../..",
           "mkdir build",
           "cd build",
-          "cmake ..",
+          "cmake ../ReferenceDesigns/qrd",
           "make report"
         ]
       }
@@ -40,9 +44,11 @@
           "set CL_CONFIG_CPU_FORCE_PRIVATE_MEM_SIZE=32MB"
         ],
         "steps": [
+          "dpcpp --version",
+          "cd ../..",
           "mkdir build",
           "cd build",
-          "cmake -G \"NMake Makefiles\" ..",
+          "cmake -G \"NMake Makefiles\" ../ReferenceDesigns/qrd",
           "nmake fpga_emu",
           "qrd.fpga_emu.exe"
         ]
@@ -50,9 +56,11 @@
       {
         "id": "report",
         "steps": [
+          "dpcpp --version",
+          "cd ../..",
           "mkdir build",
           "cd build",
-          "cmake -G \"NMake Makefiles\" ..",
+          "cmake -G \"NMake Makefiles\" ../ReferenceDesigns/qrd",
           "nmake report"
         ]
       }

--- a/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/buffered_host_streaming/sample.json
+++ b/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/buffered_host_streaming/sample.json
@@ -13,9 +13,11 @@
       {
         "id": "fpga_emu",
         "steps": [
+          "dpcpp --version",
+          "cd ../../..",
           "mkdir build",
           "cd build",
-          "cmake ..",
+          "cmake ../Tutorials/DesignPatterns/buffered_host_streaming",
           "make fpga_emu",
           "./buffered_host_streaming.fpga_emu"
         ]
@@ -23,9 +25,11 @@
       {
         "id": "report",
         "steps": [
+          "dpcpp --version",
+          "cd ../../..",
           "mkdir build",
           "cd build",
-          "cmake ..",
+          "cmake ../Tutorials/DesignPatterns/buffered_host_streaming",
           "make report"
         ]
       }
@@ -34,9 +38,11 @@
       {
         "id": "fpga_emu",
         "steps": [
+          "dpcpp --version",
+          "cd ../../..",
           "mkdir build",
           "cd build",
-          "cmake -G \"NMake Makefiles\" ..",
+          "cmake -G \"NMake Makefiles\" ../Tutorials/DesignPatterns/buffered_host_streaming",
           "nmake fpga_emu",
           "buffered_host_streaming.fpga_emu.exe"
         ]
@@ -44,9 +50,11 @@
       {
         "id": "report",
         "steps": [
+          "dpcpp --version",
+          "cd ../../..",
           "mkdir build",
           "cd build",
-          "cmake -G \"NMake Makefiles\" ..",
+          "cmake -G \"NMake Makefiles\" ../Tutorials/DesignPatterns/buffered_host_streaming",
           "nmake report"
         ]
       }

--- a/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/buffered_host_streaming/sample.json
+++ b/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/buffered_host_streaming/sample.json
@@ -14,10 +14,9 @@
         "id": "fpga_emu",
         "steps": [
           "dpcpp --version",
-          "cd ../../..",
           "mkdir build",
           "cd build",
-          "cmake ../Tutorials/DesignPatterns/buffered_host_streaming",
+          "cmake ..",
           "make fpga_emu",
           "./buffered_host_streaming.fpga_emu"
         ]
@@ -26,10 +25,9 @@
         "id": "report",
         "steps": [
           "dpcpp --version",
-          "cd ../../..",
           "mkdir build",
           "cd build",
-          "cmake ../Tutorials/DesignPatterns/buffered_host_streaming",
+          "cmake ..",
           "make report"
         ]
       }

--- a/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/compute_units/sample.json
+++ b/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/compute_units/sample.json
@@ -14,10 +14,9 @@
         "id": "fpga_emu",
         "steps": [
           "dpcpp --version",
-          "cd ../../..",
           "mkdir build",
           "cd build",
-          "cmake ../Tutorials/DesignPatterns/compute_units",
+          "cmake ..",
           "make fpga_emu",
           "./compute_units.fpga_emu"
         ]
@@ -26,10 +25,9 @@
         "id": "report",
         "steps": [
           "dpcpp --version",
-          "cd ../../..",
           "mkdir build",
           "cd build",
-          "cmake ../Tutorials/DesignPatterns/compute_units",
+          "cmake ..",
           "make report"
         ]
       }

--- a/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/compute_units/sample.json
+++ b/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/compute_units/sample.json
@@ -13,9 +13,11 @@
       {
         "id": "fpga_emu",
         "steps": [
+          "dpcpp --version",
+          "cd ../../..",
           "mkdir build",
           "cd build",
-          "cmake ..",
+          "cmake ../Tutorials/DesignPatterns/compute_units",
           "make fpga_emu",
           "./compute_units.fpga_emu"
         ]
@@ -23,9 +25,11 @@
       {
         "id": "report",
         "steps": [
+          "dpcpp --version",
+          "cd ../../..",
           "mkdir build",
           "cd build",
-          "cmake ..",
+          "cmake ../Tutorials/DesignPatterns/compute_units",
           "make report"
         ]
       }
@@ -34,9 +38,11 @@
       {
         "id": "fpga_emu",
         "steps": [
+          "dpcpp --version",
+          "cd ../../..",
           "mkdir build",
           "cd build",
-          "cmake -G \"NMake Makefiles\" ..",
+          "cmake -G \"NMake Makefiles\" ../Tutorials/DesignPatterns/compute_units",
           "nmake fpga_emu",
           "compute_units.fpga_emu.exe"
         ]
@@ -44,9 +50,11 @@
       {
         "id": "report",
         "steps": [
+          "dpcpp --version",
+          "cd ../../..",
           "mkdir build",
           "cd build",
-          "cmake -G \"NMake Makefiles\" ..",
+          "cmake -G \"NMake Makefiles\" ../Tutorials/DesignPatterns/compute_units",
           "nmake report"
         ]
       }

--- a/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/double_buffering/sample.json
+++ b/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/double_buffering/sample.json
@@ -13,9 +13,11 @@
       {
         "id": "fpga_emu",
         "steps": [
+          "dpcpp --version",
+          "cd ../../..",
           "mkdir build",
           "cd build",
-          "cmake ..",
+          "cmake ../Tutorials/DesignPatterns/double_buffering",
           "make fpga_emu",
           "./double_buffering.fpga_emu"
         ]
@@ -23,9 +25,11 @@
       {
         "id": "report",
         "steps": [
+          "dpcpp --version",
+          "cd ../../..",
           "mkdir build",
           "cd build",
-          "cmake ..",
+          "cmake ../Tutorials/DesignPatterns/double_buffering",
           "make report"
         ]
       }
@@ -34,9 +38,11 @@
       {
         "id": "fpga_emu",
         "steps": [
+          "dpcpp --version",
+          "cd ../../..",
           "mkdir build",
           "cd build",
-          "cmake -G \"NMake Makefiles\" ..",
+          "cmake -G \"NMake Makefiles\" ../Tutorials/DesignPatterns/double_buffering",
           "nmake fpga_emu",
           "double_buffering.fpga_emu.exe"
         ]
@@ -44,9 +50,11 @@
       {
         "id": "report",
         "steps": [
+          "dpcpp --version",
+          "cd ../../..",
           "mkdir build",
           "cd build",
-          "cmake -G \"NMake Makefiles\" ..",
+          "cmake -G \"NMake Makefiles\" ../Tutorials/DesignPatterns/double_buffering",
           "nmake report"
         ]
       }

--- a/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/double_buffering/sample.json
+++ b/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/double_buffering/sample.json
@@ -14,10 +14,9 @@
         "id": "fpga_emu",
         "steps": [
           "dpcpp --version",
-          "cd ../../..",
           "mkdir build",
           "cd build",
-          "cmake ../Tutorials/DesignPatterns/double_buffering",
+          "cmake ..",
           "make fpga_emu",
           "./double_buffering.fpga_emu"
         ]
@@ -26,10 +25,9 @@
         "id": "report",
         "steps": [
           "dpcpp --version",
-          "cd ../../..",
           "mkdir build",
           "cd build",
-          "cmake ../Tutorials/DesignPatterns/double_buffering",
+          "cmake ..",
           "make report"
         ]
       }

--- a/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/explicit_data_movement/sample.json
+++ b/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/explicit_data_movement/sample.json
@@ -13,9 +13,11 @@
       {
         "id": "fpga_emu",
         "steps": [
+          "dpcpp --version",
+          "cd ../../..",
           "mkdir build",
           "cd build",
-          "cmake ..",
+          "cmake ../Tutorials/DesignPatterns/explicit_data_movement",
           "make fpga_emu",
           "./explicit_data_movement.fpga_emu"
         ]
@@ -23,9 +25,11 @@
       {
         "id": "report",
         "steps": [
+          "dpcpp --version",
+          "cd ../../..",
           "mkdir build",
           "cd build",
-          "cmake ..",
+          "cmake ../Tutorials/DesignPatterns/explicit_data_movement",
           "make report"
         ]
       }
@@ -34,9 +38,11 @@
       {
         "id": "fpga_emu",
         "steps": [
+          "dpcpp --version",
+          "cd ../../..",
           "mkdir build",
           "cd build",
-          "cmake -G \"NMake Makefiles\" ..",
+          "cmake -G \"NMake Makefiles\" ../Tutorials/DesignPatterns/explicit_data_movement",
           "nmake fpga_emu",
           "explicit_data_movement.fpga_emu.exe"
         ]
@@ -44,9 +50,11 @@
       {
         "id": "report",
         "steps": [
+          "dpcpp --version",
+          "cd ../../..",
           "mkdir build",
           "cd build",
-          "cmake -G \"NMake Makefiles\" ..",
+          "cmake -G \"NMake Makefiles\" ../Tutorials/DesignPatterns/explicit_data_movement",
           "nmake report"
         ]
       }

--- a/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/explicit_data_movement/sample.json
+++ b/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/explicit_data_movement/sample.json
@@ -14,10 +14,9 @@
         "id": "fpga_emu",
         "steps": [
           "dpcpp --version",
-          "cd ../../..",
           "mkdir build",
           "cd build",
-          "cmake ../Tutorials/DesignPatterns/explicit_data_movement",
+          "cmake ..",
           "make fpga_emu",
           "./explicit_data_movement.fpga_emu"
         ]
@@ -26,10 +25,9 @@
         "id": "report",
         "steps": [
           "dpcpp --version",
-          "cd ../../..",
           "mkdir build",
           "cd build",
-          "cmake ../Tutorials/DesignPatterns/explicit_data_movement",
+          "cmake ..",
           "make report"
         ]
       }

--- a/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/io_streaming/sample.json
+++ b/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/io_streaming/sample.json
@@ -14,10 +14,9 @@
         "id": "fpga_emu",
         "steps": [
           "dpcpp --version",
-          "cd ../../..",
           "mkdir build",
           "cd build",
-          "cmake ../Tutorials/DesignPatterns/io_streaming",
+          "cmake ..",
           "make fpga_emu",
           "./io_streaming.fpga_emu"
         ]
@@ -26,10 +25,9 @@
         "id": "report",
         "steps": [
           "dpcpp --version",
-          "cd ../../..",
           "mkdir build",
           "cd build",
-          "cmake ../Tutorials/DesignPatterns/io_streaming",
+          "cmake ..",
           "make report"
         ]
       }

--- a/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/io_streaming/sample.json
+++ b/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/io_streaming/sample.json
@@ -13,9 +13,11 @@
       {
         "id": "fpga_emu",
         "steps": [
+          "dpcpp --version",
+          "cd ../../..",
           "mkdir build",
           "cd build",
-          "cmake ..",
+          "cmake ../Tutorials/DesignPatterns/io_streaming",
           "make fpga_emu",
           "./io_streaming.fpga_emu"
         ]
@@ -23,9 +25,11 @@
       {
         "id": "report",
         "steps": [
+          "dpcpp --version",
+          "cd ../../..",
           "mkdir build",
           "cd build",
-          "cmake ..",
+          "cmake ../Tutorials/DesignPatterns/io_streaming",
           "make report"
         ]
       }
@@ -34,9 +38,11 @@
       {
         "id": "fpga_emu",
         "steps": [
+          "dpcpp --version",
+          "cd ../../..",
           "mkdir build",
           "cd build",
-          "cmake -G \"NMake Makefiles\" ..",
+          "cmake -G \"NMake Makefiles\" ../Tutorials/DesignPatterns/io_streaming",
           "nmake fpga_emu",
           "io_streaming.fpga_emu.exe"
         ]
@@ -44,9 +50,11 @@
       {
         "id": "report",
         "steps": [
+          "dpcpp --version",
+          "cd ../../..",
           "mkdir build",
           "cd build",
-          "cmake -G \"NMake Makefiles\" ..",
+          "cmake -G \"NMake Makefiles\" ../Tutorials/DesignPatterns/io_streaming",
           "nmake report"
         ]
       }

--- a/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/loop_carried_dependency/sample.json
+++ b/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/loop_carried_dependency/sample.json
@@ -13,9 +13,11 @@
       {
         "id": "fpga_emu",
         "steps": [
+          "dpcpp --version",
+          "cd ../../..",
           "mkdir build",
           "cd build",
-          "cmake ..",
+          "cmake ../Tutorials/DesignPatterns/loop_carried_dependency",
           "make fpga_emu",
           "./loop_carried_dependency.fpga_emu"
         ]
@@ -23,9 +25,11 @@
       {
         "id": "report",
         "steps": [
+          "dpcpp --version",
+          "cd ../../..",
           "mkdir build",
           "cd build",
-          "cmake ..",
+          "cmake ../Tutorials/DesignPatterns/loop_carried_dependency",
           "make report"
         ]
       }
@@ -34,9 +38,11 @@
       {
         "id": "fpga_emu",
         "steps": [
+          "dpcpp --version",
+          "cd ..\..\..",
           "mkdir build",
           "cd build",
-          "cmake -G \"NMake Makefiles\" ..",
+          "cmake -G \"NMake Makefiles\" ..\Tutorials\DesignPatterns\loop_carried_dependency",
           "nmake fpga_emu",
           "loop_carried_dependency.fpga_emu.exe"
         ]
@@ -44,9 +50,11 @@
       {
         "id": "report",
         "steps": [
+          "dpcpp --version",
+          "cd ..\..\..",
           "mkdir build",
           "cd build",
-          "cmake -G \"NMake Makefiles\" ..",
+          "cmake -G \"NMake Makefiles\" ..\Tutorials\DesignPatterns\loop_carried_dependency",
           "nmake report"
         ]
       }

--- a/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/loop_carried_dependency/sample.json
+++ b/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/loop_carried_dependency/sample.json
@@ -39,10 +39,10 @@
         "id": "fpga_emu",
         "steps": [
           "dpcpp --version",
-          "cd ..\..\..",
+          "cd ../../..",
           "mkdir build",
           "cd build",
-          "cmake -G \"NMake Makefiles\" ..\Tutorials\DesignPatterns\loop_carried_dependency",
+          "cmake -G \"NMake Makefiles\" ../Tutorials/DesignPatterns/loop_carried_dependency",
           "nmake fpga_emu",
           "loop_carried_dependency.fpga_emu.exe"
         ]
@@ -51,10 +51,10 @@
         "id": "report",
         "steps": [
           "dpcpp --version",
-          "cd ..\..\..",
+          "cd ../../..",
           "mkdir build",
           "cd build",
-          "cmake -G \"NMake Makefiles\" ..\Tutorials\DesignPatterns\loop_carried_dependency",
+          "cmake -G \"NMake Makefiles\" ../Tutorials/DesignPatterns/loop_carried_dependency",
           "nmake report"
         ]
       }

--- a/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/loop_carried_dependency/sample.json
+++ b/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/loop_carried_dependency/sample.json
@@ -14,10 +14,9 @@
         "id": "fpga_emu",
         "steps": [
           "dpcpp --version",
-          "cd ../../..",
           "mkdir build",
           "cd build",
-          "cmake ../Tutorials/DesignPatterns/loop_carried_dependency",
+          "cmake ..",
           "make fpga_emu",
           "./loop_carried_dependency.fpga_emu"
         ]
@@ -26,10 +25,9 @@
         "id": "report",
         "steps": [
           "dpcpp --version",
-          "cd ../../..",
           "mkdir build",
           "cd build",
-          "cmake ../Tutorials/DesignPatterns/loop_carried_dependency",
+          "cmake ..",
           "make report"
         ]
       }

--- a/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/n_way_buffering/sample.json
+++ b/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/n_way_buffering/sample.json
@@ -13,9 +13,11 @@
       {
         "id": "fpga_emu",
         "steps": [
+          "dpcpp --version",
+          "cd ../../..",
           "mkdir build",
           "cd build",
-          "cmake ..",
+          "cmake ../Tutorials/DesignPatterns/n_way_buffering",
           "make fpga_emu",
           "./n_way_buffering.fpga_emu"
         ]
@@ -23,9 +25,11 @@
       {
         "id": "report",
         "steps": [
+          "dpcpp --version",
+          "cd ../../..",
           "mkdir build",
           "cd build",
-          "cmake ..",
+          "cmake ../Tutorials/DesignPatterns/n_way_buffering",
           "make report"
         ]
       }
@@ -34,9 +38,11 @@
       {
         "id": "fpga_emu",
         "steps": [
+          "dpcpp --version",
+          "cd ../../..",
           "mkdir build",
           "cd build",
-          "cmake -G \"NMake Makefiles\" ..",
+          "cmake -G \"NMake Makefiles\" ../Tutorials/DesignPatterns/n_way_buffering",
           "nmake fpga_emu",
           "n_way_buffering.fpga_emu.exe"
         ]
@@ -44,9 +50,11 @@
       {
         "id": "report",
         "steps": [
+          "dpcpp --version",
+          "cd ../../..",
           "mkdir build",
           "cd build",
-          "cmake -G \"NMake Makefiles\" ..",
+          "cmake -G \"NMake Makefiles\" ../Tutorials/DesignPatterns/n_way_buffering",
           "nmake report"
         ]
       }

--- a/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/n_way_buffering/sample.json
+++ b/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/n_way_buffering/sample.json
@@ -14,10 +14,9 @@
         "id": "fpga_emu",
         "steps": [
           "dpcpp --version",
-          "cd ../../..",
           "mkdir build",
           "cd build",
-          "cmake ../Tutorials/DesignPatterns/n_way_buffering",
+          "cmake ..",
           "make fpga_emu",
           "./n_way_buffering.fpga_emu"
         ]
@@ -26,10 +25,9 @@
         "id": "report",
         "steps": [
           "dpcpp --version",
-          "cd ../../..",
           "mkdir build",
           "cd build",
-          "cmake ../Tutorials/DesignPatterns/n_way_buffering",
+          "cmake ..",
           "make report"
         ]
       }

--- a/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/onchip_memory_cache/sample.json
+++ b/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/onchip_memory_cache/sample.json
@@ -14,10 +14,9 @@
         "id": "fpga_emu",
         "steps": [
           "dpcpp --version",
-          "cd ../../..",
           "mkdir build",
           "cd build",
-          "cmake ../Tutorials/DesignPatterns/onchip_memory_cache",
+          "cmake ..",
           "make fpga_emu",
           "./onchip_memory_cache.fpga_emu"
         ]
@@ -26,10 +25,9 @@
         "id": "report",
         "steps": [
           "dpcpp --version",
-          "cd ../../..",
           "mkdir build",
           "cd build",
-          "cmake ../Tutorials/DesignPatterns/onchip_memory_cache",
+          "cmake ..",
           "make report"
         ]
       }

--- a/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/onchip_memory_cache/sample.json
+++ b/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/onchip_memory_cache/sample.json
@@ -13,9 +13,11 @@
       {
         "id": "fpga_emu",
         "steps": [
+          "dpcpp --version",
+          "cd ../../..",
           "mkdir build",
           "cd build",
-          "cmake ..",
+          "cmake ../Tutorials/DesignPatterns/onchip_memory_cache",
           "make fpga_emu",
           "./onchip_memory_cache.fpga_emu"
         ]
@@ -23,9 +25,11 @@
       {
         "id": "report",
         "steps": [
+          "dpcpp --version",
+          "cd ../../..",
           "mkdir build",
           "cd build",
-          "cmake ..",
+          "cmake ../Tutorials/DesignPatterns/onchip_memory_cache",
           "make report"
         ]
       }
@@ -34,9 +38,11 @@
       {
         "id": "fpga_emu",
         "steps": [
+          "dpcpp --version",
+          "cd ../../..",
           "mkdir build",
           "cd build",
-          "cmake -G \"NMake Makefiles\" ..",
+          "cmake -G \"NMake Makefiles\" ../Tutorials/DesignPatterns/onchip_memory_cache",
           "nmake fpga_emu",
           "onchip_memory_cache.fpga_emu.exe"
         ]
@@ -44,9 +50,11 @@
       {
         "id": "report",
         "steps": [
+          "dpcpp --version",
+          "cd ../../..",
           "mkdir build",
           "cd build",
-          "cmake -G \"NMake Makefiles\" ..",
+          "cmake -G \"NMake Makefiles\" ../Tutorials/DesignPatterns/onchip_memory_cache",
           "nmake report"
         ]
       }

--- a/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/optimize_inner_loop/sample.json
+++ b/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/optimize_inner_loop/sample.json
@@ -13,9 +13,11 @@
       {
         "id": "fpga_emu",
         "steps": [
+          "dpcpp --version",
+          "cd ../../..",
           "mkdir build",
           "cd build",
-          "cmake ..",
+          "cmake ../Tutorials/DesignPatterns/optimize_inner_loop",
           "make fpga_emu",
           "./optimize_inner_loop.fpga_emu"
         ]
@@ -23,9 +25,11 @@
       {
         "id": "report",
         "steps": [
+          "dpcpp --version",
+          "cd ../../..",
           "mkdir build",
           "cd build",
-          "cmake ..",
+          "cmake ../Tutorials/DesignPatterns/optimize_inner_loop",
           "make report"
         ]
       }
@@ -34,9 +38,11 @@
       {
         "id": "fpga_emu",
         "steps": [
+          "dpcpp --version",
+          "cd ../../..",
           "mkdir build",
           "cd build",
-          "cmake -G \"NMake Makefiles\" ..",
+          "cmake -G \"NMake Makefiles\" ../Tutorials/DesignPatterns/optimize_inner_loop",
           "nmake fpga_emu",
           "optimize_inner_loop.fpga_emu.exe"
         ]
@@ -44,9 +50,11 @@
       {
         "id": "report",
         "steps": [
+          "dpcpp --version",
+          "cd ../../..",
           "mkdir build",
           "cd build",
-          "cmake -G \"NMake Makefiles\" ..",
+          "cmake -G \"NMake Makefiles\" ../Tutorials/DesignPatterns/optimize_inner_loop",
           "nmake report"
         ]
       }

--- a/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/optimize_inner_loop/sample.json
+++ b/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/optimize_inner_loop/sample.json
@@ -14,10 +14,9 @@
         "id": "fpga_emu",
         "steps": [
           "dpcpp --version",
-          "cd ../../..",
           "mkdir build",
           "cd build",
-          "cmake ../Tutorials/DesignPatterns/optimize_inner_loop",
+          "cmake ..",
           "make fpga_emu",
           "./optimize_inner_loop.fpga_emu"
         ]
@@ -26,10 +25,9 @@
         "id": "report",
         "steps": [
           "dpcpp --version",
-          "cd ../../..",
           "mkdir build",
           "cd build",
-          "cmake ../Tutorials/DesignPatterns/optimize_inner_loop",
+          "cmake ..",
           "make report"
         ]
       }

--- a/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/pipe_array/sample.json
+++ b/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/pipe_array/sample.json
@@ -14,10 +14,9 @@
         "id": "fpga_emu",
         "steps": [
           "dpcpp --version",
-          "cd ../../..",
           "mkdir build",
           "cd build",
-          "cmake ../Tutorials/DesignPatterns/pipe_array",
+          "cmake ..",
           "make fpga_emu",
           "./pipe_array.fpga_emu"
         ]
@@ -26,10 +25,9 @@
         "id": "report",
         "steps": [
           "dpcpp --version",
-          "cd ../../..",
           "mkdir build",
           "cd build",
-          "cmake ../Tutorials/DesignPatterns/pipe_array",
+          "cmake ..",
           "make report"
         ]
       }

--- a/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/pipe_array/sample.json
+++ b/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/pipe_array/sample.json
@@ -13,9 +13,11 @@
       {
         "id": "fpga_emu",
         "steps": [
+          "dpcpp --version",
+          "cd ../../..",
           "mkdir build",
           "cd build",
-          "cmake ..",
+          "cmake ../Tutorials/DesignPatterns/pipe_array",
           "make fpga_emu",
           "./pipe_array.fpga_emu"
         ]
@@ -23,9 +25,11 @@
       {
         "id": "report",
         "steps": [
+          "dpcpp --version",
+          "cd ../../..",
           "mkdir build",
           "cd build",
-          "cmake ..",
+          "cmake ../Tutorials/DesignPatterns/pipe_array",
           "make report"
         ]
       }
@@ -34,9 +38,11 @@
       {
         "id": "fpga_emu",
         "steps": [
+          "dpcpp --version",
+          "cd ../../..",
           "mkdir build",
           "cd build",
-          "cmake -G \"NMake Makefiles\" ..",
+          "cmake -G \"NMake Makefiles\" ../Tutorials/DesignPatterns/pipe_array",
           "nmake fpga_emu",
           "pipe_array.fpga_emu.exe"
         ]
@@ -44,9 +50,11 @@
       {
         "id": "report",
         "steps": [
+          "dpcpp --version",
+          "cd ../../..",
           "mkdir build",
           "cd build",
-          "cmake -G \"NMake Makefiles\" ..",
+          "cmake -G \"NMake Makefiles\" ../Tutorials/DesignPatterns/pipe_array",
           "nmake report"
         ]
       }

--- a/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/shannonization/sample.json
+++ b/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/shannonization/sample.json
@@ -13,9 +13,11 @@
       {
         "id": "fpga_emu",
         "steps": [
+          "dpcpp --version",
+          "cd ../../..",
           "mkdir build",
           "cd build",
-          "cmake ..",
+          "cmake ../Tutorials/DesignPatterns/shannonization",
           "make fpga_emu",
           "./shannonization.fpga_emu"
         ]
@@ -23,9 +25,11 @@
       {
         "id": "report",
         "steps": [
+          "dpcpp --version",
+          "cd ../../..",
           "mkdir build",
           "cd build",
-          "cmake ..",
+          "cmake ../Tutorials/DesignPatterns/shannonization",
           "make report"
         ]
       }
@@ -34,9 +38,11 @@
       {
         "id": "fpga_emu",
         "steps": [
+          "dpcpp --version",
+          "cd ../../..",
           "mkdir build",
           "cd build",
-          "cmake -G \"NMake Makefiles\" ..",
+          "cmake -G \"NMake Makefiles\" ../Tutorials/DesignPatterns/shannonization",
           "nmake fpga_emu",
           "shannonization.fpga_emu.exe"
         ]
@@ -44,9 +50,11 @@
       {
         "id": "report",
         "steps": [
+          "dpcpp --version",
+          "cd ../../..",
           "mkdir build",
           "cd build",
-          "cmake -G \"NMake Makefiles\" ..",
+          "cmake -G \"NMake Makefiles\" ../Tutorials/DesignPatterns/shannonization",
           "nmake report"
         ]
       }

--- a/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/shannonization/sample.json
+++ b/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/shannonization/sample.json
@@ -14,10 +14,9 @@
         "id": "fpga_emu",
         "steps": [
           "dpcpp --version",
-          "cd ../../..",
           "mkdir build",
           "cd build",
-          "cmake ../Tutorials/DesignPatterns/shannonization",
+          "cmake ..",
           "make fpga_emu",
           "./shannonization.fpga_emu"
         ]
@@ -26,10 +25,9 @@
         "id": "report",
         "steps": [
           "dpcpp --version",
-          "cd ../../..",
           "mkdir build",
           "cd build",
-          "cmake ../Tutorials/DesignPatterns/shannonization",
+          "cmake ..",
           "make report"
         ]
       }

--- a/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/simple_host_streaming/sample.json
+++ b/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/simple_host_streaming/sample.json
@@ -14,10 +14,9 @@
         "id": "fpga_emu",
         "steps": [
           "dpcpp --version",
-          "cd ../../..",
           "mkdir build",
           "cd build",
-          "cmake ../Tutorials/DesignPatterns/simple_host_streaming",
+          "cmake ..",
           "make fpga_emu",
           "./simple_host_streaming.fpga_emu"
         ]
@@ -26,10 +25,9 @@
         "id": "report",
         "steps": [
           "dpcpp --version",
-          "cd ../../..",
           "mkdir build",
           "cd build",
-          "cmake ../Tutorials/DesignPatterns/simple_host_streaming",
+          "cmake ..",
           "make report"
         ]
       }

--- a/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/simple_host_streaming/sample.json
+++ b/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/simple_host_streaming/sample.json
@@ -13,9 +13,11 @@
       {
         "id": "fpga_emu",
         "steps": [
+          "dpcpp --version",
+          "cd ../../..",
           "mkdir build",
           "cd build",
-          "cmake ..",
+          "cmake ../Tutorials/DesignPatterns/simple_host_streaming",
           "make fpga_emu",
           "./simple_host_streaming.fpga_emu"
         ]
@@ -23,9 +25,11 @@
       {
         "id": "report",
         "steps": [
+          "dpcpp --version",
+          "cd ../../..",
           "mkdir build",
           "cd build",
-          "cmake ..",
+          "cmake ../Tutorials/DesignPatterns/simple_host_streaming",
           "make report"
         ]
       }
@@ -34,9 +38,11 @@
       {
         "id": "fpga_emu",
         "steps": [
+          "dpcpp --version",
+          "cd ../../..",
           "mkdir build",
           "cd build",
-          "cmake -G \"NMake Makefiles\" ..",
+          "cmake -G \"NMake Makefiles\" ../Tutorials/DesignPatterns/simple_host_streaming",
           "nmake fpga_emu",
           "simple_host_streaming.fpga_emu.exe"
         ]
@@ -44,9 +50,11 @@
       {
         "id": "report",
         "steps": [
+          "dpcpp --version",
+          "cd ../../..",
           "mkdir build",
           "cd build",
-          "cmake -G \"NMake Makefiles\" ..",
+          "cmake -G \"NMake Makefiles\" ../Tutorials/DesignPatterns/simple_host_streaming",
           "nmake report"
         ]
       }

--- a/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/triangular_loop/sample.json
+++ b/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/triangular_loop/sample.json
@@ -14,10 +14,9 @@
         "id": "fpga_emu",
         "steps": [
           "dpcpp --version",
-          "cd ../../..",
           "mkdir build",
           "cd build",
-          "cmake ../Tutorials/DesignPatterns/triangular_loop",
+          "cmake ..",
           "make fpga_emu",
           "./triangular_loop.fpga_emu"
         ]
@@ -26,10 +25,9 @@
         "id": "report",
         "steps": [
           "dpcpp --version",
-          "cd ../../..",
           "mkdir build",
           "cd build",
-          "cmake ../Tutorials/DesignPatterns/triangular_loop",
+          "cmake ..",
           "make report"
         ]
       }

--- a/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/triangular_loop/sample.json
+++ b/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/triangular_loop/sample.json
@@ -13,9 +13,11 @@
       {
         "id": "fpga_emu",
         "steps": [
+          "dpcpp --version",
+          "cd ../../..",
           "mkdir build",
           "cd build",
-          "cmake ..",
+          "cmake ../Tutorials/DesignPatterns/triangular_loop",
           "make fpga_emu",
           "./triangular_loop.fpga_emu"
         ]
@@ -23,9 +25,11 @@
       {
         "id": "report",
         "steps": [
+          "dpcpp --version",
+          "cd ../../..",
           "mkdir build",
           "cd build",
-          "cmake ..",
+          "cmake ../Tutorials/DesignPatterns/triangular_loop",
           "make report"
         ]
       }
@@ -34,9 +38,11 @@
       {
         "id": "fpga_emu",
         "steps": [
+          "dpcpp --version",
+          "cd ../../..",
           "mkdir build",
           "cd build",
-          "cmake -G \"NMake Makefiles\" ..",
+          "cmake -G \"NMake Makefiles\" ../Tutorials/DesignPatterns/triangular_loop",
           "nmake fpga_emu",
           "triangular_loop.fpga_emu.exe"
         ]
@@ -44,9 +50,11 @@
       {
         "id": "report",
         "steps": [
+          "dpcpp --version",
+          "cd ../../..",
           "mkdir build",
           "cd build",
-          "cmake -G \"NMake Makefiles\" ..",
+          "cmake -G \"NMake Makefiles\" ../Tutorials/DesignPatterns/triangular_loop",
           "nmake report"
         ]
       }

--- a/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/zero_copy_data_transfer/sample.json
+++ b/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/zero_copy_data_transfer/sample.json
@@ -13,9 +13,11 @@
       {
         "id": "fpga_emu",
         "steps": [
+          "dpcpp --version",
+          "cd ../../..",
           "mkdir build",
           "cd build",
-          "cmake ..",
+          "cmake ../Tutorials/DesignPatterns/zero_copy_data_transfer",
           "make fpga_emu",
           "./zero_copy_data_transfer.fpga_emu"
         ]
@@ -23,9 +25,11 @@
       {
         "id": "report",
         "steps": [
+          "dpcpp --version",
+          "cd ../../..",
           "mkdir build",
           "cd build",
-          "cmake ..",
+          "cmake ../Tutorials/DesignPatterns/zero_copy_data_transfer",
           "make report"
         ]
       }
@@ -34,9 +38,11 @@
       {
         "id": "fpga_emu",
         "steps": [
+          "dpcpp --version",
+          "cd ../../..",
           "mkdir build",
           "cd build",
-          "cmake -G \"NMake Makefiles\" ..",
+          "cmake -G \"NMake Makefiles\" ../Tutorials/DesignPatterns/zero_copy_data_transfer",
           "nmake fpga_emu",
           "zero_copy_data_transfer.fpga_emu.exe"
         ]
@@ -44,9 +50,11 @@
       {
         "id": "report",
         "steps": [
+          "dpcpp --version",
+          "cd ../../..",
           "mkdir build",
           "cd build",
-          "cmake -G \"NMake Makefiles\" ..",
+          "cmake -G \"NMake Makefiles\" ../Tutorials/DesignPatterns/zero_copy_data_transfer",
           "nmake report"
         ]
       }

--- a/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/zero_copy_data_transfer/sample.json
+++ b/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/zero_copy_data_transfer/sample.json
@@ -14,10 +14,9 @@
         "id": "fpga_emu",
         "steps": [
           "dpcpp --version",
-          "cd ../../..",
           "mkdir build",
           "cd build",
-          "cmake ../Tutorials/DesignPatterns/zero_copy_data_transfer",
+          "cmake ..",
           "make fpga_emu",
           "./zero_copy_data_transfer.fpga_emu"
         ]
@@ -26,10 +25,9 @@
         "id": "report",
         "steps": [
           "dpcpp --version",
-          "cd ../../..",
           "mkdir build",
           "cd build",
-          "cmake ../Tutorials/DesignPatterns/zero_copy_data_transfer",
+          "cmake ..",
           "make report"
         ]
       }

--- a/DirectProgramming/DPC++FPGA/Tutorials/Features/fpga_reg/sample.json
+++ b/DirectProgramming/DPC++FPGA/Tutorials/Features/fpga_reg/sample.json
@@ -13,9 +13,11 @@
       {
         "id": "fpga_emu",
         "steps": [
+          "dpcpp --version",
+          "cd ../../..",
           "mkdir build",
           "cd build",
-          "cmake ..",
+          "cmake ../Tutorials/Features/fpga_reg",
           "make fpga_emu",
           "./fpga_reg.fpga_emu"
         ]
@@ -23,9 +25,11 @@
       {
         "id": "report",
         "steps": [
+          "dpcpp --version",
+          "cd ../../..",
           "mkdir build",
           "cd build",
-          "cmake ..",
+          "cmake ../Tutorials/Features/fpga_reg",
           "make report"
         ]
       }
@@ -34,9 +38,11 @@
       {
         "id": "fpga_emu",
         "steps": [
+          "dpcpp --version",
+          "cd ../../..",
           "mkdir build",
           "cd build",
-          "cmake -G \"NMake Makefiles\" ..",
+          "cmake -G \"NMake Makefiles\" ../Tutorials/Features/fpga_reg",
           "nmake fpga_emu",
           "fpga_reg.fpga_emu.exe"
         ]
@@ -44,9 +50,11 @@
       {
         "id": "report",
         "steps": [
+          "dpcpp --version",
+          "cd ../../..",
           "mkdir build",
           "cd build",
-          "cmake -G \"NMake Makefiles\" ..",
+          "cmake -G \"NMake Makefiles\" ../Tutorials/Features/fpga_reg",
           "nmake report"
         ]
       }

--- a/DirectProgramming/DPC++FPGA/Tutorials/Features/fpga_reg/sample.json
+++ b/DirectProgramming/DPC++FPGA/Tutorials/Features/fpga_reg/sample.json
@@ -14,10 +14,9 @@
         "id": "fpga_emu",
         "steps": [
           "dpcpp --version",
-          "cd ../../..",
           "mkdir build",
           "cd build",
-          "cmake ../Tutorials/Features/fpga_reg",
+          "cmake ..",
           "make fpga_emu",
           "./fpga_reg.fpga_emu"
         ]
@@ -26,10 +25,9 @@
         "id": "report",
         "steps": [
           "dpcpp --version",
-          "cd ../../..",
           "mkdir build",
           "cd build",
-          "cmake ../Tutorials/Features/fpga_reg",
+          "cmake ..",
           "make report"
         ]
       }

--- a/DirectProgramming/DPC++FPGA/Tutorials/Features/kernel_args_restrict/sample.json
+++ b/DirectProgramming/DPC++FPGA/Tutorials/Features/kernel_args_restrict/sample.json
@@ -13,9 +13,11 @@
       {
         "id": "fpga_emu",
         "steps": [
+          "dpcpp --version",
+          "cd ../../..",
           "mkdir build",
           "cd build",
-          "cmake ..",
+          "cmake ../Tutorials/Features/kernel_args_restrict",
           "make fpga_emu",
           "./kernel_args_restrict.fpga_emu"
         ]
@@ -23,9 +25,11 @@
       {
         "id": "report",
         "steps": [
+          "dpcpp --version",
+          "cd ../../..",
           "mkdir build",
           "cd build",
-          "cmake ..",
+          "cmake ../Tutorials/Features/kernel_args_restrict",
           "make report"
         ]
       }
@@ -34,9 +38,11 @@
       {
         "id": "fpga_emu",
         "steps": [
+          "dpcpp --version",
+          "cd ../../..",
           "mkdir build",
           "cd build",
-          "cmake -G \"NMake Makefiles\" ..",
+          "cmake -G \"NMake Makefiles\" ../Tutorials/Features/kernel_args_restrict",
           "nmake fpga_emu",
           "kernel_args_restrict.fpga_emu.exe"
         ]
@@ -44,9 +50,11 @@
       {
         "id": "report",
         "steps": [
+          "dpcpp --version",
+          "cd ../../..",
           "mkdir build",
           "cd build",
-          "cmake -G \"NMake Makefiles\" ..",
+          "cmake -G \"NMake Makefiles\" ../Tutorials/Features/kernel_args_restrict",
           "nmake report"
         ]
       }

--- a/DirectProgramming/DPC++FPGA/Tutorials/Features/kernel_args_restrict/sample.json
+++ b/DirectProgramming/DPC++FPGA/Tutorials/Features/kernel_args_restrict/sample.json
@@ -14,10 +14,9 @@
         "id": "fpga_emu",
         "steps": [
           "dpcpp --version",
-          "cd ../../..",
           "mkdir build",
           "cd build",
-          "cmake ../Tutorials/Features/kernel_args_restrict",
+          "cmake ..",
           "make fpga_emu",
           "./kernel_args_restrict.fpga_emu"
         ]
@@ -26,10 +25,9 @@
         "id": "report",
         "steps": [
           "dpcpp --version",
-          "cd ../../..",
           "mkdir build",
           "cd build",
-          "cmake ../Tutorials/Features/kernel_args_restrict",
+          "cmake ..",
           "make report"
         ]
       }

--- a/DirectProgramming/DPC++FPGA/Tutorials/Features/loop_coalesce/sample.json
+++ b/DirectProgramming/DPC++FPGA/Tutorials/Features/loop_coalesce/sample.json
@@ -14,10 +14,9 @@
         "id": "fpga_emu",
         "steps": [
           "dpcpp --version",
-          "cd ../../..",
           "mkdir build",
           "cd build",
-          "cmake ../Tutorials/Features/loop_coalesce",
+          "cmake ..",
           "make fpga_emu",
           "./loop_coalesce.fpga_emu"
         ]
@@ -26,10 +25,9 @@
         "id": "report",
         "steps": [
           "dpcpp --version",
-          "cd ../../..",
           "mkdir build",
           "cd build",
-          "cmake ../Tutorials/Features/loop_coalesce",
+          "cmake ..",
           "make report"
         ]
       }

--- a/DirectProgramming/DPC++FPGA/Tutorials/Features/loop_coalesce/sample.json
+++ b/DirectProgramming/DPC++FPGA/Tutorials/Features/loop_coalesce/sample.json
@@ -13,9 +13,11 @@
       {
         "id": "fpga_emu",
         "steps": [
+          "dpcpp --version",
+          "cd ../../..",
           "mkdir build",
           "cd build",
-          "cmake ..",
+          "cmake ../Tutorials/Features/loop_coalesce",
           "make fpga_emu",
           "./loop_coalesce.fpga_emu"
         ]
@@ -23,9 +25,11 @@
       {
         "id": "report",
         "steps": [
+          "dpcpp --version",
+          "cd ../../..",
           "mkdir build",
           "cd build",
-          "cmake ..",
+          "cmake ../Tutorials/Features/loop_coalesce",
           "make report"
         ]
       }
@@ -34,9 +38,11 @@
       {
         "id": "fpga_emu",
         "steps": [
+          "dpcpp --version",
+          "cd ../../..",
           "mkdir build",
           "cd build",
-          "cmake -G \"NMake Makefiles\" ..",
+          "cmake -G \"NMake Makefiles\" ../Tutorials/Features/loop_coalesce",
           "nmake fpga_emu",
           "loop_coalesce.fpga_emu.exe"
         ]
@@ -44,9 +50,11 @@
       {
         "id": "report",
         "steps": [
+          "dpcpp --version",
+          "cd ../../..",
           "mkdir build",
           "cd build",
-          "cmake -G \"NMake Makefiles\" ..",
+          "cmake -G \"NMake Makefiles\" ../Tutorials/Features/loop_coalesce",
           "nmake report"
         ]
       }

--- a/DirectProgramming/DPC++FPGA/Tutorials/Features/loop_initiation_interval/sample.json
+++ b/DirectProgramming/DPC++FPGA/Tutorials/Features/loop_initiation_interval/sample.json
@@ -14,10 +14,9 @@
         "id": "fpga_emu",
         "steps": [
           "dpcpp --version",
-          "cd ../../..",
           "mkdir build",
           "cd build",
-          "cmake ../Tutorials/Features/loop_initiation_interval",
+          "cmake ..",
           "make fpga_emu",
           "./loop_ii.fpga_emu"
         ]
@@ -26,10 +25,9 @@
         "id": "report",
         "steps": [
           "dpcpp --version",
-          "cd ../../..",
           "mkdir build",
           "cd build",
-          "cmake ../Tutorials/Features/loop_initiation_interval",
+          "cmake ..",
           "make report"
         ]
       }

--- a/DirectProgramming/DPC++FPGA/Tutorials/Features/loop_initiation_interval/sample.json
+++ b/DirectProgramming/DPC++FPGA/Tutorials/Features/loop_initiation_interval/sample.json
@@ -13,9 +13,11 @@
       {
         "id": "fpga_emu",
         "steps": [
+          "dpcpp --version",
+          "cd ../../..",
           "mkdir build",
           "cd build",
-          "cmake ..",
+          "cmake ../Tutorials/Features/loop_initiation_interval",
           "make fpga_emu",
           "./loop_ii.fpga_emu"
         ]
@@ -23,9 +25,11 @@
       {
         "id": "report",
         "steps": [
+          "dpcpp --version",
+          "cd ../../..",
           "mkdir build",
           "cd build",
-          "cmake ..",
+          "cmake ../Tutorials/Features/loop_initiation_interval",
           "make report"
         ]
       }
@@ -34,9 +38,11 @@
       {
         "id": "fpga_emu",
         "steps": [
+          "dpcpp --version",
+          "cd ../../..",
           "mkdir build",
           "cd build",
-          "cmake -G \"NMake Makefiles\" ..",
+          "cmake -G \"NMake Makefiles\" ../Tutorials/Features/loop_initiation_interval",
           "nmake fpga_emu",
           "loop_ii.fpga_emu.exe"
         ]
@@ -44,9 +50,11 @@
       {
         "id": "report",
         "steps": [
+          "dpcpp --version",
+          "cd ../../..",
           "mkdir build",
           "cd build",
-          "cmake -G \"NMake Makefiles\" ..",
+          "cmake -G \"NMake Makefiles\" ../Tutorials/Features/loop_initiation_interval",
           "nmake report"
         ]
       }

--- a/DirectProgramming/DPC++FPGA/Tutorials/Features/loop_ivdep/sample.json
+++ b/DirectProgramming/DPC++FPGA/Tutorials/Features/loop_ivdep/sample.json
@@ -14,10 +14,9 @@
         "id": "fpga_emu",
         "steps": [
           "dpcpp --version",
-          "cd ../../..",
           "mkdir build",
           "cd build",
-          "cmake ../Tutorials/Features/loop_ivdep",
+          "cmake ..",
           "make fpga_emu",
           "./loop_ivdep.fpga_emu"
         ]
@@ -26,10 +25,9 @@
         "id": "report",
         "steps": [
           "dpcpp --version",
-          "cd ../../..",
           "mkdir build",
           "cd build",
-          "cmake ../Tutorials/Features/loop_ivdep",
+          "cmake ..",
           "make report"
         ]
       }

--- a/DirectProgramming/DPC++FPGA/Tutorials/Features/loop_ivdep/sample.json
+++ b/DirectProgramming/DPC++FPGA/Tutorials/Features/loop_ivdep/sample.json
@@ -13,9 +13,11 @@
       {
         "id": "fpga_emu",
         "steps": [
+          "dpcpp --version",
+          "cd ../../..",
           "mkdir build",
           "cd build",
-          "cmake ..",
+          "cmake ../Tutorials/Features/loop_ivdep",
           "make fpga_emu",
           "./loop_ivdep.fpga_emu"
         ]
@@ -23,9 +25,11 @@
       {
         "id": "report",
         "steps": [
+          "dpcpp --version",
+          "cd ../../..",
           "mkdir build",
           "cd build",
-          "cmake ..",
+          "cmake ../Tutorials/Features/loop_ivdep",
           "make report"
         ]
       }
@@ -34,9 +38,11 @@
       {
         "id": "fpga_emu",
         "steps": [
+          "dpcpp --version",
+          "cd ../../..",
           "mkdir build",
           "cd build",
-          "cmake -G \"NMake Makefiles\" ..",
+          "cmake -G \"NMake Makefiles\" ../Tutorials/Features/loop_ivdep",
           "nmake fpga_emu",
           "loop_ivdep.fpga_emu.exe"
         ]
@@ -44,9 +50,11 @@
       {
         "id": "report",
         "steps": [
+          "dpcpp --version",
+          "cd ../../..",
           "mkdir build",
           "cd build",
-          "cmake -G \"NMake Makefiles\" ..",
+          "cmake -G \"NMake Makefiles\" ../Tutorials/Features/loop_ivdep",
           "nmake report"
         ]
       }

--- a/DirectProgramming/DPC++FPGA/Tutorials/Features/loop_unroll/sample.json
+++ b/DirectProgramming/DPC++FPGA/Tutorials/Features/loop_unroll/sample.json
@@ -14,10 +14,9 @@
         "id": "fpga_emu",
         "steps": [
           "dpcpp --version",
-          "cd ../../..",
           "mkdir build",
           "cd build",
-          "cmake ../Tutorials/Features/loop_unroll",
+          "cmake ..",
           "make fpga_emu",
           "./loop_unroll.fpga_emu"
         ]
@@ -26,10 +25,9 @@
         "id": "report",
         "steps": [
           "dpcpp --version",
-          "cd ../../..",
           "mkdir build",
           "cd build",
-          "cmake ../Tutorials/Features/loop_unroll",
+          "cmake ..",
           "make report"
         ]
       }

--- a/DirectProgramming/DPC++FPGA/Tutorials/Features/loop_unroll/sample.json
+++ b/DirectProgramming/DPC++FPGA/Tutorials/Features/loop_unroll/sample.json
@@ -13,9 +13,11 @@
       {
         "id": "fpga_emu",
         "steps": [
+          "dpcpp --version",
+          "cd ../../..",
           "mkdir build",
           "cd build",
-          "cmake ..",
+          "cmake ../Tutorials/Features/loop_unroll",
           "make fpga_emu",
           "./loop_unroll.fpga_emu"
         ]
@@ -23,9 +25,11 @@
       {
         "id": "report",
         "steps": [
+          "dpcpp --version",
+          "cd ../../..",
           "mkdir build",
           "cd build",
-          "cmake ..",
+          "cmake ../Tutorials/Features/loop_unroll",
           "make report"
         ]
       }
@@ -34,9 +38,11 @@
       {
         "id": "fpga_emu",
         "steps": [
+          "dpcpp --version",
+          "cd ../../..",
           "mkdir build",
           "cd build",
-          "cmake -G \"NMake Makefiles\" ..",
+          "cmake -G \"NMake Makefiles\" ../Tutorials/Features/loop_unroll",
           "nmake fpga_emu",
           "loop_unroll.fpga_emu.exe"
         ]
@@ -44,9 +50,11 @@
       {
         "id": "report",
         "steps": [
+          "dpcpp --version",
+          "cd ../../..",
           "mkdir build",
           "cd build",
-          "cmake -G \"NMake Makefiles\" ..",
+          "cmake -G \"NMake Makefiles\" ../Tutorials/Features/loop_unroll",
           "nmake report"
         ]
       }

--- a/DirectProgramming/DPC++FPGA/Tutorials/Features/lsu_control/sample.json
+++ b/DirectProgramming/DPC++FPGA/Tutorials/Features/lsu_control/sample.json
@@ -13,9 +13,11 @@
       {
         "id": "fpga_emu",
         "steps": [
+          "dpcpp --version",
+          "cd ../../..",
           "mkdir build",
           "cd build",
-          "cmake ..",
+          "cmake ../Tutorials/Features/lsu_control",
           "make fpga_emu",
           "./lsu_control.fpga_emu"
         ]
@@ -23,9 +25,11 @@
       {
         "id": "report",
         "steps": [
+          "dpcpp --version",
+          "cd ../../..",
           "mkdir build",
           "cd build",
-          "cmake ..",
+          "cmake ../Tutorials/Features/lsu_control",
           "make report"
         ]
       }
@@ -34,9 +38,11 @@
       {
         "id": "fpga_emu",
         "steps": [
+          "dpcpp --version",
+          "cd ../../..",
           "mkdir build",
           "cd build",
-          "cmake -G \"NMake Makefiles\" ..",
+          "cmake -G \"NMake Makefiles\" ../Tutorials/Features/lsu_control",
           "nmake fpga_emu",
           "lsu_control.fpga_emu.exe"
         ]
@@ -44,9 +50,11 @@
       {
         "id": "report",
         "steps": [
+          "dpcpp --version",
+          "cd ../../..",
           "mkdir build",
           "cd build",
-          "cmake -G \"NMake Makefiles\" ..",
+          "cmake -G \"NMake Makefiles\" ../Tutorials/Features/lsu_control",
           "nmake report"
         ]
       }

--- a/DirectProgramming/DPC++FPGA/Tutorials/Features/lsu_control/sample.json
+++ b/DirectProgramming/DPC++FPGA/Tutorials/Features/lsu_control/sample.json
@@ -14,10 +14,9 @@
         "id": "fpga_emu",
         "steps": [
           "dpcpp --version",
-          "cd ../../..",
           "mkdir build",
           "cd build",
-          "cmake ../Tutorials/Features/lsu_control",
+          "cmake ..",
           "make fpga_emu",
           "./lsu_control.fpga_emu"
         ]
@@ -26,10 +25,9 @@
         "id": "report",
         "steps": [
           "dpcpp --version",
-          "cd ../../..",
           "mkdir build",
           "cd build",
-          "cmake ../Tutorials/Features/lsu_control",
+          "cmake ..",
           "make report"
         ]
       }

--- a/DirectProgramming/DPC++FPGA/Tutorials/Features/max_interleaving/sample.json
+++ b/DirectProgramming/DPC++FPGA/Tutorials/Features/max_interleaving/sample.json
@@ -13,9 +13,11 @@
       {
         "id": "fpga_emu",
         "steps": [
+          "dpcpp --version",
+          "cd ../../..",
           "mkdir build",
           "cd build",
-          "cmake ..",
+          "cmake ../Tutorials/Features/max_interleaving",
           "make fpga_emu",
           "./max_interleaving.fpga_emu"
         ]
@@ -23,9 +25,11 @@
       {
         "id": "report",
         "steps": [
+          "dpcpp --version",
+          "cd ../../..",
           "mkdir build",
           "cd build",
-          "cmake ..",
+          "cmake ../Tutorials/Features/max_interleaving",
           "make report"
         ]
       }
@@ -34,9 +38,11 @@
       {
         "id": "fpga_emu",
         "steps": [
+          "dpcpp --version",
+          "cd ../../..",
           "mkdir build",
           "cd build",
-          "cmake -G \"NMake Makefiles\" ..",
+          "cmake -G \"NMake Makefiles\" ../Tutorials/Features/max_interleaving",
           "nmake fpga_emu",
           "max_interleaving.fpga_emu.exe"
         ]
@@ -44,9 +50,11 @@
       {
         "id": "report",
         "steps": [
+          "dpcpp --version",
+          "cd ../../..",
           "mkdir build",
           "cd build",
-          "cmake -G \"NMake Makefiles\" ..",
+          "cmake -G \"NMake Makefiles\" ../Tutorials/Features/max_interleaving",
           "nmake report"
         ]
       }

--- a/DirectProgramming/DPC++FPGA/Tutorials/Features/max_interleaving/sample.json
+++ b/DirectProgramming/DPC++FPGA/Tutorials/Features/max_interleaving/sample.json
@@ -14,10 +14,9 @@
         "id": "fpga_emu",
         "steps": [
           "dpcpp --version",
-          "cd ../../..",
           "mkdir build",
           "cd build",
-          "cmake ../Tutorials/Features/max_interleaving",
+          "cmake ..",
           "make fpga_emu",
           "./max_interleaving.fpga_emu"
         ]
@@ -26,10 +25,9 @@
         "id": "report",
         "steps": [
           "dpcpp --version",
-          "cd ../../..",
           "mkdir build",
           "cd build",
-          "cmake ../Tutorials/Features/max_interleaving",
+          "cmake ..",
           "make report"
         ]
       }

--- a/DirectProgramming/DPC++FPGA/Tutorials/Features/memory_attributes/sample.json
+++ b/DirectProgramming/DPC++FPGA/Tutorials/Features/memory_attributes/sample.json
@@ -14,10 +14,9 @@
         "id": "fpga_emu",
         "steps": [
           "dpcpp --version",
-          "cd ../../..",
           "mkdir build",
           "cd build",
-          "cmake ../Tutorials/Features/memory_attributes",
+          "cmake ..",
           "make fpga_emu",
           "./memory_attributes.fpga_emu"
         ]
@@ -26,10 +25,9 @@
         "id": "report",
         "steps": [
           "dpcpp --version",
-          "cd ../../..",
           "mkdir build",
           "cd build",
-          "cmake ../Tutorials/Features/memory_attributes",
+          "cmake ..",
           "make report"
         ]
       }

--- a/DirectProgramming/DPC++FPGA/Tutorials/Features/memory_attributes/sample.json
+++ b/DirectProgramming/DPC++FPGA/Tutorials/Features/memory_attributes/sample.json
@@ -13,9 +13,11 @@
       {
         "id": "fpga_emu",
         "steps": [
+          "dpcpp --version",
+          "cd ../../..",
           "mkdir build",
           "cd build",
-          "cmake ..",
+          "cmake ../Tutorials/Features/memory_attributes",
           "make fpga_emu",
           "./memory_attributes.fpga_emu"
         ]
@@ -23,9 +25,11 @@
       {
         "id": "report",
         "steps": [
+          "dpcpp --version",
+          "cd ../../..",
           "mkdir build",
           "cd build",
-          "cmake ..",
+          "cmake ../Tutorials/Features/memory_attributes",
           "make report"
         ]
       }
@@ -34,9 +38,11 @@
       {
         "id": "fpga_emu",
         "steps": [
+          "dpcpp --version",
+          "cd ../../..",
           "mkdir build",
           "cd build",
-          "cmake -G \"NMake Makefiles\" ..",
+          "cmake -G \"NMake Makefiles\" ../Tutorials/Features/memory_attributes",
           "nmake fpga_emu",
           "memory_attributes.fpga_emu.exe"
         ]
@@ -44,9 +50,11 @@
       {
         "id": "report",
         "steps": [
+          "dpcpp --version",
+          "cd ../../..",
           "mkdir build",
           "cd build",
-          "cmake -G \"NMake Makefiles\" ..",
+          "cmake -G \"NMake Makefiles\" ../Tutorials/Features/memory_attributes",
           "nmake report"
         ]
       }

--- a/DirectProgramming/DPC++FPGA/Tutorials/Features/pipes/sample.json
+++ b/DirectProgramming/DPC++FPGA/Tutorials/Features/pipes/sample.json
@@ -14,10 +14,9 @@
         "id": "fpga_emu",
         "steps": [
           "dpcpp --version",
-          "cd ../../..",
           "mkdir build",
           "cd build",
-          "cmake ../Tutorials/Features/pipes",
+          "cmake ..",
           "make fpga_emu",
           "./pipes.fpga_emu"
         ]
@@ -26,10 +25,9 @@
         "id": "report",
         "steps": [
           "dpcpp --version",
-          "cd ../../..",
           "mkdir build",
           "cd build",
-          "cmake ../Tutorials/Features/pipes",
+          "cmake ..",
           "make report"
         ]
       }

--- a/DirectProgramming/DPC++FPGA/Tutorials/Features/pipes/sample.json
+++ b/DirectProgramming/DPC++FPGA/Tutorials/Features/pipes/sample.json
@@ -13,9 +13,11 @@
       {
         "id": "fpga_emu",
         "steps": [
+          "dpcpp --version",
+          "cd ../../..",
           "mkdir build",
           "cd build",
-          "cmake ..",
+          "cmake ../Tutorials/Features/pipes",
           "make fpga_emu",
           "./pipes.fpga_emu"
         ]
@@ -23,9 +25,11 @@
       {
         "id": "report",
         "steps": [
+          "dpcpp --version",
+          "cd ../../..",
           "mkdir build",
           "cd build",
-          "cmake ..",
+          "cmake ../Tutorials/Features/pipes",
           "make report"
         ]
       }
@@ -34,9 +38,11 @@
       {
         "id": "fpga_emu",
         "steps": [
+          "dpcpp --version",
+          "cd ../../..",
           "mkdir build",
           "cd build",
-          "cmake -G \"NMake Makefiles\" ..",
+          "cmake -G \"NMake Makefiles\" ../Tutorials/Features/pipes",
           "nmake fpga_emu",
           "pipes.fpga_emu.exe"
         ]
@@ -44,9 +50,11 @@
       {
         "id": "report",
         "steps": [
+          "dpcpp --version",
+          "cd ../../..",
           "mkdir build",
           "cd build",
-          "cmake -G \"NMake Makefiles\" ..",
+          "cmake -G \"NMake Makefiles\" ../Tutorials/Features/pipes",
           "nmake report"
         ]
       }

--- a/DirectProgramming/DPC++FPGA/Tutorials/Features/printf/sample.json
+++ b/DirectProgramming/DPC++FPGA/Tutorials/Features/printf/sample.json
@@ -14,10 +14,9 @@
         "id": "fpga_emu",
         "steps": [
           "dpcpp --version",
-          "cd ../../..",
           "mkdir build",
           "cd build",
-          "cmake ../Tutorials/Features/printf",
+          "cmake ..",
           "make fpga_emu",
           "./printf.fpga_emu"
         ]
@@ -26,10 +25,9 @@
         "id": "report",
         "steps": [
           "dpcpp --version",
-          "cd ../../..",
           "mkdir build",
           "cd build",
-          "cmake ../Tutorials/Features/printf",
+          "cmake ..",
           "make report"
         ]
       }

--- a/DirectProgramming/DPC++FPGA/Tutorials/Features/printf/sample.json
+++ b/DirectProgramming/DPC++FPGA/Tutorials/Features/printf/sample.json
@@ -13,9 +13,11 @@
       {
         "id": "fpga_emu",
         "steps": [
+          "dpcpp --version",
+          "cd ../../..",
           "mkdir build",
           "cd build",
-          "cmake ..",
+          "cmake ../Tutorials/Features/printf",
           "make fpga_emu",
           "./printf.fpga_emu"
         ]
@@ -23,9 +25,11 @@
       {
         "id": "report",
         "steps": [
+          "dpcpp --version",
+          "cd ../../..",
           "mkdir build",
           "cd build",
-          "cmake ..",
+          "cmake ../Tutorials/Features/printf",
           "make report"
         ]
       }
@@ -34,9 +38,11 @@
       {
         "id": "fpga_emu",
         "steps": [
+          "dpcpp --version",
+          "cd ../../..",
           "mkdir build",
           "cd build",
-          "cmake -G \"NMake Makefiles\" ..",
+          "cmake -G \"NMake Makefiles\" ../Tutorials/Features/printf",
           "nmake fpga_emu",
           "printf.fpga_emu.exe"
         ]
@@ -44,9 +50,11 @@
       {
         "id": "report",
         "steps": [
+          "dpcpp --version",
+          "cd ../../..",
           "mkdir build",
           "cd build",
-          "cmake -G \"NMake Makefiles\" ..",
+          "cmake -G \"NMake Makefiles\" ../Tutorials/Features/printf",
           "nmake report"
         ]
       }

--- a/DirectProgramming/DPC++FPGA/Tutorials/Features/private_copies/sample.json
+++ b/DirectProgramming/DPC++FPGA/Tutorials/Features/private_copies/sample.json
@@ -14,10 +14,9 @@
         "id": "fpga_emu",
         "steps": [
           "dpcpp --version",
-          "cd ../../..",
           "mkdir build",
           "cd build",
-          "cmake ../Tutorials/Features/private_copies",
+          "cmake ..",
           "make fpga_emu",
           "./private_copies.fpga_emu"
         ]
@@ -26,10 +25,9 @@
         "id": "report",
         "steps": [
           "dpcpp --version",
-          "cd ../../..",
           "mkdir build",
           "cd build",
-          "cmake ../Tutorials/Features/private_copies",
+          "cmake ..",
           "make report"
         ]
       }

--- a/DirectProgramming/DPC++FPGA/Tutorials/Features/private_copies/sample.json
+++ b/DirectProgramming/DPC++FPGA/Tutorials/Features/private_copies/sample.json
@@ -13,9 +13,11 @@
       {
         "id": "fpga_emu",
         "steps": [
+          "dpcpp --version",
+          "cd ../../..",
           "mkdir build",
           "cd build",
-          "cmake ..",
+          "cmake ../Tutorials/Features/private_copies",
           "make fpga_emu",
           "./private_copies.fpga_emu"
         ]
@@ -23,9 +25,11 @@
       {
         "id": "report",
         "steps": [
+          "dpcpp --version",
+          "cd ../../..",
           "mkdir build",
           "cd build",
-          "cmake ..",
+          "cmake ../Tutorials/Features/private_copies",
           "make report"
         ]
       }
@@ -34,9 +38,11 @@
       {
         "id": "fpga_emu",
         "steps": [
+          "dpcpp --version",
+          "cd ../../..",
           "mkdir build",
           "cd build",
-          "cmake -G \"NMake Makefiles\" ..",
+          "cmake -G \"NMake Makefiles\" ../Tutorials/Features/private_copies",
           "nmake fpga_emu",
           "private_copies.fpga_emu.exe"
         ]
@@ -44,9 +50,11 @@
       {
         "id": "report",
         "steps": [
+          "dpcpp --version",
+          "cd ../../..",
           "mkdir build",
           "cd build",
-          "cmake -G \"NMake Makefiles\" ..",
+          "cmake -G \"NMake Makefiles\" ../Tutorials/Features/private_copies",
           "nmake report"
         ]
       }

--- a/DirectProgramming/DPC++FPGA/Tutorials/Features/scheduler_target_fmax/sample.json
+++ b/DirectProgramming/DPC++FPGA/Tutorials/Features/scheduler_target_fmax/sample.json
@@ -13,9 +13,11 @@
       {
         "id": "fpga_emu",
         "steps": [
+          "dpcpp --version",
+          "cd ../../..",
           "mkdir build",
           "cd build",
-          "cmake ..",
+          "cmake ../Tutorials/Features/scheduler_target_fmax",
           "make fpga_emu",
           "./scheduler_target_fmax.fpga_emu"
         ]
@@ -23,9 +25,11 @@
       {
         "id": "report",
         "steps": [
+          "dpcpp --version",
+          "cd ../../..",
           "mkdir build",
           "cd build",
-          "cmake ..",
+          "cmake ../Tutorials/Features/scheduler_target_fmax",
           "make report"
         ]
       }
@@ -34,9 +38,11 @@
       {
         "id": "fpga_emu",
         "steps": [
+          "dpcpp --version",
+          "cd ../../..",
           "mkdir build",
           "cd build",
-          "cmake -G \"NMake Makefiles\" ..",
+          "cmake -G \"NMake Makefiles\" ../Tutorials/Features/scheduler_target_fmax",
           "nmake fpga_emu",
           "scheduler_target_fmax.fpga_emu.exe"
         ]
@@ -44,9 +50,11 @@
       {
         "id": "report",
         "steps": [
+          "dpcpp --version",
+          "cd ../../..",
           "mkdir build",
           "cd build",
-          "cmake -G \"NMake Makefiles\" ..",
+          "cmake -G \"NMake Makefiles\" ../Tutorials/Features/scheduler_target_fmax",
           "nmake report"
         ]
       }

--- a/DirectProgramming/DPC++FPGA/Tutorials/Features/scheduler_target_fmax/sample.json
+++ b/DirectProgramming/DPC++FPGA/Tutorials/Features/scheduler_target_fmax/sample.json
@@ -14,10 +14,9 @@
         "id": "fpga_emu",
         "steps": [
           "dpcpp --version",
-          "cd ../../..",
           "mkdir build",
           "cd build",
-          "cmake ../Tutorials/Features/scheduler_target_fmax",
+          "cmake ..",
           "make fpga_emu",
           "./scheduler_target_fmax.fpga_emu"
         ]
@@ -26,10 +25,9 @@
         "id": "report",
         "steps": [
           "dpcpp --version",
-          "cd ../../..",
           "mkdir build",
           "cd build",
-          "cmake ../Tutorials/Features/scheduler_target_fmax",
+          "cmake ..",
           "make report"
         ]
       }

--- a/DirectProgramming/DPC++FPGA/Tutorials/Features/speculated_iterations/sample.json
+++ b/DirectProgramming/DPC++FPGA/Tutorials/Features/speculated_iterations/sample.json
@@ -13,9 +13,11 @@
       {
         "id": "fpga_emu",
         "steps": [
+          "dpcpp --version",
+          "cd ../../..",
           "mkdir build",
           "cd build",
-          "cmake ..",
+          "cmake ../Tutorials/Features/speculated_iterations",
           "make fpga_emu",
           "./speculated_iterations.fpga_emu"
         ]
@@ -23,9 +25,11 @@
       {
         "id": "report",
         "steps": [
+          "dpcpp --version",
+          "cd ../../..",
           "mkdir build",
           "cd build",
-          "cmake ..",
+          "cmake ../Tutorials/Features/speculated_iterations",
           "make report"
         ]
       }
@@ -34,9 +38,11 @@
       {
         "id": "fpga_emu",
         "steps": [
+          "dpcpp --version",
+          "cd ../../..",
           "mkdir build",
           "cd build",
-          "cmake -G \"NMake Makefiles\" ..",
+          "cmake -G \"NMake Makefiles\" ../Tutorials/Features/speculated_iterations",
           "nmake fpga_emu",
           "speculated_iterations.fpga_emu.exe"
         ]
@@ -44,9 +50,11 @@
       {
         "id": "report",
         "steps": [
+          "dpcpp --version",
+          "cd ../../..",
           "mkdir build",
           "cd build",
-          "cmake -G \"NMake Makefiles\" ..",
+          "cmake -G \"NMake Makefiles\" ../Tutorials/Features/speculated_iterations",
           "nmake report"
         ]
       }

--- a/DirectProgramming/DPC++FPGA/Tutorials/Features/speculated_iterations/sample.json
+++ b/DirectProgramming/DPC++FPGA/Tutorials/Features/speculated_iterations/sample.json
@@ -14,10 +14,9 @@
         "id": "fpga_emu",
         "steps": [
           "dpcpp --version",
-          "cd ../../..",
           "mkdir build",
           "cd build",
-          "cmake ../Tutorials/Features/speculated_iterations",
+          "cmake ..",
           "make fpga_emu",
           "./speculated_iterations.fpga_emu"
         ]
@@ -26,10 +25,9 @@
         "id": "report",
         "steps": [
           "dpcpp --version",
-          "cd ../../..",
           "mkdir build",
           "cd build",
-          "cmake ../Tutorials/Features/speculated_iterations",
+          "cmake ..",
           "make report"
         ]
       }

--- a/DirectProgramming/DPC++FPGA/Tutorials/Features/stall_enable/sample.json
+++ b/DirectProgramming/DPC++FPGA/Tutorials/Features/stall_enable/sample.json
@@ -14,10 +14,9 @@
         "id": "fpga_emu",
         "steps": [
           "dpcpp --version",
-          "cd ../../..",
           "mkdir build",
           "cd build",
-          "cmake ../Tutorials/Features/stall_enable",
+          "cmake ..",
           "make fpga_emu",
           "./stall_enable.fpga_emu",
           "./stall_free.fpga_emu"
@@ -27,10 +26,9 @@
         "id": "report",
         "steps": [
           "dpcpp --version",
-          "cd ../../..",
           "mkdir build",
           "cd build",
-          "cmake ../Tutorials/Features/stall_enable",
+          "cmake ..",
           "make report"
         ]
       }

--- a/DirectProgramming/DPC++FPGA/Tutorials/Features/stall_enable/sample.json
+++ b/DirectProgramming/DPC++FPGA/Tutorials/Features/stall_enable/sample.json
@@ -13,9 +13,11 @@
       {
         "id": "fpga_emu",
         "steps": [
+          "dpcpp --version",
+          "cd ../../..",
           "mkdir build",
           "cd build",
-          "cmake ..",
+          "cmake ../Tutorials/Features/stall_enable",
           "make fpga_emu",
           "./stall_enable.fpga_emu",
           "./stall_free.fpga_emu"
@@ -24,9 +26,11 @@
       {
         "id": "report",
         "steps": [
+          "dpcpp --version",
+          "cd ../../..",
           "mkdir build",
           "cd build",
-          "cmake ..",
+          "cmake ../Tutorials/Features/stall_enable",
           "make report"
         ]
       }
@@ -35,9 +39,11 @@
       {
         "id": "fpga_emu",
         "steps": [
+          "dpcpp --version",
+          "cd ../../..",
           "mkdir build",
           "cd build",
-          "cmake -G \"NMake Makefiles\" ..",
+          "cmake -G \"NMake Makefiles\" ../Tutorials/Features/stall_enable",
           "nmake fpga_emu",
           "stall_enable.fpga_emu.exe",
           "stall_free.fpga_emu.exe"
@@ -46,9 +52,11 @@
       {
         "id": "report",
         "steps": [
+          "dpcpp --version",
+          "cd ../../..",
           "mkdir build",
           "cd build",
-          "cmake -G \"NMake Makefiles\" ..",
+          "cmake -G \"NMake Makefiles\" ../Tutorials/Features/stall_enable",
           "nmake report"
         ]
       }

--- a/DirectProgramming/DPC++FPGA/Tutorials/GettingStarted/fast_recompile/sample.json
+++ b/DirectProgramming/DPC++FPGA/Tutorials/GettingStarted/fast_recompile/sample.json
@@ -14,10 +14,9 @@
         "id": "fpga_emu",
         "steps": [
           "dpcpp --version",
-          "cd ../../..",
           "mkdir build",
           "cd build",
-          "cmake ../Tutorials/GettingStarted/fast_recompile",
+          "cmake ..",
           "make fpga_emu",
           "./fast_recompile.fpga_emu"
         ]

--- a/DirectProgramming/DPC++FPGA/Tutorials/GettingStarted/fast_recompile/sample.json
+++ b/DirectProgramming/DPC++FPGA/Tutorials/GettingStarted/fast_recompile/sample.json
@@ -13,9 +13,11 @@
       {
         "id": "fpga_emu",
         "steps": [
+          "dpcpp --version",
+          "cd ../../..",
           "mkdir build",
           "cd build",
-          "cmake ..",
+          "cmake ../Tutorials/GettingStarted/fast_recompile",
           "make fpga_emu",
           "./fast_recompile.fpga_emu"
         ]
@@ -25,9 +27,11 @@
       {
         "id": "fpga_emu",
         "steps": [
+          "dpcpp --version",
+          "cd ../../..",
           "mkdir build",
           "cd build",
-          "cmake -G \"NMake Makefiles\" ..",
+          "cmake -G \"NMake Makefiles\" ../Tutorials/GettingStarted/fast_recompile",
           "nmake fpga_emu",
           "fast_recompile.fpga_emu.exe"
         ]

--- a/DirectProgramming/DPC++FPGA/Tutorials/GettingStarted/fpga_compile/sample.json
+++ b/DirectProgramming/DPC++FPGA/Tutorials/GettingStarted/fpga_compile/sample.json
@@ -14,10 +14,9 @@
         "id": "fpga_emu",
         "steps": [
           "dpcpp --version",
-          "cd ../../..",
           "mkdir build",
           "cd build",
-          "cmake ../Tutorials/GettingStarted/fpga_compile",
+          "cmake ..",
           "make fpga_emu",
           "./fpga_compile.fpga_emu"
         ]
@@ -26,10 +25,9 @@
         "id": "report",
         "steps": [
           "dpcpp --version",
-          "cd ../../..",
           "mkdir build",
           "cd build",
-          "cmake ../Tutorials/GettingStarted/fpga_compile",
+          "cmake ..",
           "make report"
         ]
       }

--- a/DirectProgramming/DPC++FPGA/Tutorials/GettingStarted/fpga_compile/sample.json
+++ b/DirectProgramming/DPC++FPGA/Tutorials/GettingStarted/fpga_compile/sample.json
@@ -13,9 +13,11 @@
       {
         "id": "fpga_emu",
         "steps": [
+          "dpcpp --version",
+          "cd ../../..",
           "mkdir build",
           "cd build",
-          "cmake ..",
+          "cmake ../Tutorials/GettingStarted/fpga_compile",
           "make fpga_emu",
           "./fpga_compile.fpga_emu"
         ]
@@ -23,9 +25,11 @@
       {
         "id": "report",
         "steps": [
+          "dpcpp --version",
+          "cd ../../..",
           "mkdir build",
           "cd build",
-          "cmake ..",
+          "cmake ../Tutorials/GettingStarted/fpga_compile",
           "make report"
         ]
       }
@@ -34,9 +38,11 @@
       {
         "id": "fpga_emu",
         "steps": [
+          "dpcpp --version",
+          "cd ../../..",
           "mkdir build",
           "cd build",
-          "cmake -G \"NMake Makefiles\" ..",
+          "cmake -G \"NMake Makefiles\" ../Tutorials/GettingStarted/fpga_compile",
           "nmake fpga_emu",
           "fpga_compile.fpga_emu.exe"
         ]
@@ -44,9 +50,11 @@
       {
         "id": "report",
         "steps": [
+          "dpcpp --version",
+          "cd ../../..",
           "mkdir build",
           "cd build",
-          "cmake -G \"NMake Makefiles\" ..",
+          "cmake -G \"NMake Makefiles\" ../Tutorials/GettingStarted/fpga_compile",
           "nmake report"
         ]
       }

--- a/DirectProgramming/DPC++FPGA/Tutorials/Tools/dynamic_profiler/sample.json
+++ b/DirectProgramming/DPC++FPGA/Tutorials/Tools/dynamic_profiler/sample.json
@@ -13,9 +13,11 @@
       {
         "id": "fpga_emu",
         "steps": [
+          "dpcpp --version",
+          "cd ../../..",
           "mkdir build",
           "cd build",
-          "cmake ..",
+          "cmake ../Tutorials/Tools/dynamic_profiler",
           "make fpga_emu",
           "./dynamic_profiler.fpga_emu"
         ]

--- a/DirectProgramming/DPC++FPGA/Tutorials/Tools/dynamic_profiler/sample.json
+++ b/DirectProgramming/DPC++FPGA/Tutorials/Tools/dynamic_profiler/sample.json
@@ -14,10 +14,9 @@
         "id": "fpga_emu",
         "steps": [
           "dpcpp --version",
-          "cd ../../..",
           "mkdir build",
           "cd build",
-          "cmake ../Tutorials/Tools/dynamic_profiler",
+          "cmake ..",
           "make fpga_emu",
           "./dynamic_profiler.fpga_emu"
         ]

--- a/DirectProgramming/DPC++FPGA/Tutorials/Tools/system_profiling/sample.json
+++ b/DirectProgramming/DPC++FPGA/Tutorials/Tools/system_profiling/sample.json
@@ -13,9 +13,11 @@
       {
         "id": "fpga_emu",
         "steps": [
+          "dpcpp --version",
+          "cd ../../..",
           "mkdir build",
           "cd build",
-          "cmake ..",
+          "cmake ../Tutorials/Tools/system_profiling",
           "make fpga_emu",
           "./double_buffering.fpga_emu"
         ]

--- a/DirectProgramming/DPC++FPGA/Tutorials/Tools/system_profiling/sample.json
+++ b/DirectProgramming/DPC++FPGA/Tutorials/Tools/system_profiling/sample.json
@@ -14,10 +14,9 @@
         "id": "fpga_emu",
         "steps": [
           "dpcpp --version",
-          "cd ../../..",
           "mkdir build",
           "cd build",
-          "cmake ../Tutorials/Tools/system_profiling",
+          "cmake ..",
           "make fpga_emu",
           "./double_buffering.fpga_emu"
         ]


### PR DESCRIPTION
# Existing Sample Changes
## Description

Update sample.json:
1. execute "dpcpp --version" in the beginning of each test to make obvious what compiler version the CI is running with
2. cd up a few levels to circumvent the Windows CI long path issue