### PR TITLE
Fixing bug in FPGA design DB Q11

### DIFF
--- a/DirectProgramming/DPC++FPGA/ReferenceDesigns/db/README.md
+++ b/DirectProgramming/DPC++FPGA/ReferenceDesigns/db/README.md
@@ -16,16 +16,7 @@ The [oneAPI Programming Guide](https://software.intel.com/en-us/oneapi-programmi
 _Notice: This example design is only officially supported for the Intel® FPGA PAC D5005 (with Intel Stratix® 10 SX)_
 
 **Performance**
-In this design, we accelerate four database queries as *offload accelerators*. In an offload accelerator scheme, the queries are performed by transferring the relevant data from the CPU host to the FPGA, starting the query kernel on the FPGA, and copying the results back. This means that the relevant performance number is the latency (i.e., the wall clock time) from when the query is requested to the time the output data is accessible by the host. This includes the time to transfer data between the CPU and FPGA over PCIe (with an approximate read and write bandwidth of 6877 and 6582 MB/s, respectively). As shown in the table below, most of the total query time is spent transferring the data between the CPU and FPGA, and the query kernels themselves are a small portion of the total latency.
-
-The performance data below was gathered using the Intel® FPGA PAC D5005 (with Intel Stratix® 10 SX) with a database scale factor (SF) of 1. Please see the [Database files](#database-files) section for more information on generating data for a scale factor of 1.
-
-| Query | Approximate Data Transfer Time (ms) | Measured Total Query Processing Time (ms)
-|:---   |:---                                 |:---
-| 1     | 35                                  | 39
-| 9     | 37                                  | 43
-| 11    | 5                                   | 11
-| 12    | 16                                  | 26
+In this design, we accelerate four database queries as *offload accelerators*. In an offload accelerator scheme, the queries are performed by transferring the relevant data from the CPU host to the FPGA, starting the query kernel on the FPGA, and copying the results back. This means that the relevant performance number is the processing time (i.e., the wall clock time) from when the query is requested to the time the output data is accessible by the host. This includes the time to transfer data between the CPU and FPGA over PCIe (with an approximate read and write bandwidth of 6877 and 6582 MB/s, respectively). As shown in the table below, most of the total query time is spent transferring the data between the CPU and FPGA, and the query kernels themselves are a small portion of the total latency.
 
 ## Purpose
 The database in this tutorial has 8-tables and a set of 21 business-oriented queries with broad industry-wide relevance. This reference design shows how four queries can be accelerated using the Intel® FPGA PAC D5005 (with Intel Stratix® 10 SX) and oneAPI. To do so, we create a set of common database operators (found in the `src/db_utils/` directory) that are are combined in different ways to build the four queries.
@@ -231,7 +222,9 @@ You should see the following output in the console:
     Validating query 1 test results
     Running Q1 within 90 days of 1998-12-1
     Validating query 1 test results
-    Processing time: 40.2986 ms
+    Total processing time: 40.2986 ms
+    Kernel processing time: XX ms
+    Throughput: XX queries/s
     PASSED
     ```
     NOTE: the scale factor 1 (SF=1) database files (`../data/sf1`) are **not** shipped with this reference design. Please refer to the [Database files](#database-files) section for information on how to generate these files yourself.

--- a/DirectProgramming/DPC++FPGA/ReferenceDesigns/db/README.md
+++ b/DirectProgramming/DPC++FPGA/ReferenceDesigns/db/README.md
@@ -222,9 +222,9 @@ You should see the following output in the console:
     Validating query 1 test results
     Running Q1 within 90 days of 1998-12-1
     Validating query 1 test results
-    Total processing time: 40.2986 ms
-    Kernel processing time: XX ms
-    Throughput: XX queries/s
+    Total processing time: 34.389 ms
+    Kernel processing time: 3.16621 ms
+    Throughput: 315.835 queries/s
     PASSED
     ```
     NOTE: the scale factor 1 (SF=1) database files (`../data/sf1`) are **not** shipped with this reference design. Please refer to the [Database files](#database-files) section for information on how to generate these files yourself.

--- a/DirectProgramming/DPC++FPGA/ReferenceDesigns/db/src/db.cpp
+++ b/DirectProgramming/DPC++FPGA/ReferenceDesigns/db/src/db.cpp
@@ -332,7 +332,7 @@ bool DoQuery1(queue& q, Database& dbinfo, std::string& db_root_dir,
   unsigned int low_date_compact = low_date.ToCompact();
 
   std::cout << "Running Q1 within " << DELTA << " days of " << date.year << "-"
-            << date.month << "-" << date.day << "\n";
+            << date.month << "-" << date.day << std::endl;
 
   // the query output data
   std::array<DBDecimal, kQuery1OutSize> sum_qty = {0}, sum_base_price = {0},
@@ -385,7 +385,7 @@ bool DoQuery9(queue& q, Database& dbinfo, std::string& db_root_dir,
   // convert the colour regex to uppercase characters (convention)
   transform(colour.begin(), colour.end(), colour.begin(), ::toupper);
 
-  std::cout << "Running Q9 with colour regex: " << colour << "\n";
+  std::cout << "Running Q9 with colour regex: " << colour << std::endl;
 
   // the output of the query
   std::array<DBDecimal, 25 * 2020> sum_profit;
@@ -431,7 +431,8 @@ bool DoQuery11(queue& q, Database& dbinfo, std::string& db_root_dir,
   transform(nation.begin(), nation.end(), nation.begin(), ::toupper);
 
   std::cout << "Running Q11 for nation " << nation.c_str()
-            << " (key=" << (int)(dbinfo.n.name_key_map[nation]) << ")\n";
+            << " (key=" << (int)(dbinfo.n.name_key_map[nation]) << ")"
+            << std::endl;
 
   // the query output
   std::vector<DBIdentifier> partkeys(kPartTableSize);
@@ -499,7 +500,7 @@ bool DoQuery12(queue& q, Database& dbinfo, std::string& db_root_dir,
 
   std::cout << "Running Q12 between years " << low_date.year << " and "
             << high_date.year << " for SHIPMODES " << shipmode1 << " and "
-            << shipmode2 << "\n";
+            << shipmode2 << std::endl;;
 
   // the output of the query
   std::array<DBDecimal, 2> high_line_count, low_line_count;

--- a/DirectProgramming/DPC++FPGA/ReferenceDesigns/db/src/db.cpp
+++ b/DirectProgramming/DPC++FPGA/ReferenceDesigns/db/src/db.cpp
@@ -268,8 +268,13 @@ int main(int argc, char* argv[]) {
           std::accumulate(total_latency.begin() + 1, total_latency.end(), 0.0) /
           (double)(runs - 1);
 
+      double kernel_latency_avg =
+        std::accumulate(kernel_latency.begin() + 1, kernel_latency.end(), 0.0) /
+        (double)(runs - 1);
+
       // print the performance results
       std::cout << "Processing time: " << total_latency_avg << " ms\n";
+      std::cout << "Kernel time" << kernel_latency_avg << "ms\n";
 #endif
 
       std::cout << "PASSED\n";

--- a/DirectProgramming/DPC++FPGA/ReferenceDesigns/db/src/db.cpp
+++ b/DirectProgramming/DPC++FPGA/ReferenceDesigns/db/src/db.cpp
@@ -274,7 +274,9 @@ int main(int argc, char* argv[]) {
 
       // print the performance results
       std::cout << "Processing time: " << total_latency_avg << " ms\n";
-      std::cout << "Kernel time" << kernel_latency_avg << "ms\n";
+      std::cout << "Kernel time: " << kernel_latency_avg << " ms\n";
+      std::cout << "Throughput: " << ((1 / kernel_latency_avg) * 1e3)
+                << " queries/s\n";
 #endif
 
       std::cout << "PASSED\n";

--- a/DirectProgramming/DPC++FPGA/ReferenceDesigns/db/src/db_utils/Accumulator.hpp
+++ b/DirectProgramming/DPC++FPGA/ReferenceDesigns/db/src/db_utils/Accumulator.hpp
@@ -89,13 +89,13 @@ class BRAMAccumulator {
   // initialize the memory entries
   void Init() {
     // initialize the memory entries
-    for (IndexType i = 0; i < size; i++) {
+    for (int i = 0; i < size; i++) {
       mem[i] = 0;
     }
 
 // initialize the cache
 #pragma unroll
-    for (IndexType i = 0; i < cache_size + 1; i++) {
+    for (int i = 0; i < cache_size + 1; i++) {
       cache_value[i] = 0;
       cache_tag[i] = 0;
     }
@@ -104,34 +104,33 @@ class BRAMAccumulator {
   // accumulate 'value' into register 'index' (i.e. registers[index] += value)
   void Accumulate(IndexType index, StorageType value) {
     // get value from memory
-    StorageType currVal = mem[index];
+    StorageType curr_val = mem[index];
 
 // check if value is in cache
 #pragma unroll
-    for (IndexType i = 0; i < cache_size + 1; i++) {
+    for (int i = 0; i < cache_size + 1; i++) {
       if (cache_tag[i] == index) {
-        currVal = cache_value[i];
+        curr_val = cache_value[i];
       }
     }
 
     // write the new value to both the shift register cache and the local mem
-    const StorageType newVal = currVal + value;
-    mem[index] = cache_value[cache_size] = newVal;
+    StorageType new_val = curr_val + value;
+    mem[index] = new_val;
+    cache_value[cache_size] = new_val;
     cache_tag[cache_size] = index;
 
 // Cache is just a shift register, so shift it
 // pushing into back of the shift register done above
 #pragma unroll
-    for (IndexType i = 0; i < cache_size; i++) {
+    for (int i = 0; i < cache_size; i++) {
       cache_value[i] = cache_value[i + 1];
       cache_tag[i] = cache_tag[i + 1];
     }
   }
 
   // get the value of memory at 'index'
-  StorageType Get(IndexType index) {
-    return mem[index];
-  }
+  StorageType Get(IndexType index) { return mem[index]; }
 
   // internal storage
   StorageType mem[size];

--- a/DirectProgramming/DPC++FPGA/ReferenceDesigns/db/src/db_utils/MapJoin.hpp
+++ b/DirectProgramming/DPC++FPGA/ReferenceDesigns/db/src/db_utils/MapJoin.hpp
@@ -31,9 +31,8 @@ class ArrayMap {
     }
   }
 
-  std::pair<bool, Type> Get(unsigned int key) {
-    return {valid[key], map[key]};
-  }
+  Type Get(unsigned int key) { return map[key]; }
+  bool HasKey(unsigned int key) { return valid[key]; }
 
   void Set(unsigned int key, Type data) {
     map[key] = data;
@@ -89,10 +88,9 @@ void MapJoin(MapType& map) {
         const unsigned int t2_key =
             in_data.data.template get<j>().PrimaryKey();
 
-        auto [data_valid, map_data] = map.Get(t2_key);
-
-        if (t2_win_valid && data_valid) {
+        if (t2_win_valid && map.HasKey(t2_key)) {
           // NOTE: order below important if Join() overrides valid
+          auto map_data = map.Get(t2_key);
           join_data.data.template get<j>().valid = true;
           join_data.data.template get<j>().Join(map_data,
                                                 in_data.data.template get<j>());

--- a/DirectProgramming/DPC++FPGA/ReferenceDesigns/db/src/dbdata.cpp
+++ b/DirectProgramming/DPC++FPGA/ReferenceDesigns/db/src/dbdata.cpp
@@ -507,7 +507,7 @@ bool Database::ValidateQ1(std::string db_root_dir,
                           std::array<DBDecimal, 3 * 2>& avg_price,
                           std::array<DBDecimal, 3 * 2>& avg_discount,
                           std::array<DBDecimal, 3 * 2>& count) {
-  std::cout << "Validating query 1 test results\n";
+  std::cout << "Validating query 1 test results" << std::endl;
 
   // populate date row by row (as presented in the file)
   std::string path(db_root_dir + kSeparator + "answers" + kSeparator + "q1.out");
@@ -630,7 +630,7 @@ bool Database::ValidateQ1(std::string db_root_dir,
 //
 bool Database::ValidateQ9(std::string db_root_dir,
                           std::array<DBDecimal, 25 * 2020>& sum_profit) {
-  std::cout << "Validating query 9 test results\n";
+  std::cout << "Validating query 9 test results" << std::endl;
 
   // populate date row by row (as presented in the file)
   std::string path(db_root_dir + kSeparator + "answers" + kSeparator + "q9.out");
@@ -684,7 +684,7 @@ bool Database::ValidateQ9(std::string db_root_dir,
 bool Database::ValidateQ11(std::string db_root_dir,
                            std::vector<DBIdentifier>& partkeys,
                            std::vector<DBDecimal>& partkey_values) {
-  std::cout << "Validating query 11 test results\n";
+  std::cout << "Validating query 11 test results" << std::endl;
 
   // populate date row by row (as presented in the file)
   std::string path(db_root_dir + kSeparator + "answers" + kSeparator + "q11.out");

--- a/DirectProgramming/DPC++FPGA/ReferenceDesigns/db/src/query11/query11_kernel.cpp
+++ b/DirectProgramming/DPC++FPGA/ReferenceDesigns/db/src/query11/query11_kernel.cpp
@@ -161,10 +161,10 @@ bool SubmitQuery11(queue& q, Database& dbinfo, std::string& nation,
   auto compute_event = q.submit([&](handler& h) {
     // kernel to produce the PARTSUPPLIER table
     h.single_task<Compute>([=]() [[intel::kernel_args_restrict]] {
-      constexpr int kAccumeCacheSize = 15;
+      constexpr int kAccumCacheSize = 15;
       BRAMAccumulator<DBDecimal,
                       kPartTableSize,
-                      kAccumeCacheSize,
+                      kAccumCacheSize,
                       DBIdentifier> partkey_values;
 
       // initialize accumulator
@@ -172,7 +172,7 @@ bool SubmitQuery11(queue& q, Database& dbinfo, std::string& nation,
 
       bool done = false;
 
-      [[intel::initiation_interval(1), intel::ivdep(kAccumeCacheSize)]]
+      [[intel::initiation_interval(1), intel::ivdep(kAccumCacheSize)]]
       while (!done) {
         SupplierPartSupplierJoinedPipeData pipe_data = 
             PartSupplierPartsPipe::read();

--- a/DirectProgramming/DPC++FPGA/ReferenceDesigns/db/src/query11/query11_kernel.cpp
+++ b/DirectProgramming/DPC++FPGA/ReferenceDesigns/db/src/query11/query11_kernel.cpp
@@ -161,10 +161,10 @@ bool SubmitQuery11(queue& q, Database& dbinfo, std::string& nation,
   auto compute_event = q.submit([&](handler& h) {
     // kernel to produce the PARTSUPPLIER table
     h.single_task<Compute>([=]() [[intel::kernel_args_restrict]] {
-      constexpr int ACCUM_CACHE_SIZE = 5;
+      constexpr int kAccumeCacheSize = 5;
       BRAMAccumulator<DBDecimal,
                       kPartTableSize,
-                      ACCUM_CACHE_SIZE,
+                      kAccumeCacheSize,
                       DBIdentifier> partkey_values;
 
       // initialize accumulator
@@ -172,7 +172,7 @@ bool SubmitQuery11(queue& q, Database& dbinfo, std::string& nation,
 
       bool done = false;
 
-      [[intel::initiation_interval(1), intel::ivdep]]
+      [[intel::initiation_interval(1), intel::ivdep(kAccumeCacheSize)]]
       while (!done) {
         SupplierPartSupplierJoinedPipeData pipe_data = 
             PartSupplierPartsPipe::read();

--- a/DirectProgramming/DPC++FPGA/ReferenceDesigns/db/src/query11/query11_kernel.cpp
+++ b/DirectProgramming/DPC++FPGA/ReferenceDesigns/db/src/query11/query11_kernel.cpp
@@ -161,7 +161,7 @@ bool SubmitQuery11(queue& q, Database& dbinfo, std::string& nation,
   auto compute_event = q.submit([&](handler& h) {
     // kernel to produce the PARTSUPPLIER table
     h.single_task<Compute>([=]() [[intel::kernel_args_restrict]] {
-      constexpr int kAccumeCacheSize = 5;
+      constexpr int kAccumeCacheSize = 15;
       BRAMAccumulator<DBDecimal,
                       kPartTableSize,
                       kAccumeCacheSize,


### PR DESCRIPTION
# Existing Sample Changes
## Description
This fixes a functional bug in the DB Q11 design for the FPGA. The cache in the compute kernel allows us to break the loop-carried dependency for a distance equal to the cache depth - 1. The ivdep pragma was applied with no 'safelen' and therefore broke the dependency for all loop iterations, which is not functionally correct.

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)
- 
## How Has This Been Tested?
- [X] Command Line
- [X] regtests