### PR TITLE
Fixed iota in FPGA pipes tutorial

### DIFF
--- a/DirectProgramming/DPC++FPGA/Tutorials/Features/pipes/src/pipes.cpp
+++ b/DirectProgramming/DPC++FPGA/Tutorials/Features/pipes/src/pipes.cpp
@@ -14,10 +14,10 @@
 using namespace sycl;
 
 using ProducerToConsumerPipe =
-    ext::intel::pipe<               // Defined in the SYCL headers.
-      class ProducerConsumerPipe,   // An identifier for the pipe.
-      int,                          // The type of data in the pipe.
-      4>;                           // The capacity of the pipe.
+    ext::intel::pipe<                 // Defined in the SYCL headers.
+      class ProducerConsumerPipeId,   // An identifier for the pipe.
+      int,                            // The type of data in the pipe.
+      4>;                             // The capacity of the pipe.
 
 // Forward declare the kernel names in the global scope.
 // This FPGA best practice reduces name mangling in the optimization reports.

--- a/DirectProgramming/DPC++FPGA/Tutorials/Features/pipes/src/pipes.cpp
+++ b/DirectProgramming/DPC++FPGA/Tutorials/Features/pipes/src/pipes.cpp
@@ -100,7 +100,7 @@ int main(int argc, char *argv[]) {
   std::vector<int> consumer_output(array_size, -1);
 
   // Initialize the input data with numbers from 0, 1, 2, ..., array_size-1
-  std::iota(producer_input.begin(), producer_input.begin(), 0);
+  std::iota(producer_input.begin(), producer_input.end(), 0);
 
 #if defined(FPGA_EMULATOR)
   ext::intel::fpga_emulator_selector device_selector;

--- a/DirectProgramming/DPC++FPGA/Tutorials/Features/pipes/src/pipes.cpp
+++ b/DirectProgramming/DPC++FPGA/Tutorials/Features/pipes/src/pipes.cpp
@@ -13,10 +13,11 @@
 
 using namespace sycl;
 
-using ProducerToConsumerPipe = ext::intel::pipe<  // Defined in the SYCL headers.
-    class ProducerConsumerPipe,              // An identifier for the pipe.
-    int,                                     // The type of data in the pipe.
-    4>;                                      // The capacity of the pipe.
+using ProducerToConsumerPipe =
+    ext::intel::pipe<               // Defined in the SYCL headers.
+      class ProducerConsumerPipe,   // An identifier for the pipe.
+      int,                          // The type of data in the pipe.
+      4>;                           // The capacity of the pipe.
 
 // Forward declare the kernel names in the global scope.
 // This FPGA best practice reduces name mangling in the optimization reports.

--- a/DirectProgramming/DPC++FPGA/Tutorials/Features/pipes/src/pipes.cpp
+++ b/DirectProgramming/DPC++FPGA/Tutorials/Features/pipes/src/pipes.cpp
@@ -12,10 +12,9 @@
 
 using namespace sycl;
 
-class ProducerConsumerPipeId;
 using ProducerToConsumerPipe =
     ext::intel::pipe<                 // Defined in the SYCL headers.
-      ProducerConsumerPipeId,         // An identifier for the pipe.
+      class ProducerConsumerPipeId,   // An identifier for the pipe.
       int,                            // The type of data in the pipe.
       4>;                             // The capacity of the pipe.
 

--- a/DirectProgramming/DPC++FPGA/Tutorials/Features/pipes/src/pipes.cpp
+++ b/DirectProgramming/DPC++FPGA/Tutorials/Features/pipes/src/pipes.cpp
@@ -10,12 +10,12 @@
 // e.g., $ONEAPI_ROOT/dev-utilities//include/dpc_common.hpp
 #include "dpc_common.hpp"
 
-
 using namespace sycl;
 
+class ProducerConsumerPipeId;
 using ProducerToConsumerPipe =
     ext::intel::pipe<                 // Defined in the SYCL headers.
-      class ProducerConsumerPipeId,   // An identifier for the pipe.
+      ProducerConsumerPipeId,         // An identifier for the pipe.
       int,                            // The type of data in the pipe.
       4>;                             // The capacity of the pipe.
 


### PR DESCRIPTION
# Existing Sample Changes
## Description
Fixing a host call to std::iota in the FPGA pipes tutorial. Previously the call to iota didn't actually initialize anything.

Fixes #903 

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
- [X] Command Line