### PR TITLE
Adding a section on VS code for the read_only_cache tutorial

### DIFF
--- a/DirectProgramming/DPC++FPGA/Tutorials/Features/read_only_cache/README.md
+++ b/DirectProgramming/DPC++FPGA/Tutorials/Features/read_only_cache/README.md
@@ -97,6 +97,26 @@ information, see the Intel® oneAPI Base Toolkit Get Started Guide
 When compiling for FPGA hardware, it is recommended to increase the job timeout
 to 12h.
 
+### Using Visual Studio Code*  (Optional)
+
+You can use Visual Studio Code (VS Code) extensions to set your environment,
+create launch configurations, and browse and download samples.
+
+The basic steps to build and run a sample using VS Code include:
+ - Download a sample using the extension **Code Sample Browser for Intel oneAPI
+   Toolkits**.
+ - Configure the oneAPI environment with the extension **Environment
+   Configurator for Intel oneAPI Toolkits**.
+ - Open a Terminal in VS Code (**Terminal>New Terminal**).
+ - Run the sample in the VS Code terminal using the instructions below.
+
+To learn more about the extensions and how to configure the oneAPI environment,
+see [Using Visual Studio Code with Intel® oneAPI
+Toolkits](https://software.intel.com/content/www/us/en/develop/documentation/using-vs-code-with-intel-oneapi/top.html).
+
+After learning how to use the extensions for Intel oneAPI Toolkits, return to
+this readme for instructions on how to build and run a sample.
+
 ### On a Linux* System
 
 1. Generate the `Makefile` by running `cmake`.


### PR DESCRIPTION
Signed-off-by: mohammadfawaz <mohammad.fawaz@intel.com>

# Existing Sample Changes
## Description

Updating the README.md file for the read_only_cache to include a section on VS code.

- [X] Simple README.md change.