### PR TITLE
Update FPGA mem_channel tutorial output message and minor cmake clean up

### DIFF
--- a/DirectProgramming/DPC++FPGA/Tutorials/Features/mem_channel/README.md
+++ b/DirectProgramming/DPC++FPGA/Tutorials/Features/mem_channel/README.md
@@ -313,7 +313,7 @@ Vector size: 100000
 Verification PASSED
 
 Kernel execution time: 0.004004 seconds
-Kernel throughput 749.230914 MB/s
+Kernel throughput: 749.230914 MB/s
 ```
 
 Running `./mem_channel_no_interleaving.fpga`:
@@ -322,7 +322,7 @@ Vector size: 100000
 Verification PASSED
 
 Kernel execution time: 0.003767 seconds
-Kernel throughput 796.379552 MB/s
+Kernel throughput without burst-interleaving: 796.379552 MB/s
 ```
 
 ### Discussion of Results

--- a/DirectProgramming/DPC++FPGA/Tutorials/Features/mem_channel/src/CMakeLists.txt
+++ b/DirectProgramming/DPC++FPGA/Tutorials/Features/mem_channel/src/CMakeLists.txt
@@ -32,10 +32,11 @@ set(HARDWARE_COMPILE_FLAGS "-Wall ${WIN_FLAG} -fintelfpga")
 set(HARDWARE_LINK_FLAGS "-fintelfpga -Xshardware -Xsboard=${FPGA_BOARD} ${USER_HARDWARE_FLAGS}")
 # use cmake -D USER_HARDWARE_FLAGS=<flags> to set extra flags for FPGA backend compilation
 
+set(NO_INTERLEAVING_HARDWARE_COMPILE_FLAGS "-DNO_INTERLEAVING")
 if (FPGA_BOARD STREQUAL "intel_a10gx_pac:pac_a10")
-  set(NO_INTERLEAVING_HARDWARE_COMPILE_FLAGS "-DNO_INTERLEAVING -DTWO_CHANNELS")
+  string(APPEND NO_INTERLEAVING_HARDWARE_COMPILE_FLAGS " -DTWO_CHANNELS")
 elseif (FPGA_BOARD STREQUAL "intel_s10sx_pac:pac_s10")
-  set(NO_INTERLEAVING_HARDWARE_COMPILE_FLAGS "-DNO_INTERLEAVING -DFOUR_CHANNELS")
+  string(APPEND NO_INTERLEAVING_HARDWARE_COMPILE_FLAGS " -DFOUR_CHANNELS")
 endif()
 
 ###############################################################################

--- a/DirectProgramming/DPC++FPGA/Tutorials/Features/mem_channel/src/mem_channel.cpp
+++ b/DirectProgramming/DPC++FPGA/Tutorials/Features/mem_channel/src/mem_channel.cpp
@@ -141,7 +141,7 @@ int main() {
 #if !defined(NO_INTERLEAVING)
     std::cout << "Kernel throughput: " << (num_mb / time_kernel) << " MB/s\n\n";
 #else
-    std::cout << "Kernel throughput without burst-interleaving "
+    std::cout << "Kernel throughput without burst-interleaving: "
               << (num_mb / time_kernel) << " MB/s\n\n";
 #endif
   } else {

--- a/DirectProgramming/DPC++FPGA/Tutorials/Features/mem_channel/src/mem_channel.cpp
+++ b/DirectProgramming/DPC++FPGA/Tutorials/Features/mem_channel/src/mem_channel.cpp
@@ -29,7 +29,7 @@ event runVecAdd(sycl::queue &q, const std::vector<int> &a_vec,
   buffer a_buf(a_vec, {property::buffer::mem_channel{1}});
   buffer b_buf(b_vec, {property::buffer::mem_channel{2}});
   buffer c_buf(c_vec, {property::buffer::mem_channel{1}});
-  buffer sum_buf(sum_vec, {property::buffer::mem_channel{2}}); 
+  buffer sum_buf(sum_vec, {property::buffer::mem_channel{2}});
 #elif defined(NO_INTERLEAVING) && defined(FOUR_CHANNELS)
   buffer a_buf(a_vec, {property::buffer::mem_channel{1}});
   buffer b_buf(b_vec, {property::buffer::mem_channel{2}});
@@ -138,7 +138,12 @@ int main() {
 
     // Report kernel execution time and throughput
     std::cout << "Kernel execution time: " << time_kernel << " seconds\n";
-    std::cout << "Kernel throughput " << (num_mb / time_kernel) << " MB/s\n\n";
+#if !defined(NO_INTERLEAVING)
+    std::cout << "Kernel throughput: " << (num_mb / time_kernel) << " MB/s\n\n";
+#else
+    std::cout << "Kernel throughput without burst-interleaving "
+              << (num_mb / time_kernel) << " MB/s\n\n";
+#endif
   } else {
     std::cerr << "Verification FAILED\n";
     return 1;


### PR DESCRIPTION
## Description
Update messages printed when running the mem_channel tutorial, and update the sample output in the README file to match.

Also did some minor clean-up in the CMake file.

## How Has This Been Tested?
- [x] Command Line
- [ ] oneapi-cli
- [ ] Visual Studio
- [ ] Eclipse IDE
- [ ] VSCode
- [ ] When compiling the compliler flag "-Wall -Wformat-security -Werror=format-security" was used
- [x] Using internal testing infrastructure.