### PR TITLE
Update run instructions for DPC++ OpenCL Interrogability Sample

### DIFF
--- a/DirectProgramming/DPC++/OpenCLInterop/README.md
+++ b/DirectProgramming/DPC++/OpenCLInterop/README.md
@@ -83,8 +83,7 @@ Perform the following steps:
 
 2. Run the program:
     ```
-    make run_prog1
-    make run_prog2
+    make run
     ```
 
 3. Clean the program using:
@@ -104,9 +103,6 @@ dependencies and permissions errors. See [Diagnostics Utility for Intel&reg; one
 
 ### Output Example
 ```
-Device: Intel(R) HD Graphics 630 [0x5912]
-PASSED!
-Built target run_prog1
 
 Kernel Loading Done
 Platforms Found: 3
@@ -114,7 +110,7 @@ Using Platform: Intel(R) FPGA Emulation Platform for OpenCL(TM)
 Devices Found: 1
 Device: Intel(R) FPGA Emulation Device
 Passed!
-Built target run_prog2
+Built target run
 ```
 ## License
 


### PR DESCRIPTION
Signed-off-by: Emmanuel Moncada <emmanuel.moncada27@gmail.com>

# Existing Sample Changes
## Description

Updates the run command for the sample         ########OpenCLInterop

Fixes Issue #994 

## External Dependencies

None

## Type of change

Please delete options that are not relevant. Add a 'X' to the one that is applicable. 

- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [X] Command Line
- [ ] oneapi-cli
- [ ] Visual Studio
- [ ] Eclipse IDE
- [ ] VSCode
- [ ] When compiling the compliler flag "-Wall -Wformat-security -Werror=format-security" was used

1. navigate to DirectProgramming/DPC++/OpenCLInterop/ 
2. create a build dir `mkdir build`, then `cd build`
3. run `cmake ..` then `make`
4. running `make run_prog1` or `make run_prog2` (as per readme) will produce an error saying there are no matching targets.
5. running `make run` will run the program with the desired output. 



