### PR TITLE
Document --in-root option in all README.md for SYCLomatic

### DIFF
--- a/Tools/Migration/rodinia-nw-dpct/README.md
+++ b/Tools/Migration/rodinia-nw-dpct/README.md
@@ -87,6 +87,12 @@ $ intercept-build make
 
 2. Use the Intel® DPC++ Compatibility Tool and compilation database to migrate
    the CUDA code. The new project will be created in the `migration` directory.
+   The dpct `--in-root` option is used to set the root location of the program
+   sources that are to be migrated. Only files and folders located within the
+   --in-root directory will be considered for migration by the tool. Files located
+   outside the`--in-root` directory are considered system files and will not be
+   migrated, even if they are included by a source file located within the
+   `--in-root`directory.
 
 ```sh
 $ dpct -p compile_commands.json --in-root=. --out-root=migration

--- a/Tools/Migration/vector-add-dpct/README.md
+++ b/Tools/Migration/vector-add-dpct/README.md
@@ -72,6 +72,12 @@ to a SYCL*-compliant project.
 ### Command Line On a Linux* System
 1. Use dpct to migrate the CUDA code. The  migrated source code will be
    created in a new directory, by default named `dpct_output`.
+   The dpct `--in-root` option is used to set the root location of the program
+   sources that are to be migrated. Only files and folders located within the
+   --in-root directory will be considered for migration by the tool. Files located
+   outside the`--in-root` directory are considered system files and will not be
+   migrated, even if they are included by a source file located within the
+   `--in-root`directory.
 
 ```sh
 # From the repo root directory:


### PR DESCRIPTION
Signed-off-by: Lu, John <john.lu@intel.com>

Add explanation of --in-root option for all README.md for SYCLomatic.  Make purpose of --in-root clear in every example.
