### PR TITLE
[FPGA] FPGA Simulator support for loop_coalesce, loop_ii and spec itrs

### DIFF
--- a/DirectProgramming/DPC++FPGA/Tutorials/Features/loop_coalesce/README.md
+++ b/DirectProgramming/DPC++FPGA/Tutorials/Features/loop_coalesce/README.md
@@ -126,6 +126,10 @@ To learn more about the extensions and how to configure the oneAPI environment, 
      ```
      make report
      ```
+   * Compile for simulation (fast compile time, targets simulated FPGA device):
+     ```
+     make fpga_sim
+     ```
    * Compile for FPGA hardware (longer compile time, targets FPGA device):
      ```
      make fpga
@@ -163,6 +167,10 @@ To learn more about the extensions and how to configure the oneAPI environment, 
      ```
      nmake report
      ```
+   * Compile for simulation (fast compile time, targets simulated FPGA device):
+     ```
+     nmake fpga_sim
+     ```
    * Compile for FPGA hardware (longer compile time, targets FPGA device):
      ```
      nmake fpga
@@ -195,12 +203,17 @@ On the main report page, scroll down to the section titled `Compile Estimated Ke
 ## Running the Sample
 
  1. Run the sample on the FPGA emulator (the kernel executes on the CPU):
-     ```
+     ```bash
      ./loop_coalesce.fpga_emu     (Linux)
      loop_coalesce.fpga_emu.exe   (Windows)
      ```
-2. Run the sample on the FPGA device:
+ 2. Run the sample on the FPGA simulator device:
+     ```bash
+     ./loop_coalesce.fpga_sim     (Linux)
+     loop_coalesce.fpga_sim.exe   (Windows)
      ```
+ 3. Run the sample on the FPGA device:
+     ```bash
      ./loop_coalesce.fpga         (Linux)
      loop_coalesce.fpga.exe       (Windows)
      ```

--- a/DirectProgramming/DPC++FPGA/Tutorials/Features/loop_coalesce/src/CMakeLists.txt
+++ b/DirectProgramming/DPC++FPGA/Tutorials/Features/loop_coalesce/src/CMakeLists.txt
@@ -4,6 +4,7 @@
 set(SOURCE_FILE loop_coalesce.cpp)
 set(TARGET_NAME loop_coalesce)
 set(EMULATOR_TARGET ${TARGET_NAME}.fpga_emu)
+set(SIMULATOR_TARGET ${TARGET_NAME}.fpga_sim)
 set(FPGA_TARGET ${TARGET_NAME}.fpga)
 
 # FPGA board selection
@@ -22,6 +23,9 @@ endif()
 #    For this reason, FPGA backend flags must be passed as link flags in CMake.
 set(EMULATOR_COMPILE_FLAGS "-Wall -fintelfpga -DFPGA_EMULATOR")
 set(EMULATOR_LINK_FLAGS "-fintelfpga")
+set(SIMULATOR_COMPILE_FLAGS "-Wall -fintelfpga -DFPGA_SIMULATOR ${DEVICE_FLAG}")
+set(SIMULATOR_LINK_FLAGS "-fintelfpga -Xssimulation -Xstarget=${FPGA_DEVICE} ${DEVICE_FLAG} ${USER_SIMULATOR_FLAGS}")
+# use cmake -D USER_SIMULATOR_FLAGS=<flags> to set extra flags for FPGA simulator compilation
 set(HARDWARE_COMPILE_FLAGS "-Wall -fintelfpga")
 set(HARDWARE_LINK_FLAGS "-fintelfpga -Xshardware -Xstarget=${FPGA_DEVICE} ${USER_HARDWARE_FLAGS}")
 # use cmake -D USER_HARDWARE_FLAGS=<flags> to set extra flags for FPGA backend compilation
@@ -53,6 +57,19 @@ add_custom_target(report DEPENDS ${FPGA_EARLY_IMAGE})
 set_target_properties(${FPGA_EARLY_IMAGE} PROPERTIES COMPILE_FLAGS "${HARDWARE_COMPILE_FLAGS}")
 set_target_properties(${FPGA_EARLY_IMAGE} PROPERTIES LINK_FLAGS "${HARDWARE_LINK_FLAGS} -fsycl-link=early")
 # fsycl-link=early stops the compiler after RTL generation, before invoking Quartus®
+
+###############################################################################
+### FPGA Simulator
+###############################################################################
+# To compile in a single command:
+#    dpcpp -fintelfpga -Xssimulation -Xstarget=<FPGA_DEVICE> -DFPGA_SIMULATOR loop_coalesce.cpp -o loop_coalesce.fpga_sim
+# CMake executes:
+#    [compile] dpcpp -fintelfpga -DFPGA_SIMULATOR -o loop_coalesce.cpp.o -c loop_coalesce.cpp
+#    [link]    dpcpp -fintelfpga -Xssimulation -Xstarget=<FPGA_DEVICE> loop_coalesce.cpp.o -o loop_coalesce.fpga_sim
+add_executable(${SIMULATOR_TARGET} ${SOURCE_FILE})
+add_custom_target(fpga_sim DEPENDS ${SIMULATOR_TARGET})
+set_target_properties(${SIMULATOR_TARGET} PROPERTIES COMPILE_FLAGS "${SIMULATOR_COMPILE_FLAGS}")
+set_target_properties(${SIMULATOR_TARGET} PROPERTIES LINK_FLAGS "${SIMULATOR_LINK_FLAGS}")
 
 ###############################################################################
 ### FPGA Hardware

--- a/DirectProgramming/DPC++FPGA/Tutorials/Features/loop_coalesce/src/CMakeLists.txt
+++ b/DirectProgramming/DPC++FPGA/Tutorials/Features/loop_coalesce/src/CMakeLists.txt
@@ -67,6 +67,7 @@ set_target_properties(${FPGA_EARLY_IMAGE} PROPERTIES LINK_FLAGS "${HARDWARE_LINK
 #    [compile] dpcpp -fintelfpga -DFPGA_SIMULATOR -o loop_coalesce.cpp.o -c loop_coalesce.cpp
 #    [link]    dpcpp -fintelfpga -Xssimulation -Xstarget=<FPGA_DEVICE> loop_coalesce.cpp.o -o loop_coalesce.fpga_sim
 add_executable(${SIMULATOR_TARGET} ${SOURCE_FILE})
+target_include_directories(${SIMULATOR_TARGET} PRIVATE ../../../../include)
 add_custom_target(fpga_sim DEPENDS ${SIMULATOR_TARGET})
 set_target_properties(${SIMULATOR_TARGET} PROPERTIES COMPILE_FLAGS "${SIMULATOR_COMPILE_FLAGS}")
 set_target_properties(${SIMULATOR_TARGET} PROPERTIES LINK_FLAGS "${SIMULATOR_LINK_FLAGS}")

--- a/DirectProgramming/DPC++FPGA/Tutorials/Features/loop_coalesce/src/loop_coalesce.cpp
+++ b/DirectProgramming/DPC++FPGA/Tutorials/Features/loop_coalesce/src/loop_coalesce.cpp
@@ -142,6 +142,8 @@ int main() {
 
 #if defined(FPGA_EMULATOR)
   ext::intel::fpga_emulator_selector selector;
+#elif defined(FPGA_SIMULATOR)
+  ext::intel::fpga_simulator_selector selector;
 #else
   ext::intel::fpga_selector selector;
 #endif

--- a/DirectProgramming/DPC++FPGA/Tutorials/Features/loop_coalesce/src/loop_coalesce.cpp
+++ b/DirectProgramming/DPC++FPGA/Tutorials/Features/loop_coalesce/src/loop_coalesce.cpp
@@ -29,11 +29,17 @@ template <int N> class KernelCompute;
 // This is not meant to be a high performance implementation on FPGA!
 // It's just a simple kernel with nested loops to illustrate loop coalescing.
 template <int coalesce_factor>
-void MatrixMultiply(const device_selector &selector,
-                    const std::vector<float> &matrix_a,
+void MatrixMultiply(const std::vector<float> &matrix_a,
                     const std::vector<float> &matrix_b,
                     std::vector<float> &res) {
   double kernel_time = 0.0;
+#if defined(FPGA_EMULATOR)
+  ext::intel::fpga_emulator_selector selector;
+#elif defined(FPGA_SIMULATOR)
+  ext::intel::fpga_simulator_selector selector;
+#else
+  ext::intel::fpga_selector selector;
+#endif
   try {
     auto prop_list = property_list{property::queue::enable_profiling()};
 
@@ -140,19 +146,11 @@ int main() {
     }
   }
 
-#if defined(FPGA_EMULATOR)
-  ext::intel::fpga_emulator_selector selector;
-#elif defined(FPGA_SIMULATOR)
-  ext::intel::fpga_simulator_selector selector;
-#else
-  ext::intel::fpga_selector selector;
-#endif
-
   // Two versions of the simple matrix multiply kernel will be enqueued:
   //  - with coalesce_factor=1 (i.e. no loop coalescing)
   //  - with coalesce_factor=2 (coalesce two nested levels)
-  MatrixMultiply<1>(selector, matrix_a, matrix_b, matrix_output_no_col);
-  MatrixMultiply<2>(selector, matrix_a, matrix_b, matrix_output);
+  MatrixMultiply<1>(matrix_a, matrix_b, matrix_output_no_col);
+  MatrixMultiply<2>(matrix_a, matrix_b, matrix_output);
 
   // Correctness check
   bool passed = true;

--- a/DirectProgramming/DPC++FPGA/Tutorials/Features/loop_initiation_interval/README.md
+++ b/DirectProgramming/DPC++FPGA/Tutorials/Features/loop_initiation_interval/README.md
@@ -195,6 +195,12 @@ To learn more about the extensions and how to configure the oneAPI environment, 
      make report
      ```
 
+   * Compile for simulation (fast compile time, targets simulated FPGA device, reduced data size):
+
+     ```bash
+     make fpga_sim
+     ```
+
    * Compile for FPGA hardware (longer compile time, targets an FPGA device) using:
 
      ```bash
@@ -234,6 +240,10 @@ To learn more about the extensions and how to configure the oneAPI environment, 
      ```
      nmake report
      ```
+   * Compile for simulation (fast compile time, targets simulated FPGA device, reduced data  size):
+     ```
+     nmake fpga_sim
+     ``
    * Compile for FPGA hardware (longer compile time, targets FPGA device):
      ```
      nmake fpga
@@ -279,19 +289,28 @@ Compare the results to the report for the version of the design using the `intel
 1. Run the sample on the FPGA emulator (the kernel executes on the CPU):
 
    ```bash
-   ./loop_ii.fpga_emu    (Linux)
-   loop_ii.fpga_emu.exe  (Windows)
+   ./loop_ii.fpga_emu               (Linux)
+   loop_ii.fpga_emu.exe             (Windows)
    ```
 
-2. Run the sample on the FPGA device
+2. Run the sample on the FPGA simulator device:
+   ```bash
+   # Sample without intel::initiation_interval attribute
+   ./loop_ii.fpga_sim               (Linux)
+   loop_ii.fpga_sim.exe             (Windows)
+   # Sample with intel::initiation_interval attribute
+   ./loop_ii_enable_ii.fpga_sim     (Linux)
+   loop_ii_enable_ii.fpga_sim.exe   (Windows)
+
+3. Run the sample on the FPGA device
 
    ```bash
    # Sample without intel::initiation_interval attribute
-   ./loop_ii.fpga               (Linux)
-   loop_ii.fpga.exe             (Windows)
+   ./loop_ii.fpga                   (Linux)
+   loop_ii.fpga.exe                 (Windows)
    # Sample with intel::initiation_interval attribute
-   ./loop_ii_enable_ii.fpga     (Linux)
-   loop_ii_enable_ii.fpga.exe   (Windows)
+   ./loop_ii_enable_ii.fpga         (Linux)
+   loop_ii_enable_ii.fpga.exe       (Windows)
    ```
 
 ### Example of Output

--- a/DirectProgramming/DPC++FPGA/Tutorials/Features/loop_initiation_interval/src/CMakeLists.txt
+++ b/DirectProgramming/DPC++FPGA/Tutorials/Features/loop_initiation_interval/src/CMakeLists.txt
@@ -5,6 +5,8 @@ set(SOURCE_FILE loop_initiation_interval.cpp)
 set(TARGET_NAME loop_ii)
 set(TARGET_NAME_ENABLE_II loop_ii_enable_ii)
 set(EMULATOR_TARGET ${TARGET_NAME}.fpga_emu)
+set(SIMULATOR_TARGET ${TARGET_NAME}.fpga_sim)
+set(SIMULATOR_TARGET_ENABLE_II ${TARGET_NAME_ENABLE_II}.fpga_sim)
 set(FPGA_TARGET ${TARGET_NAME}.fpga)
 set(FPGA_TARGET_ENABLE_II ${TARGET_NAME_ENABLE_II}.fpga)
 
@@ -38,6 +40,9 @@ endif()
 #    For this reason, FPGA backend flags must be passed as link flags in CMake.
 set(EMULATOR_COMPILE_FLAGS "-Wall -fintelfpga -DFPGA_EMULATOR ${DEVICE_FLAG}")
 set(EMULATOR_LINK_FLAGS "-fintelfpga")
+set(SIMULATOR_COMPILE_FLAGS "-Wall ${WIN_FLAG} -fintelfpga -DFPGA_SIMULATOR ${DEVICE_FLAG}")
+set(SIMULATOR_LINK_FLAGS "-fintelfpga -Xssimulation -Xstarget=${FPGA_DEVICE} ${DEVICE_FLAG} ${USER_SIMULATOR_FLAGS}")
+# use cmake -D USER_SIMULATOR_FLAGS=<flags> to set extra flags for FPGA simulator compilation
 set(HARDWARE_COMPILE_FLAGS "-Wall -fintelfpga ${DEVICE_FLAG}")
 set(HARDWARE_LINK_FLAGS "-fintelfpga -Xshardware -Xstarget=${FPGA_DEVICE} ${DEVICE_FLAG} ${USER_HARDWARE_FLAGS}")
 # use cmake -D USER_HARDWARE_FLAGS=<flags> to set extra flags for FPGA backend compilation
@@ -46,10 +51,10 @@ set(HARDWARE_LINK_FLAGS "-fintelfpga -Xshardware -Xstarget=${FPGA_DEVICE} ${DEVI
 ### FPGA Emulator
 ###############################################################################
 # To compile in a single command:
-#    dpcpp -fintelfpga -DFPGA_EMULATOR -DA10 fpga_compile.cpp -o fpga_compile.fpga_emu
+#    dpcpp -fintelfpga -DFPGA_EMULATOR -DA10 loop_initiation_interval.cpp -o loop_ii.fpga_emu
 # CMake executes:
-#    [compile] dpcpp -fintelfpga -DFPGA_EMULATOR -DA10 -o fpga_compile.cpp.o -c fpga_compile.cpp
-#    [link]    dpcpp -fintelfpga fpga_compile.cpp.o -o fpga_compile.fpga_emu
+#    [compile] dpcpp -fintelfpga -DFPGA_EMULATOR -DA10 -o loop_ii.cpp.o -c loop_initiation_interval.cpp
+#    [link]    dpcpp -fintelfpga loop_ii.cpp.o -o loop_ii.fpga_emu
 add_executable(${EMULATOR_TARGET} ${SOURCE_FILE})
 target_include_directories(${EMULATOR_TARGET} PRIVATE ../../../../include)
 set_target_properties(${EMULATOR_TARGET} PROPERTIES COMPILE_FLAGS "${EMULATOR_COMPILE_FLAGS}")
@@ -76,13 +81,29 @@ set_target_properties(${FPGA_EARLY_IMAGE_ENABLE_II} PROPERTIES LINK_FLAGS "${HAR
 # fsycl-link=early stops the compiler after RTL generation, before invoking Quartus®
 
 ###############################################################################
+### FPGA Simulator
+###############################################################################
+# To compile in a single command:
+#    dpcpp -fintelfpga -Xssimulation -Xstarget=<FPGA_DEVICE> -DFPGA_SIMULATOR -DA10 loop_initiation_interval.cpp -o loop_ii.fpga_sim
+# CMake executes:
+#    [compile] dpcpp -fintelfpga -DFPGA_SIMULATOR -DA10 -o loop_ii.cpp.o -c loop_initiation_interval.cpp
+#    [link]    dpcpp -fintelfpga -Xssimulation -Xstarget=<FPGA_DEVICE> -DA10 loop_ii.cpp.o -o loop_ii.fpga_sim
+add_executable(${SIMULATOR_TARGET} ${SOURCE_FILE})
+add_executable(${SIMULATOR_TARGET_ENABLE_II} ${SOURCE_FILE})
+add_custom_target(fpga_sim DEPENDS ${SIMULATOR_TARGET} ${SIMULATOR_TARGET_ENABLE_II})
+set_target_properties(${SIMULATOR_TARGET} PROPERTIES COMPILE_FLAGS "${SIMULATOR_COMPILE_FLAGS}")
+set_target_properties(${SIMULATOR_TARGET} PROPERTIES LINK_FLAGS "${SIMULATOR_LINK_FLAGS}")
+set_target_properties(${SIMULATOR_TARGET_ENABLE_II} PROPERTIES COMPILE_FLAGS "${SIMULATOR_COMPILE_FLAGS} -DENABLE_II")
+set_target_properties(${SIMULATOR_TARGET_ENABLE_II} PROPERTIES LINK_FLAGS "${SIMULATOR_LINK_FLAGS}")
+
+###############################################################################
 ### FPGA Hardware
 ###############################################################################
 # To compile in a single command:
 #   dpcpp -fintelfpga -Xshardware -Xstarget=<FPGA_DEVICE> -DA10 loop_initiation_interval.cpp -o loop_ii.fpga
 # CMake executes:
-#   [compile] dpcpp -fintelfpga -o loop_initiation_interval.cpp.o -DA10 -c loop_initiation_interval.cpp
-#   [link]    dpcpp -fintelfpga -Xshardware -Xstarget=<FPGA_DEVICE> -DA10 loop_initiation_interval.cpp.o -o loop_ii.fpga
+#   [compile] dpcpp -fintelfpga -o loop_ii.cpp.o -DA10 -c loop_initiation_interval.cpp
+#   [link]    dpcpp -fintelfpga -Xshardware -Xstarget=<FPGA_DEVICE> -DA10 loop_ii.cpp.o -o loop_ii.fpga
 add_executable(${FPGA_TARGET} EXCLUDE_FROM_ALL ${SOURCE_FILE})
 target_include_directories(${FPGA_TARGET} PRIVATE ../../../../include)
 add_executable(${FPGA_TARGET_ENABLE_II} EXCLUDE_FROM_ALL ${SOURCE_FILE})

--- a/DirectProgramming/DPC++FPGA/Tutorials/Features/loop_initiation_interval/src/CMakeLists.txt
+++ b/DirectProgramming/DPC++FPGA/Tutorials/Features/loop_initiation_interval/src/CMakeLists.txt
@@ -89,7 +89,9 @@ set_target_properties(${FPGA_EARLY_IMAGE_ENABLE_II} PROPERTIES LINK_FLAGS "${HAR
 #    [compile] dpcpp -fintelfpga -DFPGA_SIMULATOR -DA10 -o loop_ii.cpp.o -c loop_initiation_interval.cpp
 #    [link]    dpcpp -fintelfpga -Xssimulation -Xstarget=<FPGA_DEVICE> -DA10 loop_ii.cpp.o -o loop_ii.fpga_sim
 add_executable(${SIMULATOR_TARGET} ${SOURCE_FILE})
+target_include_directories(${SIMULATOR_TARGET} PRIVATE ../../../../include)
 add_executable(${SIMULATOR_TARGET_ENABLE_II} ${SOURCE_FILE})
+target_include_directories(${SIMULATOR_TARGET_ENABLE_II} PRIVATE ../../../../include)
 add_custom_target(fpga_sim DEPENDS ${SIMULATOR_TARGET} ${SIMULATOR_TARGET_ENABLE_II})
 set_target_properties(${SIMULATOR_TARGET} PROPERTIES COMPILE_FLAGS "${SIMULATOR_COMPILE_FLAGS}")
 set_target_properties(${SIMULATOR_TARGET} PROPERTIES LINK_FLAGS "${SIMULATOR_LINK_FLAGS}")

--- a/DirectProgramming/DPC++FPGA/Tutorials/Features/loop_initiation_interval/src/loop_initiation_interval.cpp
+++ b/DirectProgramming/DPC++FPGA/Tutorials/Features/loop_initiation_interval/src/loop_initiation_interval.cpp
@@ -17,11 +17,11 @@ constexpr size_t kInitLoopSize = 10;
 constexpr size_t kLongLoopSize = 10000;
 // problem input size
 #if defined(FPGA_EMULATOR)
-  constexpr size_t kInputSize = 10000;
+constexpr size_t kInputSize = 10000;
 #elif defined(FPGA_SIMULATOR)
-  constexpr size_t kInputSize = 10;
+constexpr size_t kInputSize = 10;
 #else
-  constexpr size_t kInputSize = 1000000;
+constexpr size_t kInputSize = 1000000;
 #endif
 
 // Forward declare the kernel name in the global scope
@@ -93,16 +93,17 @@ void RunKernel(std::vector<int> &in, std::vector<int> &out) {
 
           // All kernels share a common clock domain, thus this design needs to
           // be compiled twice to showcase the same design with different fMAX
-          // If ENABLE_II is defined, the intel::initiation_interval attribute will be set for
-          // the next loop, the short initialization loop Explicitly setting the
-          // II for a loop will tell the compiler to schedule the loop while
-          // enforcing the set II, overriding the default heuristic of finding
-          // the minimum II * (1/fMAX) Relaxing the II on a short loop with a
-          // long feedback path will remove the bottleneck the loop had on the
-          // maximum achievable fMAX of the design The default targeted fMAX is
-          // 240MHz for Arria® 10 and 480MHz for Stratix® 10, so different IIs
-          // need to be specified so the compiler can schedule the loop such
-          // that it does not restrict the maximum fMAX
+          // If ENABLE_II is defined, the intel::initiation_interval attribute
+          // will be set for the next loop, the short initialization loop
+          // Explicitly setting the II for a loop will tell the compiler to
+          // schedule the loop while enforcing the set II, overriding the
+          // default heuristic of finding the minimum II * (1/fMAX) Relaxing the
+          // II on a short loop with a long feedback path will remove the
+          // bottleneck the loop had on the maximum achievable fMAX of the
+          // design The default targeted fMAX is 240MHz for Arria® 10 and 480MHz
+          // for Stratix® 10, so different IIs need to be specified so the
+          // compiler can schedule the loop such that it does not restrict the
+          // maximum fMAX
 #if defined(ENABLE_II)
 #if defined(A10)
           [[intel::initiation_interval(3)]]
@@ -142,13 +143,13 @@ void RunKernel(std::vector<int> &in, std::vector<int> &out) {
 
           int sum = 0;
 
-          // The intel::initiation_interval attribute is added here to "assert" that II=1 for
-          // this loop. Even though we fully expect the compiler to achieve
-          // II=1 here by default, some developers find it helful to include
-          // the attribute to "document" this expectation. If a future code
-          // change causes an unexpected II regression, the compiler will error
-          // out. Without the intel::initiation_interval attribute, an II regression may go
-          // unnoticed.
+          // The intel::initiation_interval attribute is added here to "assert"
+          // that II=1 for this loop. Even though we fully expect the compiler
+          // to achieve II=1 here by default, some developers find it helful to
+          // include the attribute to "document" this expectation. If a future
+          // code change causes an unexpected II regression, the compiler will
+          // error out. Without the intel::initiation_interval attribute, an II
+          // regression may go unnoticed.
 #if defined(ENABLE_II)
           [[intel::initiation_interval(1)]]
 #endif
@@ -161,9 +162,9 @@ void RunKernel(std::vector<int> &in, std::vector<int> &out) {
           // "sum" calculated in the last operation of a previous iteration The
           // compiler is able to achieve an II of 1 and the default targeted
           // fMAX for Arria® 10, but falls a little short on Stratix® 10. The
-          // intel::initiation_interval attribute should not be used to relax the II of this loop
-          // as the drop in occupancy of the long loop is not worth achieving a
-          // slightly higher fMAX
+          // intel::initiation_interval attribute should not be used to relax
+          // the II of this loop as the drop in occupancy of the long loop is
+          // not worth achieving a slightly higher fMAX
           for (size_t k = 0; k < kLongLoopSize; k++) {
             sum += SomethingComplicated(num + k);
           }
@@ -217,10 +218,11 @@ int main() {
   }
 
   // Run kernel once. Since fMAX is a global constraint, we cannot run two
-  // kernels demonstrating the use of the intel::initiation_interval attribute since the kernel
-  // without the intel::initiation_interval attribute would restrict the global fMAX, thus
-  // affecting the design with the intel::initiation_interval attribute. Rely on the preprocessor
-  // defines to change the kernel behaviour.
+  // kernels demonstrating the use of the intel::initiation_interval attribute
+  // since the kernel without the intel::initiation_interval attribute would
+  // restrict the global fMAX, thus affecting the design with the
+  // intel::initiation_interval attribute. Rely on the preprocessor defines to
+  // change the kernel behaviour.
   RunKernel(in, out);
 
   // validate results

--- a/DirectProgramming/DPC++FPGA/Tutorials/Features/loop_initiation_interval/src/loop_initiation_interval.cpp
+++ b/DirectProgramming/DPC++FPGA/Tutorials/Features/loop_initiation_interval/src/loop_initiation_interval.cpp
@@ -14,12 +14,17 @@ using namespace sycl;
 // short initialization loop trip count
 constexpr size_t kInitLoopSize = 10;
 // long-running loop trip count
+#if defined(FPGA_SIMULATOR)
+constexpr size_t kLongLoopSize = 100;
+#else
 constexpr size_t kLongLoopSize = 10000;
+#endif
+
 // problem input size
 #if defined(FPGA_EMULATOR)
 constexpr size_t kInputSize = 10000;
 #elif defined(FPGA_SIMULATOR)
-constexpr size_t kInputSize = 10;
+constexpr size_t kInputSize = 1;
 #else
 constexpr size_t kInputSize = 1000000;
 #endif

--- a/DirectProgramming/DPC++FPGA/Tutorials/Features/loop_initiation_interval/src/loop_initiation_interval.cpp
+++ b/DirectProgramming/DPC++FPGA/Tutorials/Features/loop_initiation_interval/src/loop_initiation_interval.cpp
@@ -16,7 +16,13 @@ constexpr size_t kInitLoopSize = 10;
 // long-running loop trip count
 constexpr size_t kLongLoopSize = 10000;
 // problem input size
-constexpr size_t kInputSize = 1000000;
+#if defined(FPGA_EMULATOR)
+  constexpr size_t kInputSize = 10000;
+#elif defined(FPGA_SIMULATOR)
+  constexpr size_t kInputSize = 10;
+#else
+  constexpr size_t kInputSize = 1000000;
+#endif
 
 // Forward declare the kernel name in the global scope
 // This FPGA best practice reduces name mangling in the optimization reports
@@ -59,6 +65,8 @@ double GetExecutionTime(const event &e) {
 void RunKernel(std::vector<int> &in, std::vector<int> &out) {
 #if defined(FPGA_EMULATOR)
   ext::intel::fpga_emulator_selector selector;
+#elif defined(FPGA_SIMULATOR)
+  ext::intel::fpga_simulator_selector selector;
 #else
   ext::intel::fpga_selector selector;
 #endif

--- a/DirectProgramming/DPC++FPGA/Tutorials/Features/speculated_iterations/README.md
+++ b/DirectProgramming/DPC++FPGA/Tutorials/Features/speculated_iterations/README.md
@@ -127,6 +127,10 @@ To learn more about the extensions, see the
      ```
      make report
      ```
+   * Compile for simulation (fast compile time, targets simulated FPGA device, reduced data size):
+     ```
+     make fpga_sim
+     ```
    * Compile for FPGA hardware (longer compile time, targets FPGA device):
      ```
      make fpga
@@ -163,6 +167,10 @@ To learn more about the extensions, see the
    * Generate the optimization report:
      ```
      nmake report
+     ```
+   * Compile for simulation (fast compile time, targets simulated FPGA device, reduced data size:
+     ```
+     nmake fpga_sim
      ```
    * Compile for FPGA hardware (longer compile time, targets FPGA device):
      ```
@@ -201,14 +209,21 @@ These results make sense when you recall that the loop exit computation has a la
 ## Running the Sample
 
  1. Run the sample on the FPGA emulator (the kernel executes on the CPU):
+     ```bash
+     ./speculated_iterations.fpga_emu     (Linux)
+     speculated_iterations.fpga_emu.exe   (Windows)
      ```
-     ./speculated iterations.fpga_emu     (Linux)
-     speculated iterations.fpga_emu.exe   (Windows)
+
+ 2. Run the sample on the FPGA simulator device:
+     ```bash
+     ./speculated_iterations.fpga_sim     (Linux)
+     speculated_iterations.fpga_sim.exe   (Windows)
      ```
-2. Run the sample on the FPGA device:
-     ```
-     ./speculated iterations.fpga         (Linux)
-     speculated iterations.fpga.exe       (Windows)
+
+ 3. Run the sample on the FPGA device:
+     ```bash
+     ./speculated_iterations.fpga         (Linux)
+     speculated_iterations.fpga.exe       (Windows)
      ```
 
 ### Example of Output

--- a/DirectProgramming/DPC++FPGA/Tutorials/Features/speculated_iterations/src/CMakeLists.txt
+++ b/DirectProgramming/DPC++FPGA/Tutorials/Features/speculated_iterations/src/CMakeLists.txt
@@ -82,6 +82,7 @@ set_target_properties(${FPGA_EARLY_IMAGE} PROPERTIES LINK_FLAGS "${HARDWARE_LINK
 #    [compile] dpcpp -fintelfpga -DFPGA_SIMULATOR -DA10 -o speculated_iterations.cpp.o -c speculated_iterations.cpp
 #    [link]    dpcpp -fintelfpga -Xssimulation -Xstarget=<FPGA_DEVICE> -DA10 speculated_iterations.cpp.o -o speculated_iterations.fpga_sim
 add_executable(${SIMULATOR_TARGET} ${SOURCE_FILE})
+target_include_directories(${SIMULATOR_TARGET} PRIVATE ../../../../include)
 add_custom_target(fpga_sim DEPENDS ${SIMULATOR_TARGET})
 set_target_properties(${SIMULATOR_TARGET} PROPERTIES COMPILE_FLAGS "${SIMULATOR_COMPILE_FLAGS}")
 set_target_properties(${SIMULATOR_TARGET} PROPERTIES LINK_FLAGS "${SIMULATOR_LINK_FLAGS}")

--- a/DirectProgramming/DPC++FPGA/Tutorials/Features/speculated_iterations/src/CMakeLists.txt
+++ b/DirectProgramming/DPC++FPGA/Tutorials/Features/speculated_iterations/src/CMakeLists.txt
@@ -39,7 +39,7 @@ endif()
 set(EMULATOR_COMPILE_FLAGS "-Wall -fintelfpga -DFPGA_EMULATOR ${DEVICE_FLAG}")
 set(EMULATOR_LINK_FLAGS "-fintelfpga")
 set(SIMULATOR_COMPILE_FLAGS "-Wall -fintelfpga -DFPGA_SIMULATOR ${DEVICE_FLAG}")
-set(SIMULATOR_LINK_FLAGS "-fintelfpga -Xssimulation -Xstarget=${FPGA_TARGET} ${DEVICE_FLAG} ${USER_SIMULATOR_FLAGS}")
+set(SIMULATOR_LINK_FLAGS "-fintelfpga -Xssimulation -Xstarget=${FPGA_DEVICE} ${DEVICE_FLAG} ${USER_SIMULATOR_FLAGS}")
 # use cmake -D USER_SIMULATOR_FLAGS=<flags> to set extra flags for FPGA simulator compilation
 set(HARDWARE_COMPILE_FLAGS "-Wall -fintelfpga ${DEVICE_FLAG}")
 set(HARDWARE_LINK_FLAGS "-fintelfpga -Xshardware -Xstarget=${FPGA_DEVICE} ${DEVICE_FLAG} ${USER_HARDWARE_FLAGS}")

--- a/DirectProgramming/DPC++FPGA/Tutorials/Features/speculated_iterations/src/CMakeLists.txt
+++ b/DirectProgramming/DPC++FPGA/Tutorials/Features/speculated_iterations/src/CMakeLists.txt
@@ -6,6 +6,7 @@ set(TARGET_NAME speculated_iterations)
 set(EMULATOR_TARGET ${TARGET_NAME}.fpga_emu)
 set(FPGA_TARGET ${TARGET_NAME}.fpga)
 set(REPORTS_TARGET ${TARGET_NAME}_report)
+set(SIMULATOR_TARGET ${TARGET_NAME}.fpga_sim)
 
 # FPGA board selection
 if(NOT DEFINED FPGA_DEVICE)
@@ -37,6 +38,9 @@ endif()
 #    For this reason, FPGA backend flags must be passed as link flags in CMake.
 set(EMULATOR_COMPILE_FLAGS "-Wall -fintelfpga -DFPGA_EMULATOR ${DEVICE_FLAG}")
 set(EMULATOR_LINK_FLAGS "-fintelfpga")
+set(SIMULATOR_COMPILE_FLAGS "-Wall -fintelfpga -DFPGA_SIMULATOR ${DEVICE_FLAG}")
+set(SIMULATOR_LINK_FLAGS "-fintelfpga -Xssimulation -Xstarget=${FPGA_TARGET} ${DEVICE_FLAG} ${USER_SIMULATOR_FLAGS}")
+# use cmake -D USER_SIMULATOR_FLAGS=<flags> to set extra flags for FPGA simulator compilation
 set(HARDWARE_COMPILE_FLAGS "-Wall -fintelfpga ${DEVICE_FLAG}")
 set(HARDWARE_LINK_FLAGS "-fintelfpga -Xshardware -Xstarget=${FPGA_DEVICE} ${DEVICE_FLAG} ${USER_HARDWARE_FLAGS}")
 # use cmake -D USER_HARDWARE_FLAGS=<flags> to set extra flags for FPGA backend compilation
@@ -68,6 +72,19 @@ add_custom_target(report DEPENDS ${FPGA_EARLY_IMAGE})
 set_target_properties(${FPGA_EARLY_IMAGE} PROPERTIES COMPILE_FLAGS "${HARDWARE_COMPILE_FLAGS}")
 set_target_properties(${FPGA_EARLY_IMAGE} PROPERTIES LINK_FLAGS "${HARDWARE_LINK_FLAGS} -fsycl-link=early")
 # fsycl-link=early stops the compiler after RTL generation, before invoking Quartus®
+
+###############################################################################
+### FPGA Simulator
+###############################################################################
+# To compile in a single command:
+#    dpcpp -fintelfpga -Xssimulation -Xstarget=<FPGA_DEVICE> -DFPGA_SIMULATOR -DA10 speculated_iterations.cpp -o speculated_iterations.fpga_sim
+# CMake executes:
+#    [compile] dpcpp -fintelfpga -DFPGA_SIMULATOR -DA10 -o speculated_iterations.cpp.o -c speculated_iterations.cpp
+#    [link]    dpcpp -fintelfpga -Xssimulation -Xstarget=<FPGA_DEVICE> -DA10 speculated_iterations.cpp.o -o fpga_speculated_iterationscompile.fpga_sim
+add_executable(${SIMULATOR_TARGET} ${SOURCE_FILE})
+add_custom_target(fpga_sim DEPENDS ${SIMULATOR_TARGET})
+set_target_properties(${SIMULATOR_TARGET} PROPERTIES COMPILE_FLAGS "${SIMULATOR_COMPILE_FLAGS}")
+set_target_properties(${SIMULATOR_TARGET} PROPERTIES LINK_FLAGS "${SIMULATOR_LINK_FLAGS}")
 
 ###############################################################################
 ### FPGA Hardware

--- a/DirectProgramming/DPC++FPGA/Tutorials/Features/speculated_iterations/src/CMakeLists.txt
+++ b/DirectProgramming/DPC++FPGA/Tutorials/Features/speculated_iterations/src/CMakeLists.txt
@@ -80,7 +80,7 @@ set_target_properties(${FPGA_EARLY_IMAGE} PROPERTIES LINK_FLAGS "${HARDWARE_LINK
 #    dpcpp -fintelfpga -Xssimulation -Xstarget=<FPGA_DEVICE> -DFPGA_SIMULATOR -DA10 speculated_iterations.cpp -o speculated_iterations.fpga_sim
 # CMake executes:
 #    [compile] dpcpp -fintelfpga -DFPGA_SIMULATOR -DA10 -o speculated_iterations.cpp.o -c speculated_iterations.cpp
-#    [link]    dpcpp -fintelfpga -Xssimulation -Xstarget=<FPGA_DEVICE> -DA10 speculated_iterations.cpp.o -o fpga_speculated_iterationscompile.fpga_sim
+#    [link]    dpcpp -fintelfpga -Xssimulation -Xstarget=<FPGA_DEVICE> -DA10 speculated_iterations.cpp.o -o speculated_iterations.fpga_sim
 add_executable(${SIMULATOR_TARGET} ${SOURCE_FILE})
 add_custom_target(fpga_sim DEPENDS ${SIMULATOR_TARGET})
 set_target_properties(${SIMULATOR_TARGET} PROPERTIES COMPILE_FLAGS "${SIMULATOR_COMPILE_FLAGS}")

--- a/DirectProgramming/DPC++FPGA/Tutorials/Features/speculated_iterations/src/speculated_iterations.cpp
+++ b/DirectProgramming/DPC++FPGA/Tutorials/Features/speculated_iterations/src/speculated_iterations.cpp
@@ -13,12 +13,16 @@
 
 #include "exception_handler.hpp"
 
-// Use smaller values if run on the emulator to keep the CPU runtime reasonable
+// Use smaller values if run on the emulator or simulator to keep the CPU
+// runtime/simulation time reasonable
 // Use the largest possible int values on the FPGA to show the difference in
 // performance with and without speculated_iterations
 #if defined(FPGA_EMULATOR)
 constexpr float kUpper = 3.0f;
 constexpr size_t kExpectedIterations = 1e3;
+#elif defined(FPGA_SIMULATOR)
+constexpr float kUpper = 2.0f;
+constexpr size_t kExpectedIterations = 1e2;
 #else
 constexpr float kUpper = 8.0f;
 constexpr size_t kExpectedIterations = 1e8;
@@ -95,6 +99,8 @@ void ComplexExit(const device_selector &selector, float bound, int &res) {
 int main(int argc, char *argv[]) {
 #if defined(FPGA_EMULATOR)
   ext::intel::fpga_emulator_selector selector;
+#elif defined(FPGA_SIMULATOR)
+  ext::intel::fpga_simulator_selector selector;
 #else
   ext::intel::fpga_selector selector;
 #endif

--- a/DirectProgramming/DPC++FPGA/Tutorials/Features/speculated_iterations/src/speculated_iterations.cpp
+++ b/DirectProgramming/DPC++FPGA/Tutorials/Features/speculated_iterations/src/speculated_iterations.cpp
@@ -35,7 +35,14 @@ using namespace sycl;
 template <int N> class KernelCompute;
 
 template <int spec_iter>
-void ComplexExit(const device_selector &selector, float bound, int &res) {
+void ComplexExit(float bound, int &res) {
+#if defined(FPGA_EMULATOR)
+  ext::intel::fpga_emulator_selector selector;
+#elif defined(FPGA_SIMULATOR)
+  ext::intel::fpga_simulator_selector selector;
+#else
+  ext::intel::fpga_selector selector;
+#endif
   double kernel_time_ms = 0.0;
   try {
     // create the device queue with profiling enabled
@@ -97,13 +104,6 @@ void ComplexExit(const device_selector &selector, float bound, int &res) {
 }
 
 int main(int argc, char *argv[]) {
-#if defined(FPGA_EMULATOR)
-  ext::intel::fpga_emulator_selector selector;
-#elif defined(FPGA_SIMULATOR)
-  ext::intel::fpga_simulator_selector selector;
-#else
-  ext::intel::fpga_selector selector;
-#endif
 
   float bound = kUpper;
 
@@ -120,17 +120,17 @@ int main(int argc, char *argv[]) {
 // This reflects compute latency differences on different hardware
 // architectures, and is a low-level optimization.
 #if defined(A10)
-  ComplexExit<0>(selector, bound, r0);
-  ComplexExit<10>(selector, bound, r1);
-  ComplexExit<27>(selector, bound, r2);
+  ComplexExit<0>(bound, r0);
+  ComplexExit<10>(bound, r1);
+  ComplexExit<27>(bound, r2);
 #elif defined(S10)
-  ComplexExit<0>(selector, bound, r0);
-  ComplexExit<10>(selector, bound, r1);
-  ComplexExit<54>(selector, bound, r2);
+  ComplexExit<0>(bound, r0);
+  ComplexExit<10>(bound, r1);
+  ComplexExit<54>(bound, r2);
 #elif defined(Agilex)
-  ComplexExit<0>(selector, bound, r0);
-  ComplexExit<10>(selector, bound, r1);
-  ComplexExit<50>(selector, bound, r2);
+  ComplexExit<0>(bound, r0);
+  ComplexExit<10>(bound, r1);
+  ComplexExit<50>(bound, r2);
 #else
   std::static_assert(false, "Invalid FPGA board macro");
 #endif


### PR DESCRIPTION
# Existing Sample Changes
DirectProgramming/DPC++FPGA/Tutorials/Features/loop_initiation_interval
DirectProgramming/DPC++FPGA/Tutorials/Features/speculated_iterations
DirectProgramming/DPC++FPGA/Tutorials/Features/loop_coalesce

## Description

Add support for running loop_initiation_interval, loop_coalesce, and speculated_iterations on the FPGA simulator. Uses ext::intel::fpga_simulator_selector class to choose the simulator. Reduced data sizes to ensure reasonable execution times, as simulator is 1000-10000x slower than hardware

## Type of change

- [X] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

This has been run manually on Linux and Windows

- [X] Command Line
- [ ] oneapi-cli
- [ ] Visual Studio
- [ ] Eclipse IDE
- [ ] VSCode
- [X] When compiling the compliler flag "-Wall -Wformat-security -Werror=format-security" was used
