### PR TITLE
Use IntelDPCPPConfig in array-transform sample

### DIFF
--- a/Tools/ApplicationDebugger/array-transform/CMakeLists.txt
+++ b/Tools/ApplicationDebugger/array-transform/CMakeLists.txt
@@ -1,6 +1,19 @@
-cmake_minimum_required (VERSION 3.4)
-set (CMAKE_CXX_COMPILER "dpcpp")
+cmake_minimum_required (VERSION 3.20)
 project (array-transform LANGUAGES CXX)
+
+set(CMAKE_C_COMPILER "icx")
+set(CMAKE_CXX_COMPILER "icpx")
+if (UNIX)
+  set(IntelDPCPP_DIR $ENV{ONEAPI_ROOT}/compiler/latest/linux/IntelDPCPP)
+  set(ENV{SYCL_INCLUDE_DIR_HINT} "$ENV{ONEAPI_ROOT}/compiler/latest/linux")
+  set(ENV{SYCL_LIBRARY_DIR_HINT} "$ENV{ONEAPI_ROOT}/compiler/latest/linux")
+elseif (WIN32)
+  set(IntelDPCPP_DIR $ENV{ONEAPI_ROOT}/compiler/latest/windows/IntelDPCPP)
+  set(ENV{SYCL_INCLUDE_DIR_HINT} "$ENV{ONEAPI_ROOT}/compiler/latest/windows")
+  set(ENV{SYCL_LIBRARY_DIR_HINT} "$ENV{ONEAPI_ROOT}/compiler/latest/windows")
+endif ()
+
+find_package(IntelDPCPP REQUIRED)
 
 if (NOT CMAKE_CXX_STANDARD)
   set (CMAKE_CXX_STANDARD 17)


### PR DESCRIPTION
# Existing Sample Changes
## Description

Take advantage of IntelDPCPPConfig.cmake module in compiler/latest/linux/IntelDPCPP.
Using this module requires cmake 3.20 (linux) or 3.22.3 (windows) or newer.

## Type of change

Please delete options that are not relevant. Add a 'X' to the one that is applicable. 

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Implement fixes for ONSAM Jiras

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [X] Command Line
- [ ] oneapi-cli
- [ ] Visual Studio
- [ ] Eclipse IDE
- [ ] VSCode
- [ ] When compiling the compliler flag "-Wall -Wformat-security -Werror=format-security" was used
