### PR TITLE
FPGA: adding stack size flag to windows linker for the qrd reference design

### DIFF
--- a/DirectProgramming/DPC++FPGA/ReferenceDesigns/qrd/src/CMakeLists.txt
+++ b/DirectProgramming/DPC++FPGA/ReferenceDesigns/qrd/src/CMakeLists.txt
@@ -17,7 +17,7 @@ endif()
 # This is a Windows-specific flag that enables error handling in host code
 if(WIN32)
     set(PLATFORM_SPECIFIC_COMPILE_FLAGS "/EHsc /Qactypes /Wall")
-    set(PLATFORM_SPECIFIC_LINK_FLAGS "/Qactypes")
+    set(PLATFORM_SPECIFIC_LINK_FLAGS "/Qactypes /F 12582912")
 else()
     set(PLATFORM_SPECIFIC_COMPILE_FLAGS "-qactypes -Wall")
     set(PLATFORM_SPECIFIC_LINK_FLAGS "")


### PR DESCRIPTION
Signed-off-by: Yohann Uguen <yohann.uguen@intel.com>

# Existing Sample Changes
## Description

When compiling on Windows, VS sets the default stack size of the resulting executable to 1MB.
This value is too small to store all the local variables of the large qrd design when targeting Stratix 10.
This change sets the stack size to 12MB, which is the default GCC value.


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Ran both the emulator and the hardware flow for Arria 10 and Stratix 10 on Windows.

- [x] Command Line
- [x] When compiling the compliler flag "-Wall -Wformat-security -Werror=format-security" was used
