### PR TITLE
[MODIN]: Add time results verifier for getting started notebook

### DIFF
--- a/AI-and-Analytics/Getting-Started-Samples/IntelModin_GettingStarted/IntelModin_GettingStarted.ipynb
+++ b/AI-and-Analytics/Getting-Started-Samples/IntelModin_GettingStarted/IntelModin_GettingStarted.ipynb
@@ -48,6 +48,50 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# ****** Do not change the code below! It verifies that the notebook is being run correctly! ******\n",
+    "\n",
+    "def verify_and_print_times(pandas_time, modin_time):\n",
+    "    if modin_time < pandas_time:\n",
+    "        print(f\"Modin was {pandas_time / modin_time:.2f}X faster than stock Pandas!\")\n",
+    "        return\n",
+    "    print(\n",
+    "        f\"Oops, stock Pandas appears to be {modin_time / pandas_time:.2f}X faster than Modin in this case. \"\n",
+    "        \"This is unlikely but could happen sometimes on certain machines/environments/datasets. \"\n",
+    "        \"One of the most probable reasons is the excessive amount of partitions being assigned to a single worker. \"\n",
+    "        \"You may visit Modin's optimization guide in order to learn more about such cases and how to fix them: \"\n",
+    "        \"\\nhttps://modin.readthedocs.io/en/latest/usage_guide/optimization_notes/index.html\\n\\n\"\n",
+    "        \"But first, verify that you're using the latest Modin version, also, try to use different executions, \"\n",
+    "        \"for basic usage we recommend non-experimental 'PandasOnRay'\\n\"\n",
+    "        \"Current execution is:\"\n",
+    "    )\n",
+    "    try:\n",
+    "        import modin.config as cfg\n",
+    "\n",
+    "        try:\n",
+    "            storage_format = cfg.StorageFormat.get()\n",
+    "        except AttributeError:\n",
+    "            # for modin versions < 0.12\n",
+    "            storage_format = cfg.Backend.get()\n",
+    "        print(\n",
+    "            f\"\\tExecution: {storage_format}On{cfg.Engine.get()}\\n\"\n",
+    "            f\"\\tIs experimental: {cfg.IsExperimental.get()}\\n\"\n",
+    "            f\"\\tCores to use by Modin (check that Modin uses all cores on your machine): {cfg.CpuCount.get()}\\n\"\n",
+    "            f\"\\tIs in debug mode (debug mode may perform slower): {cfg.IsDebug.get()}\"\n",
+    "        )\n",
+    "    except ImportError:\n",
+    "        # for modin versions < 0.8.2\n",
+    "        pass\n",
+    "    import modin\n",
+    "\n",
+    "    print(f\"\\tModin version: {modin.__version__}\")   "
+   ]
+  },
+  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -612,6 +656,7 @@
     "modin_time = time.time() - t1\n",
     "\n",
     "print(\"Pandas Time(seconds):\",pandas_time,\"\\nModin Time(seconds):\",modin_time)\n",
+    "verify_and_print_times(pandas_time, modin_time)\n",
     "outputDict={\"Pandas\":pandas_time,\"Modin\":modin_time}\n",
     "plotter(outputDict)"
    ]
@@ -693,7 +738,7 @@
     }
    ],
    "source": [
-    "print(\"Modin was {}X faster than stock Pandas!\".format(round(pandas_time/modin_time, 2)))"
+    "verify_and_print_times(pandas_time, modin_time)"
    ]
   },
   {
@@ -852,7 +897,7 @@
     }
    ],
    "source": [
-    "print(\"Modin was {}X faster than stock Pandas!\".format(round(pandas_time/modin_time, 2)))"
+    "verify_and_print_times(pandas_time, modin_time)"
    ]
   },
   {
@@ -1000,7 +1045,7 @@
     }
    ],
    "source": [
-    "print(\"Modin was {}X faster than stock Pandas!\".format(round(pandas_time/modin_time, 2)))"
+    "verify_and_print_times(pandas_time, modin_time)"
    ]
   },
   {

--- a/AI-and-Analytics/Getting-Started-Samples/IntelModin_GettingStarted/IntelModin_GettingStarted.ipynb
+++ b/AI-and-Analytics/Getting-Started-Samples/IntelModin_GettingStarted/IntelModin_GettingStarted.ipynb
@@ -102,7 +102,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We will also be importing **stock Pandas as pd** and **Modin as mpd to show differentiation**. You can see importing Modin is simple and **does not require any additional steps.**"
+    "We will also be importing **stock Pandas as pandas** and **Modin as pd to show differentiation**. You can see importing Modin is simple and **does not require any additional steps.**"
    ]
   },
   {


### PR DESCRIPTION
# Existing Sample Changes
## Description

The notebook is supposed to show the performance improvement after switching from stock Pandas to Modin, it compares the execution times of Pandas and Modin in various scenarios. The previous version of the notebook didn't imply that the Modin could be slower than Pandas anyhow and so confused users if such happened.
 
The changes in this PR introduce a time verifier, that compares Modin and Pandas execution times and prints a note if Modin appears to be slower with the possible reasons for it (poor CPU performance, old Modin version, silly environment variables).

Fixes [Jira MODIN6-135](https://jira.devtools.intel.com/browse/MODIN6-135).

## External Dependencies

The changes do not add any new dependencies.

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] Implement fixes for Jiras

## How Has This Been Tested?

- [x] Command Line

As there are no automatic test cases for jupyter notebooks in the repo, the changes have been tested manually:
1. Create an environment with Modin installed if you don't have one:
```
conda create -n test_env "python>=3.8.1" -c conda-forge
conda activate test_env
pip install modin[all]
```
2. Install requirements for the notebook:
```
cd path/to/getting/started/notebook
pip install -r requirements.txt
```
3. Run the notebook:
```
ipython IntelModin_GettingStarted.ipynb
```
4. Verify that the last line of the output is "[CODE_SAMPLE_COMPLETED_SUCCESFULLY]"

**Note:** currently, tests in CI are failing due to environment problems, there's a Jira ticket that's supposed to resolve this ([REIE-1371](https://jira.devtools.intel.com/browse/REIE-1371)). I suppose that the PR is blocked until the CI problems will be resolved.

Would also like to get a review from Modin folks: @Garra1980 @YarShev @vnlitvinov 