### PR TITLE
changes to oneDPL parallel API notebook

### DIFF
--- a/DirectProgramming/DPC++/Jupyter/oneapi-essentials-training/07_DPCPP_Library/oneDPL_parallel_API.ipynb
+++ b/DirectProgramming/DPC++/Jupyter/oneapi-essentials-training/07_DPCPP_Library/oneDPL_parallel_API.ipynb
@@ -4,7 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# oneDPL - Extension APIs"
+    "# oneDPL - Parallel API"
    ]
   },
   {
@@ -13,21 +13,27 @@
    "source": [
     "## Learning Objectives\n",
     "\n",
-    "* Explain oneDPL Extension API Algorithms with examples\n",
-    "* Explain oneDPL Extension API Iterators with examples\n",
+    "* Explain oneDPL Parallel API Algorithms with examples\n",
+    "* Explain oneDPL Parallel API Iterators with examples\n",
     "* Explain oneDPL Extension API Utility classes with examples\n",
     "\n",
     "\n",
-    "oneDPL consists of an additional set of library classes and functions called the __Extension API__. The Extension API currently includes six algorithms and three functional utility classes and three Iterators.\n",
+    "oneDPL consists of an additional set of library classes and functions called the __Parallel API__. Intel® oneAPI DPC++ Library (oneDPL) provides specific versions of the algorithms, including:\n",
+    "* Segmented reduce\n",
+    "* Segmented scan\n",
+    "* Vectorized search algorithms\n",
     "\n",
-    "In this notebook we introduce you to the above __Extension APIs__ and how we can use these in DPC++ program to perform some of the parallel STL operations in heterogenous environments."
+    "Parallel API offers support for the parallel and vectorized execution of algorithms on Intel® processors and heterogeneity support with a SYCL based implementation for device execution policies. \n",
+    "The Extension API currently includes six algorithms and three functional utility classes and three Iterators.\n",
+    "\n",
+    "In this notebook we introduce you to the above __Parallel APIs__ and how we can use these in SYCL program to perform some of the parallel STL operations in heterogenous environments."
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## List of oneDPL Extension APIs\n",
+    "## List of oneDPL Parallel APIs\n",
     "\n",
     "| Type | function call | Description |\n",
     "|:---|:---|:---|\n",
@@ -55,8 +61,8 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## oneDPL Extension API Algorithms\n",
-    "Below section talks about the list of the six Extension API algorithms"
+    "## oneDPL Parallel API Algorithms\n",
+    "Below section talks about the list of the six Parallel API algorithms"
    ]
   },
   {
@@ -1663,7 +1669,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3.7 (Intel® oneAPI)",
+   "display_name": "Python 3.8 (Intel® oneAPI)",
    "language": "python",
    "name": "c009-intel_distribution_of_python_3_oneapi-beta05-python"
   },
@@ -1677,7 +1683,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.7"
+   "version": "3.9.10"
   },
   "toc": {
    "base_numbering": 1,


### PR DESCRIPTION
# Existing Sample Changes
## Description

Verbiage changes to oneDPL parallel API notebook . Small naming changes from from extension API to parallel API. No changes in code snippets


