### PR TITLE
DPC++ to SYCL changes in DPC++FPGA

### DIFF
--- a/DirectProgramming/DPC++FPGA/ReferenceDesigns/anr/README.md
+++ b/DirectProgramming/DPC++FPGA/ReferenceDesigns/anr/README.md
@@ -1,42 +1,44 @@
 # Adaptive Noise Reduction (ANR)
-This DPC++ reference design demonstrates a highly optimized image sensor adaptive noise reduction (ANR) algorithm on an FPGA.
+This SYCL*-compliant reference design demonstrates a highly optimized image sensor adaptive noise reduction (ANR) algorithm for field programmable gate arrays (FPGAs).
 
-***Documentation***:
-* [DPC++ FPGA Code Samples Guide](https://software.intel.com/content/www/us/en/develop/articles/explore-dpcpp-through-intel-fpga-code-samples.html) helps you to navigate the samples and build your knowledge of DPC++ for FPGA. <br>
-* [oneAPI DPC++ FPGA Optimization Guide](https://software.intel.com/content/www/us/en/develop/documentation/oneapi-fpga-optimization-guide) is the reference manual for targeting FPGAs through DPC++. <br>
-* [oneAPI Programming Guide](https://software.intel.com/en-us/oneapi-programming-guide) is a general resource for target-independent DPC++ programming.
-
-| Optimized for                     | Description
+| Property                     | Description
 ---                                 |---
-| OS                                | Ubuntu* 18.04/20.04, RHEL*/CentOS* 8, SUSE* 15; Windows* 10
-| Hardware                          | Intel&reg; Programmable Acceleration Card (PAC) with Intel Arria&reg; 10 GX FPGA <br> Intel&reg; FPGA Programmable Acceleration Card (PAC) D5005 (with Intel Stratix&reg; 10 SX) <br> Intel Xeon&reg; CPU E5-1650 v2 @ 3.50GHz (host machine)
-| Software                          | Intel&reg; oneAPI DPC++ Compiler <br> Intel&reg; FPGA Add-On for oneAPI Base Toolkit
-| What you will learn               | How to create a parameterizable image processing pipeline to implement an Adaptive Noise Reduction (ANR) algorithm on an FPGA.
-| Time to complete                  | 1 hour
+| What you will learn               | How to create a parameterizable image processing pipeline to implement an Adaptive Noise Reduction (ANR) algorithm on a FPGA.
+| Time to complete                  | ~1 hour
 
 ## Purpose
-This FPGA reference design demonstrates a parameterizable image processing pipeline that implements an Adaptive Noise Reduction (ANR) algorithm using a bilateral filter. See the [Additional Design Information Section](#additional-design-information) for more information on the ANR algorithm itself and how it was implemented for the FPGA.
+This FPGA reference design demonstrates a parameterizable image processing pipeline that implements an Adaptive Noise Reduction (ANR) algorithm using a bilateral filter. 
 
-## License
-Code samples are licensed under the MIT license. See
-[License.txt](https://github.com/oneapi-src/oneAPI-samples/blob/master/License.txt) for details.
+See the [Additional Design Information Section](#additional-design-information) for more information on the ANR algorithm itself and how it was implemented for the FPGA.
+
+## Prerequisites
+
+| Optimized for                     | Description
+|:---                               |:---
+| OS                                | Ubuntu* 18.04/20.04 <bR>RHEL*/CentOS* 8 <BR>SUSE* 15 <BR>Windows* 10
+| Hardware                          | Intel&reg; Programmable Acceleration Card (PAC) with Intel Arria&reg; 10 GX FPGA <br>Intel&reg; FPGA Programmable Acceleration Card (PAC) D5005 (with Intel Stratix&reg; 10 SX) <br>Intel Xeon&reg; CPU E5-1650 v2 @ 3.50GHz (host machine)
+| Software                          | Intel&reg; oneAPI DPC++ Compiler <br>Intel&reg; FPGA Add-On for oneAPI Base Toolkit
+
+### Additional Documentation
+- [Explore SYCL* Through Intel&reg; FPGA Code Samples](https://software.intel.com/content/www/us/en/develop/articles/explore-dpcpp-through-intel-fpga-code-samples.html) helps you to navigate the samples and build your knowledge of FPGAs and SYCL.
+- [FPGA Optimization Guide for Intel&reg; oneAPI Toolkits](https://software.intel.com/content/www/us/en/develop/documentation/oneapi-fpga-optimization-guide) helps you understand how to target FPGAs using SYCL and Intel&reg; oneAPI Toolkits.
+- [Intel&reg; oneAPI Programming Guide](https://software.intel.com/en-us/oneapi-programming-guide) helps you understand target-independent, SYCL-compliant programming using Intel&reg; oneAPI Toolkits.
 
 ### Using Visual Studio Code*  (Optional)
 
-You can use Visual Studio Code (VS Code) extensions to set your environment,
+You can use Visual Studio Code* (VS Code) extensions to set your environment,
 create launch configurations, and browse and download samples.
 
 The basic steps to build and run a sample using VS Code include:
- - Download a sample using the extension **Code Sample Browser for Intel oneAPI Toolkits**.
- - Configure the oneAPI environment with the extension **Environment Configurator for Intel oneAPI Toolkits**.
+ - Download a sample using the extension **Code Sample Browser for Intel&reg; oneAPI Toolkits**.
+ - Configure the oneAPI environment with the extension **Environment Configurator for Intel&reg;oneAPI Toolkits**.
  - Open a Terminal in VS Code (**Terminal>New Terminal**).
  - Run the sample in the VS Code terminal using the instructions below.
- - (Linux only) Debug your GPU application with GDB for Intel® oneAPI toolkits using the Generate Launch Configurations extension.
+ - (Linux only) Debug your GPU application with GDB for Intel&reg; oneAPI toolkits using the Generate Launch Configurations extension.
 
 To learn more about the extensions, see
-[Using Visual Studio Code with Intel® oneAPI Toolkits](https://software.intel.com/content/www/us/en/develop/documentation/using-vs-code-with-intel-oneapi/top.html).
+[Using Visual Studio Code with Intel&reg; oneAPI Toolkits User Guide](https://software.intel.com/content/www/us/en/develop/documentation/using-vs-code-with-intel-oneapi/top.html).
 
-After learning how to use the extensions for Intel oneAPI Toolkits, return to this readme for instructions on how to build and run a sample.
 
 ## Building the Reference Design
 
@@ -44,11 +46,12 @@ After learning how to use the extensions for Intel oneAPI Toolkits, return to th
 > environment by sourcing  the `setvars` script located in
 > the root of your oneAPI installation.
 >
-> Linux Sudo: . /opt/intel/oneapi/setvars.sh
+> Linux:
+> - For system wide installations: `. /opt/intel/oneapi/setvars.sh`
+> - For private installations: `. ~/intel/oneapi/setvars.sh`
 >
-> Linux User: . ~/intel/oneapi/setvars.sh
->
-> Windows: C:\Program Files(x86)\Intel\oneAPI\setvars.bat
+> Windows:
+> - `C:\Program Files(x86)\Intel\oneAPI\setvars.bat`
 >
 >For more information on environment variables, see Use the setvars Script for [Linux or macOS](https://www.intel.com/content/www/us/en/develop/documentation/oneapi-programming-guide/top/oneapi-development-environment-setup/use-the-setvars-script-with-linux-or-macos.html), or [Windows](https://www.intel.com/content/www/us/en/develop/documentation/oneapi-programming-guide/top/oneapi-development-environment-setup/use-the-setvars-script-with-windows.html).
 
@@ -56,12 +59,12 @@ After learning how to use the extensions for Intel oneAPI Toolkits, return to th
 ### Include Files
 The include folder is located at `%ONEAPI_ROOT%\dev-utilities\latest\include` on your development system.
 
-### Running Code Samples in DevCloud
-If running a sample in the Intel DevCloud, remember that you must specify the type of compute node and whether to run in batch or interactive mode. Compiles to FPGA are only supported on fpga_compile nodes. Executing programs on FPGA hardware is only supported on fpga_runtime nodes of the appropriate type, such as fpga_runtime:arria10 or fpga_runtime:stratix10.  Neither compiling nor executing programs on FPGA hardware are supported on the login nodes. For more information, see the Intel® oneAPI Base Toolkit Get Started Guide ([https://devcloud.intel.com/oneapi/documentation/base-toolkit/](https://devcloud.intel.com/oneapi/documentation/base-toolkit/)).
+### Run Code Sample in DevCloud
+If running a sample in the Intel DevCloud, remember that you must specify the type of compute node and whether to run in batch or interactive mode. Compiles to FPGA are only supported on fpga_compile nodes. Executing programs on FPGA hardware is only supported on fpga_runtime nodes of the appropriate type, such as fpga_runtime:arria10 or fpga_runtime:stratix10.  Neither compiling nor executing programs on FPGA hardware are supported on the login nodes. For more information, see [Intel&reg; DevCloud for oneAPI documentation](https://devcloud.intel.com/oneapi/documentation/base-toolkit/).
 
 When compiling for FPGA hardware, it is recommended to increase the job timeout to 24h.
 
-### On a Linux* System
+### On Linux*
 1. Install the design into a directory `build` from the design directory by running `cmake`:
 
    ```
@@ -69,13 +72,13 @@ When compiling for FPGA hardware, it is recommended to increase the job timeout 
    cd build
    ```
 
-   If you are compiling for the Intel® PAC with Intel Arria® 10 GX FPGA, run `cmake` using the command:
+   If you are compiling for the Intel&reg; PAC with Intel Arria&reg; 10 GX FPGA, run `cmake` using the command:
 
    ```
    cmake ..
    ```
 
-   If instead you are compiling for the Intel® FPGA PAC D5005 (with Intel Stratix® 10 SX), run `cmake` using the command:
+   If instead you are compiling for the Intel&reg; FPGA PAC D5005 (with Intel Stratix&reg; 10 SX), run `cmake` using the command:
 
    ```
    cmake .. -DFPGA_BOARD=intel_s10sx_pac:pac_s10
@@ -101,19 +104,19 @@ When compiling for FPGA hardware, it is recommended to increase the job timeout 
        make fpga
        ```
 
-3. (Optional) As the above hardware compile may take several hours to complete, FPGA precompiled binaries (compatible with Linux* Ubuntu* 18.04) can be downloaded <a href="https://iotdk.intel.com/fpga-precompiled-binaries/latest/anr.fpga.tar.gz" download>here</a>.
+3. (Optional) As the above hardware compile may take several hours to complete, you can download FPGA precompiled binaries (compatible with Linux* Ubuntu* 18.04) from [https://iotdk.intel.com/fpga-precompiled-binaries/latest/anr.fpga.tar.gz](https://iotdk.intel.com/fpga-precompiled-binaries/latest/anr.fpga.tar.gz).
 
-### On a Windows* System
+### On Windows*
 1. Generate the `Makefile` by running `cmake`.
      ```
    mkdir build
    cd build
    ```
-   To compile for the Intel® PAC with Intel Arria® 10 GX FPGA, run `cmake` using the command:
+   To compile for the Intel&reg; PAC with Intel Arria&reg; 10 GX FPGA, run `cmake` using the command:
     ```
     cmake -G "NMake Makefiles" ..
    ```
-   Alternatively, to compile for the Intel® FPGA PAC D5005 (with Intel Stratix® 10 SX), run `cmake` using the command:
+   Alternatively, to compile for the Intel&reg; FPGA PAC D5005 (with Intel Stratix&reg; 10 SX), run `cmake` using the command:
    ```
    cmake -G "NMake Makefiles" .. -DFPGA_BOARD=intel_s10sx_pac:pac_s10
    ```
@@ -129,24 +132,24 @@ When compiling for FPGA hardware, it is recommended to increase the job timeout 
      ```
    * An FPGA hardware target is not provided on Windows*.
 
-*Note:* The Intel® PAC with Intel Arria® 10 GX FPGA and Intel® FPGA PAC D5005 (with Intel Stratix® 10 SX) do not yet support Windows*. Compiling to FPGA hardware on Windows* requires a third-party or custom Board Support Package (BSP) with Windows* support.<br>
-*Note:* If you encounter any issues with long paths when compiling under Windows*, you may have to create your ‘build’ directory in a shorter path, for example c:\samples\build.  You can then run cmake from that directory, and provide cmake with the full path to your sample directory.
+> **Note**: The Intel&reg; PAC with Intel Arria&reg; 10 GX FPGA and Intel&reg; FPGA PAC D5005 (with Intel Stratix&reg; 10 SX) do not yet support Windows*. Compiling to FPGA hardware on Windows* requires a third-party or custom Board Support Package (BSP) with Windows* support.
 
-
+> **Note**: If you encounter any issues with long paths when compiling under Windows*, you may have to create your ‘build’ directory in a shorter path, for example c:\samples\build.  You can then run cmake from that directory, and provide cmake with the full path to your sample directory.
 
 If an error occurs, you can get more details by running `make` with
 the `VERBOSE=1` argument:
-``make VERBOSE=1``
+```
+make VERBOSE=1
+```
 For more comprehensive troubleshooting, use the Diagnostics Utility for
-Intel® oneAPI Toolkits, which provides system checks to find missing
-dependencies and permissions errors.
-[Learn more](https://software.intel.com/content/www/us/en/develop/documentation/diagnostic-utility-user-guide/top.html).
+Intel&reg; oneAPI Toolkits, which provides system checks to find missing
+dependencies and permissions errors. See the [Diagnostics Utility for Intel&reg; oneAPI Toolkits User Guide](https://software.intel.com/content/www/us/en/develop/documentation/diagnostic-utility-user-guide/top.html).
 
 ### In Third-Party Integrated Development Environments (IDEs)
 
-You can compile and run this Reference Design in the Eclipse* IDE (in Linux*) and the Visual Studio* IDE (in Windows*). For instructions, refer to the following link: [Intel® oneAPI DPC++ FPGA Workflows on Third-Party IDEs](https://www.intel.com/content/www/us/en/developer/articles/technical/intel-oneapi-dpcpp-fpga-workflow-on-ide.html)
+You can compile and run this Reference Design in the Eclipse* IDE (in Linux*) and the Visual Studio* IDE (in Windows*). For instructions, refer to the following link: [FPGA Workflows on Third-Party IDEs for Intel&reg; oneAPI Toolkits](https://www.intel.com/content/www/us/en/developer/articles/technical/intel-oneapi-dpcpp-fpga-workflow-on-ide.html).
 
-## Running the Reference Design
+## Run the Reference Design
 
  1. Run the sample on the FPGA emulator (the kernel executes on the CPU).
      ```
@@ -160,7 +163,7 @@ You can compile and run this Reference Design in the Eclipse* IDE (in Linux*) an
      anr.fpga.exe      (Windows)
      ```
 
-### Example of Output
+## Example Output
 You should see output similar to the following in the console:
 ```
 Runs:             2
@@ -175,7 +178,7 @@ Execution time: 45.0012 ms
 Throughput: 488.876 MB/s
 PASSED
 ```
-NOTE: When running on the FPGA emulator, the *Execution time* and *Throughput* do not reflect the design's actual hardware performance.
+> **Note**: When running on the FPGA emulator, the *Execution time* and *Throughput* do not reflect the design's actual hardware performance.
 
 
 ## Additional Design Information
@@ -205,9 +208,9 @@ The ANR algorithm works on an input image that is in [Bayer format](https://en.w
 
 <img src="bayer.png" alt="bayer" width="400"/>
 
-The ANR algorithm uses a [bilateral filter](https://en.wikipedia.org/wiki/Bilateral_filter). Unilateral filters (e.g., a [Box blur](https://en.wikipedia.org/wiki/Box_blur) or [Gaussian blur](https://en.wikipedia.org/wiki/Gaussian_blur)) replace the intensity of a given pixel with a weighted average of the neighbouring pixels, where the weight of each neighouring pixel depends on the spatial distance from the pixel being computed. With bilateral filters, like the one used in this design, the weight of each neighbouring pixel depends on both the spatial distance, and the difference in pixel intensity. This makes bilateral filters much better at preserving sharp edges. <br/>
+The ANR algorithm uses a [bilateral filter](https://en.wikipedia.org/wiki/Bilateral_filter). Unilateral filters (e.g., a [Box blur](https://en.wikipedia.org/wiki/Box_blur) or [Gaussian blur](https://en.wikipedia.org/wiki/Gaussian_blur)) replace the intensity of a given pixel with a weighted average of the neighboring pixels, where the weight of each neighboring pixel depends on the spatial distance from the pixel being computed. With bilateral filters, like the one used in this design, the weight of each neighboring pixel depends on both the spatial distance, and the difference in pixel intensity. This makes bilateral filters much better at preserving sharp edges. <br/>
 
-Bilateral filters are non-linear and therefore non-separable. Note that in the case of a 5x5 window (shown below), only 9 pixels (not 25) are used in the computation; this is an artifact of the Bayer image format. The most accurate approach would produce the bilateral filter window and convolve the entire window of the given pixel colour (for the image below, red) at once to generate the output pixel (the middle pixel). For the 5x5 case, this would result in 9 multiplications that need to be summed. <br/>
+Bilateral filters are non-linear and therefore non-separable. In the case of a 5x5 window (shown below), only 9 pixels (not 25) are used in the computation; this is an artifact of the Bayer image format. The most accurate approach would produce the bilateral filter window and convolve the entire window of the given pixel color (for the image below, red) at once to generate the output pixel (the middle pixel). For the 5x5 case, this would result in 9 multiplications that need to be summed. <br/>
 
 <img src="conv.png" alt="conv" width="400"/>
 
@@ -243,7 +246,12 @@ In this design, we use the following generic header files:
   - `RowStencil` (*row_stencil.hpp*): A library for generalizing a row stencil (i.e., the horizontal filter) using C++ functors for callbacks to perform the filter. This library hides the details of the shift register and padding logic and allows the user to simply worry about the filter convolution.
   - `ShiftReg` (*shift_reg.hpp*): A library to implement a shift register. This hides the logic necessary to ensure the compiler infers an efficient shift register behind easy-to-use API calls.
   - `UnrolledLoop` (*unrolled_loop.hpp*): A library that implements a front-end unrolled loop using C++ metaprogramming.
-  - *mp_math.hpp*: A set of various `constexpr` math functions that are implemented using C++ metaprogramming.
+  - `mp_math.hpp`: A set of various `constexpr` math functions that are implemented using C++ metaprogramming.
 
   For more information on the usage and implementation of these header libraries, view the source code (the `.hpp` files), which are well commented for documentation.
 
+## License
+
+Code samples are licensed under the MIT license. See [License.txt](https://github.com/oneapi-src/oneAPI-samples/blob/master/License.txt) for details.
+
+Third-party program Licenses can be found here: [third-party-programs.txt](https://github.com/oneapi-src/oneAPI-samples/blob/master/third-party-programs.txt).

--- a/DirectProgramming/DPC++FPGA/ReferenceDesigns/cholesky/README.md
+++ b/DirectProgramming/DPC++FPGA/ReferenceDesigns/cholesky/README.md
@@ -1,51 +1,51 @@
 # Cholesky Decomposition of Matrices
-The streaming_cholesky.hpp linear algebra header library implements the Cholesky decomposition of matrices with pipe interfaces.
-Its template parameters can be set to decompose custom sized real or complex square matrices.
-This DPC++ reference design demonstrates the use of this Cholesky decomposition header library on 32 * 32 real matrices.
+The `streaming_cholesky.hpp` linear algebra header library implements the Cholesky decomposition of matrices with pipe interfaces. You can set the template parameters to decompose custom-sized real or complex square matrices.
 
+This SYCL*-compliant reference design demonstrates the use of this Cholesky decomposition header library on 32x32 real matrices.
 
-***Documentation***:  The [DPC++ FPGA Code Samples Guide](https://software.intel.com/content/www/us/en/develop/articles/explore-dpcpp-through-intel-fpga-code-samples.html) helps you to navigate the samples and build your knowledge of DPC++ for FPGA. <br>
-The [oneAPI DPC++ FPGA Optimization Guide](https://software.intel.com/content/www/us/en/develop/documentation/oneapi-fpga-optimization-guide) is the reference manual for targeting FPGAs through DPC++. <br>
-The [oneAPI Programming Guide](https://software.intel.com/en-us/oneapi-programming-guide) is a general resource for target-independent DPC++ programming.
-
-| Optimized for                     | Description
----                                 |---
-| OS                                | Linux* Ubuntu* 18.04/20.04, RHEL*/CentOS* 8, SUSE* 15; Windows* 10
-| Hardware                          | Intel® Programmable Acceleration Card (PAC) with Intel Arria® 10 GX FPGA <br> Intel® FPGA Programmable Acceleration Card (PAC) D5005 (with Intel Stratix® 10 SX) <br> Intel Xeon® CPU E5-1650 v2 @ 3.50GHz (host machine)
-| Software                          | Intel® oneAPI DPC++ Compiler <br> Intel® FPGA Add-On for oneAPI Base Toolkit
-| What you will learn               | Implementing high performance Cholesky matrix decomposition on FPGAs.
-| Time to complete                  | 1 hr (not including compile time)
-
-
-
-
-**Performance**
-Please refer to the performance disclaimer at the end of this README.
-
-| Device                                            | Throughput
-|:---                                               |:---
-| Intel® PAC with Intel Arria® 10 GX FPGA           | 221k matrices/s for real matrices of size 32 * 32
-| Intel® FPGA PAC D5005 (with Intel Stratix® 10 SX) | 214k matrices/s for real matrices of size 32 * 32
-
+| Property                     | Description
+|:---                          |:---
+| What you will learn               | How to implement high performance matrix Cholesky decomposition on field programmable gate arrays (FPGAs).
+| Time to complete                  | ~1 hr (excluding compile time)
 
 ## Purpose
 
-This FPGA reference design demonstrates Cholesky decomposition, a common operation employed in linear algebra, through use of the streaming_cholesky.hpp header library.
+This FPGA reference design demonstrates Cholesky decomposition, a common operation employed in linear algebra, through use of the `streaming_cholesky.hpp` header library.
 The Cholesky decomposition takes a hermitian, positive-definite matrix _A_ (input) and computes the lower triangular matrix _L_ such that: _L_ * _L*_ = A, where _L*_ in the conjugate transpose of _L_.
-The algorithm employed by the header library is an FPGA throughput optimized version of the Cholesky–Banachiewicz algorithm. Background information on the Cholesky decomposition and this algorithm can be found in Wikipedia's [Cholesky decomposition](https://en.wikipedia.org/wiki/Cholesky_decomposition) article. 
+The algorithm employed by the header library is a FPGA throughput optimized version of the Cholesky–Banachiewicz algorithm. (You can find information on the Cholesky decomposition and this algorithm can be found in the [Cholesky decomposition](https://en.wikipedia.org/wiki/Cholesky_decomposition) article on Wikipedia.)
 
-The Cholesky decomposition is used extensively in machine learning applications such as least-squares regressions and Monte-Carlo simulations.
+Cholesky decomposition is used extensively in machine learning applications such as least-squares regressions and Monte-Carlo simulations.
 
+## Prerequisites
 
-### Matrix dimensions and FPGA resources
+| Optimized for                     | Description
+|:---                               |:---
+| OS                                | Ubuntu* 18.04/20.04 <br>RHEL*/CentOS* 8 <br>SUSE* 15 <br>Windows* 10
+| Hardware                          | Intel&reg; Programmable Acceleration Card (PAC) with Intel Arria&reg; 10 GX FPGA <br> Intel&reg; FPGA Programmable Acceleration Card (PAC) D5005 (with Intel Stratix&reg; 10 SX) <br> Intel Xeon&reg; CPU E5-1650 v2 @ 3.50GHz (host machine)
+| Software                          | Intel&reg; oneAPI DPC++ Compiler <br> Intel&reg; FPGA Add-On for oneAPI Base Toolkit
+
+### Performance
+> **Note**: Please refer to the [Performance Disclaimers](#performance-disclaimers) section below.
+
+| Device                                            | Throughput
+|:---                                               |:---
+| Intel&reg; PAC with Intel Arria&reg; 10 GX FPGA           | 221k matrices/s for real matrices of size 32x32
+| Intel&reg; FPGA PAC D5005 (with Intel Stratix&reg; 10 SX) | 214k matrices/s for real matrices of size 32x32
+
+## Matrix Dimensions and FPGA resources
 
 In this reference design, the Cholesky decomposition algorithm is used to factor a real _n_ × _n_ matrix. The algorithm computes the vector dot product of two rows of the matrix. In our FPGA implementation, the dot product is computed in a loop over the row's _n_ elements. The loop is fully unrolled to maximize throughput. As a result, *n* real multiplication operations are performed in parallel on the FPGA, followed by sequential additions to compute the dot product result.
 
-We use the compiler flag `-fp-relaxed`, which permits the compiler to reorder floating point additions (i.e. to assume that floating point addition is commutative). The compiler uses this freedom to reorder the additions so that the dot product arithmetic can be optimally implemented using the FPGA's specialized floating point DSP (Digital Signal Processing) hardware.
+We use the compiler option `-fp-relaxed`, which permits the compiler to reorder floating point additions (for example, to assume that floating point addition is commutative). The compiler uses this freedom to reorder the additions so that the dot product arithmetic can be optimally implemented using the FPGA's specialized floating point Digital Signal Processing (DSP) hardware.
 
-With this optimization, our FPGA implementation requires _n_ DSPs to compute the real floating point dot product.
-The input matrix is also replicated two times in order to be able to read two full rows per cycle.
+With this optimization, our FPGA implementation requires _n_ DSPs to compute the real floating point dot product. The input matrix is also replicated two times in order to be able to read two full rows per cycle.
 Thus, the matrix size is constrained by the total FPGA DSP and RAM resources available.
+
+
+### Additional Documentation
+- [Explore SYCL* Through Intel&reg; FPGA Code Samples](https://software.intel.com/content/www/us/en/develop/articles/explore-dpcpp-through-intel-fpga-code-samples.html) helps you to navigate the samples and build your knowledge of FPGAs and SYCL.
+- [FPGA Optimization Guide for Intel&reg; oneAPI Toolkits](https://software.intel.com/content/www/us/en/develop/documentation/oneapi-fpga-optimization-guide) helps you understand how to target FPGAs using SYCL and Intel&reg; oneAPI Toolkits.
+- [Intel&reg; oneAPI Programming Guide](https://software.intel.com/en-us/oneapi-programming-guide) helps you understand target-independent, SYCL-compliant programming using Intel&reg; oneAPI Toolkits.
 
 
 ## Key Implementation Details
@@ -54,35 +54,29 @@ Thus, the matrix size is constrained by the total FPGA DSP and RAM resources ava
 | Cholesky          | Implements a modified Cholesky–Banachiewicz Cholesky decomposition algorithm.
 
 To optimize the performance-critical loop in its algorithm, the design leverages concepts discussed in the following FPGA tutorials:
-* **Triangular Loop Optimization** (triangular_loop)
-* **Explicit Pipelining with `fpga_reg`** (fpga_register)
-* **Loop `ivdep` Attribute** (loop_ivdep)
-* **Unrolling Loops** (loop_unroll)
+- **Triangular Loop Optimization** (triangular_loop)
+- **Explicit Pipelining with `fpga_reg`** (fpga_register)
+- **Loop `ivdep` Attribute** (loop_ivdep)
+- **Unrolling Loops** (loop_unroll)
 
  The key optimization techniques used are as follows:
-   1. Traversing the matrix in a column fashion to increase the read-after-write (RAW) loop iteration distance 
-   2. Using two copies of the compute matrix in order to be able to read a full row and a full column per cycle
+   1. Traversing the matrix in a column fashion to increase the read-after-write (RAW) loop iteration distance.
+   2. Using two copies of the compute matrix in order to be able to read a full row and a full column per cycle.
    3. Converting the nested loop into a single merged loop and applying Triangular Loop optimizations. This allows us to generate a design that is very well pipelined.
    4. Fully vectorizing the dot products using loop unrolling.
-   5. Using the compiler flag -Xsfp-relaxed to re-order floating point operations and allowing the inference of a specialised dot-product DSP. This further reduces the number of DSP blocks needed by the implementation, the overall latency, and pipeline depth.
+   5. Using the compiler flag -Xsfp-relaxed to re-order floating point operations and allowing the inference of a specialized dot-product DSP. This further reduces the number of DSP blocks needed by the implementation, the overall latency, and pipeline depth.
    6. Using an efficient memory banking scheme to generate high performance hardware (all local memories are single-read, single-write).
    7. Using the `fpga_reg` attribute to insert more pipeline stages where needed to improve the frequency achieved by the design.
-
-## License
-Code samples are licensed under the MIT license. See
-[License.txt](https://github.com/oneapi-src/oneAPI-samples/blob/master/License.txt) for details.
-
-Third party program Licenses can be found here: [third-party-programs.txt](https://github.com/oneapi-src/oneAPI-samples/blob/master/third-party-programs.txt)
 
 ## Building the Reference Design
 
 ### Include Files
 The include folder is located at `%ONEAPI_ROOT%\dev-utilities\latest\include` on your development system.
 
-### Running Code Samples in DevCloud
-If running a sample in the Intel DevCloud, remember that you must specify the type of compute node and whether to run in batch or interactive mode. Compiles to FPGA are only supported on fpga_compile nodes. Executing programs on FPGA hardware is only supported on fpga_runtime nodes of the appropriate type, such as fpga_runtime:arria10 or fpga_runtime:stratix10.  Neither compiling nor executing programs on FPGA hardware are supported on the login nodes. For more information, see the Intel® oneAPI Base Toolkit Get Started Guide ([https://devcloud.intel.com/oneapi/documentation/base-toolkit/](https://devcloud.intel.com/oneapi/documentation/base-toolkit/)).
+### Run Code Sample in Intel&reg; DevCloud
+If running a sample in the Intel&reg; DevCloud, remember that you must specify the type of compute node and whether to run in batch or interactive mode. Compiles to FPGA are only supported on fpga_compile nodes. Executing programs on FPGA hardware is only supported on fpga_runtime nodes of the appropriate type, such as fpga_runtime:arria10 or fpga_runtime:stratix10.  Neither compiling nor executing programs on FPGA hardware are supported on the login nodes. For more information, see the Intel&reg; oneAPI Base Toolkit Get Started Guide ([https://devcloud.intel.com/oneapi/documentation/base-toolkit/](https://devcloud.intel.com/oneapi/documentation/base-toolkit/)).
 
-When compiling for FPGA hardware, it is recommended to increase the job timeout to 24h.
+When compiling for FPGA hardware, it is recommended to increase the job timeout to **24h**.
 
 
 ### Using Visual Studio Code*  (Optional)
@@ -91,17 +85,15 @@ You can use Visual Studio Code (VS Code) extensions to set your environment, cre
 and browse and download samples.
 
 The basic steps to build and run a sample using VS Code include:
- - Download a sample using the extension **Code Sample Browser for Intel oneAPI Toolkits**.
- - Configure the oneAPI environment with the extension **Environment Configurator for Intel oneAPI Toolkits**.
+ - Download a sample using the extension **Code Sample Browser for Intel&reg; oneAPI Toolkits**.
+ - Configure the oneAPI environment with the extension **Environment Configurator for Intel&reg; oneAPI Toolkits**.
  - Open a Terminal in VS Code (**Terminal>New Terminal**).
  - Run the sample in the VS Code terminal using the instructions below.
 
 To learn more about the extensions and how to configure the oneAPI environment, see
-[Using Visual Studio Code with Intel® oneAPI Toolkits](https://software.intel.com/content/www/us/en/develop/documentation/using-vs-code-with-intel-oneapi/top.html).
+[Using Visual Studio Code with Intel&reg; oneAPI Toolkits](https://software.intel.com/content/www/us/en/develop/documentation/using-vs-code-with-intel-oneapi/top.html).
 
-After learning how to use the extensions for Intel oneAPI Toolkits, return to this readme for instructions on how to build and run a sample.
-
-### On a Linux* System
+### On Linux*
 1. Install the design into a directory `build` from the design directory by running `cmake`:
 
    ```
@@ -109,13 +101,13 @@ After learning how to use the extensions for Intel oneAPI Toolkits, return to th
    cd build
    ```
 
-   If you are compiling for the Intel® PAC with Intel Arria® 10 GX FPGA, run `cmake` using the command:
+   If you are compiling for the Intel&reg; PAC with Intel Arria&reg; 10 GX FPGA, run `cmake` using the command:
 
    ```
    cmake ..
    ```
 
-   If instead you are compiling for the Intel® FPGA PAC D5005 (with Intel Stratix® 10 SX), run `cmake` using the command:
+   If instead you are compiling for the Intel&reg; FPGA PAC D5005 (with Intel Stratix&reg; 10 SX), run `cmake` using the command:
 
    ```
    cmake .. -DFPGA_BOARD=intel_s10sx_pac:pac_s10
@@ -123,78 +115,76 @@ After learning how to use the extensions for Intel oneAPI Toolkits, return to th
 
 2. Compile the design through the generated `Makefile`. The following targets are provided, and they match the recommended development flow:
 
-    * Compile for emulation (fast compile time, targets emulated FPGA device).
+    - Compile for emulation (fast compile time, targets emulated FPGA device).
 
        ```
        make fpga_emu
        ```
 
-    * Generate HTML performance report. Find the report in `cholesky_report.prj/reports/report.html`directory.
+    - Generate HTML performance report. Find the report in `cholesky_report.prj/reports/report.html`directory.
 
        ```
        make report
        ```
 
-    * Compile for FPGA hardware (longer compile time, targets FPGA device).
+    - Compile for FPGA hardware (longer compile time, targets FPGA device).
 
        ```
        make fpga
        ```
 
-3. (Optional) As the above hardware compile may take several hours to complete, FPGA precompiled binaries (compatible with Linux* Ubuntu* 18.04) can be downloaded <a href="https://iotdk.intel.com/fpga-precompiled-binaries/latest/cholesky.fpga.tar.gz" download>here</a>.
+3. (Optional) As the above hardware compile may take several hours to complete, you can download FPGA precompiled binaries (compatible with Linux* Ubuntu* 18.04) from [https://iotdk.intel.com/fpga-precompiled-binaries/latest/cholesky.fpga.tar.gz](https://iotdk.intel.com/fpga-precompiled-binaries/latest/cholesky.fpga.tar.gz).
 
-### On a Windows* System
+### On Windows*
 1. Generate the `Makefile` by running `cmake`.
      ```
    mkdir build
    cd build
    ```
-   To compile for the Intel® PAC with Intel Arria® 10 GX FPGA, run `cmake` using the command:
+   To compile for the Intel&reg; PAC with Intel Arria&reg; 10 GX FPGA, run `cmake` using the command:
     ```
     cmake -G "NMake Makefiles" ..
    ```
-   Alternatively, to compile for the Intel® FPGA PAC D5005 (with Intel Stratix® 10 SX), run `cmake` using the command:
+   Alternatively, to compile for the Intel&reg; FPGA PAC D5005 (with Intel Stratix&reg; 10 SX), run `cmake` using the command:
    ```
    cmake -G "NMake Makefiles" .. -DFPGA_BOARD=intel_s10sx_pac:pac_s10
    ```
 
 2. Compile the design through the generated `Makefile`. The following build targets are provided, matching the recommended development flow:
-   * Compile for emulation (fast compile time, targets emulated FPGA device):
+   - Compile for emulation (fast compile time, targets emulated FPGA device):
      ```
      nmake fpga_emu
      ```
-   * Generate the optimization report:
+   - Generate the optimization report:
      ```
      nmake report
      ```
-   * An FPGA hardware target is not provided on Windows*.
+   - An FPGA hardware target is not provided on Windows*.
 
-*Note:* The Intel® PAC with Intel Arria® 10 GX FPGA and Intel® FPGA PAC D5005 (with Intel Stratix® 10 SX) do not yet support Windows*. Compiling to FPGA hardware on Windows* requires a third-party or custom Board Support Package (BSP) with Windows* support.<br>
+> **Note**: The Intel&reg; PAC with Intel Arria&reg; 10 GX FPGA and Intel&reg; FPGA PAC D5005 (with Intel Stratix&reg; 10 SX) do not yet support Windows*. Compiling to FPGA hardware on Windows* requires a third-party or custom Board Support Package (BSP) with Windows* support.<br>
 
-*Note:* If you encounter any issues with long paths when compiling under Windows*, you may have to create your ‘build’ directory in a shorter path, for example c:\samples\build. You can then run cmake from that directory, and provide cmake with the full path to your sample directory.
+> **Note**: If you encounter any issues with long paths when compiling under Windows*, you may have to create your ‘build’ directory in a shorter path, for example c:\samples\build. You can then run cmake from that directory, and provide cmake with the full path to your sample directory.
 
 
 ### In Third-Party Integrated Development Environments (IDEs)
 
-You can compile and run this Reference Design in the Eclipse* IDE (in Linux*) and the Visual Studio* IDE (in Windows*). For instructions, refer to the following link: [Intel® oneAPI DPC++ FPGA Workflows on Third-Party IDEs](https://www.intel.com/content/www/us/en/developer/articles/technical/intel-oneapi-dpcpp-fpga-workflow-on-ide.html)
+You can compile and run this Reference Design in the Eclipse* IDE (in Linux*) and the Visual Studio* IDE (in Windows*). For instructions, refer to [FPGA Workflows on Third-Party IDEs for Intel&reg; oneAPI Toolkits](https://www.intel.com/content/www/us/en/developer/articles/technical/intel-oneapi-dpcpp-fpga-workflow-on-ide.html).
 
 ## Running the Reference Design
 You can apply the Cholesky decomposition to a number of matrices, as shown below. This step performs the following:
-* Generates 8 random matrices (this number can be changed in cholesky_demo.cpp).
-* Computes the Cholesky decomposition on all matrices.
-* Repeats the operation multiple times (specified as the command line argument) to evaluate performance.
+- Generates 8 random matrices (this number can be changed in cholesky_demo.cpp).
+- Computes the Cholesky decomposition on all matrices.
+- Repeats the operation multiple times (specified as the command line argument) to evaluate performance.
 
  1. Run the sample on the FPGA emulator (the kernel executes on the CPU).
      ```
      ./cholesky.fpga_emu           (Linux)
-
      cholesky.fpga_emu.exe         (Windows)
      ```
 
 2. Run the sample on the FPGA device.
      ```
      ./cholesky.fpga         (Linux)
-     
      cholesky.fpga.exe       (Windows)
      ```
 ### Application Parameters
@@ -205,7 +195,7 @@ You can apply the Cholesky decomposition to a number of matrices, as shown below
 
 ### Example of Output
 
-Example output when running on Intel® PAC with Intel Arria® 10 GX FPGA for 8 matrices 819200 times (each matrix consisting of 32*32 real numbers):
+Example output when running on Intel&reg; PAC with Intel Arria&reg; 10 GX FPGA for 8 matrices 819200 times (each matrix consisting of 32*32 real numbers):
 
 ```
 Device name: pac_a10 : Intel PAC Platform (pac_f100000)
@@ -218,7 +208,7 @@ Verifying results...
 PASSED
 ```
 
-Example output when running on Intel® FPGA PAC D5005 (with Intel Stratix® 10 SX) for the decomposition of 8 matrices 819200 times (each matrix consisting of 32*32 real numbers):
+Example output when running on Intel&reg; FPGA PAC D5005 (with Intel Stratix&reg; 10 SX) for the decomposition of 8 matrices 819200 times (each matrix consisting of 32*32 real numbers):
 
 ```
 Device name: pac_s10 : Intel PAC Platform (pac_f100000)
@@ -239,7 +229,6 @@ The following source files can be found in the `src/` sub-directory.
 | File                                | Description
 |:---                                 |:---
 |`cholesky_demo.cpp`                  | Contains the `main()` function which generates the input matrices, calls the compute function and validates the results.
-|                                     |
 |`cholesky.hpp`                       | Contains the compute function that calls the kernels.
 |`memory_transfers.hpp`               | Contains functions to transfer matrices from/to the FPGA DDR with streaming interfaces.
 
@@ -251,16 +240,16 @@ For `constexpr_math.hpp`, `memory_utils.hpp`, `metaprogramming_utils.hpp`, and `
 ---    |---
 `-Xshardware` | Target FPGA hardware (as opposed to FPGA emulator)
 `-Xsclock=<target fmax>MHz` | The FPGA backend attempts to achieve <target fmax> MHz
-`-Xsfp-relaxed` | Allows the FPGA backend to re-order floating point arithmetic operations (e.g. permit assuming (a + b + c) == (c + a + b) )
+`-Xsfp-relaxed` | Allows the FPGA backend to re-order floating point arithmetic operations (for example, permit assuming $(a + b + c) == (c + a + b)$ )
 `-Xsparallel=2` | Use 2 cores when compiling the bitstream through Quartus
 `-Xsseed` | Specifies the Quartus compile seed, to potentially yield slightly higher fmax
 `-DMATRIX_DIMENSION` | Specifies the number of rows/columns of the matrix
 `-DFIXED_ITERATIONS` | Used to set the ivdep safelen attribute for the performance critical triangular loop
 `-DCOMPLEX` | Used to select between the complex and real QR decomposition (real is the default)
 
-NOTE: The values for `seed`, `FIXED_ITERATIONS`, `MATRIX_DIMENSION`, `COMPLEX` are set according to the board being targeted.
+> **Note**: The values for `seed`, `FIXED_ITERATIONS`, `MATRIX_DIMENSION`, `COMPLEX` are set according to the board being targeted.
 
-### Performance disclaimers
+## Performance Disclaimers
 
 Tests document performance of components on a particular test, in specific systems. Differences in hardware, software, or configuration will affect actual performance. Consult other sources of information to evaluate performance as you consider your purchase.  For more complete information about performance and benchmark results, visit [this page](https://edc.intel.com/content/www/us/en/products/performance/benchmarks/overview).
 
@@ -270,4 +259,10 @@ Intel technologies’ features and benefits depend on system configuration and m
 
 Intel and the Intel logo are trademarks of Intel Corporation or its subsidiaries in the U.S. and/or other countries.
 
-(C) Intel Corporation.
+&copy; Intel Corporation.
+
+## License
+Code samples are licensed under the MIT license. See
+[License.txt](https://github.com/oneapi-src/oneAPI-samples/blob/master/License.txt) for details.
+
+Third party program Licenses can be found here: [third-party-programs.txt](https://github.com/oneapi-src/oneAPI-samples/blob/master/third-party-programs.txt).

--- a/DirectProgramming/DPC++FPGA/ReferenceDesigns/cholesky_inversion/README.md
+++ b/DirectProgramming/DPC++FPGA/ReferenceDesigns/cholesky_inversion/README.md
@@ -1,31 +1,13 @@
 # Cholesky-based Inversion of Matrices
-The streaming_cholesky.hpp linear algebra header library implements the Cholesky decomposition of matrices with pipe interfaces.
-Similarly, the streaming_cholesky_inversion.hpp linear algebra header library implements the inversion of matrices with pipe interfaces, based on the outputs of the cholesky decomposition implemented in streaming_cholesky.hpp.
+The `streaming_cholesky.hpp` linear algebra header library implements the Cholesky decomposition of matrices with pipe interfaces.
+Similarly, the `streaming_cholesky_inversion.hpp` linear algebra header library implements the inversion of matrices with pipe interfaces, based on the outputs of the cholesky decomposition implemented in `streaming_cholesky.hpp`.
 Both the decomposition and the inversion have template parameters that can be set to decompose/invert custom sized real or complex square matrices.
-This DPC++ reference design demonstrates the use of these Cholesky decomposition and inversion header libraries on 32 * 32 real matrices.
+This SYCL*-compliant reference design demonstrates the use of these Cholesky decomposition and inversion header libraries on 32x32 real matrices.
 
-
-***Documentation***:  The [DPC++ FPGA Code Samples Guide](https://software.intel.com/content/www/us/en/develop/articles/explore-dpcpp-through-intel-fpga-code-samples.html) helps you to navigate the samples and build your knowledge of DPC++ for FPGA. <br>
-The [oneAPI DPC++ FPGA Optimization Guide](https://software.intel.com/content/www/us/en/develop/documentation/oneapi-fpga-optimization-guide) is the reference manual for targeting FPGAs through DPC++. <br>
-The [oneAPI Programming Guide](https://software.intel.com/en-us/oneapi-programming-guide) is a general resource for target-independent DPC++ programming.
-
-| Optimized for                     | Description
----                                 |---
-| OS                                | Linux* Ubuntu* 18.04/20.04, RHEL*/CentOS* 8, SUSE* 15; Windows* 10
-| Hardware                          | Intel® Programmable Acceleration Card (PAC) with Intel Arria® 10 GX FPGA <br> Intel® FPGA Programmable Acceleration Card (PAC) D5005 (with Intel Stratix® 10 SX)
-| Software                          | Intel® oneAPI DPC++ Compiler <br> Intel® FPGA Add-On for oneAPI Base Toolkit
-| What you will learn               | Implementing high performance Cholesky matrix decomposition on FPGAs.
-| Time to complete                  | 1 hr (not including compile time)
-
-
-**Performance**
-Please refer to the performance disclaimer at the end of this README.
-
-| Device                                            | Throughput
-|:---                                               |:---
-| Intel® PAC with Intel Arria® 10 GX FPGA           | 215k matrices/s for real matrices of size 32 * 32
-| Intel® FPGA PAC D5005 (with Intel Stratix® 10 SX) | 255k matrices/s for real matrices of size 32 * 32
-
+| Property                     | Description
+|:---                          |:---
+| What you will learn               | How to implement high performance Cholesky matrix decomposition on field programmable gate arrays (FPGAs).
+| Time to complete                  | ~1 hr (excluding compile time)
 
 ## Purpose
 
@@ -39,12 +21,26 @@ Therefore, in order to compute the inverse of A, one can: compute $LI$, the inve
 $$ A^{-1} = LI^{\star}LI $$
 Because $A^{-1}$  is going to be symmetric, one can also compute only half of the values.
 
+## Prerequisites
+| Optimized for                     | Description
+---                                 |---
+| OS                                | Ubuntu* 18.04/20.04 <br>RHEL*/CentOS* 8 <br>SUSE* 15 <br>Windows* 10
+| Hardware                          | Intel&reg; Programmable Acceleration Card (PAC) with Intel Arria&reg; 10 GX FPGA <br> Intel&reg; FPGA Programmable Acceleration Card (PAC) D5005 (with Intel Stratix&reg; 10 SX)
+| Software                          | Intel&reg; oneAPI DPC++ Compiler <br> Intel&reg; FPGA Add-On for oneAPI Base Toolkit
 
-### Matrix dimensions and FPGA resources
+### Performance
+> **Note**: Please refer to the [Performance Disclaimers](#performance-disclaimers) section below.
+
+| Device                                            | Throughput
+|:---                                               |:---
+| Intel&reg; PAC with Intel Arria&reg; 10 GX FPGA           | 215k matrices/s for real matrices of size 32x32
+| Intel&reg; FPGA PAC D5005 (with Intel Stratix&reg; 10 SX) | 255k matrices/s for real matrices of size 32x32
+
+## Matrix Dimensions and FPGA resources
 
 In this reference design, the Cholesky decomposition algorithm is used to factor a real _n_ × _n_ matrix. The algorithm computes the vector dot product of two rows of the matrix. In our FPGA implementation, the dot product is computed in a loop over the row's _n_ elements. The loop is fully unrolled to maximize throughput. As a result, *n* real multiplication operations are performed in parallel on the FPGA, followed by sequential additions to compute the dot product result.
 
-We use the compiler flag `-fp-relaxed`, which permits the compiler to reorder floating point additions (i.e. to assume that floating point addition is commutative). The compiler uses this freedom to reorder the additions so that the dot product arithmetic can be optimally implemented using the FPGA's specialized floating point DSP (Digital Signal Processing) hardware.
+We use the compiler option `-fp-relaxed`, which permits the compiler to reorder floating point additions (i.e. to assume that floating point addition is commutative). The compiler uses this freedom to reorder the additions so that the dot product arithmetic can be optimally implemented using the FPGA's specialized floating point DSP (Digital Signal Processing) hardware.
 
 With this optimization, our FPGA implementation requires _n_ DSPs to compute the real floating point dot product.
 The input matrix is also replicated two times in order to be able to read two full rows per cycle.
@@ -56,43 +52,42 @@ Finally, the matrix product of $LI^{\star}LI$ also requires _n_ DSPs.
 
 A handful of extra DSPs are required to perform various arithmetic operations such as division, reciprocal square root, etc.
 
+### Additional Documentation
+- [Explore SYCL* Through Intel&reg; FPGA Code Samples](https://software.intel.com/content/www/us/en/develop/articles/explore-dpcpp-through-intel-fpga-code-samples.html) helps you to navigate the samples and build your knowledge of FPGAs and SYCL.
+- [FPGA Optimization Guide for Intel&reg; oneAPI Toolkits](https://software.intel.com/content/www/us/en/develop/documentation/oneapi-fpga-optimization-guide) helps you understand how to target FPGAs using SYCL and Intel&reg; oneAPI Toolkits.
+- [Intel&reg; oneAPI Programming Guide](https://software.intel.com/en-us/oneapi-programming-guide) helps you understand target-independent, SYCL-compliant programming using Intel&reg; oneAPI Toolkits.
+
 ## Key Implementation Details
 | Kernel                | Description
----                     |---
+|:---                   |:---
 | CholeskyDecomposition | Implements a modified Cholesky–Banachiewicz decomposition algorithm.
 | CholeskyInversion     | Implements the matrix inversion based on the CholeskyDecomposition's outputs.
 
 To optimize the performance-critical loops in these algorithms, the design leverages concepts discussed in the following FPGA tutorials:
-* **Triangular Loop Optimization** (triangular_loop)
-* **Explicit Pipelining with `fpga_reg`** (fpga_register)
-* **Loop `ivdep` Attribute** (loop_ivdep)
-* **Unrolling Loops** (loop_unroll)
+- **Triangular Loop Optimization** (triangular_loop)
+- **Explicit Pipelining with `fpga_reg`** (fpga_register)
+- **Loop `ivdep` Attribute** (loop_ivdep)
+- **Unrolling Loops** (loop_unroll)
 
  The key optimization techniques used are:
    1. Traversing the matrix in a column fashion to increase the read-after-write (RAW) loop iteration distance 
    2. Using two copies of the compute matrix in order to be able to read a full row and a full column per cycle
    3. Converting the nested loop into a single merged loop and applying Triangular Loop optimizations. This allows us to generate a design that is very well pipelined.
    4. Fully vectorizing the dot products using loop unrolling.
-   5. Using the compiler flag -Xsfp-relaxed to re-order floating point operations and allowing the inference of a specialised dot-product DSP. This further reduces the number of DSP blocks needed by the implementation, the overall latency, and pipeline depth.
+   5. Using the compiler flag -Xsfp-relaxed to re-order floating point operations and allowing the inference of a specialized dot-product DSP. This further reduces the number of DSP blocks needed by the implementation, the overall latency, and pipeline depth.
    6. Using an efficient memory banking scheme to generate high performance hardware (all local memories are single-read, single-write).
    7. Using the `fpga_reg` attribute to insert more pipeline stages where needed to improve the frequency achieved by the design.
    8. Using the input matrices properties (hermitian positive matrices) to reduce the number of operations. For example, the (_LI_*) * _LI_ computation only requires to compute half of the output matrix as the result is symmetric.
-
-## License
-Code samples are licensed under the MIT license. See
-[License.txt](https://github.com/oneapi-src/oneAPI-samples/blob/master/License.txt) for details.
-
-Third party program Licenses can be found here: [third-party-programs.txt](https://github.com/oneapi-src/oneAPI-samples/blob/master/third-party-programs.txt)
 
 ## Building the Reference Design
 
 ### Include Files
 The include folder is located at `%ONEAPI_ROOT%\dev-utilities\latest\include` on your development system.
 
-### Running Code Samples in DevCloud
-If running a sample in the Intel DevCloud, remember that you must specify the type of compute node and whether to run in batch or interactive mode. Compiles to FPGA are only supported on fpga_compile nodes. Executing programs on FPGA hardware is only supported on fpga_runtime nodes of the appropriate type, such as fpga_runtime:arria10 or fpga_runtime:stratix10.  Neither compiling nor executing programs on FPGA hardware are supported on the login nodes. For more information, see the Intel® oneAPI Base Toolkit Get Started Guide ([https://devcloud.intel.com/oneapi/documentation/base-toolkit/](https://devcloud.intel.com/oneapi/documentation/base-toolkit/)).
+### Run Code Samples in DevCloud
+If running a sample in the Intel DevCloud, remember that you must specify the type of compute node and whether to run in batch or interactive mode. Compiles to FPGA are only supported on fpga_compile nodes. Executing programs on FPGA hardware is only supported on fpga_runtime nodes of the appropriate type, such as fpga_runtime:arria10 or fpga_runtime:stratix10.  Neither compiling nor executing programs on FPGA hardware are supported on the login nodes. For more information, see the Intel&reg; oneAPI Base Toolkit Get Started Guide ([https://devcloud.intel.com/oneapi/documentation/base-toolkit/](https://devcloud.intel.com/oneapi/documentation/base-toolkit/)).
 
-When compiling for FPGA hardware, it is recommended to increase the job timeout to 24h.
+When compiling for FPGA hardware, it is recommended to increase the job timeout to **24h**.
 
 
 ### Using Visual Studio Code*  (Optional)
@@ -106,12 +101,12 @@ The basic steps to build and run a sample using VS Code include:
  - Open a Terminal in VS Code (**Terminal>New Terminal**).
  - Run the sample in the VS Code terminal using the instructions below.
 
-To learn more about the extensions and how to configure the oneAPI environment, see
-[Using Visual Studio Code with Intel® oneAPI Toolkits](https://software.intel.com/content/www/us/en/develop/documentation/using-vs-code-with-intel-oneapi/top.html).
+To learn more about the extensions and how to configure the oneAPI environment, see the 
+[Using Visual Studio Code with Intel&reg; oneAPI Toolkits User Guide](https://software.intel.com/content/www/us/en/develop/documentation/using-vs-code-with-intel-oneapi/top.html).
 
 After learning how to use the extensions for Intel oneAPI Toolkits, return to this readme for instructions on how to build and run a sample.
 
-### On a Linux* System
+### On Linux*
 1. Install the design into a directory `build` from the design directory by running `cmake`:
 
    ```
@@ -119,13 +114,13 @@ After learning how to use the extensions for Intel oneAPI Toolkits, return to th
    cd build
    ```
 
-   If you are compiling for the Intel® PAC with Intel Arria® 10 GX FPGA, run `cmake` using the command:
+   If you are compiling for the Intel&reg; PAC with Intel Arria&reg; 10 GX FPGA, run `cmake` using the command:
 
    ```
    cmake ..
    ```
 
-   If instead you are compiling for the Intel® FPGA PAC D5005 (with Intel Stratix® 10 SX), run `cmake` using the command:
+   If instead you are compiling for the Intel&reg; FPGA PAC D5005 (with Intel Stratix&reg; 10 SX), run `cmake` using the command:
 
    ```
    cmake .. -DFPGA_BOARD=intel_s10sx_pac:pac_s10
@@ -133,66 +128,66 @@ After learning how to use the extensions for Intel oneAPI Toolkits, return to th
 
 2. Compile the design through the generated `Makefile`. The following targets are provided, and they match the recommended development flow:
 
-    * Compile for emulation (fast compile time, targets emulated FPGA device).
+    - Compile for emulation (fast compile time, targets emulated FPGA device).
 
        ```
        make fpga_emu
        ```
 
-    * Generate HTML performance report. Find the report in `cholesky_inversion_report.prj/reports/report.html`directory.
+    - Generate HTML performance report. Find the report in `cholesky_inversion_report.prj/reports/report.html`directory.
 
        ```
        make report
        ```
 
-    * Compile for FPGA hardware (longer compile time, targets FPGA device).
+    - Compile for FPGA hardware (longer compile time, targets FPGA device).
 
        ```
        make fpga
        ```
 
-3. (Optional) As the above hardware compile may take several hours to complete, FPGA precompiled binaries (compatible with Linux* Ubuntu* 18.04) can be downloaded <a href="https://iotdk.intel.com/fpga-precompiled-binaries/latest/cholesky_inversion.fpga.tar.gz" download>here</a>.
+3. (Optional) As the above hardware compile may take several hours to complete, you can download FPGA precompiled binaries (compatible with Linux* Ubuntu* 18.04) from [https://iotdk.intel.com/fpga-precompiled-binaries/latest/cholesky_inversion.fpga.tar.gz](https://iotdk.intel.com/fpga-precompiled-binaries/latest/cholesky_inversion.fpga.tar.gz).
 
-### On a Windows* System
+### On Windows*
 1. Generate the `Makefile` by running `cmake`.
      ```
    mkdir build
    cd build
    ```
-   To compile for the Intel® PAC with Intel Arria® 10 GX FPGA, run `cmake` using the command:
+   To compile for the Intel&reg; PAC with Intel Arria&reg; 10 GX FPGA, run `cmake` using the command:
     ```
     cmake -G "NMake Makefiles" ..
    ```
-   Alternatively, to compile for the Intel® FPGA PAC D5005 (with Intel Stratix® 10 SX), run `cmake` using the command:
+   Alternatively, to compile for the Intel&reg; FPGA PAC D5005 (with Intel Stratix&reg; 10 SX), run `cmake` using the command:
    ```
    cmake -G "NMake Makefiles" .. -DFPGA_BOARD=intel_s10sx_pac:pac_s10
    ```
 
 2. Compile the design through the generated `Makefile`. The following build targets are provided, matching the recommended development flow:
-   * Compile for emulation (fast compile time, targets emulated FPGA device):
+   - Compile for emulation (fast compile time, targets emulated FPGA device):
      ```
      nmake fpga_emu
      ```
-   * Generate the optimization report:
+   - Generate the optimization report:
      ```
      nmake report
      ```
-   * An FPGA hardware target is not provided on Windows*.
+   - An FPGA hardware target is not provided on Windows*.
 
-*Note:* The Intel® PAC with Intel Arria® 10 GX FPGA and Intel® FPGA PAC D5005 (with Intel Stratix® 10 SX) do not yet support Windows*. Compiling to FPGA hardware on Windows* requires a third-party or custom Board Support Package (BSP) with Windows* support.<br>
+> **Note**: The Intel&reg; PAC with Intel Arria&reg; 10 GX FPGA and Intel&reg; FPGA PAC D5005 (with Intel Stratix&reg; 10 SX) do not yet support Windows*. Compiling to FPGA hardware on Windows* requires a third-party or custom Board Support Package (BSP) with Windows* support.<br>
 
-*Note:* If you encounter any issues with long paths when compiling under Windows*, you may have to create your ‘build’ directory in a shorter path, for example c:\samples\build. You can then run cmake from that directory, and provide cmake with the full path to your sample directory.
+> **Note**: If you encounter any issues with long paths when compiling under Windows*, you may have to create your ‘build’ directory in a shorter path, for example c:\samples\build. You can then run cmake from that directory, and provide cmake with the full path to your sample directory.
 
 
 ### In Third-Party Integrated Development Environments (IDEs)
 
-You can compile and run this Reference Design in the Eclipse* IDE (in Linux*) and the Visual Studio* IDE (in Windows*). For instructions, refer to the following link: [Intel® oneAPI DPC++ FPGA Workflows on Third-Party IDEs](https://software.intel.com/en-us/articles/intel-oneapi-dpcpp-fpga-workflow-on-ide)
+You can compile and run this Reference Design in the Eclipse* IDE (in Linux*) and the Visual Studio* IDE (in Windows*). For instructions, refer to the following link: [FPGA Workflows on Third-Party IDEs for Intel&reg; oneAPI Toolkits](https://www.intel.com/content/www/us/en/developer/articles/technical/intel-oneapi-dpcpp-fpga-workflow-on-ide.html).
 
-## Running the Reference Design
+## Run the Reference Design
 You can apply the Cholesky-based inversion to 8 matrices repeated a number of times, as shown below. This step performs the following:
-* Generates 8 random matrices (this number can be changed in cholesky_inversion_demo.cpp).
-* Computes the Cholesky-based inversion on all matrices.
-* Repeats the operation multiple times (optionally specified as the command line argument) to evaluate performance.
+- Generates 8 random matrices (this number can be changed in cholesky_inversion_demo.cpp).
+- Computes the Cholesky-based inversion on all matrices.
+- Repeats the operation multiple times (optionally specified as the command line argument) to evaluate performance.
 
  1. Run the sample on the FPGA emulator (the kernel executes on the CPU).
      ```
@@ -208,12 +203,12 @@ You can apply the Cholesky-based inversion to 8 matrices repeated a number of ti
 ### Application Parameters
 
 | Argument | Description
----        |---
+|:---        |:---
 | `<num>`  | Optional argument that specifies the number of times to repeat the inversion of 8 matrices. Its default value is `16` for the emulation flow and '819200' for the FPGA flow.
 
 ### Example of Output
 
-Example output when running on Intel® PAC with Intel Arria® 10 GX FPGA for 8 matrices 819200 times (each matrix consisting of 32*32 real numbers):
+Example output when running on Intel&reg; PAC with Intel Arria&reg; 10 GX FPGA for 8 matrices 819200 times (each matrix consisting of 32*32 real numbers):
 
 ```
 Device name: pac_a10 : Intel PAC Platform (pac_f100000)
@@ -226,7 +221,7 @@ Verifying results...
 PASSED
 ```
 
-Example output when running on Intel® FPGA PAC D5005 (with Intel Stratix® 10 SX) for the decomposition of 8 matrices 819200 times (each matrix consisting of 32*32 real numbers):
+Example output when running on Intel&reg; FPGA PAC D5005 (with Intel Stratix&reg; 10 SX) for the decomposition of 8 matrices 819200 times (each matrix consisting of 32*32 real numbers):
 
 ```
 Device name: pac_s10 : Intel PAC Platform (pac_f100000)
@@ -247,7 +242,6 @@ The following source files can be found in the `src/` sub-directory.
 | File                                | Description
 |:---                                 |:---
 |`cholesky_inversion_demo.cpp`        | Contains the `main()` function which generates the input matrices, calls the compute function and validates the results.
-|                                     |
 |`cholesky_inversion.hpp`             | Contains the compute function that calls the kernels.
 |`memory_transfers.hpp`               | Contains functions to transfer matrices from/to the FPGA DDR with streaming interfaces.
 
@@ -256,10 +250,10 @@ For descriptions of `streaming_cholesky.hpp`, `streaming_cholesky_inversion.hpp`
 ### Compiler Flags Used
 
 | Flag                             | Description
----                                |---
+|:---                              |:---
 `-Xshardware`                      | Target FPGA hardware (as opposed to FPGA emulator)
 `-Xsclock=<target fmax>MHz`        | The FPGA backend attempts to achieve <target fmax> MHz
-`-Xsfp-relaxed`                    | Allows the FPGA backend to re-order floating point arithmetic operations (e.g. permit assuming (a + b + c) == (c + a + b) )
+`-Xsfp-relaxed`                    | Allows the FPGA backend to re-order floating point arithmetic operations (for example, permit assuming $(a + b + c) == (c + a + b)$)
 `-Xsparallel=2`                    | Use 2 cores when compiling the bitstream through Quartus
 `-Xsseed`                          | Specifies the Quartus compile seed, to potentially yield slightly higher fmax
 `-DMATRIX_DIMENSION`               | Specifies the number of rows/columns of the matrix
@@ -267,9 +261,9 @@ For descriptions of `streaming_cholesky.hpp`, `streaming_cholesky_inversion.hpp`
 `-DFIXED_ITERATIONS_INVERSION`     | Used to set the ivdep safelen attribute for the performance critical triangular loop of the inversion kernel
 `-DCOMPLEX`                        | Used to select between the complex and real QR decomposition (real is the default)
 
-NOTE: The values for `seed`, `FIXED_ITERATIONS_DECOMPOSITION`, `DFIXED_ITERATIONS_INVERSION`, `MATRIX_DIMENSION`, `COMPLEX` are set according to the board being targeted.
+> **Note**: The values for `seed`, `FIXED_ITERATIONS_DECOMPOSITION`, `DFIXED_ITERATIONS_INVERSION`, `MATRIX_DIMENSION`, `COMPLEX` are set according to the board being targeted.
 
-### Performance disclaimers
+## Performance Disclaimers
 
 Tests document performance of components on a particular test, in specific systems. Differences in hardware, software, or configuration will affect actual performance. Consult other sources of information to evaluate performance as you consider your purchase.  For more complete information about performance and benchmark results, visit [www.intel.com/benchmarks](www.intel.com/benchmarks).
 
@@ -279,4 +273,10 @@ Intel technologies’ features and benefits depend on system configuration and m
 
 Intel and the Intel logo are trademarks of Intel Corporation or its subsidiaries in the U.S. and/or other countries.
 
-(C) Intel Corporation.
+&copy; Intel Corporation.
+
+## License
+Code samples are licensed under the MIT license. See
+[License.txt](https://github.com/oneapi-src/oneAPI-samples/blob/master/License.txt) for details.
+
+Third party program Licenses can be found here: [third-party-programs.txt](https://github.com/oneapi-src/oneAPI-samples/blob/master/third-party-programs.txt).

--- a/DirectProgramming/DPC++FPGA/ReferenceDesigns/crr/README.md
+++ b/DirectProgramming/DPC++FPGA/ReferenceDesigns/crr/README.md
@@ -1,36 +1,31 @@
 # CRR Binomial Tree Model for Option Pricing
-An FPGA-optimized reference design computing the Cox-Ross-Rubinstein (CRR) binomial tree model with Greeks for American exercise options.
-
-***Documentation***:  The [DPC++ FPGA Code Samples Guide](https://software.intel.com/content/www/us/en/develop/articles/explore-dpcpp-through-intel-fpga-code-samples.html) helps you to navigate the samples and build your knowledge of DPC++ for FPGA. <br>
-The [oneAPI DPC++ FPGA Optimization Guide](https://software.intel.com/content/www/us/en/develop/documentation/oneapi-fpga-optimization-guide) is the reference manual for targeting FPGAs through DPC++. <br>
-The [oneAPI Programming Guide](https://software.intel.com/en-us/oneapi-programming-guide) is a general resource for target-independent DPC++ programming. <br>
-Additional reference material specific to option pricing algorithms is provided in the References section of this README.
-
-| Optimized for                     | Description
----                                 |---
-| OS                                | Linux* Ubuntu* 18.04/20.04, RHEL*/CentOS* 8, SUSE* 15; Windows* 10
-| Hardware                          | Intel® Programmable Acceleration Card (PAC) with Intel Arria® 10 GX FPGA; <br> Intel® FPGA Programmable Acceleration Card (PAC) D5005 (with Intel Stratix® 10 SX)
-| Software                          | Intel® oneAPI DPC++ Compiler <br> Intel® FPGA Add-On for oneAPI Base Toolkit
-| What you will learn               | Review a high performance DPC++ design optimized for FPGA
-| Time to complete                  | 1 hr (not including compile time)
-
-
-
-
-**Performance**
-Please refer to the performance disclaimer at the end of this README.
-
-| Device                                         | Throughput
-|:---                                            |:---
-| Intel® PAC with Intel Arria® 10 GX FPGA        | 118 assets/s
-| Intel® FPGA PAC D5005 (with Intel Stratix® 10 SX)      | 243 assets/s
-
+A field programmable gate array (FPGA)-optimized reference design computing the Cox-Ross-Rubinstein (CRR) binomial tree model with Greeks for American exercise options.
 
 ## Purpose
 This sample implements the Cox-Ross-Rubinstein (CRR) binomial tree model that is used in the finance field for American exercise options with five Greeks (delta, gamma, theta, vega and rho). The simple idea is to model all possible asset price paths using a binomial tree.
 
-## Key Implementation Details
+## Prerequisites
+| Optimized for                     | Description
+---                                 |---
+| OS                                | Ubuntu* 18.04/20.04 <br>RHEL*/CentOS* 8 <br>SUSE* 15 <br>Windows* 10
+| Hardware                          | Intel&reg; Programmable Acceleration Card (PAC) with Intel Arria&reg; 10 GX FPGA; <br> Intel&reg; FPGA Programmable Acceleration Card (PAC) D5005 (with Intel Stratix&reg; 10 SX)
+| Software                          | Intel&reg; oneAPI DPC++ Compiler <br> Intel&reg; FPGA Add-On for oneAPI Base Toolkit
 
+### Performance
+> **Note**: Please refer to the [Performance Disclaimers](#performance-disclaimers) section below.
+
+| Device                                         | Throughput
+|:---                                            |:---
+| Intel&reg; PAC with Intel Arria&reg; 10 GX FPGA        | 118 assets/s
+| Intel&reg; FPGA PAC D5005 (with Intel Stratix&reg; 10 SX)      | 243 assets/s
+
+### Additional Documentation
+- [Explore SYCL* Through Intel&reg; FPGA Code Samples](https://software.intel.com/content/www/us/en/develop/articles/explore-dpcpp-through-intel-fpga-code-samples.html) helps you to navigate the samples and build your knowledge of FPGAs and SYCL.
+- [FPGA Optimization Guide for Intel&reg; oneAPI Toolkits](https://software.intel.com/content/www/us/en/develop/documentation/oneapi-fpga-optimization-guide) helps you understand how to target FPGAs using SYCL and Intel&reg; oneAPI Toolkits.
+- [Intel&reg; oneAPI Programming Guide](https://software.intel.com/en-us/oneapi-programming-guide) helps you understand target-independent, SYCL-compliant programming using Intel&reg; oneAPI Toolkits.
+
+
+## Key Implementation Details
 ### Design Inputs
 This design reads inputs from the `ordered_inputs.csv` file. The inputs are:
 
@@ -57,22 +52,11 @@ This design writes outputs to the `ordered_outputs.csv` file. The outputs are:
 | `theta`                           | Measures the sensitivity of the derivative's value to the passage of time.
 | `rho`                             | Measures sensitivity to the interest of rate.
 
-### Design Correctness
+#### Design Correctness
 This design tests the optimized FPGA code's correctness by comparing its output to a golden result computed on the CPU.
 
-### Design Performance
+#### Design Performance
 This design measures the FPGA performance to determine how many assets can be processed per second.
-
-## License
-Code samples are licensed under the MIT license. See
-[License.txt](https://github.com/oneapi-src/oneAPI-samples/blob/master/License.txt) for details.
-
-Third party program Licenses can be found here: [third-party-programs.txt](https://github.com/oneapi-src/oneAPI-samples/blob/master/third-party-programs.txt)
-
-To learn more about the extensions, see
-[Using Visual Studio Code with Intel® oneAPI Toolkits](https://software.intel.com/content/www/us/en/develop/documentation/using-vs-code-with-intel-oneapi/top.html).
-
-After learning how to use the extensions for Intel oneAPI Toolkits, return to this readme for instructions on how to build and run a sample.
 
 ## Building the CRR Program
 
@@ -80,21 +64,22 @@ After learning how to use the extensions for Intel oneAPI Toolkits, return to th
 > environment by sourcing  the `setvars` script located in
 > the root of your oneAPI installation.
 >
-> Linux Sudo: . /opt/intel/oneapi/setvars.sh
+> Linux:
+> - For system wide installations: `. /opt/intel/oneapi/setvars.sh`
+> - For private installations: `. ~/intel/oneapi/setvars.sh`
 >
-> Linux User: . ~/intel/oneapi/setvars.sh
->
-> Windows: C:\Program Files(x86)\Intel\oneAPI\setvars.bat
+> Windows:
+> - `C:\Program Files(x86)\Intel\oneAPI\setvars.bat`
 >
 >For more information on environment variables, see Use the setvars Script for [Linux or macOS](https://www.intel.com/content/www/us/en/develop/documentation/oneapi-programming-guide/top/oneapi-development-environment-setup/use-the-setvars-script-with-linux-or-macos.html), or [Windows](https://www.intel.com/content/www/us/en/develop/documentation/oneapi-programming-guide/top/oneapi-development-environment-setup/use-the-setvars-script-with-windows.html).
 
 ### Include Files
 The included header `dpc_common.hpp` is located at `%ONEAPI_ROOT%\dev-utilities\latest\include` on your development system.
 
-### Running Samples in DevCloud
-If running a sample in the Intel DevCloud, remember that you must specify the type of compute node and whether to run in batch or interactive mode. Compiles to FPGA are only supported on fpga_compile nodes. Executing programs on FPGA hardware is only supported on fpga_runtime nodes of the appropriate type, such as fpga_runtime:arria10 or fpga_runtime:stratix10.  Neither compiling nor executing programs on FPGA hardware are supported on the login nodes. For more information, see the Intel® oneAPI Base Toolkit Get Started Guide ([https://devcloud.intel.com/oneapi/documentation/base-toolkit/](https://devcloud.intel.com/oneapi/documentation/base-toolkit/)).
+### Run Samples in DevCloud
+If running a sample in the Intel DevCloud, remember that you must specify the type of compute node and whether to run in batch or interactive mode. Compiles to FPGA are only supported on fpga_compile nodes. Executing programs on FPGA hardware is only supported on fpga_runtime nodes of the appropriate type, such as fpga_runtime:arria10 or fpga_runtime:stratix10.  Neither compiling nor executing programs on FPGA hardware are supported on the login nodes. For more information, see [Intel&reg; DevCloud for oneAPI Get Started](https://devcloud.intel.com/oneapi/documentation/base-toolkit/).
 
-When compiling for FPGA hardware, it is recommended to increase the job timeout to 48h.
+When compiling for FPGA hardware, it is recommended to increase the job timeout to **48h**.
 
 
 ### Using Visual Studio Code*  (Optional)
@@ -108,23 +93,20 @@ The basic steps to build and run a sample using VS Code include:
  - Open a Terminal in VS Code (**Terminal>New Terminal**).
  - Run the sample in the VS Code terminal using the instructions below.
 
-To learn more about the extensions and how to configure the oneAPI environment, see
-[Using Visual Studio Code with Intel® oneAPI Toolkits](https://software.intel.com/content/www/us/en/develop/documentation/using-vs-code-with-intel-oneapi/top.html).
+To learn more about the extensions and how to configure the oneAPI environment, see [Using Visual Studio Code with Intel&reg; oneAPI Toolkits User Guide](https://software.intel.com/content/www/us/en/develop/documentation/using-vs-code-with-intel-oneapi/top.html).
 
-After learning how to use the extensions for Intel oneAPI Toolkits, return to this readme for instructions on how to build and run a sample.
-
-### On a Linux* System
+### On Linux*
 
 1. Generate the `Makefile` by running `cmake`.
      ```
    mkdir build
    cd build
    ```
-   To compile for the Intel® PAC with Intel Arria® 10 GX FPGA, run `cmake` using the command:
+   To compile for the Intel&reg; PAC with Intel Arria&reg; 10 GX FPGA, run `cmake` using the command:
     ```
     cmake ..
    ```
-   Alternatively, to compile for the Intel® FPGA PAC D5005 (with Intel Stratix® 10 SX), run `cmake` using the command:
+   Alternatively, to compile for the Intel&reg; FPGA PAC D5005 (with Intel Stratix&reg; 10 SX), run `cmake` using the command:
 
    ```
    cmake .. -DFPGA_BOARD=intel_s10sx_pac:pac_s10
@@ -144,20 +126,20 @@ After learning how to use the extensions for Intel oneAPI Toolkits, return to th
      ```
      make fpga
      ```
-3. (Optional) As the above hardware compile may take several hours to complete, FPGA precompiled binaries (compatible with Linux* Ubuntu* 18.04) can be downloaded <a href="https://iotdk.intel.com/fpga-precompiled-binaries/latest/crr.fpga.tar.gz" download>here</a>.
+3. (Optional) As the above hardware compile may take several hours to complete, you can download FPGA precompiled binaries (compatible with Linux* Ubuntu* 18.04) from [https://iotdk.intel.com/fpga-precompiled-binaries/latest/crr.fpga.tar.gz](https://iotdk.intel.com/fpga-precompiled-binaries/latest/crr.fpga.tar.gz).
 
-### On a Windows* System
+### On Windows*
 
 1. Generate the `Makefile` by running `cmake`.
      ```
    mkdir build
    cd build
    ```
-   To compile for the Intel® PAC with Intel Arria® 10 GX FPGA, run `cmake` using the command:
+   To compile for the Intel&reg; PAC with Intel Arria&reg; 10 GX FPGA, run `cmake` using the command:
     ```
     cmake -G "NMake Makefiles" ..
    ```
-   Alternatively, to compile for the Intel® FPGA PAC D5005 (with Intel Stratix® 10 SX), run `cmake` using the command:
+   Alternatively, to compile for the Intel&reg; FPGA PAC D5005 (with Intel Stratix&reg; 10 SX), run `cmake` using the command:
 
    ```
    cmake -G "NMake Makefiles" .. -DFPGA_BOARD=intel_s10sx_pac:pac_s10
@@ -175,22 +157,21 @@ After learning how to use the extensions for Intel oneAPI Toolkits, return to th
      ```
    * An FPGA hardware target is not provided on Windows*.
 
-*Note:* The Intel® PAC with Intel Arria® 10 GX FPGA and Intel® FPGA PAC D5005 (with Intel Stratix® 10 SX) do not yet support Windows*. Compiling to FPGA hardware on Windows* requires a third-party or custom Board Support Package (BSP) with Windows* support.<br>
-*Note:* If you encounter any issues with long paths when compiling under Windows*, you may have to create your ‘build’ directory in a shorter path, for example c:\samples\build.  You can then run cmake from that directory, and provide cmake with the full path to your sample directory.
+> **Note**: The Intel&reg; PAC with Intel Arria&reg; 10 GX FPGA and Intel&reg; FPGA PAC D5005 (with Intel Stratix&reg; 10 SX) do not yet support Windows*. Compiling to FPGA hardware on Windows* requires a third-party or custom Board Support Package (BSP) with Windows* support.<br>
 
+> **Note**: If you encounter any issues with long paths when compiling under Windows*, you may have to create your ‘build’ directory in a shorter path, for example c:\samples\build.  You can then run cmake from that directory, and provide cmake with the full path to your sample directory.
 
 ## Troubleshooting
 If an error occurs, you can get more details by running `make` with
 the `VERBOSE=1` argument:
 ``make VERBOSE=1``
 For more comprehensive troubleshooting, use the Diagnostics Utility for
-Intel® oneAPI Toolkits, which provides system checks to find missing
-dependencies and permissions errors.
-[Learn more](https://software.intel.com/content/www/us/en/develop/documentation/diagnostic-utility-user-guide/top.html).
+Intel&reg; oneAPI Toolkits, which provides system checks to find missing
+dependencies and permissions errors. See the [Diagnostics Utility for Intel&reg; oneAPI Toolkits User Guide](https://software.intel.com/content/www/us/en/develop/documentation/diagnostic-utility-user-guide/top.html) for more information.
 
 ### In Third-Party Integrated Development Environments (IDEs)
 
-You can compile and run this tutorial in the Eclipse* IDE (in Linux*) and the Visual Studio* IDE (in Windows*). For instructions, refer to the following link: [Intel® oneAPI DPC++ FPGA Workflows on Third-Party IDEs](https://www.intel.com/content/www/us/en/developer/articles/technical/intel-oneapi-dpcpp-fpga-workflow-on-ide.html)
+You can compile and run this tutorial in the Eclipse* IDE (in Linux*) and the Visual Studio* IDE (in Windows*). For instructions, see [FPGA Workflows on Third-Party IDEs for Intel&reg; oneAPI Toolkits](https://www.intel.com/content/www/us/en/developer/articles/technical/intel-oneapi-dpcpp-fpga-workflow-on-ide.html).
 
 ## Running the Reference Design
 
@@ -242,8 +223,8 @@ Avg throughput: 66.2 assets/s
 `-Xshardware`                       | Target FPGA hardware (as opposed to FPGA emulator)
 `-Xsdaz`                            | Denormals are zero
 `-Xsrounding=faithful`              | Rounds results to either the upper or lower nearest single-precision numbers
-`-Xsparallel=2`                     | Uses 2 cores when compiling the bitstream through Quartus®
-`-Xsseed=2`                         | Uses seed 2 during Quartus®, yields slightly higher f<sub>MAX</sub>
+`-Xsparallel=2`                     | Uses 2 cores when compiling the bitstream through Quartus&reg;
+`-Xsseed=2`                         | Uses seed 2 during Quartus&reg;, yields slightly higher f<sub>MAX</sub>
 
 ### Preprocessor Define Flags
 
@@ -254,9 +235,9 @@ Avg throughput: 66.2 assets/s
 `-DOUTER_UNROLL_POW2=1`             | Uses the value 1 for the constant OUTER_UNROLL_POW2, controls the number of memory banks
 
 
-NOTE: The Xsseed, DOUTER_UNROLL, DINNER_UNROLL and DOUTER_UNROLL_POW2 values differ depending on the board being targeted. More information about the unroll factors can be found in `/src/CRR_common.hpp`.
+> **Note**: The `Xsseed`, `DOUTER_UNROLL`, `DINNER_UNROLL` and `DOUTER_UNROLL_POW2` values differ depending on the board being targeted. More information about the unroll factors can be found in `/src/CRR_common.hpp`.
 
-### Performance disclaimers
+### Performance Disclaimers
 
 Tests document performance of components on a particular test, in specific systems. Differences in hardware, software, or configuration will affect actual performance. Consult other sources of information to evaluate performance as you consider your purchase. For more complete information about performance and benchmark results, visit [this page](https://edc.intel.com/content/www/us/en/products/performance/benchmarks/overview).
 
@@ -268,15 +249,20 @@ The performance was measured by Intel on July 20, 2020
 
 Intel and the Intel logo are trademarks of Intel Corporation or its subsidiaries in the U.S. and/or other countries.
 
-(C) Intel Corporation.
+&copy; Intel Corporation.
 
-### References
+## Additional References
 
-[Khronous SYCL Resources](https://www.khronos.org/sycl/resources)
+- [Khronous Group SYCL Resources](https://www.khronos.org/sycl/resources)
 
-[Binomial options pricing model](https://en.wikipedia.org/wiki/Binomial_options_pricing_model)
+- [Wikipedia article on Binomial options pricing model](https://en.wikipedia.org/wiki/Binomial_options_pricing_model)
 
-[Wike page for finance Greeks](https://en.wikipedia.org/wiki/Greeks_(finance))
+- [Wikipedia article on Greeks (finance)](https://en.wikipedia.org/wiki/Greeks_(finance))
 
-[OpenCL Intercept Layer](https://github.com/intel/opencl-intercept-layer)
+- [GitHub repository for Intercept Layer for OpenCL&trade; Applications](https://github.com/intel/opencl-intercept-layer)
 
+## License
+Code samples are licensed under the MIT license. See
+[License.txt](https://github.com/oneapi-src/oneAPI-samples/blob/master/License.txt) for details.
+
+Third party program Licenses can be found here: [third-party-programs.txt](https://github.com/oneapi-src/oneAPI-samples/blob/master/third-party-programs.txt).

--- a/DirectProgramming/DPC++FPGA/include/README.md
+++ b/DirectProgramming/DPC++FPGA/include/README.md
@@ -1,5 +1,5 @@
 # Include for Shared Header Libraries
-This directory contains utility header libraries optimized for FPGA DPC++ designs. Examples of their usage can be found in ReferenceDesigns and Tutorials.
+This directory contains utility header libraries optimized for SYCL*-compliant FPGA designs. Find usage examples in the **ReferenceDesigns** and **Tutorials** directories.
 
 ## Available Header Libraries
 
@@ -7,26 +7,26 @@ This directory contains utility header libraries optimized for FPGA DPC++ design
 
 | Filename                     | Description
 ---                            |---
-| constexpr_math.hpp           | Defines utilities for statically computing math functions (e.g. Log2 and Pow2).
-| memory_utils.hpp             | Generic functions for streaming data from memory to a SYCL pipe, and vice versa.
-| metaprogramming_utils.hpp    | Defines various metapgramming utilities (e.g. generating a power of 2 sequence and checking if a type has a subscript operator).
-| onchip_memory_with_cache.hpp | Class that contains an on-chip memory array with a register backed cache to achieve high performance read-modify-write loops.
-| pipe_utils.hpp               | Utility classes for working with pipes, such as PipeArray.
-| rom_base.hpp                 | A generic base class to create ROMs in the FPGA using and initializer lambda or functor.
-| tuple.hpp                    | Defines a template to implement tuples.
-| unrolled_loop.hpp            | Defines a templated implementation of unrolled loops.
+| `constexpr_math.hpp`           | Defines utilities for statically computing math functions (for example, Log2 and Pow2).
+| `memory_utils.hpp`             | Generic functions for streaming data from memory to a SYCL pipe and vise versa.
+| `metaprogramming_utils.hpp`    | Defines various metaprogramming utilities (for example, generating a power of 2 sequence and checking if a type has a subscript operator).
+| `onchip_memory_with_cache.hpp` | Class that contains an on-chip memory array with a register backed cache to achieve high performance read-modify-write loops.
+| `pipe_utils.hpp`               | Utility classes for working with pipes, such as PipeArray.
+| `rom_base.hpp`                 | A generic base class to create ROMs in the FPGA using and initializer lambda or functor.
+| `tuple.hpp`                    | Defines a template to implement tuples.
+| `unrolled_loop.hpp`            | Defines a templated implementation of unrolled loops.
 
 ### Linear Algebra
 
 | Filename               | Description
 ---                      |---
-| streaming_qrd.hpp      | QR decomposition of matrices with pipe interfaces.
-| streaming_qri.hpp      | QR-based inversion of matrices with pipe interfaces.
-| streaming_cholesky.hpp | Cholesky decomposition of matrices with pipe interfaces.
-| streaming_cholesky_inversion.hpp | Cholesky-based inversion of matrices with pipe interfaces.
+| `streaming_qrd.hpp`      | QR decomposition of matrices with pipe interfaces.
+| `streaming_qri.hpp`      | QR-based inversion of matrices with pipe interfaces.
+| `streaming_cholesky.hpp` | Cholesky decomposition of matrices with pipe interfaces.
+| `streaming_cholesky_inversion.hpp` | Cholesky-based inversion of matrices with pipe interfaces.
 
 ## License
-Code samples are licensed under the MIT license. See
-[License.txt](https://github.com/oneapi-src/oneAPI-samples/blob/master/License.txt) for details.
 
-Third party program Licenses can be found here: [third-party-programs.txt](https://github.com/oneapi-src/oneAPI-samples/blob/master/third-party-programs.txt)
+Code samples are licensed under the MIT license. See [License.txt](https://github.com/oneapi-src/oneAPI-samples/blob/master/License.txt) for details.
+
+Third-party program Licenses can be found here: [third-party-programs.txt](https://github.com/oneapi-src/oneAPI-samples/blob/master/third-party-programs.txt).


### PR DESCRIPTION
First batch of changes related to DPC++ to SYCL changes in DPC++FPGA directories.

# Existing Sample Changes
## Description

Begin work DPC++ to SYCL changes in DPC++FPGA directories.

File: ...\DirectProgramming\DPC++FPGA\include\README.md
Changes: Focus on changes from DPC++ to SYCL. Changed one instance of DPC++. Updated some formatting and fixed spelling errors.

File: **...\DirectProgramming\DPC++FPGA\ReferenceDesigns\anr\README.md**
Changes: Focus on changes from DPC++ to SYCL. (Full restructure later.) Removed or changed DPC++ instances in favor of SYCL. Corrected multiple formatting issues. Made modest/limited structural changes related to new template guidance. Updated the out-of-date documentation links and sections. Updated license information. Updated setting vars. Noted that link to precompiled binary does not work. Need sample owner to provide updated link.

File: **...\DirectProgramming\DPC++FPGA\ReferenceDesigns\cholesky\README.md**
Changes: Focus on changes from DPC++ to SYCL. (Full restructure later.) Removed or changed DPC++ instances in favor of SYCL. Corrected multiple formatting issues. Made modest/limited structural changes related to new template guidance. Updated the out-of-date documentation links and sections. Updated license information. Updated setting vars. Noted that link to precompiled binary does not work. Need sample owner to provide updated link.

File: **...\oneAPI-samples\DirectProgramming\DPC++FPGA\ReferenceDesigns\cholesky_inversion**
Changes: Focus on changes from DPC++ to SYCL. (Full restructure later.) Removed or changed DPC++ instances in favor of SYCL. Corrected multiple formatting issues. Made modest/limited structural changes related to new template guidance. Updated the out-of-date documentation links and sections. Updated license information. Updated setting vars. Fixed multiple links references to point to current URIs/URLS. Noted that link to precompiled binary does not work. Need sample owner to provide updated link.

File: **...\DirectProgramming\DPC++FPGA\ReferenceDesigns\crr\README.md**
Changes: Focus on changes from DPC++ to SYCL. (Full restructure later.) Removed or changed DPC++ instances in favor of SYCL. Corrected multiple formatting issues. Made modest/limited structural changes related to new template guidance. Updated the out-of-date documentation links and sections. Updated license information. Updated setting vars. Fixed multiple links references to point to current URIs/URLS.

Fixes Issue# 

## External Dependencies

N/A

## Type of change

Please delete options that are not relevant. Add a 'X' to the one that is applicable. 
- [x] Documentation

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Command Line
- [x] VSCode
