### PR TITLE
MODIN: fix getting started samples testing in CI

### DIFF
--- a/AI-and-Analytics/Getting-Started-Samples/IntelModin_GettingStarted/sample.json
+++ b/AI-and-Analytics/Getting-Started-Samples/IntelModin_GettingStarted/sample.json
@@ -10,17 +10,16 @@
   "ciTests": {
   	"linux": [
     {
-  		"env": [
-  			"set -e # Terminate the script on first error",
-  			"source $(conda info --base)/etc/profile.d/conda.sh # Bypassing conda's disability to activate environments inside a bash script: https://github.com/conda/conda/issues/7980",
-  			"conda create -y -n intel-aikit-modin intel-aikit-modin -c intel",
-  			"conda activate intel-aikit-modin",
-  			"pip install -r requirements.txt # Installing notebook's dependencies",
-  			"pip install runipy # Installing 'runipy' for extended abilities to execute the notebook"
-  		],
+  		"env": [],
   		"id": "Intel_Modin_GS_py",
   		"steps": [
-  			"runipy IntelModin_GettingStarted.ipynb"
+			"set -e # Terminate the script on first error",
+			"source $(conda info --base)/etc/profile.d/conda.sh # Bypassing conda's disability to activate environments inside a bash script: https://github.com/conda/conda/issues/7980",
+			"conda create -y -n intel-aikit-modin intel-aikit-modin -c intel",
+			"conda activate intel-aikit-modin",
+			"pip install -r requirements.txt # Installing notebook's dependencies",
+			"pip install runipy # Installing 'runipy' for extended abilities to execute the notebook",
+			"runipy IntelModin_GettingStarted.ipynb"
   		]
   	}
     ]

--- a/AI-and-Analytics/Getting-Started-Samples/IntelModin_GettingStarted/sample.json
+++ b/AI-and-Analytics/Getting-Started-Samples/IntelModin_GettingStarted/sample.json
@@ -10,11 +10,18 @@
   "ciTests": {
   	"linux": [
     {
-  		"env": ["source /opt/intel/oneapi/setvars.sh --force", "conda create -n aikit-modin-test -c intel -c conda-forge matplotlib runipy intel-aikit-modin", "source activate aikit-modin-test"],
+  		"env": [
+  			"set -e # Terminate the script on first error",
+  			"source $(conda info --base)/etc/profile.d/conda.sh # Bypassing conda's disability to activate environments inside a bash script: https://github.com/conda/conda/issues/7980",
+  			"conda create -y -n intel-aikit-modin intel-aikit-modin -c intel",
+  			"conda activate intel-aikit-modin",
+  			"pip install -r requirements.txt # Installing notebook's dependencies",
+  			"pip install runipy # Installing 'runipy' for extended abilities to execute the notebook"
+  		],
   		"id": "Intel_Modin_GS_py",
   		"steps": [
-         "runipy IntelModin_GettingStarted.ipynb" 
-  		 ]
+  			"runipy IntelModin_GettingStarted.ipynb"
+  		]
   	}
     ]
 }


### PR DESCRIPTION
Signed-off-by: Dmitry Chigarev <dmitry.chigarev@intel.com>

# Existing Sample Changes
## Description

This PR is supposed to fix [failing CI testing](https://github.com/oneapi-src/oneAPI-samples/pull/843#commitcomment-66044784) for Modin's getting started samples. The CI flow has been failing due to conda's failures during environment initialization inside the bash script (conda/conda#7980). The CI script was modified as follows to resolve the problem:
1. Source `conda.sh` before using conda to be able to activate environments inside a bash script (conda/conda#7980).
2. Use [`set -e`](https://www.gnu.org/software/bash/manual/html_node/The-Set-Builtin.html#:~:text=%2De,function%20call%20completes.) at the beginning of the CI script to ease debugging if something goes wrong.
3. Install notebook's dependencies from [`requirements.txt`](https://github.com/oneapi-src/oneAPI-samples/blob/master/AI-and-Analytics/Getting-Started-Samples/IntelModin_GettingStarted/requirements.txt) rather than manually listing them.

Fixes [Jira REIE-1371](https://jira.devtools.intel.com/browse/REIE-1371).

## External Dependencies

No external dependencies were added.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] Command Line

To test the changes locally:
1. Combine steps from the `sample.json` into a single bash script.
2. Run the script and ensure that the last notebook's cell printed"[CODE_SAMPLE_COMPLETED_SUCCESFULLY]"
