### PR TITLE
Fixing spelling of "lambda"

### DIFF
--- a/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/buffered_host_streaming/src/streaming_with_api.hpp
+++ b/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/buffered_host_streaming/src/streaming_with_api.hpp
@@ -131,7 +131,7 @@ void DoOneIterationAPI(queue& q, size_t buffers, size_t buffer_count,
   start = high_resolution_clock::now();
 
   // Start the producer thread.
-  // The code in the lamda runs in a different thread and therefore does not
+  // The code in the lambda runs in a different thread and therefore does not
   // block the process of the 'main' thread.
   std::thread producer_thread([&] {
     size_t rep = 0;

--- a/DirectProgramming/DPC++FPGA/include/unrolled_loop.hpp
+++ b/DirectProgramming/DPC++FPGA/include/unrolled_loop.hpp
@@ -133,7 +133,7 @@ using make_index_pow2_sequence = integer_pow2_sequence<std::size_t, N>;
 // Templated on:
 //    ItType    - the type of the iterator (size_t, int, char, ...)
 //    ItType... - the indices to iterate on
-//    F         - the function to run for each index (i.e. the lamda)
+//    F         - the function to run for each index (i.e. the lambda)
 //
 template <class ItType, ItType... inds, class F>
 constexpr void UnrolledLoop(std::integer_sequence<ItType, inds...>, F&& f) {


### PR DESCRIPTION
# Existing Sample Changes
## Description
Fixing spelling

## Type of change
- [X] spelling

## How Has This Been Tested?
N/A