### PR TITLE
FPGA: add instructions to generate the sf1 dataset in the db design

### DIFF
--- a/DirectProgramming/DPC++FPGA/ReferenceDesigns/db/README.md
+++ b/DirectProgramming/DPC++FPGA/ReferenceDesigns/db/README.md
@@ -283,7 +283,14 @@ You should see the following output in the console:
 ### Database files
 In the `data/` directory, you will find database files for a scale factor of 0.01. These files were generated manually and can be used to verify the queries in emulation. However, **these files are too small to showcase the true performance of the FPGA hardware**.
 
-To generate larger database files to run on the hardware, you can use TPC's `dbgen` tool. Instructions for downloading, building and running the `dbgen` tool can be found on the [TPC-H website](http://www.tpc.org/tpch/). Note that this reference design currently only supports databases with scale factors of 0.01 or 1.
+To generate larger database files to run on the hardware, you can use TPC's `dbgen` tool. Instructions for downloading, building and running the `dbgen` tool can be found on the [TPC-H website](http://www.tpc.org/tpch/).
+At the time of writing (12th of September 2022), one can:
+- clone the [tpch-dbgen](https://github.com/electrum/tpch-dbgen) repository  
+- run `make`
+- generate the files using a scale factor of 1: `./dbgen -s 1`
+- copy all the generated `.tbl` files and the `answers` folder in a new `data/sf1` folder.
+ 
+Note that this reference design currently only supports databases with scale factors of 0.01 or 1.
 
 ### Query Implementation
 The following sections will describe, at a high level, how queries 1, 9, 11 and 12 are implemented on the FPGA using a set of generalized database operators (found in `db_utils/`). In the block diagrams below, the blocks are oneAPI kernels, and the arrows represent `pipes` that shows the flow of data from one kernel to another.


### PR DESCRIPTION
# Existing Sample Changes
## Description

The `db` design was missing instructions on how to generate the dataset with a scale factor of 1.
This PR improves the README to provide more detailed instructions.
