### PR TITLE
a fix for ONSAM-1475

### DIFF
--- a/Libraries/oneDNN/tutorials/tutorial_verbose_jitdump.ipynb
+++ b/Libraries/oneDNN/tutorials/tutorial_verbose_jitdump.ipynb
@@ -172,6 +172,7 @@
     "!cp $ONEAPI_INSTALL/dnnl/latest/cpu_dpcpp_gpu_dpcpp/examples/cnn_inference_f32.cpp lab/\n",
     "!cp $ONEAPI_INSTALL/dnnl/latest/cpu_dpcpp_gpu_dpcpp/examples/example_utils.hpp lab/\n",
     "!cp $ONEAPI_INSTALL/dnnl/latest/cpu_dpcpp_gpu_dpcpp/examples/example_utils.h lab/\n",
+    "!cp $ONEAPI_INSTALL/dnnl/latest/cpu_dpcpp_gpu_dpcpp/examples/dpcpp_driver_check.cmake lab/\n",
     "!cp $ONEAPI_INSTALL/dnnl/latest/cpu_dpcpp_gpu_dpcpp/examples/CMakeLists.txt lab/"
    ]
   },


### PR DESCRIPTION
# Existing Sample Changes
## Description

a fix for ONSAM-1475 related to compiling failure.

Fixes Issue# ONSAM-1475

## External Dependencies

No.

## Type of change

Please delete options that are not relevant. Add a 'X' to the one that is applicable. 

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Implement fixes for ONSAM Jiras

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Command Line
- [ ] oneapi-cli
- [ ] Visual Studio
- [ ] Eclipse IDE
- [ ] VSCode
- [ ] When compiling the compliler flag "-Wall -Wformat-security -Werror=format-security" was used

