### PR TITLE
Removing CMake warning for zero_copy_data_transfer

### DIFF
--- a/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/zero_copy_data_transfer/src/CMakeLists.txt
+++ b/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/zero_copy_data_transfer/src/CMakeLists.txt
@@ -20,16 +20,12 @@ endif()
 # this tutorial requires USM host allocations. Check the BSP name (which should contain the text 'usm')
 # to ensure the BSP has the required support. Allow the user to define USM_HOST_ALLOCATIONS_ENABLED
 # to override this check (e.g., cmake .. -DUSM_HOST_ALLOCATIONS_ENABLED=1)
-if(NOT FPGA_BOARD MATCHES ".usm.*" AND (NOT DEFINED USM_HOST_ALLOCATIONS_ENABLED OR USM_HOST_ALLOCATIONS STREQUAL "0"))
+if(NOT FPGA_BOARD MATCHES ".usm.*" AND (NOT DEFINED USM_HOST_ALLOCATIONS_ENABLED OR USM_HOST_ALLOCATIONS_ENABLED STREQUAL "0"))
     message(FATAL_ERROR "This tutorial requires a BSP that has USM host allocations enabled.")
 endif()
 
-if (DEFINED USM_HOST_ALLOCATIONS_ENABLED)
-  message(STATUS "USM host allocations manually enabled with USM_HOST_ALLOCATIONS_ENABLED=${USM_HOST_ALLOCATIONS_ENABLED}")
-endif()
-
-if (USM_HOST_ALLOCATIONS)
-  message(STATUS "USM_HOST_ALLOCATIONS enabled  manually!")
+if (USM_HOST_ALLOCATIONS_ENABLED)
+  message(STATUS "USM_HOST_ALLOCATIONS_ENABLED set enabled  manually!")
 endif()
 
 # This is a Windows-specific flag that enables exception handling in host code

--- a/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/zero_copy_data_transfer/src/CMakeLists.txt
+++ b/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/zero_copy_data_transfer/src/CMakeLists.txt
@@ -20,7 +20,7 @@ endif()
 # this tutorial requires USM host allocations. Check the BSP name (which should contain the text 'usm')
 # to ensure the BSP has the required support. Allow the user to define USM_HOST_ALLOCATIONS_ENABLED
 # to override this check (e.g., cmake .. -DUSM_HOST_ALLOCATIONS_ENABLED=1)
-if(NOT FPGA_BOARD MATCHES ".usm.*" AND NOT DEFINED USM_HOST_ALLOCATIONS_ENABLED)
+if(NOT FPGA_BOARD MATCHES ".usm.*" AND (NOT DEFINED USM_HOST_ALLOCATIONS_ENABLED OR USM_HOST_ALLOCATIONS STREQUAL "0"))
     message(FATAL_ERROR "This tutorial requires a BSP that has USM host allocations enabled.")
 endif()
 
@@ -28,8 +28,8 @@ if (DEFINED USM_HOST_ALLOCATIONS_ENABLED)
   message(STATUS "USM host allocations manually enabled with USM_HOST_ALLOCATIONS_ENABLED=${USM_HOST_ALLOCATIONS_ENABLED}")
 endif()
 
-if (DEFINED USM_HOST_ALLOCATIONS)
-    message(STATUS "USM_HOST_ALLOCATIONS=${USM_HOST_ALLOCATIONS} set manually!")
+if (USM_HOST_ALLOCATIONS)
+  message(STATUS "USM_HOST_ALLOCATIONS enabled  manually!")
 endif()
 
 # This is a Windows-specific flag that enables exception handling in host code

--- a/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/zero_copy_data_transfer/src/CMakeLists.txt
+++ b/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/zero_copy_data_transfer/src/CMakeLists.txt
@@ -25,7 +25,7 @@ if(NOT FPGA_BOARD MATCHES ".usm.*" AND (NOT DEFINED USM_HOST_ALLOCATIONS_ENABLED
 endif()
 
 if (USM_HOST_ALLOCATIONS_ENABLED)
-  message(STATUS "USM_HOST_ALLOCATIONS_ENABLED set enabled  manually!")
+    message(STATUS "USM_HOST_ALLOCATIONS_ENABLED set manually!")
 endif()
 
 # This is a Windows-specific flag that enables exception handling in host code

--- a/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/zero_copy_data_transfer/src/CMakeLists.txt
+++ b/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/zero_copy_data_transfer/src/CMakeLists.txt
@@ -21,7 +21,15 @@ endif()
 # to ensure the BSP has the required support. Allow the user to define USM_HOST_ALLOCATIONS_ENABLED
 # to override this check (e.g., cmake .. -DUSM_HOST_ALLOCATIONS_ENABLED=1)
 if(NOT FPGA_BOARD MATCHES ".usm.*" AND NOT DEFINED USM_HOST_ALLOCATIONS_ENABLED)
-    message(FATAL_ERROR "This tutorial requires a BSP that has USM host allocations enabled")
+    message(FATAL_ERROR "This tutorial requires a BSP that has USM host allocations enabled.")
+endif()
+
+if (DEFINED USM_HOST_ALLOCATIONS_ENABLED)
+  message(STATUS "USM host allocations manually enabled with USM_HOST_ALLOCATIONS_ENABLED=${USM_HOST_ALLOCATIONS_ENABLED}")
+endif()
+
+if (DEFINED USM_HOST_ALLOCATIONS)
+    message(STATUS "USM_HOST_ALLOCATIONS=${USM_HOST_ALLOCATIONS} set manually!")
 endif()
 
 # This is a Windows-specific flag that enables exception handling in host code


### PR DESCRIPTION
# Existing Sample Changes
## Description
Removing 'Manually-specified variables were not used by the project' warning from CMake

## Type of change
- [X] removing warnings

## How Has This Been Tested?
- [X] Command Line