### PR TITLE
set compiler prior to project config

### DIFF
--- a/DirectProgramming/DPC++/GraphAlgorithms/all-pairs-shortest-paths/CMakeLists.txt
+++ b/DirectProgramming/DPC++/GraphAlgorithms/all-pairs-shortest-paths/CMakeLists.txt
@@ -1,7 +1,8 @@
 cmake_minimum_required (VERSION 3.5)
+set(CMAKE_CXX_COMPILER dpcpp)
+
 project (all-pairs-shortest-paths)
 
-set(CMAKE_CXX_COMPILER dpcpp)
 
 
 # Set default build type to RelWithDebInfo if not specified


### PR DESCRIPTION
Signed-off-by: Emmanuel Moncada <emmanuel.moncada27@gmail.com>

# Existing Sample Changes
## Description

Sets compiler prior to project being configured so it actually takes effect.

Fixes Issue #1002 

## External Dependencies

None

## Type of change

Please delete options that are not relevant. Add a 'X' to the one that is applicable. 

- [X] Bug fix (non-breaking change which fixes an issue)


## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [X] Command Line

running `mkdir build && cd build && cmake ..` now selects and configures dpcpp as the compiler to be used, shown by the output of running `cmake ..`