### PR TITLE
Changing CMake file for USM-only tutorials to get rid of CMake warning

### DIFF
--- a/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/buffered_host_streaming/src/CMakeLists.txt
+++ b/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/buffered_host_streaming/src/CMakeLists.txt
@@ -21,7 +21,7 @@ endif()
 # to ensure the BSP has the required support. Allow the user to define USM_HOST_ALLOCATIONS_ENABLED
 # to override this check (e.g., cmake .. -DUSM_HOST_ALLOCATIONS_ENABLED=1)
 if(NOT FPGA_BOARD MATCHES ".usm.*" AND (NOT DEFINED USM_HOST_ALLOCATIONS_ENABLED OR USM_HOST_ALLOCATIONS_ENABLED STREQUAL "0"))
-    message(FATAL_ERROR "This tutorial requires a BSP that has USM host allocations enabled.")
+    message(FATAL_ERROR "ERROR: This tutorial requires a BSP that has USM host allocations enabled.")
 endif()
 
 if (USM_HOST_ALLOCATIONS_ENABLED)

--- a/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/buffered_host_streaming/src/CMakeLists.txt
+++ b/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/buffered_host_streaming/src/CMakeLists.txt
@@ -20,8 +20,12 @@ endif()
 # this tutorial requires USM host allocations. Check the BSP name (which should contain the text 'usm')
 # to ensure the BSP has the required support. Allow the user to define USM_HOST_ALLOCATIONS_ENABLED
 # to override this check (e.g., cmake .. -DUSM_HOST_ALLOCATIONS_ENABLED=1)
-if(NOT FPGA_BOARD MATCHES ".usm.*" AND NOT DEFINED USM_HOST_ALLOCATIONS_ENABLED)
-    message(FATAL_ERROR "This tutorial requires a BSP that has USM host allocations enabled")
+if(NOT FPGA_BOARD MATCHES ".usm.*" AND (NOT DEFINED USM_HOST_ALLOCATIONS_ENABLED OR USM_HOST_ALLOCATIONS_ENABLED STREQUAL "0"))
+    message(FATAL_ERROR "This tutorial requires a BSP that has USM host allocations enabled.")
+endif()
+
+if (USM_HOST_ALLOCATIONS_ENABLED)
+    message(STATUS "USM_HOST_ALLOCATIONS_ENABLED set manually!")
 endif()
 
 if(UNIX)

--- a/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/simple_host_streaming/src/CMakeLists.txt
+++ b/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/simple_host_streaming/src/CMakeLists.txt
@@ -21,7 +21,7 @@ endif()
 # to ensure the BSP has the required support. Allow the user to define USM_HOST_ALLOCATIONS_ENABLED
 # to override this check (e.g., cmake .. -DUSM_HOST_ALLOCATIONS_ENABLED=1)
 if(NOT FPGA_BOARD MATCHES ".usm.*" AND (NOT DEFINED USM_HOST_ALLOCATIONS_ENABLED OR USM_HOST_ALLOCATIONS_ENABLED STREQUAL "0"))
-    message(FATAL_ERROR "This tutorial requires a BSP that has USM host allocations enabled.")
+    message(FATAL_ERROR "ERROR: This tutorial requires a BSP that has USM host allocations enabled.")
 endif()
 
 if (USM_HOST_ALLOCATIONS_ENABLED)

--- a/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/simple_host_streaming/src/CMakeLists.txt
+++ b/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/simple_host_streaming/src/CMakeLists.txt
@@ -20,8 +20,12 @@ endif()
 # this tutorial requires USM host allocations. Check the BSP name (which should contain the text 'usm')
 # to ensure the BSP has the required support. Allow the user to define USM_HOST_ALLOCATIONS_ENABLED
 # to override this check (e.g., cmake .. -DUSM_HOST_ALLOCATIONS_ENABLED=1)
-if(NOT FPGA_BOARD MATCHES ".usm.*" AND NOT DEFINED USM_HOST_ALLOCATIONS_ENABLED)
-    message(FATAL_ERROR "This tutorial requires a BSP that has USM host allocations enabled")
+if(NOT FPGA_BOARD MATCHES ".usm.*" AND (NOT DEFINED USM_HOST_ALLOCATIONS_ENABLED OR USM_HOST_ALLOCATIONS_ENABLED STREQUAL "0"))
+    message(FATAL_ERROR "This tutorial requires a BSP that has USM host allocations enabled.")
+endif()
+
+if (USM_HOST_ALLOCATIONS_ENABLED)
+    message(STATUS "USM_HOST_ALLOCATIONS_ENABLED set manually!")
 endif()
 
 # This is a Windows-specific flag that enables exception handling in host code

--- a/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/zero_copy_data_transfer/src/CMakeLists.txt
+++ b/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/zero_copy_data_transfer/src/CMakeLists.txt
@@ -21,7 +21,7 @@ endif()
 # to ensure the BSP has the required support. Allow the user to define USM_HOST_ALLOCATIONS_ENABLED
 # to override this check (e.g., cmake .. -DUSM_HOST_ALLOCATIONS_ENABLED=1)
 if(NOT FPGA_BOARD MATCHES ".usm.*" AND (NOT DEFINED USM_HOST_ALLOCATIONS_ENABLED OR USM_HOST_ALLOCATIONS_ENABLED STREQUAL "0"))
-    message(FATAL_ERROR "This tutorial requires a BSP that has USM host allocations enabled.")
+    message(FATAL_ERROR "ERROR: This tutorial requires a BSP that has USM host allocations enabled.")
 endif()
 
 if (USM_HOST_ALLOCATIONS_ENABLED)


### PR DESCRIPTION
# Existing Sample Changes
## Description
Same as [this change](https://github.com/oneapi-src/oneAPI-samples/commit/95e618298f00be070c0a0b9810461a476b26ce9f).
Previous PR: #838.

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)
- [X] Removing CMake warnings.

## How Has This Been Tested?
- [X] Command Line
- [X] Regtest