### PR TITLE
setting complier correctly in all samples using cmake

### DIFF
--- a/DirectProgramming/DPC++/DenseLinearAlgebra/jacobi_iterative/CMakeLists.txt
+++ b/DirectProgramming/DPC++/DenseLinearAlgebra/jacobi_iterative/CMakeLists.txt
@@ -1,8 +1,8 @@
 cmake_minimum_required (VERSION 3.4.0)
-project (jacobi_iterative)
 
 set(CMAKE_CXX_COMPILER "dpcpp")
 
+project (jacobi_iterative)
 # Set default build type to RelWithDebInfo if not specified
 if (NOT CMAKE_BUILD_TYPE)
 	message (STATUS "Default CMAKE_BUILD_TYPE not set using Release with Debug Info")

--- a/DirectProgramming/DPC++/GraphTraversal/bitonic-sort/CMakeLists.txt
+++ b/DirectProgramming/DPC++/GraphTraversal/bitonic-sort/CMakeLists.txt
@@ -1,13 +1,14 @@
 # required cmake version
 cmake_minimum_required(VERSION 3.5)
 
-project (bitonic-sort)
 
 if(WIN32)
         set(CMAKE_CXX_COMPILER "dpcpp-cl")
 else()
         set(CMAKE_CXX_COMPILER "dpcpp")
 endif()
+
+project (bitonic-sort)
 
 # Set default build type to RelWithDebInfo if not specified
 if (NOT CMAKE_BUILD_TYPE)

--- a/DirectProgramming/DPC++/GraphTraversal/hidden-markov-models/CMakeLists.txt
+++ b/DirectProgramming/DPC++/GraphTraversal/hidden-markov-models/CMakeLists.txt
@@ -1,13 +1,13 @@
 # required cmake version
 cmake_minimum_required(VERSION 3.5)
 
-project (hidden-markov-models)
-
 if(WIN32)
         set(CMAKE_CXX_COMPILER "dpcpp-cl")
 else()
         set(CMAKE_CXX_COMPILER "dpcpp")
 endif()
+
+project (hidden-markov-models)
 
 # Set default build type to RelWithDebInfo if not specified
 if (NOT CMAKE_BUILD_TYPE)

--- a/DirectProgramming/DPC++/GraphTraversal/odd-even-merge-sort/CMakeLists.txt
+++ b/DirectProgramming/DPC++/GraphTraversal/odd-even-merge-sort/CMakeLists.txt
@@ -1,8 +1,8 @@
 cmake_minimum_required (VERSION 3.4.0)
-project (odd-even-merge-sort)
 
 set(CMAKE_CXX_COMPILER "dpcpp")
 
+project (odd-even-merge-sort)
 # Set default build type to RelWithDebInfo if not specified
 if (NOT CMAKE_BUILD_TYPE)
 	message (STATUS "Default CMAKE_BUILD_TYPE not set using Release with Debug Info")

--- a/DirectProgramming/DPC++/ParallelPatterns/PrefixSum/CMakeLists.txt
+++ b/DirectProgramming/DPC++/ParallelPatterns/PrefixSum/CMakeLists.txt
@@ -1,13 +1,13 @@
 # required cmake version
 cmake_minimum_required(VERSION 3.5)
 
-project (PrefixSum)
-
 if(WIN32)
         set(CMAKE_CXX_COMPILER "dpcpp")
 else()
         set(CMAKE_CXX_COMPILER "dpcpp")
 endif()
+
+project (PrefixSum)
 
 # Set default build type to RelWithDebInfo if not specified
 if (NOT CMAKE_BUILD_TYPE)

--- a/DirectProgramming/DPC++/ParallelPatterns/dpc_reduce/CMakeLists.txt
+++ b/DirectProgramming/DPC++/ParallelPatterns/dpc_reduce/CMakeLists.txt
@@ -1,8 +1,9 @@
 # required cmake version
 cmake_minimum_required(VERSION 3.5)
 
-project (dpc_reduce)
 set(CMAKE_CXX_COMPILER "mpiicpc")
+
+project (dpc_reduce)
 
 # Set default build type to RelWithDebInfo if not specified
 if (NOT CMAKE_BUILD_TYPE)

--- a/DirectProgramming/DPC++/ParallelPatterns/histogram/CMakeLists.txt
+++ b/DirectProgramming/DPC++/ParallelPatterns/histogram/CMakeLists.txt
@@ -1,8 +1,8 @@
 cmake_minimum_required (VERSION 3.5)
-project(histogram LANGUAGES CXX)
 
 set(CMAKE_CXX_COMPILER "dpcpp")
 
+project(histogram LANGUAGES CXX)
 # Set default build type to RelWithDebInfo if not specified
 if (NOT CMAKE_BUILD_TYPE)
     message (STATUS "Default CMAKE_BUILD_TYPE not set using Release")

--- a/DirectProgramming/DPC++/ParallelPatterns/loop-unroll/CMakeLists.txt
+++ b/DirectProgramming/DPC++/ParallelPatterns/loop-unroll/CMakeLists.txt
@@ -1,7 +1,9 @@
 cmake_minimum_required (VERSION 3.5)
-project (loop-unroll)
 
 set(CMAKE_CXX_COMPILER dpcpp)
+
+project (loop-unroll)
+
 
 # Set default build type to RelWithDebInfo if not specified
 if (NOT CMAKE_BUILD_TYPE)

--- a/DirectProgramming/DPC++/SparseLinearAlgebra/merge-spmv/CMakeLists.txt
+++ b/DirectProgramming/DPC++/SparseLinearAlgebra/merge-spmv/CMakeLists.txt
@@ -1,7 +1,8 @@
 cmake_minimum_required (VERSION 3.5)
-project (merge-spmv)
 
 set(CMAKE_CXX_COMPILER dpcpp)
+
+project (merge-spmv)
 
 # Set default build type to RelWithDebInfo if not specified
 if (NOT CMAKE_BUILD_TYPE)

--- a/DirectProgramming/DPC++/StructuredGrids/1d_HeatTransfer/CMakeLists.txt
+++ b/DirectProgramming/DPC++/StructuredGrids/1d_HeatTransfer/CMakeLists.txt
@@ -1,10 +1,11 @@
 # required cmake version
 cmake_minimum_required(VERSION 3.5)
 
+set(CMAKE_CXX_COMPILER "dpcpp")
+
 # CMakeLists.txt for 1d_HeatTransfer project
 project (1d_HeatTransfer)
 
-set(CMAKE_CXX_COMPILER "dpcpp")
 
 # Set default build type to RelWithDebInfo if not specified
 if (NOT CMAKE_BUILD_TYPE)

--- a/DirectProgramming/DPC++/StructuredGrids/iso2dfd_dpcpp/CMakeLists.txt
+++ b/DirectProgramming/DPC++/StructuredGrids/iso2dfd_dpcpp/CMakeLists.txt
@@ -1,10 +1,11 @@
 # required cmake version
 cmake_minimum_required(VERSION 3.5)
 
+set(CMAKE_CXX_COMPILER "dpcpp")
+
 # CMakeLists.txt for ISO2DFD_DPCPP project
 project (iso2dfd_dpcpp)
 
-set(CMAKE_CXX_COMPILER "dpcpp")
 
 # Set default build type to RelWithDebInfo if not specified
 if (NOT CMAKE_BUILD_TYPE)

--- a/DirectProgramming/DPC++/StructuredGrids/iso3dfd_dpcpp/CMakeLists.txt
+++ b/DirectProgramming/DPC++/StructuredGrids/iso3dfd_dpcpp/CMakeLists.txt
@@ -1,4 +1,4 @@
 cmake_minimum_required (VERSION 3.4)
-project (ISO3DFD_DPCPP)
 set(CMAKE_CXX_COMPILER "dpcpp")
+project (ISO3DFD_DPCPP)
 add_subdirectory (src)


### PR DESCRIPTION
Signed-off-by: Emmanuel Moncada <emmanuel.moncada@intel.com>

# Existing Sample Changes
## Description
Updates all CMakeLists.txt for samples to set compiler prior to calling project() so that CMake selects the intended compiler.

Fixes Issue# N/A

## External Dependencies
None/N/A

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Has been tested by running `cmake ..` from build directories in each of the samples under DirectProgramming/, and verifying that the selected compiler matches what is defined in its respective CMakeLists.txt, where previously other default compilers such as usr/bin/cc and user/bin/c++ were selected.

- [X] Command Line
- [ ] oneapi-cli
- [ ] Visual Studio
- [ ] Eclipse IDE
- [ ] VSCode
- [ ] When compiling the compliler flag "-Wall -Wformat-security -Werror=format-security" was used
