### PR TITLE
FPGA: Update the include folder readme

### DIFF
--- a/DirectProgramming/DPC++FPGA/include/README.md
+++ b/DirectProgramming/DPC++FPGA/include/README.md
@@ -8,7 +8,7 @@ This directory contains utility header libraries optimized for FPGA DPC++ design
 | Filename       | Description
 ---              |---
 | constexpr_math.hpp | Defines utilities for statically computing math functions such as Log2.
-| pipe_utils.hpp | Defines utilities for working with pipes, such as PipeArray.
+| pipe_utils.hpp | Utility classes for working with pipes, such as PipeArray.
 | tuple.hpp | Defines a template to implement tuples.
 | unrolled_loop.hpp | Defines a templated implementation of unrolled loops.
 
@@ -16,8 +16,8 @@ This directory contains utility header libraries optimized for FPGA DPC++ design
 
 | Filename       | Description
 ---              |---
-| streaming_qrd.hpp | Defines a functor that implements the QR decomposition of matrices.
-| streaming_qri.hpp | Defines a functor that implements the QR-based inversion of matrices.
+| streaming_qrd.hpp | QR decomposition of matrices with pipe interfaces.
+| streaming_qri.hpp | QR-based inversion of matrices with pipe interfaces.
 
 ## License  
 Code samples are licensed under the MIT license. See

--- a/DirectProgramming/DPC++FPGA/include/README.md
+++ b/DirectProgramming/DPC++FPGA/include/README.md
@@ -2,15 +2,22 @@
 This directory contains utility header libraries optimized for FPGA DPC++ designs. Examples of their usage can be found in ReferenceDesigns and Tutorials.
 
 ## Available Header Libraries
+
+# Utilities
+
 | Filename       | Description
 ---              |---
-| pipe_utils.hpp | Defines utilities for working with pipes, such as PipeArray.
 | constexpr_math.hpp | Defines utilities for statically computing math functions such as Log2.
+| pipe_utils.hpp | Defines utilities for working with pipes, such as PipeArray.
 | tuple.hpp | Defines a template to implement tuples.
 | unrolled_loop.hpp | Defines a templated implementation of unrolled loops.
+
+# Linear algebra
+
+| Filename       | Description
+---              |---
 | streaming_qrd.hpp | Defines a functor that implements the QR decomposition of matrices.
 | streaming_qri.hpp | Defines a functor that implements the QR-based inversion of matrices.
-| utils.hpp | Defines commonly used classes.
 
 ## License  
 Code samples are licensed under the MIT license. See

--- a/DirectProgramming/DPC++FPGA/include/README.md
+++ b/DirectProgramming/DPC++FPGA/include/README.md
@@ -3,7 +3,7 @@ This directory contains utility header libraries optimized for FPGA DPC++ design
 
 ## Available Header Libraries
 
-# Utilities
+### Utilities
 
 | Filename       | Description
 ---              |---
@@ -12,7 +12,7 @@ This directory contains utility header libraries optimized for FPGA DPC++ design
 | tuple.hpp | Defines a template to implement tuples.
 | unrolled_loop.hpp | Defines a templated implementation of unrolled loops.
 
-# Linear algebra
+### Linear algebra
 
 | Filename       | Description
 ---              |---


### PR DESCRIPTION
## Description

Removes the mention of the utils.hpp file in the include folder readme as the file does not exits.
Reorganizes the table listing the files that are in the include folder.

Review
- [ ] Review DPC++ code with Paul Peterseon. (GitHub User: pmpeter1)
- [ ] Review readme with Tom Lenth(@tomlenth) and/or Project Manager
