### PR TITLE
Fix to accommodate freezing a TensorFlow Hub Keras

### DIFF
--- a/AI-and-Analytics/Features-and-Functionality/IntelTensorFlow_InferenceOptimization/scripts/freeze_optimize_v2.py
+++ b/AI-and-Analytics/Features-and-Functionality/IntelTensorFlow_InferenceOptimization/scripts/freeze_optimize_v2.py
@@ -16,6 +16,18 @@ from tensorflow.python.tools import saved_model_utils
 from tensorflow.python.framework import graph_util
 from tensorflow.python.util import nest
 
+from argparse import ArgumentParser
+
+from tensorflow.core.protobuf import config_pb2
+from tensorflow.core.protobuf import rewriter_config_pb2
+from tensorflow.core.protobuf import meta_graph_pb2
+from tensorflow.core.framework import graph_pb2
+from tensorflow.python.framework import importer
+from tensorflow.python.grappler import tf_optimizer
+from tensorflow.python.training import saver as saver_lib
+
+import tensorflow as tf
+
 
 FLAGS = None
 def run_main(unused_args):
@@ -60,8 +72,34 @@ def run_main(unused_args):
   input_nodes = [(tensor.name.split(":"))[0] for tensor in inputs]
   output_nodes = [(souts[name].name.split(":"))[0] for name in souts]
 
-  gdef = frozen_func.graph.as_graph_def()
-  opt_graph = optimize_for_inference_lib.optimize_for_inference(gdef, input_nodes, output_nodes,
+  g_def = frozen_func.graph.as_graph_def()
+  
+  # Add CPU device to the nodes.
+  for node in g_def.node:
+    node.device = "/device:CPU:0"
+
+  g = tf.Graph()
+  with g.as_default():
+    importer.import_graph_def(g_def, input_map={}, name="")
+    meta_graph = saver_lib.export_meta_graph(graph_def=g_def, graph=g)
+
+    fetch_collection = meta_graph_pb2.CollectionDef()
+    for fetch in output_nodes:
+      fetch_collection.node_list.value.append(fetch)
+    meta_graph.collection_def["train_op"].CopyFrom(fetch_collection)
+
+  config = config_pb2.ConfigProto()
+
+  # Constant folding grappler pass
+  config.graph_options.rewrite_options.CopyFrom(
+    rewriter_config_pb2.RewriterConfig(
+      remapping=rewriter_config_pb2.RewriterConfig.OFF,
+      constant_folding=rewriter_config_pb2.RewriterConfig.AGGRESSIVE))
+
+  optimized_graph = tf_optimizer.OptimizeGraph(
+      config, meta_graph)
+
+  opt_graph = optimize_for_inference_lib.optimize_for_inference(optimized_graph, input_nodes, output_nodes,
            [tensor.dtype.as_datatype_enum for tensor in inputs] )
 
   with session.Session() as sess:


### PR DESCRIPTION
Signed-off-by: Om Thakkar <om.thakkar@intel.com>

# Existing Sample Changes
## Description

While trying to freeze a (re-trained) TFHub keras model exported in the SavedModel format, the existing script was unable to convert the _Identity_ (and similar) ops to _Const_, which resulted into issues like fusions not happening in optimize_for_inference.

- Added a constant folding grappler pass before calling optimize_for_inference.

## Type of change

- New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- Command Line:
`python3 freeze_optimize_v2.py --input_saved_model_dir=<path-to-saved-model> --output_saved_model_dir=<path-to-generate-frozen-model>`