### PR TITLE
Fixing array initialization to prevent overflow

### DIFF
--- a/DirectProgramming/DPC++FPGA/Tutorials/Features/pipes/src/pipes.cpp
+++ b/DirectProgramming/DPC++FPGA/Tutorials/Features/pipes/src/pipes.cpp
@@ -99,8 +99,12 @@ int main(int argc, char *argv[]) {
   std::vector<int> producer_input(array_size, -1);
   std::vector<int> consumer_output(array_size, -1);
 
-  // Initialize the input data with numbers from 0, 1, 2, ..., array_size-1
-  std::iota(producer_input.begin(), producer_input.end(), 0);
+  // Initialize the input data with random numbers smaller than 46340.
+  // Any number larger than this will have integer overflow when squared. 
+  constexpr int max_val = 46340;
+  for (size_t i = 0; i < array_size; i++) {
+    producer_input[i] = rand() % max_val;
+  }
 
 #if defined(FPGA_EMULATOR)
   ext::intel::fpga_emulator_selector device_selector;


### PR DESCRIPTION
Signed-off-by: Justin Rosner <justin.rosner@intel.com>

# Fixing overflow in the pipes FPGA Code Sample 

## Description

This PR fixes array initialization in the pipes tutorial so that no integer overflow occurs, as signed integer overflow is undefined behaviour.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [X] Command Line
