### PR TITLE
Update default seeds for FPGA gzip Reference Design for S10

### DIFF
--- a/DirectProgramming/DPC++FPGA/ReferenceDesigns/gzip/src/CMakeLists.txt
+++ b/DirectProgramming/DPC++FPGA/ReferenceDesigns/gzip/src/CMakeLists.txt
@@ -48,7 +48,7 @@ elseif(FPGA_BOARD MATCHES ".*s10.*")
     # S10 parameters
     set(NUM_ENGINES 2)
     if(DEFINED LOW_LATENCY)
-        set(SEED "-Xsseed=19")
+        set(SEED "-Xsseed=16")
         set(NUM_REORDER "")
     else()
         set(SEED "-Xsseed=4")

--- a/DirectProgramming/DPC++FPGA/ReferenceDesigns/gzip/src/CMakeLists.txt
+++ b/DirectProgramming/DPC++FPGA/ReferenceDesigns/gzip/src/CMakeLists.txt
@@ -51,7 +51,7 @@ elseif(FPGA_BOARD MATCHES ".*s10.*")
         set(SEED "-Xsseed=19")
         set(NUM_REORDER "")
     else()
-        set(SEED "-Xsseed=18")
+        set(SEED "-Xsseed=4")
         # For the High Bandwidth variant, specify 6 reordering units to improve global memory read bandwidth across 4 channels of DDR.
         # For Low Latency variant this is not necessary since only one channel of global memory is used (host memory).
         set(NUM_REORDER "-Xsnum-reorder=6")


### PR DESCRIPTION
# Existing Sample Changes
## Description

Updating seed for 2022.2 to meet published perf target

## Type of change

- [ X] Bug fix (non-breaking change which fixes an issue)


## How Has This Been Tested?
Ran oneapi_code_samples/gzip/gzip_high_bw and gzip_ll regtests and verified we get 11.0 GB/s and 7.0GB/s respectively