### PR TITLE
New FPGA Code Sample "DSP Control"

### DIFF
--- a/DirectProgramming/DPC++FPGA/Tutorials/Features/dsp_control/CMakeLists.txt
+++ b/DirectProgramming/DPC++FPGA/Tutorials/Features/dsp_control/CMakeLists.txt
@@ -1,0 +1,20 @@
+if(UNIX)
+    # Direct CMake to use dpcpp rather than the default C++ compiler/linker
+    set(CMAKE_CXX_COMPILER dpcpp)
+else() # Windows
+    # Force CMake to use dpcpp rather than the default C++ compiler/linker 
+    # (needed on Windows only)
+    include (CMakeForceCompiler)
+    CMAKE_FORCE_CXX_COMPILER (dpcpp IntelDPCPP)
+    include (Platform/Windows-Clang)
+endif()
+
+cmake_minimum_required (VERSION 3.4)
+
+project(DSPControl CXX)
+
+set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})
+set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})
+
+add_subdirectory (src)

--- a/DirectProgramming/DPC++FPGA/Tutorials/Features/dsp_control/License.txt
+++ b/DirectProgramming/DPC++FPGA/Tutorials/Features/dsp_control/License.txt
@@ -1,0 +1,23 @@
+Copyright Intel Corporation
+
+SPDX-License-Identifier: MIT
+https://opensource.org/licenses/MIT
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+

--- a/DirectProgramming/DPC++FPGA/Tutorials/Features/dsp_control/README.md
+++ b/DirectProgramming/DPC++FPGA/Tutorials/Features/dsp_control/README.md
@@ -1,0 +1,185 @@
+# DSP Control
+This FPGA tutorial demonstrates how to set implementation preference for math operations, which affects hardware resource utilization on FPGA device.
+
+***Documentation***:  The [DPC++ FPGA Code Samples Guide](https://software.intel.com/content/www/us/en/develop/articles/explore-dpcpp-through-intel-fpga-code-samples.html) helps you to navigate the samples and build your knowledge of DPC++ for FPGA. <br>
+The [oneAPI DPC++ FPGA Optimization Guide](https://software.intel.com/content/www/us/en/develop/documentation/oneapi-fpga-optimization-guide) is the reference manual for targeting FPGAs through DPC++. <br>
+The [oneAPI Programming Guide](https://software.intel.com/en-us/oneapi-programming-guide) is a general resource for target-independent DPC++ programming.
+
+| Optimized for                     | Description
+---                                 |---
+| OS                                | Linux* Ubuntu* 18.04/20.04, RHEL*/CentOS* 8, SUSE* 15; Windows* 10
+| Hardware                          | Intel® Programmable Acceleration Card (PAC) with Intel Arria® 10 GX FPGA <br> Intel® FPGA Programmable Acceleration Card (PAC) D5005 (with Intel Stratix® 10 SX) <br> Intel® FPGA 3rd party / custom platforms with oneAPI support <br> *__Note__: Intel® FPGA PAC hardware is only compatible with Ubuntu 18.04* 
+| Software                          | Intel® oneAPI DPC++ Compiler <br> Intel® FPGA Add-On for oneAPI Base Toolkit 
+| What you will learn               |  How to apply global DSP control in command-line interface. <br> How to apply local DSP control in source code. <br> Scope of datatypes and math operations that support DSP control.
+| Time to complete                  | 15 minutes
+
+## Purpose
+This tutorial shows how to apply global and local DSP controls to set implementation preference for math operations to control usage of DSPs. The global control is applied via command-line option and affects math operations in all kernels. The local control is applied via library function and affects math operations in a block scope in one single kernel. Both global and local controls only affect math operations that support DSP control.
+
+### Scope of Datatypes and math operations
+| Datatypes              | math operations
+---                      |---
+| `float`                | Add, sub, constant mul
+| `hls_float<8, 23>`     | Add, sub, constant mul
+| `int`                  | Constant mul
+| `ac_int`               | Constant mul
+| `ac_fixed`             | Constant mul
+
+**NOTE:** _constant mul_ means one operand of the multiplication is a constant.
+
+### Global Control
+The `-Xsdsp-mode` command-line option sets implementation preference of math operations that support DSP control in all kernels. It has three valid options:
+| Option                           | Explanation
+---                                |---
+| `-Xsdsp-mode=default`            | This is the default. The compiler determines the implementation based on datatype and math operation.
+| `-Xsdsp-mode=prefer-dsp`         | Prefer math operations to be implemented in **DSPs**. If a math operation is implemented by DSPs by default, you will see no difference in resource utilization or area. Otherwise, you will notice decrease in the usage of soft-logic resources and increase in the usage of DSPs.
+| `-Xsdsp-mode=prefer-softlogic`   | Prefer math operations to be implemented in **soft-logic**. If a math operation is implemented without DSPs by default, you will see no difference in resource utilization or area. Otherwise, you will notice decrease in the usage of DSPs and increase in the suage of soft-logic resources.
+
+### Local Control
+The library function `math_dsp_control<Preference::<enum>, Propagate::<bool>>([&]{})` provides block scope local control in one single kernel. A reference-capturing lambda expression is passed as the argument to this library function. Inside the lambda expression, implementation preference of math operations that support DSP control will be determined by two template arguments.
+
+The first template argument `Preference` is an enum with three valid options:
+| Option                           | Explanation
+---                                |---
+| `Preference::DSP`                | This is the default. Prefer math operations to be implemented in **DSPs**. Its behavior on a math operation is equivalent to global control `-Xsdsp-mode=prefer-dsp`.
+| `Preference::Softlogic`          | Prefer math operations to be implemented in **soft-logic**. Its behavior on a math operation is equivalent to global control `-Xsdsp-mode=prefer-softlogic`.
+| `Preference::Compiler_default`   | Compiler determines the implementation based on datatype and math operation. Its behavir on a math operation is equivalent to global control `-Xsdsp-mode=default`.
+
+The second template argument `Propagate` is a boolean that determines propagation of the first argument `Preference` to functions called in the lambda expression:
+| Option  | Explanation
+---       |---
+| `On`    | This is the default. `Preference` is propagated to all functions called in the lambda expression, and affects all math operations on the call graph in the lambda expression until a nested `math_dsp_control<>()` call stops the propatation.
+| `Off`   | `Preference` is not propagated to functions called in the lambda expression. So `Preference` only applies to math operations directly used in the lambda expression.
+
+**NOTE:**
+1. `Preference` never applies to nested `math_dsp_control<>()` calls. Each nested `math_dsp_control<>()` has its own `Preference`.
+2. Local control overrides global control on a controlled math operation.
+
+## Key Concepts
+* How to apply global DSP control in command-line interface
+* How to apply local DSP control in source code
+* Scope of datatypes and math operations that support DSP control
+
+## License  
+Code samples are licensed under the MIT license. See
+[License.txt](https://github.com/oneapi-src/oneAPI-samples/blob/master/License.txt) for details.
+
+Third party program Licenses can be found here: [third-party-programs.txt](https://github.com/oneapi-src/oneAPI-samples/blob/master/third-party-programs.txt)
+
+## Building the `dsp_control` Tutorial
+
+### Include Files
+The included header `dpc_common.hpp` is located at `%ONEAPI_ROOT%\dev-utilities\latest\include` on your development system.
+
+### Running Samples in DevCloud
+If running a sample in the Intel DevCloud, remember that you must specify the type of compute node and whether to run in batch or interactive mode. Compiles to FPGA are only supported on fpga_compile nodes. Executing programs on FPGA hardware is only supported on fpga_runtime nodes of the appropriate type, such as fpga_runtime:arria10 or fpga_runtime:stratix10.  Neither compiling nor executing programs on FPGA hardware are supported on the login nodes. For more information, see the Intel® oneAPI Base Toolkit Get Started Guide ([https://devcloud.intel.com/oneapi/documentation/base-toolkit/](https://devcloud.intel.com/oneapi/documentation/base-toolkit/)).
+
+When compiling for FPGA hardware, it is recommended to increase the job timeout to 12h.
+
+### On a Linux* System
+
+1. Generate the `Makefile` by running `cmake`.
+     ```
+   mkdir build
+   cd build
+   ```
+   To compile for the Intel® PAC with Intel Arria® 10 GX FPGA, run `cmake` using the command:  
+    ```
+    cmake ..
+   ```
+   Alternatively, to compile for the Intel® FPGA PAC D5005 (with Intel Stratix® 10 SX), run `cmake` using the command:
+
+   ```
+   cmake .. -DFPGA_BOARD=intel_s10sx_pac:pac_s10
+   ```
+   You can also compile for a custom FPGA platform. Ensure that the board support package is installed on your system. Then run `cmake` using the command:
+   ```
+   cmake .. -DFPGA_BOARD=<board-support-package>:<board-variant>
+   ```
+
+2. Compile the design through the generated `Makefile`. The following build targets are provided, matching the recommended development flow:
+
+   * Compile for emulation (fast compile time, targets emulated FPGA device): 
+      ```
+      make fpga_emu
+      ```
+   * Generate the optimization report: 
+     ```
+     make report
+     ``` 
+   * Compile for FPGA hardware (longer compile time, targets FPGA device): 
+     ```
+     make fpga
+     ``` 
+3. (Optional) As the above hardware compile may take several hours to complete, FPGA precompiled binaries (compatible with Linux* Ubuntu* 18.04) can be downloaded <a href="https://iotdk.intel.com/fpga-precompiled-binaries/latest/dsp_control.fpga.tar.gz" download>here</a>.
+
+### On a Windows* System
+
+1. Generate the `Makefile` by running `cmake`.
+     ```
+   mkdir build
+   cd build
+   ```
+   To compile for the Intel® PAC with Intel Arria® 10 GX FPGA, run `cmake` using the command:  
+    ```
+    cmake -G "NMake Makefiles" ..
+   ```
+   Alternatively, to compile for the Intel® FPGA PAC D5005 (with Intel Stratix® 10 SX), run `cmake` using the command:
+
+   ```
+   cmake -G "NMake Makefiles" .. -DFPGA_BOARD=intel_s10sx_pac:pac_s10
+   ```
+   You can also compile for a custom FPGA platform. Ensure that the board support package is installed on your system. Then run `cmake` using the command:
+   ```
+   cmake -G "NMake Makefiles" .. -DFPGA_BOARD=<board-support-package>:<board-variant>
+   ```
+
+2. Compile the design through the generated `Makefile`. The following build targets are provided, matching the recommended development flow:
+
+   * Compile for emulation (fast compile time, targets emulated FPGA device): 
+     ```
+     nmake fpga_emu
+     ```
+   * Generate the optimization report: 
+     ```
+     nmake report
+     ``` 
+   * Compile for FPGA hardware (longer compile time, targets FPGA device):
+     ```
+     nmake fpga
+     ``` 
+
+*Note:* The Intel® PAC with Intel Arria® 10 GX FPGA and Intel® FPGA PAC D5005 (with Intel Stratix® 10 SX) do not support Windows*. Compiling to FPGA hardware on Windows* requires a third-party or custom Board Support Package (BSP) with Windows* support.
+ 
+ ### In Third-Party Integrated Development Environments (IDEs)
+
+You can compile and run this tutorial in the Eclipse* IDE (in Linux*) and the Visual Studio* IDE (in Windows*). For instructions, refer to the following link: [Intel® oneAPI DPC++ FPGA Workflows on Third-Party IDEs](https://software.intel.com/en-us/articles/intel-oneapi-dpcpp-fpga-workflow-on-ide)
+
+## Examining the Reports
+Locate `report.html` in the `dsp_control_report.prj/reports/` directory. Open the report in any of Chrome*, Firefox*, Edge*, or Internet Explorer*.
+
+1. Navigate to Area Analysis of System (Area Analysis > Area Analysis of System). In this view, you can see usage of FPGA resources which reflects the outcome of DSP control.
+2. Navigate to System Viewer (Views > System Viewer). In this view, you can verify the `Implementation Preference` on the Details Panel of the graph node of a controlled math instruction.
+
+## Running the Sample
+
+ 1. Run the sample on the FPGA emulator (the kernel executes on the CPU):
+     ```
+     ./dsp_control.fpga_emu     (Linux)
+     dsp_control.fpga_emu.exe   (Windows)
+     ```
+2. Run the sample on the FPGA device:
+     ```
+     ./dsp_control.fpga         (Linux)
+     ```
+
+### Example of Output
+```
+PASSED: all kernel results are correct.
+```
+
+### Discussion
+
+Feel free to experiment further with the tutorial code. You can:
+ - Try various control options with global control and local control.
+ - Try various datatypes and math operations that support DSP control.

--- a/DirectProgramming/DPC++FPGA/Tutorials/Features/dsp_control/README.md
+++ b/DirectProgramming/DPC++FPGA/Tutorials/Features/dsp_control/README.md
@@ -158,7 +158,7 @@ You can compile and run this tutorial in the Eclipse* IDE (in Linux*) and the Vi
 Locate `report.html` in the `dsp_control_report.prj/reports/` directory. Open the report in any of Chrome*, Firefox*, Edge*, or Internet Explorer*.
 
 1. Navigate to Area Analysis of System (Area Analysis > Area Analysis of System). In this view, you can see usage of FPGA resources, which reflects the outcome of DSP control.
-2. Navigate to System Viewer (Views > System Viewer). In this view, you can verify the `Implementation Preference` on the Details Panel of the graph node of a controlled math instruction.
+2. Navigate to System Viewer (Views > System Viewer). In this view, you can verify the `Implementation Preference` on the Details Panel of the graph node of a controlled math operation.
 
 ## Running the Sample
 

--- a/DirectProgramming/DPC++FPGA/Tutorials/Features/dsp_control/README.md
+++ b/DirectProgramming/DPC++FPGA/Tutorials/Features/dsp_control/README.md
@@ -149,7 +149,8 @@ When compiling for FPGA hardware, it is recommended to increase the job timeout 
      nmake fpga
      ``` 
 
-*Note:* The Intel® PAC with Intel Arria® 10 GX FPGA and Intel® FPGA PAC D5005 (with Intel Stratix® 10 SX) do not support Windows*. Compiling to FPGA hardware on Windows* requires a third-party or custom Board Support Package (BSP) with Windows* support.
+*Note:* The Intel® PAC with Intel Arria® 10 GX FPGA and Intel® FPGA PAC D5005 (with Intel Stratix® 10 SX) do not support Windows*. Compiling to FPGA hardware on Windows* requires a third-party or custom Board Support Package (BSP) with Windows* support.<br>
+*Note:* If you encounter any issues with long paths when compiling under Windows*, you may have to create your ‘build’ directory in a shorter path, for example c:\samples\build.  You can then run cmake from that directory, and provide cmake with the full path to your sample directory.
  
  ### In Third-Party Integrated Development Environments (IDEs)
 

--- a/DirectProgramming/DPC++FPGA/Tutorials/Features/dsp_control/README.md
+++ b/DirectProgramming/DPC++FPGA/Tutorials/Features/dsp_control/README.md
@@ -74,6 +74,22 @@ If running a sample in the Intel DevCloud, remember that you must specify the ty
 
 When compiling for FPGA hardware, it is recommended to increase the job timeout to 12h.
 
+### Using Visual Studio Code*  (Optional)
+
+You can use Visual Studio Code (VS Code) extensions to set your environment, create launch configurations,
+and browse and download samples.
+
+The basic steps to build and run a sample using VS Code include:
+ - Download a sample using the extension **Code Sample Browser for Intel oneAPI Toolkits**.
+ - Configure the oneAPI environment with the extension **Environment Configurator for Intel oneAPI Toolkits**.
+ - Open a Terminal in VS Code (**Terminal>New Terminal**).
+ - Run the sample in the VS Code terminal using the instructions below.
+
+To learn more about the extensions and how to configure the oneAPI environment, see
+[Using Visual Studio Code with Intel® oneAPI Toolkits](https://software.intel.com/content/www/us/en/develop/documentation/using-vs-code-with-intel-oneapi/top.html).
+
+After learning how to use the extensions for Intel oneAPI Toolkits, return to this readme for instructions on how to build and run a sample.
+
 ### On a Linux* System
 
 1. Generate the `Makefile` by running `cmake`.

--- a/DirectProgramming/DPC++FPGA/Tutorials/Features/dsp_control/dsp_control.sln
+++ b/DirectProgramming/DPC++FPGA/Tutorials/Features/dsp_control/dsp_control.sln
@@ -1,0 +1,25 @@
+
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 15
+VisualStudioVersion = 15.0.28307.705
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "dsp_control", "dsp_control.vcxproj", "{CF6A576B-665D-4F24-BB62-0DAE7A7B3C64}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|x64 = Debug|x64
+		Release|x64 = Release|x64
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{CF6A576B-665D-4F24-BB62-0DAE7A7B3C64}.Debug|x64.ActiveCfg = Debug|x64
+		{CF6A576B-665D-4F24-BB62-0DAE7A7B3C64}.Debug|x64.Build.0 = Debug|x64
+		{CF6A576B-665D-4F24-BB62-0DAE7A7B3C64}.Release|x64.ActiveCfg = Release|x64
+		{CF6A576B-665D-4F24-BB62-0DAE7A7B3C64}.Release|x64.Build.0 = Release|x64
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {92BEFAAB-0365-4E5A-9C4A-E50AB49B2A6B}
+	EndGlobalSection
+EndGlobal

--- a/DirectProgramming/DPC++FPGA/Tutorials/Features/dsp_control/dsp_control.vcxproj
+++ b/DirectProgramming/DPC++FPGA/Tutorials/Features/dsp_control/dsp_control.vcxproj
@@ -27,26 +27,26 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>Intel(R) oneAPI DPC++ Compiler</PlatformToolset>
+    <PlatformToolset>Intel(R) oneAPI DPC++ Compiler 2022</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>Intel(R) oneAPI DPC++ Compiler</PlatformToolset>
+    <PlatformToolset>Intel(R) oneAPI DPC++ Compiler 2022</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>Intel(R) oneAPI DPC++ Compiler</PlatformToolset>
+    <PlatformToolset>Intel(R) oneAPI DPC++ Compiler 2022</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>Intel(R) oneAPI DPC++ Compiler</PlatformToolset>
+    <PlatformToolset>Intel(R) oneAPI DPC++ Compiler 2022</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>

--- a/DirectProgramming/DPC++FPGA/Tutorials/Features/dsp_control/dsp_control.vcxproj
+++ b/DirectProgramming/DPC++FPGA/Tutorials/Features/dsp_control/dsp_control.vcxproj
@@ -1,0 +1,161 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="src\dsp_control.cpp" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="README.md" />
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <VCProjectVersion>15.0</VCProjectVersion>
+    <ProjectGuid>{cf6a576b-665d-4f24-bb62-0dae7a7b3c64}</ProjectGuid>
+    <Keyword>Win32Proj</Keyword>
+    <RootNamespace>dsp_control</RootNamespace>
+    <WindowsTargetPlatformVersion>10.0.17763.0</WindowsTargetPlatformVersion>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>Intel(R) oneAPI DPC++ Compiler</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>Intel(R) oneAPI DPC++ Compiler</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>Intel(R) oneAPI DPC++ Compiler</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>Intel(R) oneAPI DPC++ Compiler</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="Shared">
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <LinkIncremental>true</LinkIncremental>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <LinkIncremental>true</LinkIncremental>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <LinkIncremental>false</LinkIncremental>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <LinkIncremental>false</LinkIncremental>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <ClCompile>
+      <PrecompiledHeader>Use</PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>Disabled</Optimization>
+      <SDLCheck>true</SDLCheck>
+      <ConformanceMode>true</ConformanceMode>
+      <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
+      <AdditionalIncludeDirectories>$(ONEAPI_ROOT)dev-utilities\latest\include</AdditionalIncludeDirectories>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <ClCompile>
+      <PrecompiledHeader>Use</PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>Disabled</Optimization>
+      <SDLCheck>true</SDLCheck>
+      <ConformanceMode>true</ConformanceMode>
+      <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
+      <EnableFPGACompilationAhead>true</EnableFPGACompilationAhead>
+      <AdditionalOptions>-DFPGA_EMULATOR %(AdditionalOptions)</AdditionalOptions>
+      <ObjectFileName>$(IntDir)dsp_control.obj</ObjectFileName>
+      <AdditionalIncludeDirectories>$(ONEAPI_ROOT)dev-utilities\latest\include</AdditionalIncludeDirectories>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+    <Manifest />
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <ClCompile>
+      <PrecompiledHeader>Use</PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <SDLCheck>true</SDLCheck>
+      <ConformanceMode>true</ConformanceMode>
+      <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
+      <AdditionalIncludeDirectories>$(ONEAPI_ROOT)dev-utilities\latest\include</AdditionalIncludeDirectories>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile>
+      <PrecompiledHeader>Use</PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <SDLCheck>true</SDLCheck>
+      <ConformanceMode>true</ConformanceMode>
+      <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
+      <EnableFPGACompilationAhead>true</EnableFPGACompilationAhead>
+      <AdditionalOptions>-DFPGA_EMULATOR %(AdditionalOptions)</AdditionalOptions>
+      <ObjectFileName>$(IntDir)dsp_control.obj</ObjectFileName>
+      <AdditionalIncludeDirectories>$(ONEAPI_ROOT)dev-utilities\latest\include</AdditionalIncludeDirectories>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+  </ItemDefinitionGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/DirectProgramming/DPC++FPGA/Tutorials/Features/dsp_control/sample.json
+++ b/DirectProgramming/DPC++FPGA/Tutorials/Features/dsp_control/sample.json
@@ -14,10 +14,9 @@
         "id": "fpga_emu",
         "steps": [
           "dpcpp --version",
-          "cd ../../..",
           "mkdir build",
           "cd build",
-          "cmake ../Tutorials/Features/dsp_control",
+          "cmake ..",
           "make fpga_emu",
           "./dsp_control.fpga_emu"
         ]
@@ -26,10 +25,9 @@
         "id": "report",
         "steps": [
           "dpcpp --version",
-          "cd ../../..",
           "mkdir build",
           "cd build",
-          "cmake ../Tutorials/Features/dsp_control",
+          "cmake ..",
           "make report"
         ]
       }

--- a/DirectProgramming/DPC++FPGA/Tutorials/Features/dsp_control/sample.json
+++ b/DirectProgramming/DPC++FPGA/Tutorials/Features/dsp_control/sample.json
@@ -13,9 +13,11 @@
       {
         "id": "fpga_emu",
         "steps": [
+          "dpcpp --version",
+          "cd ../../..",
           "mkdir build",
           "cd build",
-          "cmake ..",
+          "cmake ../Tutorials/Features/dsp_control",
           "make fpga_emu",
           "./dsp_control.fpga_emu"
         ]
@@ -23,9 +25,11 @@
       {
         "id": "report",
         "steps": [
+          "dpcpp --version",
+          "cd ../../..",
           "mkdir build",
           "cd build",
-          "cmake ..",
+          "cmake ../Tutorials/Features/dsp_control",
           "make report"
         ]
       }
@@ -34,9 +38,11 @@
       {
         "id": "fpga_emu",
         "steps": [
+          "dpcpp --version",
+          "cd ../../..",
           "mkdir build",
           "cd build",
-          "cmake -G \"NMake Makefiles\" ..",
+          "cmake -G \"NMake Makefiles\" ../Tutorials/Features/dsp_control",
           "nmake fpga_emu",
           "dsp_control.fpga_emu.exe"
         ]
@@ -44,9 +50,11 @@
       {
         "id": "report",
         "steps": [
+          "dpcpp --version",
+          "cd ../../..",
           "mkdir build",
           "cd build",
-          "cmake -G \"NMake Makefiles\" ..",
+          "cmake -G \"NMake Makefiles\" ../Tutorials/Features/dsp_control",
           "nmake report"
         ]
       }

--- a/DirectProgramming/DPC++FPGA/Tutorials/Features/dsp_control/sample.json
+++ b/DirectProgramming/DPC++FPGA/Tutorials/Features/dsp_control/sample.json
@@ -1,0 +1,55 @@
+{
+  "guid": "77006CE8-2935-41C7-BA30-DF6EA07CD73A",
+  "name": "DSP Control",
+  "categories": ["Toolkit/oneAPI Direct Programming/DPC++ FPGA/Tutorials/Features"],
+  "description": "An Intel® FPGA tutorial demonstrating the DSP control feature",
+  "toolchain": ["dpcpp"],
+  "os": ["linux", "windows"],
+  "targetDevice": ["FPGA"],
+  "builder": ["ide", "cmake"],
+  "languages": [{"cpp":{}}],
+  "ciTests": {
+    "linux": [
+      {
+        "id": "fpga_emu",
+        "steps": [
+          "mkdir build",
+          "cd build",
+          "cmake ..",
+          "make fpga_emu",
+          "./dsp_control.fpga_emu"
+        ]
+      },
+      {
+        "id": "report",
+        "steps": [
+          "mkdir build",
+          "cd build",
+          "cmake ..",
+          "make report"
+        ]
+      }
+    ],
+    "windows": [
+      {
+        "id": "fpga_emu",
+        "steps": [
+          "mkdir build",
+          "cd build",
+          "cmake -G \"NMake Makefiles\" ..",
+          "nmake fpga_emu",
+          "dsp_control.fpga_emu.exe"
+        ]
+      },
+      {
+        "id": "report",
+        "steps": [
+          "mkdir build",
+          "cd build",
+          "cmake -G \"NMake Makefiles\" ..",
+          "nmake report"
+        ]
+      }
+    ]
+  }
+}

--- a/DirectProgramming/DPC++FPGA/Tutorials/Features/dsp_control/src/CMakeLists.txt
+++ b/DirectProgramming/DPC++FPGA/Tutorials/Features/dsp_control/src/CMakeLists.txt
@@ -1,0 +1,73 @@
+# To see a Makefile equivalent of this build system:
+# https://github.com/oneapi-src/oneAPI-samples/blob/master/DirectProgramming/DPC++/ProjectTemplates/makefile-fpga
+
+set(SOURCE_FILE dsp_control.cpp)
+set(TARGET_NAME dsp_control)
+set(EMULATOR_TARGET ${TARGET_NAME}.fpga_emu)
+set(FPGA_TARGET ${TARGET_NAME}.fpga)
+
+# FPGA board selection
+if(NOT DEFINED FPGA_BOARD)
+    set(FPGA_BOARD "intel_a10gx_pac:pac_a10")
+    message(STATUS "FPGA_BOARD was not specified.\
+                    \nConfiguring the design to run on the default FPGA board ${FPGA_BOARD} (Intel(R) PAC with Intel Arria(R) 10 GX FPGA). \
+                    \nPlease refer to the README for information on board selection.")
+else()
+    message(STATUS "Configuring the design to run on FPGA board ${FPGA_BOARD}")
+endif()
+
+# This is a Windows-specific flag that enables exception handling in host code
+if(WIN32)
+    set(WIN_FLAG "/EHsc")
+endif()
+
+# A DPC++ ahead-of-time (AoT) compile processes the device code in two stages.
+# 1. The "compile" stage compiles the device code to an intermediate representation (SPIR-V).
+# 2. The "link" stage invokes the compiler's FPGA backend before linking.
+#    For this reason, FPGA backend flags must be passed as link flags in CMake.
+set(EMULATOR_COMPILE_FLAGS "-Wall ${WIN_FLAG} -fintelfpga -DFPGA_EMULATOR")
+set(EMULATOR_LINK_FLAGS "-fintelfpga")
+set(HARDWARE_COMPILE_FLAGS "-Wall ${WIN_FLAG} -fintelfpga")
+set(HARDWARE_LINK_FLAGS "-fintelfpga -Xshardware -Xsboard=${FPGA_BOARD} -Xsdsp-mode=prefer-softlogic ${USER_HARDWARE_FLAGS}")
+# use cmake -D USER_HARDWARE_FLAGS=<flags> to set extra flags for FPGA backend compilation
+
+###############################################################################
+### FPGA Emulator
+###############################################################################
+# To compile in a single command:
+#    dpcpp -fintelfpga -DFPGA_EMULATOR dsp_control.cpp -o dsp_control.fpga_emu
+# CMake executes:
+#    [compile] dpcpp -fintelfpga -DFPGA_EMULATOR -o dsp_control.cpp.o -c dsp_control.cpp
+#    [link]    dpcpp -fintelfpga dsp_control.cpp.o -o dsp_control.fpga_emu
+add_executable(${EMULATOR_TARGET} ${SOURCE_FILE})
+set_target_properties(${EMULATOR_TARGET} PROPERTIES COMPILE_FLAGS "${EMULATOR_COMPILE_FLAGS}")
+set_target_properties(${EMULATOR_TARGET} PROPERTIES LINK_FLAGS "${EMULATOR_LINK_FLAGS}")
+add_custom_target(fpga_emu DEPENDS ${EMULATOR_TARGET})
+
+###############################################################################
+### Generate Report
+###############################################################################
+# To compile manually:
+#   dpcpp -fintelfpga -Xshardware -Xsboard=<FPGA_BOARD> -fsycl-link=early -Xsdsp-mode=prefer-softlogic dsp_control.cpp -o dsp_control_report.a
+set(FPGA_EARLY_IMAGE ${TARGET_NAME}_report.a)
+# The compile output is not an executable, but an intermediate compilation result unique to DPC++.
+add_executable(${FPGA_EARLY_IMAGE} ${SOURCE_FILE})
+add_custom_target(report DEPENDS ${FPGA_EARLY_IMAGE})
+set_target_properties(${FPGA_EARLY_IMAGE} PROPERTIES COMPILE_FLAGS "${HARDWARE_COMPILE_FLAGS}")
+set_target_properties(${FPGA_EARLY_IMAGE} PROPERTIES LINK_FLAGS "${HARDWARE_LINK_FLAGS} -fsycl-link=early")
+# fsycl-link=early stops the compiler after RTL generation, before invoking Quartus®
+
+###############################################################################
+### FPGA Hardware
+###############################################################################
+# To compile in a single command:
+#   dpcpp -fintelfpga -Xshardware -Xsboard=<FPGA_BOARD> -Xsdsp-mode=prefer-softlogic dsp_control.cpp -o dsp_control.fpga
+# CMake executes:
+#   [compile] dpcpp -fintelfpga -o dsp_control.cpp.o -c dsp_control.cpp
+#   [link]    dpcpp -fintelfpga -Xshardware -Xsboard=<FPGA_BOARD> -Xsdsp-mode=prefer-softlogic dsp_control.cpp.o -o dsp_control.fpga
+add_executable(${FPGA_TARGET} EXCLUDE_FROM_ALL ${SOURCE_FILE})
+add_custom_target(fpga DEPENDS ${FPGA_TARGET})
+set_target_properties(${FPGA_TARGET} PROPERTIES COMPILE_FLAGS "${HARDWARE_COMPILE_FLAGS}")
+set_target_properties(${FPGA_TARGET} PROPERTIES LINK_FLAGS "${HARDWARE_LINK_FLAGS} -reuse-exe=${CMAKE_BINARY_DIR}/${FPGA_TARGET}")
+# The -reuse-exe flag enables rapid recompilation of host-only code changes.
+# See DPC++FPGA/GettingStarted/fast_recompile for details.

--- a/DirectProgramming/DPC++FPGA/Tutorials/Features/dsp_control/src/dsp_control.cpp
+++ b/DirectProgramming/DPC++FPGA/Tutorials/Features/dsp_control/src/dsp_control.cpp
@@ -1,0 +1,109 @@
+//==============================================================
+// Copyright Intel Corporation
+//
+// SPDX-License-Identifier: MIT
+// =============================================================
+#include <CL/sycl.hpp>
+#include <sycl/ext/intel/fpga_extensions.hpp>
+
+// dpc_common.hpp can be found in the dev-utilities include folder.
+// e.g., $ONEAPI_ROOT/dev-utilities/include/dpc_common.hpp
+#include "dpc_common.hpp"
+
+using namespace sycl;
+
+// Forward declare the kernel names in the global scope.
+// This FPGA best practice reduces name mangling in the optimization reports.
+class GlobalControl;
+class LocalControl;
+
+// Runs the Kernel
+void KernelRun(const std::vector<float> &input_data,
+               std::vector<float> &output_data) {
+
+#if defined(FPGA_EMULATOR)
+  ext::intel::fpga_emulator_selector device_selector;
+#else
+  ext::intel::fpga_selector device_selector;
+#endif
+
+  try {
+    // create the SYCL device queue
+    queue q(device_selector, dpc_common::exception_handler,
+            property::queue::enable_profiling{});
+
+    buffer input_buffer(input_data);
+    buffer output_buffer(output_data);
+
+    q.submit([&](handler &h) {
+      accessor input_a(input_buffer, h, read_only);
+      accessor output_a(output_buffer, h, write_only, no_init);
+
+      // Kernel that demonstrates DSP global control
+      h.single_task<GlobalControl>([=]() [[intel::kernel_args_restrict]] {
+        // Command-line option `-Xsdsp-mode=prefer-softlogic` controls the
+        // floating-point addition to be implemented in soft-logic
+        output_a[0] = input_a[0] + input_a[1];
+      });
+    });
+
+    q.submit([&](handler &h) {
+      accessor input_a(input_buffer, h, read_only);
+      accessor output_a(output_buffer, h, write_only, no_init);
+
+      // Kernel that demonstrates DSP local control
+      h.single_task<LocalControl>([=]() [[intel::kernel_args_restrict]] {
+        // The local control library function overrides the global control, and
+        // makes the floating-point addition to be implemented in DSP
+        ext::intel::math_dsp_control<ext::intel::Preference::DSP,
+                                     ext::intel::Propagate::Off>(
+            [&] { output_a[1] = input_a[0] + input_a[1]; });
+      });
+    });
+
+  } catch (exception const &e) {
+    // Catches exceptions in the host code
+    std::cerr << "Caught a SYCL host exception:\n" << e.what() << "\n";
+
+    // Most likely the runtime couldn't find FPGA hardware!
+    if (e.code().value() == CL_DEVICE_NOT_FOUND) {
+      std::cerr << "If you are targeting an FPGA, please ensure that your "
+                   "system has a correctly configured FPGA board.\n";
+      std::cerr << "Run sys_check in the oneAPI root directory to verify.\n";
+      std::cerr << "If you are targeting the FPGA emulator, compile with "
+                   "-DFPGA_EMULATOR.\n";
+    }
+    std::terminate();
+  }
+}
+
+int main() {
+  std::vector<float> input_data = {1.234f, 2.345f};
+  std::vector<float> output_data(2);
+
+  KernelRun(input_data, output_data);
+
+  bool passed = true;
+  float golden = input_data[0] + input_data[1];
+
+  if (output_data[0] != golden) {
+    std::cout << "Kernel GlobalControl Output Mismatch: \n"
+              << "output = " << output_data[0] << ", golden = " << golden
+              << "\n";
+    passed = false;
+  }
+
+  if (output_data[1] != golden) {
+    std::cout << "Kernel LocalControl Output Mismatch: \n"
+              << "output = " << output_data[1] << ", golden = " << golden
+              << "\n";
+    passed = false;
+  }
+
+  if (passed) {
+    std::cout << "PASSED: all kernel results are correct.\n";
+  } else {
+    std::cout << "FAILED\n";
+  }
+  return passed ? 0 : 1;
+}

--- a/DirectProgramming/DPC++FPGA/Tutorials/Features/dsp_control/src/dsp_control.cpp
+++ b/DirectProgramming/DPC++FPGA/Tutorials/Features/dsp_control/src/dsp_control.cpp
@@ -12,14 +12,18 @@
 
 using namespace sycl;
 
+float subtract(float a, float b) { return a - b; }
+
 // Forward declare the kernel names in the global scope.
 // This FPGA best practice reduces name mangling in the optimization reports.
 class GlobalControl;
-class LocalControl;
+class LocalControlPropagateOn;
+class LocalControlPropagateOff;
 
-// Runs the Kernel
+// Runs the Kernel.
 void KernelRun(const std::vector<float> &input_data,
-               std::vector<float> &output_data) {
+               std::vector<float> &output_data_add,
+               std::vector<float> &output_data_sub) {
 
 #if defined(FPGA_EMULATOR)
   ext::intel::fpga_emulator_selector device_selector;
@@ -28,41 +32,71 @@ void KernelRun(const std::vector<float> &input_data,
 #endif
 
   try {
-    // create the SYCL device queue
+    // Create the SYCL device queue.
     queue q(device_selector, dpc_common::exception_handler,
             property::queue::enable_profiling{});
 
     buffer input_buffer(input_data);
-    buffer output_buffer(output_data);
+    buffer output_add_buffer(output_data_add);
+    buffer output_sub_buffer(output_data_sub);
 
     q.submit([&](handler &h) {
       accessor input_a(input_buffer, h, read_only);
-      accessor output_a(output_buffer, h, write_only, no_init);
+      accessor output_add_a(output_add_buffer, h, write_only, no_init);
+      accessor output_sub_a(output_sub_buffer, h, write_only, no_init);
 
-      // Kernel that demonstrates DSP global control
+      // Kernel that demonstrates DSP global control.
       h.single_task<GlobalControl>([=]() [[intel::kernel_args_restrict]] {
-        // Command-line option `-Xsdsp-mode=prefer-softlogic` controls the
-        // floating-point addition to be implemented in soft-logic
-        output_a[0] = input_a[0] + input_a[1];
+        // Command-line option `-Xsdsp-mode=prefer-softlogic` controls both
+        // addition and subtraction to be implemented in soft-logic.
+        output_add_a[0] = input_a[0] + input_a[1];
+        output_sub_a[0] = subtract(input_a[0], input_a[1]);
       });
     });
 
     q.submit([&](handler &h) {
       accessor input_a(input_buffer, h, read_only);
-      accessor output_a(output_buffer, h, write_only, no_init);
+      accessor output_add_a(output_add_buffer, h, write_only, no_init);
+      accessor output_sub_a(output_sub_buffer, h, write_only, no_init);
 
-      // Kernel that demonstrates DSP local control
-      h.single_task<LocalControl>([=]() [[intel::kernel_args_restrict]] {
-        // The local control library function overrides the global control, and
-        // makes the floating-point addition to be implemented in DSP
+      // Kernel that demonstrates DSP local control with Propagate::On.
+      h.single_task<LocalControlPropagateOn>([=
+      ]() [[intel::kernel_args_restrict]] {
+        // The local control library function overrides the global control.
+        // Because the Propagate argument is On, not only the addition directly
+        // in the lambda, but also the subtraction in the subtract() function
+        // call inside the lambda are affected by the local control and will be
+        // implemented in DSP.
+        ext::intel::math_dsp_control<>([&] {
+          output_add_a[1] = input_a[0] + input_a[1];
+          output_sub_a[1] = subtract(input_a[0], input_a[1]);
+        });
+      });
+    });
+
+    q.submit([&](handler &h) {
+      accessor input_a(input_buffer, h, read_only);
+      accessor output_add_a(output_add_buffer, h, write_only, no_init);
+      accessor output_sub_a(output_sub_buffer, h, write_only, no_init);
+
+      // Kernel that demonstrates DSP local control with Propagate::Off.
+      h.single_task<LocalControlPropagateOff>([=
+      ]() [[intel::kernel_args_restrict]] {
+        // The local control library function overrides the global control.
+        // Because the Propagate argument is Off, only the addition directly in
+        // the lambda is affected by the local control and will be implemented
+        // in DSP. The subtration in the subtract() function call is only
+        // affected by the global control so will be implemented in soft-logic.
         ext::intel::math_dsp_control<ext::intel::Preference::DSP,
-                                     ext::intel::Propagate::Off>(
-            [&] { output_a[1] = input_a[0] + input_a[1]; });
+                                     ext::intel::Propagate::Off>([&] {
+          output_add_a[2] = input_a[0] + input_a[1];
+          output_sub_a[2] = subtract(input_a[0], input_a[1]);
+        });
       });
     });
 
   } catch (exception const &e) {
-    // Catches exceptions in the host code
+    // Catches exceptions in the host code.
     std::cerr << "Caught a SYCL host exception:\n" << e.what() << "\n";
 
     // Most likely the runtime couldn't find FPGA hardware!
@@ -78,26 +112,31 @@ void KernelRun(const std::vector<float> &input_data,
 }
 
 int main() {
-  std::vector<float> input_data = {1.234f, 2.345f};
-  std::vector<float> output_data(2);
+  std::vector<float> input_data = {1.23f, 2.34f};
+  std::vector<float> output_data_add(3);
+  std::vector<float> output_data_sub(3);
 
-  KernelRun(input_data, output_data);
+  KernelRun(input_data, output_data_add, output_data_sub);
 
   bool passed = true;
-  float golden = input_data[0] + input_data[1];
+  float golden_add = input_data[0] + input_data[1];
+  float golden_sub = subtract(input_data[0], input_data[1]);
 
-  if (output_data[0] != golden) {
-    std::cout << "Kernel GlobalControl Output Mismatch: \n"
-              << "output = " << output_data[0] << ", golden = " << golden
-              << "\n";
-    passed = false;
-  }
-
-  if (output_data[1] != golden) {
-    std::cout << "Kernel LocalControl Output Mismatch: \n"
-              << "output = " << output_data[1] << ", golden = " << golden
-              << "\n";
-    passed = false;
+  std::string kernel_names[] = {"GlobalControl", "LocalControlPropagateOn",
+                                "LocalControlPropagateOff"};
+  for (int i = 0; i <= 2; i++) {
+    if (output_data_add[i] != golden_add) {
+      std::cout << "Kernel " << kernel_names[i] << " add output mismatch: \n"
+                << "output = " << output_data_add[i]
+                << ", golden = " << golden_add << "\n";
+      passed = false;
+    }
+    if (output_data_sub[i] != golden_sub) {
+      std::cout << "Kernel " << kernel_names[i] << " sub output mismatch: \n"
+                << "output = " << output_data_sub[i]
+                << ", golden = " << golden_sub << "\n";
+      passed = false;
+    }
   }
 
   if (passed) {


### PR DESCRIPTION
# Adding a New Sample "DSP Control"

## Description

This FPGA tutorial demonstrates how to set the implementation preference for certain math operations (addition, subtraction, and multiplication by a constant) between hardened DSP blocks and soft logic.

## Checklist
Administrative
- [ ] Review sample design with the appropriate [Domain Expert](https://github.com/oneapi-src/oneAPI-samples/wiki/Reviewers-and-Domain-Experts): <insert Name Here>

Code Development
- [x] Implement coding guidelines and ensure code quality. [see wiki for details](https://github.com/oneapi-src/oneAPI-samples/wiki/General-Code-Guidelines)
- [x] Adhere to readme template 
- [x] Enforce format via clang-format config file
- [x] Adhere to sample.json specification. https://github.com/oneapi-src/oneAPI-samples/wiki/sample-json-specification
- [x] Ensure/create CI test configurations for sample (ciTests field) https://github.com/oneapi-src/oneAPI-samples/wiki/sample-json-ci-test-object

Review
- [ ] Review DPC++ code with Paul Peterseon. (GitHub User: pmpeter1)
- [ ] Review readme with Tom Lenth(@tomlenth) and/or Project Manager