### PR TITLE
Better integration of giuthub repo and Devcloud

### DIFF
--- a/DirectProgramming/DPC++/DenseLinearAlgebra/complex_mult/README.md
+++ b/DirectProgramming/DPC++/DenseLinearAlgebra/complex_mult/README.md
@@ -59,11 +59,14 @@ The include folder is located at `%ONEAPI_ROOT%\dev-utilities\latest\include` on
 ### Running Samples In DevCloud
 If running a sample in the Intel DevCloud, remember that you must specify
 the compute node (CPU, GPU, FPGA) and whether to run in batch or
-interactive mode. For more information, see the Intel® oneAPI Base Toolkit
-Get Started Guide (https://devcloud.intel.com/oneapi/get-started/base-toolkit/)
+interactive mode.
 
+For specific instructions, jump to [Run the sample in the DevCloud](#run-on-devcloud)
 
-### Using Visual Studio Code*  (Optional)
+For more information, see the Intel® oneAPI Base Toolkit
+[Get Started Guide](https://devcloud.intel.com/oneapi/get-started/base-toolkit/).
+
+### Using Visual Studio Code\*  (Optional)
 
 You can use Visual Studio Code (VS Code) extensions to set your environment, create launch configurations,
 and browse and download samples.
@@ -165,7 +168,7 @@ checks to find missing dependencies and permissions errors.
 >For more information on environment variables, see Use the setvars Script for [Linux or macOS](https://www.intel.com/content/www/us/en/develop/documentation/oneapi-programming-guide/top/oneapi-development-environment-setup/use-the-setvars-script-with-linux-or-macos.html), or [Windows](https://www.intel.com/content/www/us/en/develop/documentation/oneapi-programming-guide/top/oneapi-development-environment-setup/use-the-setvars-script-with-windows.html).
 
 
-### On a Linux* System
+### On a Linux\* System
    * Build the program using Make
     make all
 
@@ -175,7 +178,8 @@ checks to find missing dependencies and permissions errors.
    * Clean the program
     make clean
 
-### On a Windows* System Using Visual Studio* Version 2017 or Newer
+### On a Windows\* System Using Visual Studio\* Version 2017 or Newer
+
 - Build the program using VS2017 or VS2019
     - Right-click on the solution file and open using either VS2017 or VS2019 IDE.
     - Right-click on the project in Solution Explorer and select Rebuild.
@@ -206,6 +210,49 @@ There are no editable parameters for this sample.
 	Complex multiplication successfully run on the device
 
 ```
+
+### Running the sample in the DevCloud<a name="run-on-devcloud"></a>
+
+#### Build and run
+
+To launch build and run jobs on DevCloud submit scripts to PBS through the qsub utility.
+> Note that all parameters are already specified in the build and run scripts.
+
+1. Build the sample on a gpu node.
+
+    ```bash
+    qsub build.sh
+    ```
+
+2. When the build job completes, there will be a `build.sh.oXXXXXX` file in the directory. After the build job completes, run the sample on a gpu node:
+
+    ```bash
+    qsub run.sh
+    ```
+
+#### Additional information
+
+1. In order to inspect the job progress, use the qstat utility.
+
+    ```bash
+    watch -n 1 qstat -n -1
+    ```
+
+    > Note: The watch `-n 1` command is used to run `qstat -n -1` and display its results every second.
+
+2. When a job terminates, a couple of files are written to the disk:
+
+    <script_name>.sh.eXXXX, which is the job stderr
+
+    <script_name>.sh.oXXXX, which is the job stdout
+
+    > Here XXXX is the job ID, which gets printed to the screen after each qsub command.
+
+3. To inspect the output of the sample use cat command.
+
+    ```bash
+    cat run.sh.oXXXX
+    ```
 
 ### Build and run additional samples
 

--- a/DirectProgramming/DPC++/DenseLinearAlgebra/complex_mult/build.sh
+++ b/DirectProgramming/DPC++/DenseLinearAlgebra/complex_mult/build.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+#PBS -l nodes=1:gpu:ppn=2
+#PBS -d .
+
+source /opt/intel/oneapi/setvars.sh > /dev/null 2>&1
+
+echo
+echo start: $(date "+%y/%m/%d %H:%M:%S.%3N")
+echo
+
+make all
+
+make build_usm
+
+echo
+echo stop: $(date "+%y/%m/%d %H:%M:%S.%3N")
+echo

--- a/DirectProgramming/DPC++/DenseLinearAlgebra/complex_mult/run.sh
+++ b/DirectProgramming/DPC++/DenseLinearAlgebra/complex_mult/run.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+#PBS -l nodes=1:gpu:ppn=2
+#PBS -d .
+
+source /opt/intel/oneapi/setvars.sh > /dev/null 2>&1
+
+echo
+echo start: $(date "+%y/%m/%d %H:%M:%S.%3N")
+echo
+
+make run
+
+echo
+echo end: $(date "+%y/%m/%d %H:%M:%S.%3N")
+echo


### PR DESCRIPTION
# Existing Sample Changes
## Description

The DevCloud uses a batch system for processing. To get the samples to run, users need to know how to create the script or know how to request an interactive mode.

To make it easier for DevCloud users to run the sample, I created scripts to build (`build.sh`) and run (`run.sh`) on DevCloud. Proper documentation explaining the process has been added to README.md.

This is the first change for better integration of oneAPI samples repository with DevCloud. It will be later followed by others for the remaining samples, according to the guidelines from this PR.

Fixes Issue# 

## External Dependencies

List any external dependencies created as a result of this change.

## Type of change

Please delete options that are not relevant. Add a 'X' to the one that is applicable. 

- [X] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [X] Command Line
