### PR TITLE
ONSAM-1467 atomic_ref is no longer extension

### DIFF
--- a/Publications/DPC++/Ch19_memory_model_and_atomics/fig_19_7_avoid_data_race_with_atomics.cpp
+++ b/Publications/DPC++/Ch19_memory_model_and_atomics/fig_19_7_avoid_data_race_with_atomics.cpp
@@ -7,7 +7,6 @@
 #include <iostream>
 
 using namespace sycl;
-using namespace sycl::ext::oneapi;
 int main() {
 
   queue Q;


### PR DESCRIPTION
# Existing Sample Changes
## Description

atomic_ref is no longer extension

Fixes Issue# 

## External Dependencies

None

## Type of change

Please delete options that are not relevant. Add a 'X' to the one that is applicable. 

- [X] Implement fixes for ONSAM Jiras

## How Has This Been Tested?

- [X] Command Line