### PR TITLE
Reduce read only cache output size

### DIFF
--- a/DirectProgramming/DPC++FPGA/Tutorials/Features/read_only_cache/README.md
+++ b/DirectProgramming/DPC++FPGA/Tutorials/Features/read_only_cache/README.md
@@ -234,22 +234,22 @@ Running `./read_only_cache_disabled.fpga`:
 ```
 
 SQRT LUT size: 512
-Number of outputs: 524288
+Number of outputs: 131072 
 Verification PASSED
 
-Kernel execution time: 0.011597 seconds
-Kernel throughput: 172.457160 MB/s
+Kernel execution time: 0.003377 seconds
+Kernel throughput: 148.06 MB/s
 ```
 
 Running `./read_only_cache_disabled.fpga`:
 ```
 
 SQRT LUT size: 512
-Number of outputs: 524288
+Number of outputs: 131072
 Verification PASSED
 
-Kernel execution time: 0.006537 seconds
-Kernel throughput with the read-only cache: 305.933426 MB/s
+Kernel execution time: 0.001675 seconds
+Kernel throughput with the read-only cache: 298.51 MB/s
 ```
 
 ### Discussion of Results
@@ -259,8 +259,8 @@ Intel® Programmable Acceleration Card with Intel® Arria® 10 GX FPGA:
 
 Configuration | Execution Time (ms) | Throughput (MB/s)
 -|-|-
-Without caching | 11.597 | 172.457160
-With caching | 6.537 | 305.933426
+Without caching | 3.377 | 148.06
+With caching | 1.675 | 298.51
 
 When the read-only cache is enabled, performance notably increases. As
 previously mentioned, when the global memory accesses are random (i.e.

--- a/DirectProgramming/DPC++FPGA/Tutorials/Features/read_only_cache/src/read_only_cache.cpp
+++ b/DirectProgramming/DPC++FPGA/Tutorials/Features/read_only_cache/src/read_only_cache.cpp
@@ -152,7 +152,8 @@ int main() {
     std::cout.setf(std::ios::fixed);
 
     // Input size in MB
-    constexpr double num_mb = (kNumOutputs * sizeof(uint32_t)) / (1024 * 1024);
+    constexpr double num_mb =
+        (static_cast<double>(kNumOutputs * sizeof(uint32_t))) / (1024 * 1024);
 
     // Report kernel execution time and throughput
     std::cout << "Kernel execution time: " << time_kernel << " seconds\n";

--- a/DirectProgramming/DPC++FPGA/Tutorials/Features/read_only_cache/src/read_only_cache.cpp
+++ b/DirectProgramming/DPC++FPGA/Tutorials/Features/read_only_cache/src/read_only_cache.cpp
@@ -16,7 +16,7 @@ using namespace sycl;
 namespace ext_oneapi = sycl::ext::oneapi;
 
 constexpr int kLUTSize = 512;       // Size of the LUT.
-constexpr int kNumOutputs = 524288; // Number of outputs.
+constexpr int kNumOutputs = 131072; // Number of outputs.
 constexpr double kNs = 1e9;         // number of nanoseconds in a second
 
 // Forward declare the kernel name in the global scope.


### PR DESCRIPTION
## Description
Reducing the size of the output and updating the sample output in the README file to match.  The smaller buffer size allows this sample to pass on Windows.

## How Has This Been Tested?
- [x] Command Line
- [ ] oneapi-cli
- [ ] Visual Studio
- [ ] Eclipse IDE
- [ ] VSCode
- [ ] When compiling the compliler flag "-Wall -Wformat-security -Werror=format-security" was used
- [x] Using internal testing infrastructure.