### PR TITLE
Require pyyaml 6.0+ due to CVE-2020-14343

### DIFF
--- a/AI-and-Analytics/Features-and-Functionality/IntelTensorFlow_Horovod_Multinode_Training/horovod-feedstock/meta.yaml
+++ b/AI-and-Analytics/Features-and-Functionality/IntelTensorFlow_Horovod_Multinode_Training/horovod-feedstock/meta.yaml
@@ -51,7 +51,7 @@ requirements:
     - intel-openmp
     - tensorflow 2.4.*
     - cloudpickle
-    - pyyaml
+    - pyyaml >=6.0
     - psutil
     - oneccl-devel
     - pip
@@ -61,7 +61,7 @@ requirements:
     - intel-openmp
     - tensorflow 2.4.*
     - cloudpickle
-    - pyyaml
+    - pyyaml >=6.0
     - psutil
     - oneccl-devel
     - impi_rt


### PR DESCRIPTION
# Existing Sample Changes
## Description

pyyaml < 6.0 is vulnerable to [CVE-2020-14343](https://nvd.nist.gov/vuln/detail/CVE-2020-14343) and/or related gap in original fix.  See discussion [here](https://github.com/yaml/pyyaml/issues/420).  In order to safeguard users, we should require pyyaml 6.0+.

## External Dependencies

None

## Type of change

Please delete options that are not relevant. Add a 'X' to the one that is applicable. 

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Implement fixes for ONSAM Jiras

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

No testing.  This PR is meant to illustrate a proposed change for review and testing by the sample owner.

