### PR TITLE
Update FPGA sample gzip to print a clear error message when compiling the Low Latency version with no USM support

### DIFF
--- a/DirectProgramming/DPC++FPGA/ReferenceDesigns/gzip/sample.json
+++ b/DirectProgramming/DPC++FPGA/ReferenceDesigns/gzip/sample.json
@@ -38,6 +38,27 @@
           "cmake ..",
           "make report"
         ]
+      },
+      {
+        "id": "fpga_emu_ll",
+        "steps": [
+          "dpcpp --version",
+          "mkdir build",
+          "cd build",
+          "cmake .. -DLOW_LATENCY=1 -DFPGA_BOARD=intel_s10sx_pac:pac_s10_usm",
+          "make fpga_emu",
+          "./gzip.fpga_emu ../src/gzip.cpp -o=test.gz"
+        ]
+      },
+      {
+        "id": "report_ll",
+        "steps": [
+          "dpcpp --version",
+          "mkdir build",
+          "cd build",
+          "cmake .. -DLOW_LATENCY=1 -DFPGA_BOARD=intel_s10sx_pac:pac_s10_usm",
+          "make report"
+        ]
       }
     ],
     "windows": [
@@ -64,7 +85,32 @@
           "cmake -G \"NMake Makefiles\" ../ReferenceDesigns/gzip",
           "nmake report"
         ]
+      },
+      {
+        "id": "fpga_emu_ll",
+        "steps": [
+          "dpcpp --version",
+          "cd ../..",
+          "mkdir build",
+          "cd build",
+          "xcopy /E ..\\ReferenceDesigns\\gzip\\src ..\\src\\",
+          "cmake -G \"NMake Makefiles\" ../ReferenceDesigns/gzip -DLOW_LATENCY=1 -DFPGA_BOARD=intel_s10sx_pac:pac_s10_usm",
+          "nmake fpga_emu",
+          "gzip.fpga_emu.exe ../src/gzip.cpp -o=test.gz"
+        ]
+      },
+      {
+        "id": "report_ll",
+        "steps": [
+          "dpcpp --version",
+          "cd ../..",
+          "mkdir build",
+          "cd build",
+          "cmake -G \"NMake Makefiles\" ../ReferenceDesigns/gzip -DLOW_LATENCY=1 -DFPGA_BOARD=intel_s10sx_pac:pac_s10_usm",
+          "nmake report"
+        ]
       }
+
     ]
   }
 }

--- a/DirectProgramming/DPC++FPGA/ReferenceDesigns/gzip/src/CMakeLists.txt
+++ b/DirectProgramming/DPC++FPGA/ReferenceDesigns/gzip/src/CMakeLists.txt
@@ -82,8 +82,11 @@ endif()
 # Presence of USM host allocations (and whether to turn on enable the low-latency target) is detected automatically by
 # looking at the name of the BSP, or manually by the user when running CMake.
 # E.g., cmake .. -DUSER_ENABLE_USM=1
-if(FPGA_BOARD MATCHES ".*usm.*" OR DEFINED USER_ENABLE_USM)
+if(FPGA_BOARD MATCHES ".*usm.*" OR USER_ENABLE_USM)
     set(USM_ENABLED 1)
+elseif(LOW_LATENCY)
+    # Low latency design requires USM, so error out
+    message(FATAL_ERROR "Error: The Low Latency variant of the design requires USM host allocations")
 endif()
 
 message(STATUS "NUM_ENGINES=${NUM_ENGINES}")


### PR DESCRIPTION
## Description

Update the CMake file to detect when the Low Latency design variant is requested in combination with a BSP that does not support USM Host Allocations, and print a clear error message at the CMake stage.  Previously, CMake would pass and the user would later get an obscure and unhelpful compile error.

Also add CI tests for the Low Latency version of the design to the sample.json.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Implement fixes for ONSAM Jiras

## How Has This Been Tested?

- [x] Command Line
Ran CMake with various options to confirm the error message will print whenever appropriate.
JSON file changes will be tested by the CI, which will run as part of this PR.
