### PR TITLE
Bug fix for FPGA sample gzip: add fpga_tools namespace to all instances of PipeArray in the low latency design variant

### DIFF
--- a/DirectProgramming/DPC++FPGA/ReferenceDesigns/gzip/src/gzipkernel_ll.cpp
+++ b/DirectProgramming/DPC++FPGA/ReferenceDesigns/gzip/src/gzipkernel_ll.cpp
@@ -62,10 +62,20 @@ using acc_dist_channel_array =
   >;
 
 using acc_dist_channel_last_array =
-    PipeArray<class dist_channel_last_pipe_id, struct DistLen, 32, NUM_ENGINES>;
+    fpga_tools::PipeArray<
+      class dist_channel_last_pipe_id,
+      struct DistLen,
+      32,
+      NUM_ENGINES
+    >;
 
 using acc_lz_to_crc_channel_array =
-    PipeArray<class crc_channel_pipe_id, char_arr_32, 32, NUM_ENGINES>;
+    fpga_tools::PipeArray<
+      class crc_channel_pipe_id,
+      char_arr_32,
+      32,
+      NUM_ENGINES
+    >;
 
 template <int Begin, int End>
 struct Unroller {


### PR DESCRIPTION
## Description

This PR: https://github.com/oneapi-src/oneAPI-samples/pull/842 placed the PipeArray class in the fpga_tools namespace, but did not update all instance of references to PipeArray in the low latency variant of the gzip design.  This PR fixes that oversight.

## Type of change

Please delete options that are not relevant. Add a 'X' to the one that is applicable. 

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] Command Line
Compiled the low latency variant of the gzip design by running CMAKE with -DLOW_LATENCY=1 as specified in the README file for that design.