### PR TITLE
ONSAM-1506

### DIFF
--- a/Publications/DPC++/Ch14_common_parallel_patterns/fig_14_15_local_stencil.cpp
+++ b/Publications/DPC++/Ch14_common_parallel_patterns/fig_14_15_local_stencil.cpp
@@ -12,10 +12,6 @@
 
 using namespace sycl;
 
-template <typename T, int dimensions>
-using local_accessor =
-    accessor<T, dimensions, access::mode::read_write, access::target::local>;
-
 int main() {
   queue Q;
 

--- a/Publications/DPC++/Ch14_common_parallel_patterns/fig_14_18-20_inclusive_scan.cpp
+++ b/Publications/DPC++/Ch14_common_parallel_patterns/fig_14_18-20_inclusive_scan.cpp
@@ -12,10 +12,6 @@
 
 using namespace sycl;
 
-template <typename T, int dimensions>
-using local_accessor =
-    accessor<T, dimensions, access::mode::read_write, access::target::local>;
-
 int main() {
   queue q;
 

--- a/Publications/DPC++/Ch14_common_parallel_patterns/fig_14_22_local_pack.cpp
+++ b/Publications/DPC++/Ch14_common_parallel_patterns/fig_14_22_local_pack.cpp
@@ -12,10 +12,6 @@
 
 using namespace sycl;
 
-template <typename T, int dimensions>
-using local_accessor =
-    accessor<T, dimensions, access::mode::read_write, access::target::local>;
-
 int main() {
   queue Q;
 

--- a/Publications/DPC++/Ch19_memory_model_and_atomics/fig_19_18_histogram.cpp
+++ b/Publications/DPC++/Ch19_memory_model_and_atomics/fig_19_18_histogram.cpp
@@ -11,10 +11,6 @@
 using namespace sycl;
 using namespace sycl::ext::oneapi;
 
-template <typename T, int dimensions>
-using local_accessor =
-    accessor<T, dimensions, access::mode::read_write, access::target::local>;
-
 std::tuple<size_t, size_t> distribute_range(group<1> g, size_t N) {
   size_t work_per_group = N / g.get_group_range(0);
   size_t remainder = N - g.get_group_range(0) * work_per_group;


### PR DESCRIPTION
# Existing Sample Changes
## Description

Removal of alias for local_accessor, access::target::local is now deprecated.

Fixes Issue# 

## External Dependencies

None

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Implement fixes for ONSAM Jiras

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Command Line
- [ ] oneapi-cli
- [ ] Visual Studio
- [ ] Eclipse IDE
- [ ] VSCode
- [ ] When compiling the compliler flag "-Wall -Wformat-security -Werror=format-security" was used
