### PR TITLE
Changing DPC++ to SYCL instances in Tools directory

### DIFF
--- a/Tools/Advisor/matrix_multiply_advisor/README.md
+++ b/Tools/Advisor/matrix_multiply_advisor/README.md
@@ -1,37 +1,32 @@
 # `Matrix Multiply` Sample
 A sample containing multiple implementations of matrix multiplication code
-sample and is implemented using the DPC++ language for CPU and GPU.
+sample and is implemented using SYCL* for CPU and GPU.
 
 | Optimized for                       | Description
 |:---                               |:---
-| OS                                | Linux Ubuntu 18.04; Windows 10
+| OS                                | Linux* Ubuntu* 18.04 <br> Windows* 10
 | Hardware                          | Kaby Lake with GEN9 or newer
-| Software                          | Intel&reg; oneAPI DPC++ Compiler; Intel&reg; Advisor
+| Software                          | Intel&reg; oneAPI DPC++ Compiler <br> Intel&reg; Advisor
 | What you will learn               | How to profile an application using Intel&reg; Advisor
 | Time to complete                  | 15 minutes
 
 ## Purpose
 
 The Matrix Multiplication sample performs basic matrix multiplication. Three
-versions are provided that use different features of DPC++.
+versions are provided that use different SYCL features.
 
 ## Key Implementation details
 
-The basic DPC++ implementation explained in the code includes device selector,
-buffer, accessor, kernel, and command groups. The include folder is located at
-%ONEAPI_ROOT%\dev-utilities\latest\include on your development system.
+The basic SYCL implementation explained in the code includes device selector,
+buffer, accessor, kernel, and command groups. 
 
-## License
-Code samples are licensed under the MIT license. See
-[License.txt](https://github.com/oneapi-src/oneAPI-samples/blob/master/License.txt) for details.
+## Include Files 
+The include folder is located at
+`%ONEAPI_ROOT%\dev-utilities\latest\include` on your development system.
 
-Third party program Licenses can be found here:
-[third-party-programs.txt](https://github.com/oneapi-src/oneAPI-samples/blob/master/third-party-programs.txt)
-
-
-### Running Samples In DevCloud
-Running samples in the Intel DevCloud requires you to specify a compute node.
-For specific instructions, jump to [Run the Matrix Multiply Advisor sample on the DevCloud](#run-matmul-advisor-on-devcloud)
+### Running Samples In Intel&reg; DevCloud
+Running samples in the Intel&reg; DevCloud requires you to specify a compute node.
+For specific instructions, jump to [Run the Matrix Multiply Advisor sample on the DevCloud](#run-matmul-advisor-on-devcloud).
 
 ## Using Visual Studio Code* (Optional)
 
@@ -39,44 +34,44 @@ You can use Visual Studio Code (VS Code) extensions to set your environment,
 create launch configurations, and browse and download samples.
 
 The basic steps to build and run a sample using VS Code include:
- - Download a sample using the extension **Code Sample Browser for Intel oneAPI Toolkits**.
- - Configure the oneAPI environment with the extension **Environment Configurator for Intel oneAPI Toolkits**.
+ - Download a sample using the extension **Code Sample Browser for Intel&reg; oneAPI Toolkits**.
+ - Configure the oneAPI environment with the extension **Environment Configurator for Intel&reg; oneAPI Toolkits**.
  - Open a Terminal in VS Code (**Terminal>New Terminal**).
  - Run the sample in the VS Code terminal using the instructions below.
  - (Linux only) Debug your GPU application with GDB for Intel® oneAPI toolkits using the **Generate Launch Configurations** extension.
 
-To learn more about the extensions, see
-[Using Visual Studio Code with Intel® oneAPI Toolkits](https://www.intel.com/content/www/us/en/develop/documentation/using-vs-code-with-intel-oneapi/top.html).
+To learn more about the extensions, see the
+[Using Visual Studio Code with Intel® oneAPI Toolkits User Guide](https://www.intel.com/content/www/us/en/develop/documentation/using-vs-code-with-intel-oneapi/top.html).
 
-After learning how to use the extensions for Intel oneAPI Toolkits, return to
-this readme for instructions on how to build and run a sample.
 
 ## How to Build
-
 > **Note**: If you have not already done so, set up your CLI
 > environment by sourcing  the `setvars` script located in
 > the root of your oneAPI installation.
 >
-> Linux Sudo: . /opt/intel/oneapi/setvars.sh
+> Linux*:
+> - For system wide installations: `. /opt/intel/oneapi/setvars.sh`
+> - For private installations: `. ~/intel/oneapi/setvars.sh`
+> - For non-POSIX shells, like csh, use the following command: `$ bash -c 'source <install-dir>/setvars.sh ; exec csh'`
 >
-> Linux User: . ~/intel/oneapi/setvars.sh
+> Windows*:
+> - `C:\Program Files(x86)\Intel\oneAPI\setvars.bat`
+> - For Windows PowerShell*, use the following command: `cmd.exe "/K" '"C:\Program Files (x86)\Intel\oneAPI\setvars.bat" && powershell'`
 >
-> Windows: C:\Program Files(x86)\Intel\oneAPI\setvars.bat
->
-> For more information on environment variables, see Use the setvars Script for [Linux or macOS](https://www.intel.com/content/www/us/en/develop/documentation/oneapi-programming-guide/top/oneapi-development-environment-setup/use-the-setvars-script-with-linux-or-macos.html), or [Windows](https://www.intel.com/content/www/us/en/develop/documentation/oneapi-programming-guide/top/oneapi-development-environment-setup/use-the-setvars-script-with-windows.html).
+> For more information on configuring environment variables, see [Use the setvars Script with Linux* or MacOS*](https://www.intel.com/content/www/us/en/develop/documentation/oneapi-programming-guide/top/oneapi-development-environment-setup/use-the-setvars-script-with-linux-or-macos.html) or [Use the setvars Script with Windows*](https://www.intel.com/content/www/us/en/develop/documentation/oneapi-programming-guide/top/oneapi-development-environment-setup/use-the-setvars-script-with-windows.html).
 
-This sample contains three versions of matrix multiplication using DPC++:
+This sample contains three versions of matrix multiplication:
 
-    multiply1 – basic implementation of matrix multiply using DPC++
-    multiply1_1 – basic implementation that replaces the buffer store with a local accessor “acc” to reduce memory traffic
-    multiply1_2 – the basic implementation, plus adding the local accessor and matrix tiling
+- `multiply1` – basic implementation of matrix multiply using SYCL
+- `multiply1_1` – basic implementation that replaces the buffer store with a local accessor “acc” to reduce memory traffic
+- `multiply1_2` – the basic implementation, plus adding the local accessor and matrix tiling
 
-Edit the line in src/multiply.hpp to select the version of the multiply function:
-#define MULTIPLY multiply1
+Edit the line in `src/multiply.hpp` to select the version of the multiply function:
+`#define MULTIPLY multiply1`.
 
 
 ### On a Linux* System
-	To build DPC++ version:
+	To build the SYCL version:
 	cd <sample dir>
 	cmake .
 	make
@@ -106,31 +101,28 @@ dependencies and permissions errors.
 
 
 ### Example of Output
+```
+./matrix.dpcpp
 
-   ./matrix.dpcpp
+Using multiply kernel: multiply1
 
-   Using multiply kernel: multiply1
+Running on Intel(R) Gen9
 
-   Running on Intel(R) Gen9
+Elapsed Time: 0.539631s
+```
 
-   Elapsed Time: 0.539631s
-
-
-## Running an Intel Advisor analysis
-------------------------------------------
-
-See the Advisor Cookbook here: https://software.intel.com/en-us/advisor-cookbook
-
+## Running an Intel® Advisor analysis
+See the [Intel® Advisor Cookbook](https://software.intel.com/en-us/advisor-cookbook).
 
 ### Running the Matrix Multiply Advisor sample in the DevCloud<a name="run-matmul-advisor-on-devcloud"></a>
-This sample contains 3 version of matrix multiplication using DPC++:
+This sample contains 3 version of matrix multiplication:
 
-    multiply1 – basic implementation of matrix multiply using DPC++
-    multiply1_1 – basic implementation that replaces the buffer store with a local accessor “acc” to reduce memory traffic
-    multiply1_2 – the basic implementation, plus adding the local accessor and matrix tiling
+- `multiply1` – basic implementation of matrix multiply using SYCL
+- `multiply1_1` – basic implementation that replaces the buffer store with a local accessor “acc” to reduce memory traffic
+- `multiply1_2` – the basic implementation, plus adding the local accessor and matrix tiling
 
-Edit the line in src/multiply.hpp to select the version of the multiply function:
-#define MULTIPLY multiply1
+Edit the line in `src/multiply.hpp` to select the version of the multiply function:
+`#define MULTIPLY multiply1`.
 
 1.  Open a terminal on your Linux system.
 2.	Log in to DevCloud.
@@ -166,7 +158,7 @@ make
 
 3.	Save and close the build.sh file.
 
-4.	Create a run.sh script with with your preferred text editor:
+4.	Create a run.sh script with your preferred text editor:
 ```
 nano run.sh
 ```
@@ -230,7 +222,7 @@ Elapsed Time: 1.79388s
 Built target run
 ```
 
-6.	Remove the stdout and stderr files and clean-up the project files.
+6.	Remove the stdout and stderr files and clean up the project files.
 ```
 rm build.sh.*; rm run.sh.*; make clean
 ```
@@ -238,11 +230,15 @@ rm build.sh.*; rm run.sh.*; make clean
 ```
 exit
 ```
-## Running an Intel Advisor analysis
-------------------------------------------
-
-See the Advisor Cookbook here: https://software.intel.com/en-us/advisor-cookbook
+## Running an Intel&reg; Advisor analysis
+See the [Intel® Advisor Cookbook](https://software.intel.com/en-us/advisor-cookbook).
 
 ### Build and run additional samples
 Several sample programs are available for you to try, many of which can be compiled and run in a similar fashion to this sample. Experiment with running the various samples on different kinds of compute nodes or adjust their source code to experiment with different workloads.
 
+## License
+Code samples are licensed under the MIT license. See
+[License.txt](https://github.com/oneapi-src/oneAPI-samples/blob/master/License.txt) for details.
+
+Third party program Licenses can be found here:
+[third-party-programs.txt](https://github.com/oneapi-src/oneAPI-samples/blob/master/third-party-programs.txt).

--- a/Tools/ApplicationDebugger/array-transform/README.md
+++ b/Tools/ApplicationDebugger/array-transform/README.md
@@ -1,25 +1,26 @@
 # `array-transform` Sample
 
-This is a small DPC++ code sample for exercising application debugging using
-Intel&reg; Distribution for GDB\*.  It is highly recommended that you go
+This is a small SYCL*-compliant code sample for exercising application debugging using
+Intel&reg; Distribution for GDB*.  It is highly recommended that you go
 through this sample *after* you familiarize yourself with the basics of
-DPC++, and *before* you start using the debugger.
+SYCL programming, and *before* you start using the debugger.
 
-This sample accompanies the
-[Get Started Guide](https://software.intel.com/en-us/get-started-with-debugging-dpcpp)
-of the application debugger.
 
 | Optimized for       | Description
 |---------------------|--------------
-| OS                  | Linux Ubuntu 18.04 to 20.04, CentOS* 8, Fedora* 30, SLES 15; Windows* 10
+| OS                  | Linux* Ubuntu* 18.04 to 20.04 <br> CentOS* 8 <br> Fedora* 30 <br> SLES 15 <br> Windows* 10
 | Hardware            | Kaby Lake with GEN9 (on GPU) or newer (on CPU)
 | Software            | Intel&reg; oneAPI DPC++/C++ Compiler
-| What you will learn | Essential debugger features for effective debugging of DPC++ on CPU, GPU, and FPGA emulator
+| What you will learn | Essential debugger features for effective debugging on CPU, GPU, and FPGA emulator
 | Time to complete    | 20 minutes for CPU or FPGA emulator; 30 minutes for GPU
+
+This sample accompanies 
+[Get Started with Intel® Distribution for GDB* on Linux* OS Host](https://software.intel.com/en-us/get-started-with-debugging-dpcpp)
+of the application debugger.
 
 ## Purpose
 
-The `array-transform` sample is a DPC++ application with a small
+The `array-transform` sample is a SYCL-conforming application with a small
 computation kernel that is designed to illustrate key debugger
 features such as breakpoint definition, thread switching,
 scheduler-locking and SIMD lane views.  The sample is intended
@@ -31,24 +32,16 @@ code sample provides the ability to select the target device by passing the
 program `cpu`, `gpu`, or `accelerator` as the command-line argument.
 The selected device is displayed in the output.  Concrete instructions
 about how to run the program and example outputs are given further
-below.  For complete setup and usage instructions, see the
-[Get Started Guide](https://software.intel.com/en-us/get-started-with-debugging-dpcpp)
+below.  For complete setup and usage instructions, see [Get Started with Intel® Distribution for GDB* on Linux* OS Host](https://software.intel.com/en-us/get-started-with-debugging-dpcpp)
 of the application debugger.
 
 
 ## Key Implementation Details
 
-The basic DPC++ implementation explained in the code includes device
+The basic SYCL implementation explained in the code includes device
 selection, buffer, accessor, and command groups.  The kernel contains
 data access via read/write accessors and a conditional statement to
-illustrate (in)active SIMD lanes on a GPU.
-
-## License
-
-Code samples are licensed under the MIT license. See
-[License.txt](https://github.com/oneapi-src/oneAPI-samples/blob/master/License.txt) for details.
-
-Third party program Licenses can be found here: [third-party-programs.txt](https://github.com/oneapi-src/oneAPI-samples/blob/master/third-party-programs.txt)
+illustrate (in) active SIMD lanes on a GPU.
 
 ## Using Visual Studio Code* (Optional)
 
@@ -62,34 +55,33 @@ The basic steps to build and run a sample using VS Code include:
  - Run the sample in the VS Code terminal using the instructions below.
  - (Linux only) Debug your GPU application with GDB for Intel® oneAPI toolkits using the **Generate Launch Configurations** extension.
 
-To learn more about the extensions, see
-[Using Visual Studio Code with Intel® oneAPI Toolkits](https://www.intel.com/content/www/us/en/develop/documentation/using-vs-code-with-intel-oneapi/top.html).
+To learn more about the extensions, see the 
+[Using Visual Studio Code with Intel® oneAPI Toolkits User Guide](https://www.intel.com/content/www/us/en/develop/documentation/using-vs-code-with-intel-oneapi/top.html).
 
-After learning how to use the extensions for Intel oneAPI Toolkits, return to
-this readme for instructions on how to build and run a sample.
 
 ## Building and Running the `array-transform` Program
-
 > **Note**: If you have not already done so, set up your CLI
 > environment by sourcing  the `setvars` script located in
 > the root of your oneAPI installation.
 >
-> Linux Sudo: . /opt/intel/oneapi/setvars.sh
+> Linux*:
+> - For system wide installations: `. /opt/intel/oneapi/setvars.sh`
+> - For private installations: `. ~/intel/oneapi/setvars.sh`
+> - For non-POSIX shells, like csh, use the following command: `$ bash -c 'source <install-dir>/setvars.sh ; exec csh'`
 >
-> Linux User: . ~/intel/oneapi/setvars.sh
+> Windows*:
+> - `C:\Program Files(x86)\Intel\oneAPI\setvars.bat`
+> - For Windows PowerShell*, use the following command: `cmd.exe "/K" '"C:\Program Files (x86)\Intel\oneAPI\setvars.bat" && powershell'`
 >
-> Windows: C:\Program Files(x86)\Intel\oneAPI\setvars.bat
->
->For more information on environment variables, see Use the setvars Script for [Linux or macOS](https://www.intel.com/content/www/us/en/develop/documentation/oneapi-programming-guide/top/oneapi-development-environment-setup/use-the-setvars-script-with-linux-or-macos.html), or [Windows](https://www.intel.com/content/www/us/en/develop/documentation/oneapi-programming-guide/top/oneapi-development-environment-setup/use-the-setvars-script-with-windows.html).
+> For more information on configuring environment variables, see [Use the setvars Script with Linux* or MacOS*](https://www.intel.com/content/www/us/en/develop/documentation/oneapi-programming-guide/top/oneapi-development-environment-setup/use-the-setvars-script-with-linux-or-macos.html) or [Use the setvars Script with Windows*](https://www.intel.com/content/www/us/en/develop/documentation/oneapi-programming-guide/top/oneapi-development-environment-setup/use-the-setvars-script-with-windows.html).
 
 ### Setup
 
 Preliminary setup steps are needed for the debugger to function.
 Please see the setup instructions in the Get Started Guide based on
-your OS:
-[Linux](https://www.intel.com/en-us/get-started-with-debugging-dpcpp-linux),
-[Windows](https://www.intel.com/en-us/get-started-with-debugging-dpcpp-windows).
-
+your OS: 
+- [Get Started with Intel® Distribution for GDB* on Linux* OS Host](https://www.intel.com/content/www/us/en/develop/documentation/get-started-with-debugging-dpcpp-linux/)
+- [Get Started with Intel® Distribution for GDB* on Windows* OS Host](https://www.intel.com/content/www/us/en/develop/documentation/get-started-with-debugging-dpcpp-windows/)
 
 ### Include Files
 
@@ -190,13 +182,12 @@ or for the Gen12 family:
 $ cmake .. -DDPCPP_COMPILE_TARGET=gen12LP
 ```
 
-> *Note:* AoT compilation is particularly helpful in larger
+> **Note**: AoT compilation is particularly helpful in larger
 > applications where compiling with debug information takes
 > considerably longer time.
 
 For instructions about starting and using the debugger, please
-see the
-[Get Started Guide (Linux)](https://software.intel.com/en-us/get-started-with-debugging-dpcpp-linux).
+see [Get Started with Intel® Distribution for GDB* on Linux* OS Host](https://www.intel.com/content/www/us/en/develop/documentation/get-started-with-debugging-dpcpp-linux/).
 
 
 If an error occurs, you can get more details by running `make` with
@@ -230,8 +221,7 @@ dependencies and permissions errors.
    respectively.
 
 For detailed instructions about starting and using the debugger,
-please see the
-[Get Started Guide (Windows)](https://software.intel.com/en-us/get-started-with-debugging-dpcpp-windows).
+please see [Get Started with Intel® Distribution for GDB* on Windows* OS Host](https://www.intel.com/content/www/us/en/develop/documentation/get-started-with-debugging-dpcpp-windows/).
 
 
 ### Example Outputs
@@ -367,7 +357,7 @@ at array-transform.cpp:56
 
 `maint jit dump <addr> <filename>`
 : Save the JIT'ed objfile that contains address `addr` into the file
-  `filename`.  Useful for extracting the DPC++ kernel when running on
+  `filename`.  Useful for extracting the kernel when running on
   the CPU device.
 
 `cond [-force] <N> <exp>`
@@ -381,3 +371,9 @@ at array-transform.cpp:56
 
 \* Intel is a trademark of Intel Corporation or its subsidiaries.  Other
 names and brands may be claimed as the property of others.
+
+## License
+Code samples are licensed under the MIT license. See
+[License.txt](https://github.com/oneapi-src/oneAPI-samples/blob/master/License.txt) for details.
+
+Third party program Licenses can be found here: [third-party-programs.txt](https://github.com/oneapi-src/oneAPI-samples/blob/master/third-party-programs.txt).

--- a/Tools/ApplicationDebugger/jacobi/README.md
+++ b/Tools/ApplicationDebugger/jacobi/README.md
@@ -1,11 +1,11 @@
 # `jacobi` Sample
 
-The 'jacobi' code sample is a small DPC++ code sample for exercising application
-debugging using Intel&reg; Distribution for GDB\*. It is highly recommended that
+The 'jacobi' code sample is a small SYCL*-compliant sample for exercising application
+debugging using Intel&reg; Distribution for GDB*. It is highly recommended that
 you go through this sample *after* you familiarize yourself with the
 [array-transform](https://github.com/oneapi-src/oneAPI-samples/tree/master/Tools/ApplicationDebugger/array-transform)
 sample and the
-[Get Started Guide](https://software.intel.com/en-us/get-started-with-debugging-dpcpp)
+[Get Started with Intel® Distribution for GDB* on Linux* OS Host](https://www.intel.com/content/www/us/en/develop/documentation/get-started-with-debugging-dpcpp-linux/top.html)
 for the debugger.
 
 This sample contains two versions of the same program: `jacobi-bugged` and
@@ -13,8 +13,8 @@ This sample contains two versions of the same program: `jacobi-bugged` and
 injected. You can try to find and fix them using the debugger.
 
 | Optimized for       | Description
-|---------------------|--------------
-| OS                  | Linux Ubuntu 18.04 to 20.04, CentOS* 8, Fedora* 30, SLES 15; Windows* 10
+|:---                 |:---
+| OS                  | Linux* Ubuntu* 18.04 to 20.04 <br> CentOS* 8 <br> Fedora* 30 <br> SLES 15 <br> Windows* 10
 | Hardware            | Kaby Lake with GEN9 (on GPU) or newer (on CPU)
 | Software            | Intel&reg; oneAPI DPC++/C++ Compiler
 | What you will learn | Find existing bugs in a program using the debugger
@@ -22,7 +22,7 @@ injected. You can try to find and fix them using the debugger.
 
 ## Purpose
 
-The `jacobi` sample is a DPC++ application that solves a hardcoded linear system
+The `jacobi` sample is a SYCL application that solves a hardcoded linear system
 of equations `Ax=b` using the Jacobi iteration. The matrix `A` is an `n x n` sparse
 matrix with diagonals `[1 1 5 1 1]`. Vectors `b` and `x` are `n x 1` vectors.
 Vector `b` is set in the way that all components of the solution vector `x` are 1.
@@ -55,12 +55,9 @@ devices. For convenience, the `jacobi` code sample provides the ability to
 select the target device by using a command-line argument of `cpu`, `gpu`, or
 `accelerator`.
 
-For an overview of the Jacobi method please refer to
-[Jacobi method|https://en.wikipedia.org/wiki/Jacobi_method].
+For an overview of the Jacobi method, please refer to the Wikipedia article on the [Jacobi method](https://en.wikipedia.org/wiki/Jacobi_method).
 
-For an overview of the debugger, please refer to the
-[Get Started Guide](https://software.intel.com/en-us/get-started-with-debugging-dpcpp)
-of the application debugger.
+For an overview of the debugger, please refer to [Get Started with Intel® Distribution for GDB* on Linux* OS Host](https://www.intel.com/content/www/us/en/develop/documentation/get-started-with-debugging-dpcpp-linux/top.html).
 
 ## Recommended commands
 
@@ -207,32 +204,29 @@ to compute L1 norms of `x_k - x_k1` and `x_k1` respectively.
 
 Second, we update `x_k` with the new value from `x_k1`.
 
-## License
-
-Code samples are licensed under the MIT license. See
-[License.txt](https://github.com/oneapi-src/oneAPI-samples/blob/master/License.txt)
-for details.
-
-Third-party program Licenses can be found here:
-[third-party-programs.txt](https://github.com/oneapi-src/oneAPI-samples/blob/master/third-party-programs.txt)
-
 ## Building and Running the `jacobi` Project
-
-If you have not already done so, set up your CLI environment by sourcing
-the setvars script located in the root of your oneAPI installation.
-
-Linux Sudo: `. /opt/intel/oneapi/setvars.sh`
-
-Linux User: `. ~/intel/oneapi/setvars.sh`
-
-Windows: `C:\Program Files(x86)\Intel\oneAPI\setvars.bat`
+> **Note**: If you have not already done so, set up your CLI
+> environment by sourcing  the `setvars` script located in
+> the root of your oneAPI installation.
+>
+> Linux*:
+> - For system wide installations: `. /opt/intel/oneapi/setvars.sh`
+> - For private installations: `. ~/intel/oneapi/setvars.sh`
+> - For non-POSIX shells, like csh, use the following command: `$ bash -c 'source <install-dir>/setvars.sh ; exec csh'`
+>
+> Windows*:
+> - `C:\Program Files(x86)\Intel\oneAPI\setvars.bat`
+> - For Windows PowerShell*, use the following command: `cmd.exe "/K" '"C:\Program Files (x86)\Intel\oneAPI\setvars.bat" && powershell'`
+>
+> For more information on configuring environment variables, see [Use the setvars Script with Linux* or MacOS*](https://www.intel.com/content/www/us/en/develop/documentation/oneapi-programming-guide/top/oneapi-development-environment-setup/use-the-setvars-script-with-linux-or-macos.html) or [Use the setvars Script with Windows*](https://www.intel.com/content/www/us/en/develop/documentation/oneapi-programming-guide/top/oneapi-development-environment-setup/use-the-setvars-script-with-windows.html).
 
 ### Setup
 
-Preliminary setup steps are needed for the debugger to function. Please see the
-setup instructions in the Get Started Guide based on your OS:
-[Linux](https://software.intel.com/en-us/get-started-with-debugging-dpcpp-linux),
-[Windows](https://software.intel.com/en-us/get-started-with-debugging-dpcpp-windows).
+Preliminary setup steps are needed for the debugger to function.
+Please see the setup instructions in the Get Started Guide based on
+your OS: 
+- [Get Started with Intel® Distribution for GDB* on Linux* OS Host](https://www.intel.com/content/www/us/en/develop/documentation/get-started-with-debugging-dpcpp-linux/)
+- [Get Started with Intel® Distribution for GDB* on Windows* OS Host](https://www.intel.com/content/www/us/en/develop/documentation/get-started-with-debugging-dpcpp-windows/)
 
 
 ### Include Files
@@ -241,9 +235,9 @@ The include folder is located at `%ONEAPI_ROOT%\dev-utilities\latest\include` on
 your development system.
 
 
-### Running Samples In DevCloud
+### Running Samples In Intel&reg; DevCloud
 
-If running a sample in the Intel DevCloud, remember that you must specify the
+If running a sample in the Intel&reg; DevCloud, remember that you must specify the
 compute node (CPU, GPU, FPGA) and whether to run in batch or interactive mode.
 We recommend running the `jacobi` sample on a node with GPU. In order to have an
 interactive debugging session, we recommend using the interactive mode. To get
@@ -267,10 +261,8 @@ The basic steps to build and run a sample using VS Code include:
  - Open a Terminal in VS Code (**Terminal>New Terminal**).
  - Run the sample in the VS Code terminal using the instructions below.
 
-To learn more about the extensions and how to configure the oneAPI environment, see
-[Using Visual Studio Code with Intel® oneAPI Toolkits](https://software.intel.com/content/www/us/en/develop/documentation/using-vs-code-with-intel-oneapi/top.html).
-
-After learning how to use the Extension Pack for Intel® oneAPI Toolkits, return to this readme for instructions on how to build and run a sample.
+To learn more about the extensions and how to configure the oneAPI environment, see the
+[Using Visual Studio Code with Intel® oneAPI Toolkits User Guide](https://software.intel.com/content/www/us/en/develop/documentation/using-vs-code-with-intel-oneapi/top.html).
 
 ### On a Linux* System
 
@@ -316,8 +308,8 @@ Perform the following steps:
     ```
 
 
-For instructions about starting and using the debugger, please see the
-[Get Started Guide (Linux)](https://software.intel.com/en-us/get-started-with-debugging-dpcpp-linux).
+For instructions about starting and using the debugger, please see 
+[Get Started with Intel® Distribution for GDB* on Linux* OS Host](https://www.intel.com/content/www/us/en/develop/documentation/get-started-with-debugging-dpcpp-linux/).
 
 ### On a Windows* System Using Visual Studio* Version 2017 or Newer
 
@@ -342,8 +334,8 @@ For instructions about starting and using the debugger, please see the
    Properties > Debugging" and set the "Command Arguments" field. Use `gpu` or
    `accelerator` to target the GPU or the FPGA emulator device, respectively.
 
-For detailed instructions about starting and using the debugger, please see the
-[Get Started Guide (Windows)](https://software.intel.com/en-us/get-started-with-debugging-dpcpp-windows).
+For detailed instructions about starting and using the debugger, please see 
+[Get Started with Intel® Distribution for GDB* on Windows* OS Host](https://www.intel.com/content/www/us/en/develop/documentation/get-started-with-debugging-dpcpp-windows/).
 
 ### Example Outputs
 
@@ -365,7 +357,7 @@ Usage: ./jacobi-fixed <host|cpu|gpu|accelerator>
 
 #### CPU
 
-When run the original `jacobi-bugged`, the program shows the first bug:
+When run, the original `jacobi-bugged` program shows the first bug:
 
 ```
 $ ./jacobi-bugged cpu
@@ -421,7 +413,7 @@ success; the relative error (9.97509e-05) is below the desired tolerance 0.0001 
 
 #### GPU
 
-We advise to start debugging GPU only after first two bugs are fixed on CPU.
+Start debugging GPU only after first two bugs are fixed on CPU.
 
 Bug 3 is immediately hit while offloading to GPU:
 
@@ -587,7 +579,7 @@ success; the relative error (9.97509e-05) is below the desired tolerance 0.0001 
 
 `maint jit dump <addr> <filename>`
 : Save the JIT'ed objfile that contains address `addr` into the file `filename`.
-  Useful for extracting the DPC++ kernel when running on the CPU device.
+  Useful for extracting the kernel when running on the CPU device.
 
 `cond [-force] <N> <exp>`
 : Define the expression `exp` as the condition for breakpoint `N`. Use the
@@ -600,3 +592,11 @@ success; the relative error (9.97509e-05) is below the desired tolerance 0.0001 
 
 \* Intel is a trademark of Intel Corporation or its subsidiaries. Other names
 and brands may be claimed as the property of others.
+
+## License
+Code samples are licensed under the MIT license. See
+[License.txt](https://github.com/oneapi-src/oneAPI-samples/blob/master/License.txt)
+for details.
+
+Third-party program Licenses can be found here:
+[third-party-programs.txt](https://github.com/oneapi-src/oneAPI-samples/blob/master/third-party-programs.txt).

--- a/Tools/Benchmarks/STREAM/README.md
+++ b/Tools/Benchmarks/STREAM/README.md
@@ -1,9 +1,9 @@
 # STREAM Sample
 
-This package contains a modified version of the [Stream Benchmark](http://www.cs.virginia.edu/stream/) implementation using DPC++ for CPU and GPU.
+This package contains a modified version of the [Stream Benchmark](http://www.cs.virginia.edu/stream/) implementation using SYCL* for CPU and GPU.
 
 
-| Optimized for                       | Description
+| Optimized for                     | Description
 |:---                               |:---
 | OS                                | Linux* Ubuntu* 20.04
 | Hardware                          | GEN9, Iris-Xe Max
@@ -16,49 +16,9 @@ This package contains a modified version of the [Stream Benchmark](http://www.cs
 The STREAM sample performs the memory bandwidth benchmark.
 
 ## Key Implementation Details
-This sample contains a STREAM implementation using DPC++ for CPU and GPU and is a variant of the [STREAM](http://www.cs.virginia.edu/stream/) benchmark code. Please review the license terms regarding publishing benchmarks.”
+This sample contains a STREAM implementation using SYCL for CPU and GPU and is a variant of the [STREAM](http://www.cs.virginia.edu/stream/) benchmark code. 
 
-## License
-Please note: **_“This package contains a modified version of the Stream Benchmark.”_**
-
-For the original [Stream License]( http://www.cs.virginia.edu/stream/FTP/Code/LICENSE.txt.), which is copied below for reference
-
-***
- Copyright 1991-2003: John D. McCalpin
-
- License:
-  1. You are free to use this program and/or to redistribute
-     this program.
-  2. You are free to modify this program for your own use,
-     including commercial use, subject to the publication
-     restrictions in item 3.
-  3. You are free to publish results obtained from running this
-     program, or from works that you derive from this program,
-     with the following limitations:
-
-     3a. In order to be referred to as "STREAM benchmark results",
-         published results must be in conformance to the STREAM
-         Run Rules, (briefly reviewed below) published at
-         http://www.cs.virginia.edu/stream/ref.html
-         and incorporated herein by reference.
-         As the copyright holder, John McCalpin retains the
-         right to determine conformity with the Run Rules.
-
-     3b. Results based on modified source code or on runs not in
-         accordance with the STREAM Run Rules must be clearly
-         labelled whenever they are published.  Examples of
-         proper labelling include:
-         "tuned STREAM benchmark results"
-         "based on a variant of the STREAM benchmark code"
-         Other comparable, clear and reasonable labelling is
-         acceptable.
-
-     3c. Submission of results to the STREAM benchmark web site
-         is encouraged, but not required.
-  4. Use of this program or creation of derived works based on this
-     program constitutes acceptance of these licensing restrictions.
-  5. Absolutely no warranty is expressed or implied.
-***
+Please review the license terms regarding publishing benchmarks.
 
 ## Using Visual Studio Code* (Optional)
 
@@ -72,8 +32,8 @@ The basic steps to build and run a sample using VS Code include:
  - Run the sample in the VS Code terminal using the instructions below.
  - (Linux only) Debug your GPU application with GDB for Intel® oneAPI toolkits using the **Generate Launch Configurations** extension.
 
-To learn more about the extensions, see
-[Using Visual Studio Code with Intel® oneAPI Toolkits](https://www.intel.com/content/www/us/en/develop/documentation/using-vs-code-with-intel-oneapi/top.html).
+To learn more about the extensions, see the
+[Using Visual Studio Code with Intel® oneAPI Toolkits User Guide](https://www.intel.com/content/www/us/en/develop/documentation/using-vs-code-with-intel-oneapi/top.html).
 
 After learning how to use the extensions for Intel oneAPI Toolkits, return to
 this readme for instructions on how to build and run a sample.
@@ -85,13 +45,12 @@ this readme for instructions on how to build and run a sample.
 > environment by sourcing  the `setvars` script located in
 > the root of your oneAPI installation.
 >
-> Linux Sudo: . /opt/intel/oneapi/setvars.sh
+> Linux*:
+> - For system wide installations: `. /opt/intel/oneapi/setvars.sh`
+> - For private installations: `. ~/intel/oneapi/setvars.sh`
+> - For non-POSIX shells, like csh, use the following command: `$ bash -c 'source <install-dir>/setvars.sh ; exec csh'`
 >
-> Linux User: . ~/intel/oneapi/setvars.sh
->
-> Windows: C:\Program Files(x86)\Intel\oneAPI\setvars.bat
->
->For more information on environment variables, see Use the setvars Script for [Linux or macOS](https://www.intel.com/content/www/us/en/develop/documentation/oneapi-programming-guide/top/oneapi-development-environment-setup/use-the-setvars-script-with-linux-or-macos.html), or [Windows](https://www.intel.com/content/www/us/en/develop/documentation/oneapi-programming-guide/top/oneapi-development-environment-setup/use-the-setvars-script-with-windows.html).
+> For more information on configuring environment variables, see [Use the setvars Script with Linux* or MacOS*](https://www.intel.com/content/www/us/en/develop/documentation/oneapi-programming-guide/top/oneapi-development-environment-setup/use-the-setvars-script-with-linux-or-macos.html).
 
 1. Build the program using the following `cmake` commands.
 ```
@@ -160,3 +119,44 @@ Solution Validates: avg error less than 1.000000e-13 on all three arrays
 -------------------------------------------------------------
 
 ```
+## License
+Please note: **_“This package contains a modified version of the Stream Benchmark.”_**
+
+For the original [Stream License]( https://www.cs.virginia.edu/stream/FTP/Code/LICENSE.txt), which is copied below for reference.
+
+***
+ Copyright 1991-2003: John D. McCalpin
+
+ License:
+  1. You are free to use this program and/or to redistribute
+     this program.
+  2. You are free to modify this program for your own use,
+     including commercial use, subject to the publication
+     restrictions in item 3.
+  3. You are free to publish results obtained from running this
+     program, or from works that you derive from this program,
+     with the following limitations:
+
+     3a. In order to be referred to as "STREAM benchmark results",
+         published results must be in conformance to the STREAM
+         Run Rules, (briefly reviewed below) published at
+         http://www.cs.virginia.edu/stream/ref.html
+         and incorporated herein by reference.
+         As the copyright holder, John McCalpin retains the
+         right to determine conformity with the Run Rules.
+
+     3b. Results based on modified source code or on runs not in
+         accordance with the STREAM Run Rules must be clearly
+         labelled whenever they are published.  Examples of
+         proper labelling include:
+         "tuned STREAM benchmark results"
+         "based on a variant of the STREAM benchmark code"
+         Other comparable, clear and reasonable labelling is
+         acceptable.
+
+     3c. Submission of results to the STREAM benchmark web site
+         is encouraged, but not required.
+  4. Use of this program or creation of derived works based on this
+     program constitutes acceptance of these licensing restrictions.
+  5. Absolutely no warranty is expressed or implied.
+***

--- a/Tools/Migration/folder-options-dpct/README.md
+++ b/Tools/Migration/folder-options-dpct/README.md
@@ -2,15 +2,15 @@
 
 ## Use the Command Line to Migrate Large Code Bases
 
-The Intel DPC++ Compatibility Tool (dpct) can migrate projects that include
+The Intel® DPC++ Compatibility Tool (dpct) can migrate projects that include
 multiple source and header files. This sample provides an example of how to
 migrate more complex projects and use options.
 
 
 | Optimized for         | Description
 |:---                   |:---
-| OS                    | Linux* Ubuntu* 18.04; Windows 10
-| Software              | Intel DPC++ Compatibility Tool;
+| OS                    | Linux* Ubuntu* 18.04 <br> Windows* 10
+| Software              | Intel® DPC++ Compatibility Tool
 | What you will learn   | Simple invocation of dpct to migrate CUDA code
 | Time to complete      | 10 minutes
 
@@ -29,8 +29,8 @@ outside the`--in-root` directory are considered system files and will not be
 migrated, even if they are included by a source file located within the
 `--in-root`directory.
 
-The dpct `--out-root` option specifies the directory into which the DPC++ code
-produced by the Intel DPC++ Compatibility Tool is written. The relative
+The dpct `--out-root` option specifies the directory into which the SYCL*-compliant code
+produced by the Intel® DPC++ Compatibility Tool is written. The relative
 location and names of the migrated files are maintained, except the file
 extensions are changed to `.dp.cpp`.
 
@@ -41,13 +41,6 @@ Use --in-root and --out-root for projects which contain more than one source
 file.  Additional migration options can be reviewed at:
 [Command Line Options Reference](https://software.intel.com/content/www/us/en/develop/documentation/intel-dpcpp-compatibility-tool-user-guide/top/command-line-options-reference.html).
 
-
-## License
-
-Code samples are licensed under the MIT license. See
-[License.txt](https://github.com/oneapi-src/oneAPI-samples/blob/master/License.txt) for details.
-
-Third party program Licenses can be found here: [third-party-programs.txt](https://github.com/oneapi-src/oneAPI-samples/blob/master/third-party-programs.txt)
 
 ## Using Visual Studio Code* (Optional)
 
@@ -66,28 +59,29 @@ To learn more about the extensions, see
 
 After learning how to use the extensions for Intel oneAPI Toolkits, return to this readme for instructions on how to build and run a sample.
 
-## Migrating the CUDA Sample to Data Parallel C++ with the Intel DPC++ Compatibility Tool
+## Migrating the CUDA Sample to Data Parallel C++ with the Intel® DPC++ Compatibility Tool
 
 Building and running the CUDA sample is not required to migrate this project
-to a Data Parallel C++ project.
+to a SYCL*-compliant project.
 
-> **NOTE:** Certain CUDA header files, referenced by the CUDA application
+> **Note**: Certain CUDA header files, referenced by the CUDA application
 > source files to be migrated, need to be accessible for the migration step.
-> See the [Getting Started Guide][cuda-headers] for more details.
-
-[cuda-headers]: <https://software.intel.com/content/www/us/en/develop/documentation/get-started-with-intel-dpcpp-compatibility-tool/top.html#top_BEFORE_YOU_BEGIN>
+> See *Before you Begin* in [Get Started with the Intel® DPC++ Compatibility Tool](https://www.intel.com/content/www/us/en/develop/documentation/get-started-with-intel-dpcpp-compatibility-tool/top.html#top_BEFORE_YOU_BEGIN).
 
 > **Note**: If you have not already done so, set up your CLI
 > environment by sourcing  the `setvars` script located in
 > the root of your oneAPI installation.
 >
-> Linux Sudo: . /opt/intel/oneapi/setvars.sh
+> Linux*:
+> - For system wide installations: `. /opt/intel/oneapi/setvars.sh`
+> - For private installations: `. ~/intel/oneapi/setvars.sh`
+> - For non-POSIX shells, like csh, use the following command: `$ bash -c 'source <install-dir>/setvars.sh ; exec csh'`
 >
-> Linux User: . ~/intel/oneapi/setvars.sh
+> Windows*:
+> - `C:\Program Files(x86)\Intel\oneAPI\setvars.bat`
+> - For Windows PowerShell*, use the following command: `cmd.exe "/K" '"C:\Program Files (x86)\Intel\oneAPI\setvars.bat" && powershell'`
 >
-> Windows: C:\Program Files(x86)\Intel\oneAPI\setvars.bat
->
->For more information on environment variables, see Use the setvars Script for [Linux or macOS](https://www.intel.com/content/www/us/en/develop/documentation/oneapi-programming-guide/top/oneapi-development-environment-setup/use-the-setvars-script-with-linux-or-macos.html), or [Windows](https://www.intel.com/content/www/us/en/develop/documentation/oneapi-programming-guide/top/oneapi-development-environment-setup/use-the-setvars-script-with-windows.html).
+> For more information on configuring environment variables, see [Use the setvars Script with Linux* or MacOS*](https://www.intel.com/content/www/us/en/develop/documentation/oneapi-programming-guide/top/oneapi-development-environment-setup/use-the-setvars-script-with-linux-or-macos.html) or [Use the setvars Script with Windows*](https://www.intel.com/content/www/us/en/develop/documentation/oneapi-programming-guide/top/oneapi-development-environment-setup/use-the-setvars-script-with-windows.html).
 
 ### Command-Line on a Linux* System
 
@@ -127,13 +121,11 @@ by the `--out-root` option:
 ```
 
 3. Inspect the migrated source code, address any `DPCT` warnings generated
-   by the Intel DPC++ Compatibility Tool, and verify the new program correctness.
+   by the Intel® DPC++ Compatibility Tool, and verify the new program correctness.
 
 Warnings are printed to the console and added as comments in the migrated
-source. See the [Diagnostic Reference][diag-ref] for more information on what
-each warning means.
+source. See *Diagnostic Reference* in the [Intel® DPC++ Compatibility Tool Developer Guide and Reference](https://www.intel.com/content/www/us/en/develop/documentation/intel-dpcpp-compatibility-tool-user-guide/top/diagnostics-reference.html) for more information on what each warning means.
 
-[diag-ref]: <https://software.intel.com/content/www/us/en/develop/documentation/get-started-with-intel-dpcpp-compatibility-tool/top/diagnostics-reference.html>
 
 This sample should generate the following warning:
 
@@ -146,8 +138,8 @@ resolve the warning.
 
 
 4. Copy the original `Makefile` into the `result` folder and update the
-   copy to build the migrated project using DPC++. Replace the CUDA
-   configurations in that new `Makefile` with the following for use with DPC++:
+   copy to build the migrated project. Replace the CUDA
+   configurations in that new `Makefile` with the following for use with SYCL:
 
 ```Makefile
 CXX = dpcpp
@@ -229,7 +221,7 @@ warning: DPCT1015:0: Output needs adjustment.
 As you have noticed, the migration of this project resulted in one DPCT
 message that needs to be addressed, DPCT1015. This message is shown because as
 the Compatibility Tool migrated from the printf-style formatted string in the
-CUDA code to the output stream supported by DPC++, manual adjustment is needed
+CUDA code to the output stream supported by SYCL, manual adjustment is needed
 to generate the equivalent output.
 
 Open result/foo/bar/util.dp.cpp and locate the error  DPCT1015. Then make the
@@ -266,7 +258,7 @@ kernel_main!
 kernel_util,2
 ```
 
-> **NOTE:** If you see the following TBB error message, you can safely it.
+> **NOTE:** If you see the following TBB error message, you can safely ignore it.
 > Not all users will see this TBB error message. It has nothing to do with the
 > migration of your application and does not mean that your application is not
 > running correctly. The issue will be resolved in a future oneAPI release.
@@ -276,4 +268,10 @@ TBB Warning: The number of workers is currently limited to 11. The request for 3
 ```
 
 If an error occurs, troubleshoot the problem using the Diagnostics Utility for Intel® oneAPI Toolkits.
-[Learn more](https://www.intel.com/content/www/us/en/develop/documentation/diagnostic-utility-user-guide/top.html)
+[Learn more](https://www.intel.com/content/www/us/en/develop/documentation/diagnostic-utility-user-guide/top.html).
+
+## License
+Code samples are licensed under the MIT license. See
+[License.txt](https://github.com/oneapi-src/oneAPI-samples/blob/master/License.txt) for details.
+
+Third party program Licenses can be found here: [third-party-programs.txt](https://github.com/oneapi-src/oneAPI-samples/blob/master/third-party-programs.txt).

--- a/Tools/Migration/rodinia-nw-dpct/README.md
+++ b/Tools/Migration/rodinia-nw-dpct/README.md
@@ -1,28 +1,25 @@
 # Intel® DPC++ Compatibility Tool: `Needleman-Wunsch` Sample
 
 This project demonstrates how to migrate a Make/CMake project from CUDA to
-Data Parallel C++ using the Intel DPC++ Compatibility Tool.
+SYCL* using the Intel® DPC++ Compatibility Tool.
 
 | Optimized for         | Description
 |:---                   |:---
-| OS                    | Linux* Ubuntu* 18.04; Windows 10
-| Software              | Intel® DPC++ Compatibility Tool;
+| OS                    | Linux* Ubuntu* 18.04 <br> Windows* 10
+| Software              | Intel® DPC++ Compatibility Tool
 | What you will learn   | Simple invocation of dpct to migrate CUDA code
 | Time to complete      | 10 minutes
 
 The program, `needleman-Wunsch`, naively implements the [Needleman-Wunsch
-algorithm][nw-algorithm], which is used in bioinformatics to align protein and
-nucleotide sequences. The code is based on [Rodinia][rodinia], a set of
+algorithm](https://en.wikipedia.org/wiki/Needleman%E2%80%93Wunsch_algorithm), which is used in bioinformatics to align protein and
+nucleotide sequences. The code is based on [Rodinia](http://lava.cs.virginia.edu/Rodinia/download_links.htm), a set of
 benchmarks for heterogeneous computing. As compared to the `Intel® DPC++
 Compatibility Tool: Vector Add` sample, this sample represents a more typical
 example of migrating a working project.
 
-[nw-algorithm]: <https://en.wikipedia.org/wiki/Needleman%E2%80%93Wunsch_algorithm>
-[rodinia]: <http://lava.cs.virginia.edu/Rodinia/download_links.htm>
-
 If your project uses Make or CMake, you can use compilation database support to
 provide compilation options, settings, macro definitions, and include paths to
-the Intel DPC++ Compatibility Tool. The compilations database is a JSON* file
+the Intel® DPC++ Compatibility Tool. The compilations database is a JSON* file
 containing the commands required to build a particular project. You can generate
 a compilation database by running the intercept-build script described below.
 
@@ -35,54 +32,44 @@ Compatibility Tool to use. Migrate the project and prepare the project to
 build and run using the Intel&reg; oneAPI DPC++ Compiler
 
 
-## License
-
-Code samples are licensed under the MIT license. See
-[License.txt](https://github.com/oneapi-src/oneAPI-samples/blob/master/License.txt) for details.
-
-Third party program Licenses can be found here: [third-party-programs.txt](https://github.com/oneapi-src/oneAPI-samples/blob/master/third-party-programs.txt)
-
-
 ## Using Visual Studio Code* (Optional)
 
 You can use Visual Studio Code (VS Code) extensions to set your environment, create launch configurations,
 and browse and download samples.
 
 The basic steps to build and run a sample using VS Code include:
- - Download a sample using the extension **Code Sample Browser for Intel oneAPI Toolkits**.
- - Configure the oneAPI environment with the extension **Environment Configurator for Intel oneAPI Toolkits**.
+ - Download a sample using the extension **Code Sample Browser for Intel&reg; oneAPI Toolkits**.
+ - Configure the oneAPI environment with the extension **Environment Configurator for Intel&reg; oneAPI Toolkits**.
  - Open a Terminal in VS Code (**Terminal>New Terminal**).
  - Run the sample in the VS Code terminal using the instructions below.
  - (Linux only) Debug your GPU application with GDB for Intel® oneAPI toolkits using the **Generate Launch Configurations** extension.
 
-To learn more about the extensions, see
-[Using Visual Studio Code with Intel® oneAPI Toolkits](https://www.intel.com/content/www/us/en/develop/documentation/using-vs-code-with-intel-oneapi/top.html).
+To learn more about the extensions, see the 
+[Using Visual Studio Code with Intel® oneAPI Toolkits User Guide](https://www.intel.com/content/www/us/en/develop/documentation/using-vs-code-with-intel-oneapi/top.html).
 
-After learning how to use the extensions for Intel oneAPI Toolkits, return to this readme for instructions on how to build and run a sample.
-
-
-## Migrating the CUDA Sample to Data Parallel C++ with the Intel DPC++ Compatibility Tool
+## Migrating the CUDA Sample to Data Parallel C++ with the Intel® DPC++ Compatibility Tool
 
 Building and running the CUDA sample is not required to migrate this project
-to a Data Parallel C++ project.
+to a SYCL-compliant project.
 
-> **NOTE:** Certain CUDA header files, referenced by the CUDA application
+> **Note**: Certain CUDA header files, referenced by the CUDA application
 > source files to be migrated, need to be accessible for the migration step.
-> See the [Getting Started Guide][cuda-headers] for more details.
-
-[cuda-headers]: <https://software.intel.com/content/www/us/en/develop/documentation/get-started-with-intel-dpcpp-compatibility-tool/top.html#top_BEFORE_YOU_BEGIN>
+> See *Before you Begin* in [Get Started with the Intel® DPC++ Compatibility Tool](https://www.intel.com/content/www/us/en/develop/documentation/get-started-with-intel-dpcpp-compatibility-tool/top.html#top_BEFORE_YOU_BEGIN).
 
 > **Note**: If you have not already done so, set up your CLI
 > environment by sourcing  the `setvars` script located in
 > the root of your oneAPI installation.
 >
-> Linux Sudo: . /opt/intel/oneapi/setvars.sh
+> Linux*:
+> - For system wide installations: `. /opt/intel/oneapi/setvars.sh`
+> - For private installations: `. ~/intel/oneapi/setvars.sh`
+> - For non-POSIX shells, like csh, use the following command: `$ bash -c 'source <install-dir>/setvars.sh ; exec csh'`
 >
-> Linux User: . ~/intel/oneapi/setvars.sh
+> Windows*:
+> - `C:\Program Files(x86)\Intel\oneAPI\setvars.bat`
+> - For Windows PowerShell*, use the following command: `cmd.exe "/K" '"C:\Program Files (x86)\Intel\oneAPI\setvars.bat" && powershell'`
 >
-> Windows: C:\Program Files(x86)\Intel\oneAPI\setvars.bat
->
->For more information on environment variables, see Use the setvars Script for [Linux or macOS](https://www.intel.com/content/www/us/en/develop/documentation/oneapi-programming-guide/top/oneapi-development-environment-setup/use-the-setvars-script-with-linux-or-macos.html), or [Windows](https://www.intel.com/content/www/us/en/develop/documentation/oneapi-programming-guide/top/oneapi-development-environment-setup/use-the-setvars-script-with-windows.html).
+> For more information on configuring environment variables, see [Use the setvars Script with Linux* or MacOS*](https://www.intel.com/content/www/us/en/develop/documentation/oneapi-programming-guide/top/oneapi-development-environment-setup/use-the-setvars-script-with-linux-or-macos.html) or [Use the setvars Script with Windows*](https://www.intel.com/content/www/us/en/develop/documentation/oneapi-programming-guide/top/oneapi-development-environment-setup/use-the-setvars-script-with-windows.html).
 
 
 ### On a Linux* System
@@ -98,7 +85,7 @@ $ intercept-build make
 ```
    This creates the file `compile_commands.json` in the working directory.
 
-2. Use the Intel DPC++ Compatibility Tool and compilation database to migrate
+2. Use the Intel® DPC++ Compatibility Tool and compilation database to migrate
    the CUDA code. The new project will be created in the `migration` directory.
 
 ```sh
@@ -106,13 +93,10 @@ $ dpct -p compile_commands.json --in-root=. --out-root=migration
 ```
 
 3. Inspect the migrated source code, address any `DPCT` warnings generated
-   by the Intel DPC++ Compatibility Tool, and verify the new program correctness.
+   by the Intel® DPC++ Compatibility Tool, and verify the new program correctness.
 
-Warnings are printed to the console and added as comments inside the migrated
-source files. See the [Diagnostic Reference][diag-ref] for more information on
-what each warning means.
-
-[diag-ref]: <https://software.intel.com/content/www/us/en/develop/documentation/get-started-with-intel-dpcpp-compatibility-tool/top/diagnostics-reference.html>
+Warnings are printed to the console and added as comments in the migrated
+source. See *Diagnostic Reference* in the [Intel® DPC++ Compatibility Tool Developer Guide and Reference](https://www.intel.com/content/www/us/en/develop/documentation/intel-dpcpp-compatibility-tool-user-guide/top/diagnostics-reference.html) for more information on what each warning means.
 
 This sample should generate the following warning messages:
 ```
@@ -128,8 +112,8 @@ See the section titled **Addressing Warnings in Migrated Code** below to
 understand how to resolve the warnings.
 
 4. Copy the original `Makefile` into the `migration` folder and update the
-   copy to build the migrated project using DPC++. Replace the CUDA
-   configurations in that new `Makefile` with the following for use with DPC++:
+   copy to build the migrated project using SYCL. Replace the CUDA
+   configurations in that new `Makefile` with the following for SYCL:
 
 ```make
 CXX = dpcpp
@@ -168,7 +152,7 @@ error: assigning to 'int' from incompatible type 'typename info::param_traits<in
    project, which will be added to the open solution.
 
 3. Inspect the generated source code and address any `DPCT` warnings generated
-   by the Intel DPC++ Compatibility Tool. Warnings appear in a tool window and
+   by the Intel® DPC++ Compatibility Tool. Warnings appear in a tool window and
    are written to a `migration.log` file in the project directory.
 
 This sample should generate the following warning messages:
@@ -201,14 +185,12 @@ warning: DPCT1049:4: The workgroup size passed to the SYCL kernel may exceed the
 warning: DPCT1049:5: The workgroup size passed to the SYCL kernel may exceed the limit. To get the device limit, query info::device::max_work_group_size. Adjust the workgroup size if needed.
 ```
 
-
 ## Resolve the DPCT1003, DPCT1009, and DPCT1043
-
 First, start with the warnings specific to `needle.dp.cpp` located in the
 migrated source directory.
 
 In this case, the original CUDA call `cudaDriverGetVersion` was migrated to an
-equivalent DPC++ construct. However, because CUDA uses error codes while DPC++
+equivalent SYCL construct. However, because CUDA uses error codes while SYCL
 uses exceptions to handle errors, `dpct` added the DPCT1003 message in the
 comments to indicate that additional manual edits are likely required. The
 same call also resulted in message DPCT1043, which warns that the device
@@ -250,7 +232,6 @@ After the code is fixed, save the file in the text editor.
 
 
 ## Resolve DPCT1049
-
 This DPCT message appears twice in `needle.dp.cpp`, and it simply warns that
 the maximum workgroup size for your GPU may be different from the CUDA limit.
 If you examine the code, we are running workgroup sizes of `BLOCK_SIZE=16`
@@ -284,7 +265,7 @@ sycl::range<2> ref_range_ct1(BLOCK_SIZE, BLOCK_SIZE);
 
 Open `needle.h`, also located in the migrated source directory.
 
-The equivalent of a CUDA block is an SYCL workgroup in DPC++. The maximum size
+The equivalent of a CUDA block is a SYCL workgroup. The maximum size
 of a block for a CUDA-enabled device may be different than the maximum size of
 a work-group for a SYCL-enabled device. You can use `clinfo` to get information
 about the max workgroup size available on your system. Often the block
@@ -308,4 +289,10 @@ Processing bottom-right matrix
 ```
 
 If an error occurs, troubleshoot the problem using the Diagnostics Utility for Intel® oneAPI Toolkits.
-[Learn more](https://www.intel.com/content/www/us/en/develop/documentation/diagnostic-utility-user-guide/top.html)
+[Learn more](https://www.intel.com/content/www/us/en/develop/documentation/diagnostic-utility-user-guide/top.html).
+
+## License
+Code samples are licensed under the MIT license. See
+[License.txt](https://github.com/oneapi-src/oneAPI-samples/blob/master/License.txt) for details.
+
+Third party program Licenses can be found here: [third-party-programs.txt](https://github.com/oneapi-src/oneAPI-samples/blob/master/third-party-programs.txt).

--- a/Tools/Migration/vector-add-dpct/README.md
+++ b/Tools/Migration/vector-add-dpct/README.md
@@ -1,92 +1,75 @@
 # Intel® DPC++ Compatibility Tool: `Vector Add` Sample
 
 This sample demonstrates how to migrate a simple program from CUDA to
-Data Parallel C++. Vector Add provides an easy way to verify that
+SYCL-compliant code. Vector Add provides an easy way to verify that
 your development environment is set up correctly to use the Intel® DPC++
 Compatibility Tool (DPCT).
 
-
 | Optimized for         | Description
 |:---                   |:---
-| OS                    | Linux* Ubuntu* 18.04; Windows 10
-| Software              | Intel&reg; DPC++ Compatibility Tool;
+| OS                    | Linux* Ubuntu* 18.04 <br> Windows* 10
+| Software              | Intel&reg; DPC++ Compatibility Tool
 | What you will learn   | Simple invocation of dpct to migrate CUDA code
 | Time to complete      | 10 minutes
 
 
 ## Purpose
 
-This simple project adds two vectors of `[1..N]` and prints the result. It starts as a CUDA project to provide you with an example of migrating from an existing CUDA project to a Data Parallel C++ project.
+This simple project adds two vectors of `[1..N]` and prints the result. It starts as a CUDA project to provide you with an example of migrating from an existing CUDA project to a SYCL-compliant project.
 
-The migration of existing CUDA projects to Data Parallel C++ projects may
+The migration of existing CUDA projects to SYCL-compliant projects may
 result in warnings printed to the console and added as comments in
 the migrated source, which will use .dp.cpp file extensions. Signs represent
 areas in the resulting source code that require additional attention from the
 developer. This is because the code could not be migrated by the tool or some
 other reasons that need further review and manual work for the
-code to be Data Parallel C++ compliant, correct, or performant. For this sample,
+code to be SYCL compliant, correct, or performant. For this sample,
 the warning results from a difference in how the original code and generated
 code handle errors.
 
-
 ## Key Implementation Details
-
 In addition to verifying that the necessary tools and files are installed, please ensure that they are
 configured correctly on your system. This sample shows the basic invocation and workflow for using dpct.
 
-
-## License
-
-Code samples are licensed under the MIT license. See
-[License.txt](https://github.com/oneapi-src/oneAPI-samples/blob/master/License.txt) for details.
-
-Third party program Licenses can be found here: [third-party-programs.txt](https://github.com/oneapi-src/oneAPI-samples/blob/master/third-party-programs.txt)
-
-
 ## Using Visual Studio Code* (Optional)
-
 You can use Visual Studio Code (VS Code) extensions to set your environment, create launch configurations,
 and browse and download samples.
 
 The basic steps to build and run a sample using VS Code include:
- - Download a sample using the extension **Code Sample Browser for Intel oneAPI Toolkits**.
- - Configure the oneAPI environment with the extension **Environment Configurator for Intel oneAPI Toolkits**.
+ - Download a sample using the extension **Code Sample Browser for Intel&reg; oneAPI Toolkits**.
+ - Configure the oneAPI environment with the extension **Environment Configurator for Intel&reg; oneAPI Toolkits**.
  - Open a Terminal in VS Code (**Terminal>New Terminal**).
  - Run the sample in the VS Code terminal using the instructions below.
  - (Linux only) Debug your GPU application with GDB for Intel® oneAPI toolkits using the **Generate Launch Configurations** extension.
 
-To learn more about the extensions, see
-[Using Visual Studio Code with Intel® oneAPI Toolkits](https://www.intel.com/content/www/us/en/develop/documentation/using-vs-code-with-intel-oneapi/top.html).
+To learn more about the extensions, see the 
+[Using Visual Studio Code with Intel® oneAPI Toolkits User Guide](https://www.intel.com/content/www/us/en/develop/documentation/using-vs-code-with-intel-oneapi/top.html).
 
-After learning how to use the extensions for Intel oneAPI Toolkits, return to this readme for instructions on how to build and run a sample.
 
-## Migrating the CUDA* Sample to Data Parallel C++ with the Intel DPC++ Compatibility Tool
-
+## Migrating the CUDA* Sample to Data Parallel C++ with the Intel® DPC++ Compatibility Tool
 Building and running the CUDA sample is not required to migrate this project
-to a Data Parallel C++ project.
+to a SYCL*-compliant project.
 
-> **NOTE:** Certain CUDA header files, referenced by the CUDA application
-> source files to be migrated need to be accessible for the migration step.
-> See the [Getting Started Guide][cuda-headers] for more details.
-
-[cuda-headers]: <https://www.intel.com/content/www/us/en/develop/documentation/get-started-with-intel-dpcpp-compatibility-tool/top.htm>
-
+> **Note**: Certain CUDA header files, referenced by the CUDA application
+> source files to be migrated, need to be accessible for the migration step.
+> See *Before you Begin* in [Get Started with the Intel® DPC++ Compatibility Tool](https://www.intel.com/content/www/us/en/develop/documentation/get-started-with-intel-dpcpp-compatibility-tool/top.html#top_BEFORE_YOU_BEGIN).
 
 > **Note**: If you have not already done so, set up your CLI
 > environment by sourcing  the `setvars` script located in
 > the root of your oneAPI installation.
 >
-> Linux Sudo: . /opt/intel/oneapi/setvars.sh
+> Linux*:
+> - For system wide installations: `. /opt/intel/oneapi/setvars.sh`
+> - For private installations: `. ~/intel/oneapi/setvars.sh`
+> - For non-POSIX shells, like csh, use the following command: `$ bash -c 'source <install-dir>/setvars.sh ; exec csh'`
 >
-> Linux User: . ~/intel/oneapi/setvars.sh
+> Windows*:
+> - `C:\Program Files(x86)\Intel\oneAPI\setvars.bat`
+> - For Windows PowerShell*, use the following command: `cmd.exe "/K" '"C:\Program Files (x86)\Intel\oneAPI\setvars.bat" && powershell'`
 >
-> Windows: C:\Program Files(x86)\Intel\oneAPI\setvars.bat
->
->For more information on environment variables, see Use the setvars Script for [Linux or macOS](https://www.intel.com/content/www/us/en/develop/documentation/oneapi-programming-guide/top/oneapi-development-environment-setup/use-the-setvars-script-with-linux-or-macos.html), or [Windows](https://www.intel.com/content/www/us/en/develop/documentation/oneapi-programming-guide/top/oneapi-development-environment-setup/use-the-setvars-script-with-windows.html).
+> For more information on configuring environment variables, see [Use the setvars Script with Linux* or MacOS*](https://www.intel.com/content/www/us/en/develop/documentation/oneapi-programming-guide/top/oneapi-development-environment-setup/use-the-setvars-script-with-linux-or-macos.html) or [Use the setvars Script with Windows*](https://www.intel.com/content/www/us/en/develop/documentation/oneapi-programming-guide/top/oneapi-development-environment-setup/use-the-setvars-script-with-windows.html).
 
 ### Command Line On a Linux* System
-
-
 1. Use dpct to migrate the CUDA code. The  migrated source code will be
    created in a new directory, by default named `dpct_output`.
 
@@ -96,13 +79,10 @@ $ dpct --in-root=. src/vector_add.cu
 ```
 
 2. Inspect the migrated source code, address any `DPCT` warnings generated
-   by the Intel DPC++ Compatibility Tool, and verify the new program correctness.
+   by the Intel® DPC++ Compatibility Tool, and verify the new program correctness.
 
 Warnings are printed to the console and added as comments in the migrated
-source. See the [Diagnostic Reference][diag-ref] for more information on what
-each warning means.
-
-[diag-ref]: <https://www.intel.com/content/www/us/en/develop/documentation/intel-dpcpp-compatibility-tool-user-guide/top/diagnostics-reference.html>
+source. See *Diagnostic Reference* in the [Intel® DPC++ Compatibility Tool Developer Guide and Reference](https://www.intel.com/content/www/us/en/develop/documentation/intel-dpcpp-compatibility-tool-user-guide/top/diagnostics-reference.html) for more information on what each warning means.
 
 This sample should generate the following warning:
 
@@ -114,8 +94,8 @@ See the section titled **Addressing Warnings in Migrated Code** below to
 understand how to resolve the warnings.
 
 3. Copy the original `Makefile` into the `dpct_output` folder and update the
-   copy to build the migrated project using DPC++. Replace the CUDA
-   configurations in that new `Makefile` with the following for use with DPC++:
+   copy to build the migrated project using SYCL. Replace the CUDA
+   configurations in that new `Makefile` with the following for use with SYCL:
 
 ```make
 CXX = dpcpp
@@ -151,7 +131,7 @@ line as long as you first initialize your environment with:
 ```
 
 3. Inspect the migrated source code and address any `DPCT` warnings generated
-   by the Intel DPC++ Compatibility Tool. Warnings appear in a tool window and
+   by the Intel® DPC++ Compatibility Tool. Warnings appear in a tool window and
    are written to a `migration.log` file in the project directory.
 
 This sample should generate the following warning:
@@ -174,7 +154,7 @@ Migration generated one warning for code that `dpct` could not migrate:
 warning: DPCT1003:0: Migrated API does not return error code. (*, 0) is inserted. You may need to rewrite this code.
 ```
 
-Since DPC++ uses exceptions rather than error codes for error handling, the
+Since SYCL uses exceptions rather than error codes for error handling, the
 tool removed the conditional statement to exit on failure and instead wrapped
 the code in a `try` block. However, `dpct` retained the error status variable
 and changed the source to always assign an error code of `0` to it. One way to
@@ -213,4 +193,10 @@ lists a group of even numbers produced by the kernel code's execution of
 ```
 
 If an error occurs, troubleshoot the problem using the Diagnostics Utility for Intel® oneAPI Toolkits.
-[Learn more](https://www.intel.com/content/www/us/en/develop/documentation/diagnostic-utility-user-guide/top.html)
+[Learn more](https://www.intel.com/content/www/us/en/develop/documentation/diagnostic-utility-user-guide/top.html).
+
+## License
+Code samples are licensed under the MIT license. See
+[License.txt](https://github.com/oneapi-src/oneAPI-samples/blob/master/License.txt) for details.
+
+Third party program Licenses can be found here: [third-party-programs.txt](https://github.com/oneapi-src/oneAPI-samples/blob/master/third-party-programs.txt).

--- a/Tools/VTuneProfiler/matrix_multiply_vtune/README.md
+++ b/Tools/VTuneProfiler/matrix_multiply_vtune/README.md
@@ -1,31 +1,27 @@
 # `Matrix Multiply` Sample
-A sample containing multiple implementations of matrix multiplication. This sample code is implemented using DPC++ language for CPU and GPU.
+A sample containing multiple implementations of matrix multiplication. This sample code is implemented using SYCL*-compliant code for CPU and GPU.
 
-| Optimized for                       | Description
+| Optimized for                     | Description
 |:---                               |:---
-| OS                                | Linux Ubuntu 18.04; Windows 10
+| OS                                | Linux* Ubuntu* 18.04 <br> Windows* 10
 | Hardware                          | Kaby Lake with GEN9 or newer
-| Software                          | Intel&reg; oneAPI DPC++ Compiler; VTune(TM) Profiler
-| What you will learn               | How to profile an application using Intel&reg; VTune(TM) Profiler
+| Software                          | Intel&reg; oneAPI DPC++ Compiler <br> Intel&reg; VTune&trade; Profiler
+| What you will learn               | How to profile an application using Intel&reg; VTune&trade; Profiler
 | Time to complete                  | 15 minutes
 
 ## Purpose
 
 The Matrix Multiplication sample performs basic matrix multiplication. Three
-version are provided that use different features of DPC++.
+versions are provided that use different SYCL features.
 
 ## Key Implementation details
 
-The basic DPC++ implementation explained in the code includes device selector,
-buffer, accessor, kernel, and command groups. Include Files The include folder
-is located at %ONEAPI_ROOT%\dev-utilities\latest\include on your development
+The basic SYCL implementation explained in the code includes device selector,
+buffer, accessor, kernel, and command groups. 
+
+## Include Files 
+The include folder is located at `%ONEAPI_ROOT%\dev-utilities\latest\include` on your development
 system.
-
-## License
-Code samples are licensed under the MIT license. See
-[License.txt](https://github.com/oneapi-src/oneAPI-samples/blob/master/License.txt) for details.
-
-Third party program Licenses can be found here: [third-party-programs.txt](https://github.com/oneapi-src/oneAPI-samples/blob/master/third-party-programs.txt)
 
 ## Using Visual Studio Code* (Optional)
 
@@ -33,43 +29,43 @@ You can use Visual Studio Code (VS Code) extensions to set your environment, cre
 and browse and download samples.
 
 The basic steps to build and run a sample using VS Code include:
- - Download a sample using the extension **Code Sample Browser for Intel oneAPI Toolkits**.
- - Configure the oneAPI environment with the extension **Environment Configurator for Intel oneAPI Toolkits**.
+ - Download a sample using the extension **Code Sample Browser for Intel&reg; oneAPI Toolkits**.
+ - Configure the oneAPI environment with the extension **Environment Configurator for Intel&reg; oneAPI Toolkits**.
  - Open a Terminal in VS Code (**Terminal>New Terminal**).
  - Run the sample in the VS Code terminal using the instructions below.
  - (Linux only) Debug your GPU application with GDB for Intel® oneAPI toolkits using the **Generate Launch Configurations** extension.
 
-To learn more about the extensions, see
-[Using Visual Studio Code with Intel® oneAPI Toolkits](https://www.intel.com/content/www/us/en/develop/documentation/using-vs-code-with-intel-oneapi/top.html).
-
-After learning how to use the extensions for Intel oneAPI Toolkits, return to this readme for instructions on how to build and run a sample.
+To learn more about the extensions, see the
+[Using Visual Studio Code with Intel® oneAPI Toolkits User Guide](https://www.intel.com/content/www/us/en/develop/documentation/using-vs-code-with-intel-oneapi/top.html).
 
 ## How to Build
-
-This sample contains 3 version of matrix multiplication using DPC++:
-
-    multiply1 – basic implementation of matrix multiply using DPC++
-    multiply1_1 – basic implementation that replaces the buffer store with a local accessor “acc” to reduce memory traffic
-    multiply1_2 – basic implementation plus the local accessor and matrix tiling
-
-Edit the line in multiply.h to select the version of the multiply function:
-#define MULTIPLY multiply1
 
 > **Note**: If you have not already done so, set up your CLI
 > environment by sourcing  the `setvars` script located in
 > the root of your oneAPI installation.
 >
-> Linux Sudo: . /opt/intel/oneapi/setvars.sh
+> Linux*:
+> - For system wide installations: `. /opt/intel/oneapi/setvars.sh`
+> - For private installations: `. ~/intel/oneapi/setvars.sh`
+> - For non-POSIX shells, like csh, use the following command: `$ bash -c 'source <install-dir>/setvars.sh ; exec csh'`
 >
-> Linux User: . ~/intel/oneapi/setvars.sh
+> Windows*:
+> - `C:\Program Files(x86)\Intel\oneAPI\setvars.bat`
+> - For Windows PowerShell*, use the following command: `cmd.exe "/K" '"C:\Program Files (x86)\Intel\oneAPI\setvars.bat" && powershell'`
 >
-> Windows: C:\Program Files(x86)\Intel\oneAPI\setvars.bat
->
->For more information on environment variables, see Use the setvars Script for [Linux or macOS](https://www.intel.com/content/www/us/en/develop/documentation/oneapi-programming-guide/top/oneapi-development-environment-setup/use-the-setvars-script-with-linux-or-macos.html), or [Windows](https://www.intel.com/content/www/us/en/develop/documentation/oneapi-programming-guide/top/oneapi-development-environment-setup/use-the-setvars-script-with-windows.html).
+> For more information on configuring environment variables, see [Use the setvars Script with Linux* or MacOS*](https://www.intel.com/content/www/us/en/develop/documentation/oneapi-programming-guide/top/oneapi-development-environment-setup/use-the-setvars-script-with-linux-or-macos.html) or [Use the setvars Script with Windows*](https://www.intel.com/content/www/us/en/develop/documentation/oneapi-programming-guide/top/oneapi-development-environment-setup/use-the-setvars-script-with-windows.html).
 
+This sample contains three versions of matrix multiplication:
+
+- `multiply1` – basic implementation of matrix multiply using SYCL
+- `multiply1_1` – basic implementation that replaces the buffer store with a local accessor “acc” to reduce memory traffic
+- `multiply1_2` – basic implementation plus the local accessor and matrix tiling
+
+Edit the line in `multiply.h` to select the version of the multiply function:
+`#define MULTIPLY multiply1`.
 
 ### On a Linux* System
-	To build DPC++ version:
+	To build SYCL version:
 	cd <sample dir>
 	cmake .
 	make
@@ -87,27 +83,35 @@ dependencies and permissions errors.
 
 
 ### On a Windows* System Using Visual Studio 2017 or newer
-   * Open Visual Studio 2017
-   * Select Menu "File > Open > Project/Solution", find "matrix_multiply" folder and select "matrix_multiply.sln"
-   * Select Menu "Project > Build" to build the selected configuration
-   * Select Menu "Debug > Start Without Debugging" to run the program
+   * Open Visual Studio 2017 or later
+     * Select Menu "File > Open > Project/Solution", find "matrix_multiply" folder and select "matrix_multiply.sln"
+     * Select Menu "Project > Build" to build the selected configuration
+     * Select Menu "Debug > Start Without Debugging" to run the program
 
 ### on Windows - command line - Build the program using MSBuild
-    DPCPP Configurations:
-    Release - MSBuild matrix_multiply.sln /t:Rebuild /p:Configuration="Release"
-    Debug - MSBuild matrix_multiply.sln /t:Rebuild /p:Configuration="Debug"
+- DPCPP Configurations:
+  - Release - `MSBuild matrix_multiply.sln /t:Rebuild /p:Configuration="Release"`
+  - Debug - `MSBuild matrix_multiply.sln /t:Rebuild /p:Configuration="Debug"`
 
 
 ## Example of Output
-   ./matrix.dpcpp
+```
+./matrix.dpcpp
 
-   Using multiply kernel: multiply1
+Using multiply kernel: multiply1
 
-   Running on Intel(R) Gen9
+Running on Intel(R) Gen9
 
-   Elapsed Time: 0.539631s
+Elapsed Time: 0.539631s
+```
 
-## Running an Intel VTune Profiler analysis
-------------------------------------------
-
+## Running an Intel&reg; VTune&trade; Profiler analysis
+```
 vtune -collect gpu-hotspots -- ./matrix.dpcpp
+```
+
+## License
+Code samples are licensed under the MIT license. See
+[License.txt](https://github.com/oneapi-src/oneAPI-samples/blob/master/License.txt) for details.
+
+Third party program Licenses can be found here: [third-party-programs.txt](https://github.com/oneapi-src/oneAPI-samples/blob/master/third-party-programs.txt).


### PR DESCRIPTION
Final batch of DPC++-to-SYCL changes in README.md files.

# Existing Sample Changes
## Description

Changing just DPC++ to SYCL where appropriate and updating branding to match legal requirements. No other restructuring except where absolutely essentials; fixed major content and formatting issues in multiple files. Fixed multiple branding issues. (Note: Excluded files in tool directory that did not contain "DPC++" instances.)

Updated the following files:
\oneAPI-samples\Tools\Advisor\matrix_multiply_advisor\README.md
\oneAPI-samples\Tools\ApplicationDebugger\array-transform\README.md
\oneAPI-samples\Tools\ApplicationDebugger\jacobi\README.md
\oneAPI-samples\Tools\Benchmarks\STREAM\README.md
\oneAPI-samples\Tools\Migration\folder-options-dpct\README.md
\oneAPI-samples\Tools\Migration\rodinia-nw-dpct\README.md
\oneAPI-samples\Tools\Migration\vector-add-dpct\README.md
\oneAPI-samples\Tools\VTuneProfiler\matrix_multiply_vtune\README.md

Fixes Issue# 

## External Dependencies

N/A
## Type of change

Please delete options that are not relevant. Add a 'X' to the one that is applicable. 

- [x] Documentation 

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] VSCode
