### PR TITLE
Fix badly formatted sample.json file in simple-add sample

### DIFF
--- a/DirectProgramming/DPC++/DenseLinearAlgebra/simple-add/sample.json
+++ b/DirectProgramming/DPC++/DenseLinearAlgebra/simple-add/sample.json
@@ -30,30 +30,30 @@
         "id": "fpga_emu_buffers",
         "steps": [
           "make fpga_emu -f Makefile.fpga BUFFERS=1",
-          "make run_emu -f Makefile.fpga BUFFERS=1"
-          "make clean -f Makefile.fpga BUFFERS=1",
+          "make run_emu -f Makefile.fpga BUFFERS=1",
+          "make clean -f Makefile.fpga BUFFERS=1"
         ]
       },
       {
         "id": "fpga_emu_usm",
         "steps": [
           "make fpga_emu -f Makefile.fpga",
-          "make run_emu -f Makefile.fpga"
-          "make clean -f Makefile.fpga",
+          "make run_emu -f Makefile.fpga",
+          "make clean -f Makefile.fpga"
         ]
       },
       {
         "id": "fpga_report_buffers",
         "steps": [
-          "make report -f Makefile.fpga BUFFERS=1"
-          "make clean -f Makefile.fpga BUFFERS=1",
+          "make report -f Makefile.fpga BUFFERS=1",
+          "make clean -f Makefile.fpga BUFFERS=1"
         ]
       },
       {
         "id": "fpga_report_usm",
         "steps": [
-          "make report -f Makefile.fpga"
-          "make clean -f Makefile.fpga",
+          "make report -f Makefile.fpga",
+          "make clean -f Makefile.fpga"
         ]
       }
     ],


### PR DESCRIPTION
# Existing Sample Changes
## Description

It's all about the commas! Several "array of strings" were missing commas and had excess commas. Resulting in sample aggregator errors.

## External Dependencies

Sample aggregator, see statement above.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] Sample aggregator.
