### PR TITLE
Increase allowable floating point rounding error in FPGA reference design mvdr_beamforming.

### DIFF
--- a/DirectProgramming/DPC++FPGA/ReferenceDesigns/mvdr_beamforming/src/mvdr_beamforming.cpp
+++ b/DirectProgramming/DPC++FPGA/ReferenceDesigns/mvdr_beamforming/src/mvdr_beamforming.cpp
@@ -54,11 +54,11 @@ std::ostream &operator<<(std::ostream &os, const ComplexType &val) {
   return os;
 }
 
-bool AlmostEqual(float x, float y, float epsilon = 0.0002f) {
+bool AlmostEqual(float x, float y, float epsilon = 0.0004f) {
   return std::fabs(x - y) < epsilon;
 }
 
-bool AlmostEqual(ComplexType x, ComplexType y, float epsilon = 0.0002f) {
+bool AlmostEqual(ComplexType x, ComplexType y, float epsilon = 0.0004f) {
   bool real_close = AlmostEqual(x.real(), y.real(), epsilon);
   bool imag_close = AlmostEqual(x.imag(), y.imag(), epsilon);
   return real_close && imag_close;


### PR DESCRIPTION
## Description

The SYCL emulator seems to have changed it's default floating point behaviour, resulting in slightly higher noise in the final output.  Increase the allowable deviation from the expected result to account for this.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] Command Line
