### PR TITLE
remove fp-model precise and fp-relaxed in qrd design

### DIFF
--- a/DirectProgramming/DPC++FPGA/ReferenceDesigns/qrd/src/CMakeLists.txt
+++ b/DirectProgramming/DPC++FPGA/ReferenceDesigns/qrd/src/CMakeLists.txt
@@ -86,8 +86,8 @@ message(STATUS "SEED=${SEED}")
 #    For this reason, FPGA backend flags must be passed as link flags in CMake.
 set(EMULATOR_COMPILE_FLAGS "-fintelfpga -Wall ${AC_TYPES_FLAG} -Wformat-security -Werror=format-security -fbracket-depth=512 -fno-finite-math-only -DFIXED_ITERATIONS=${FIXED_ITERATIONS} -DCOMPLEX=${COMPLEX} -DROWS_COMPONENT=${ROWS_COMPONENT} -DCOLS_COMPONENT=${COLS_COMPONENT} -DFPGA_EMULATOR")
 set(EMULATOR_LINK_FLAGS "-fintelfpga ${AC_TYPES_FLAG} ${WIN_LINK_FLAG}")
-set(HARDWARE_COMPILE_FLAGS "-fintelfpga -Wall ${AC_TYPES_FLAG} -Wformat-security -Werror=format-security -fbracket-depth=512 -DFIXED_ITERATIONS=${FIXED_ITERATIONS} -DCOMPLEX=${COMPLEX} -DROWS_COMPONENT=${ROWS_COMPONENT} -DCOLS_COMPONENT=${COLS_COMPONENT} -fp-model=precise -Xsfp-relaxed")
-set(HARDWARE_LINK_FLAGS "-fintelfpga ${AC_TYPES_FLAG} ${WIN_LINK_FLAG} -Xshardware -Xsclock=${CLOCK_TARGET} -Xsparallel=2 ${SEED} -Xsboard=${FPGA_BOARD} ${USER_HARDWARE_FLAGS} -fp-model=precise -Xsfp-relaxed")
+set(HARDWARE_COMPILE_FLAGS "-fintelfpga -Wall ${AC_TYPES_FLAG} -Wformat-security -Werror=format-security -fbracket-depth=512 -DFIXED_ITERATIONS=${FIXED_ITERATIONS} -DCOMPLEX=${COMPLEX} -DROWS_COMPONENT=${ROWS_COMPONENT} -DCOLS_COMPONENT=${COLS_COMPONENT}")
+set(HARDWARE_LINK_FLAGS "-fintelfpga ${AC_TYPES_FLAG} ${WIN_LINK_FLAG} -Xshardware -Xsclock=${CLOCK_TARGET} -Xsparallel=2 ${SEED} -Xsboard=${FPGA_BOARD} ${USER_HARDWARE_FLAGS}")
 # use cmake -D USER_HARDWARE_FLAGS=<flags> to set extra flags for FPGA backend compilation
 
 ###############################################################################


### PR DESCRIPTION
# Existing Sample Changes
## Description

A bug has been fixed in the release such that fast-math model does not drop Fmax and throughput anymore. Change to use default compiler configuration.
```
                qor data change vs baseline
-----------------------------------------------------------
Fmax_kernel                     +1.834% (10)  -4.1% +29.0%
Kernel_area                     +2.843% (10)  -2.3% +48.8%
Logic_util                      -2.484% (10)  -4.4%  -0.8%
Silicon_area                    -1.089% (10)  -1.9%  -0.4%
Status                         <null>-1 (20)
                               passed+1
Throughput                      -0.201%  (9)  -1.9%  +1.0%
aoc_time                        +1.215% (10) -16.1% +19.5%
dsps                            +0.000% (10)  +0.0%  +0.0%
rams                            +0.000% (10)  +0.0%  +0.0%
registers                       -3.448% (10)  -6.6%  +6.7%
Throughput_per_area             +0.802%  (9)  -1.5%  +2.0%
Throughput_per_fmax             +0.615%  (9)  -3.0%  +4.3%
Throughput_per_kernel_area      +1.106%  (9)  -1.5%  +2.4%
```

Fixes Issue# 

## External Dependencies

N/A

## Type of change

Please delete options that are not relevant. Add a 'X' to the one that is applicable. 

- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [X] Command Line