### PR TITLE
ONSAM-1487

### DIFF
--- a/DirectProgramming/DPC++/MapReduce/MonteCarloPi/src/monte_carlo_pi.cpp
+++ b/DirectProgramming/DPC++/MapReduce/MonteCarloPi/src/monte_carlo_pi.cpp
@@ -160,6 +160,5 @@ int main() {
   std::cout
       << "The simulation plot graph has been written to 'MonteCarloPi.bmp'\n";
 
-  getchar();
   return 0;
 }


### PR DESCRIPTION


# Existing Sample Changes
## Description

Remove getchar() which prevents automatically exit of the application

Fixes Issue# 

## Type of change

Please delete options that are not relevant. Add a 'X' to the one that is applicable. 
- [X] Implement fixes for ONSAM Jiras

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Command Line
- [ ] oneapi-cli
- [x] Visual Studio
- [ ] Eclipse IDE
- [ ] VSCode
- [ ] When compiling the compliler flag "-Wall -Wformat-security -Werror=format-security" was used


