### PR TITLE
depfiles break the HTML-file for FPGA optimization report

### DIFF
--- a/DirectProgramming/DPC++FPGA/Tutorials/Features/kernel_args_restrict/CMakeLists.txt
+++ b/DirectProgramming/DPC++FPGA/Tutorials/Features/kernel_args_restrict/CMakeLists.txt
@@ -16,5 +16,6 @@ project(KernelArgsRestrict CXX)
 set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})
 set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})
+unset(CMAKE_DEPFILE_FLAGS_CXX) # depfiles may break the generated HTML-file for optimization report
 
 add_subdirectory (src)


### PR DESCRIPTION

The depfiles may break the generated HTML-file for FPGA optimization report.
The added line here needs to be added for every cmake files in DPC++FPGA.

# Existing Sample Changes
## Description

Recent cmake versions (e.g. 3.20.x and 3.21.x are tested) add the generation of depfiles via `CMAKE_DEPFILE_FLAGS_${LANG}` in Makefile generator, which may break the generated HTML-file for FPGA optimization report. Unset this variable can fix the problem for the generated `report.html`.