### PR TITLE
Removing Function Pointer from CI

### DIFF
--- a/DirectProgramming/C++/CompilerInfrastructure/OpenMP_Offload_Features/README.md
+++ b/DirectProgramming/C++/CompilerInfrastructure/OpenMP_Offload_Features/README.md
@@ -28,7 +28,7 @@ The table below shows the designs and the demonstrated feature(s).
 | Design                           | Feature(s) Utilized
 | :---                             |:---
 | class_member_functor             | Usage of functor in an OpenMP offload region
-| function_pointer                 | Function called through a function pointer in an offload region (currently only for CPU target)
+| function_pointer                 | Function called through a function pointer in an offload region
 | user_defined_mapper              | Usage of the user defined mapper feature in target region map clauses
 | usm_and_composabilty_with_dpcpp  | Unified shared memory and composability with DPC++
 

--- a/DirectProgramming/C++/CompilerInfrastructure/OpenMP_Offload_Features/README.md
+++ b/DirectProgramming/C++/CompilerInfrastructure/OpenMP_Offload_Features/README.md
@@ -28,7 +28,7 @@ The table below shows the designs and the demonstrated feature(s).
 | Design                           | Feature(s) Utilized
 | :---                             |:---
 | class_member_functor             | Usage of functor in an OpenMP offload region
-| function_pointer                 | Function called through a function pointer in an offload region
+| function_pointer                 | Function called through a function pointer in an offload region (currently only for CPU target)
 | user_defined_mapper              | Usage of the user defined mapper feature in target region map clauses
 | usm_and_composabilty_with_dpcpp  | Unified shared memory and composability with DPC++
 

--- a/DirectProgramming/C++/CompilerInfrastructure/OpenMP_Offload_Features/sample.json
+++ b/DirectProgramming/C++/CompilerInfrastructure/OpenMP_Offload_Features/sample.json
@@ -18,6 +18,7 @@
           "cmake ..",
           "make",
           "make run_prog1",
+          "make run_prog2",
           "make run_prog3",
           "make clean"
         ]

--- a/DirectProgramming/C++/CompilerInfrastructure/OpenMP_Offload_Features/sample.json
+++ b/DirectProgramming/C++/CompilerInfrastructure/OpenMP_Offload_Features/sample.json
@@ -18,7 +18,6 @@
           "cmake ..",
           "make",
           "make run_prog1",
-          "make run_prog2",
           "make run_prog3",
           "make clean"
         ]

--- a/DirectProgramming/C++/CompilerInfrastructure/OpenMP_Offload_Features/src/CMakeLists.txt
+++ b/DirectProgramming/C++/CompilerInfrastructure/OpenMP_Offload_Features/src/CMakeLists.txt
@@ -10,7 +10,7 @@ add_executable(prog1 class_member_functor.cpp)
 add_custom_target(run_prog1 ./prog1)
 
 add_executable(prog2 function_pointer.cpp)
-add_custom_target(run_prog2 ./prog2)
+add_custom_target(run_prog2 ${CMAKE_COMMAND} -E env OMP_TARGET_OFFLOAD=DISABLED ./prog2)
 
 add_executable(prog3 user_defined_mapper.cpp)
 add_custom_target(run_prog3 ./prog3)


### PR DESCRIPTION
prog2 from CI automated test

There's a regression in how the compiler handles function pointers when offloading to GPU. Removing that sample from CI.
