### PR TITLE
FPGA: fix incorrect sample.json in board_test

### DIFF
--- a/DirectProgramming/DPC++FPGA/ReferenceDesigns/board_test/sample.json
+++ b/DirectProgramming/DPC++FPGA/ReferenceDesigns/board_test/sample.json
@@ -11,7 +11,7 @@
   "commonFolder": {
     "base": "../..",
     "include": [
-      "ReferenceDesigns/board_test"
+      "ReferenceDesigns/board_test",
       "include"
     ],
     "exclude": []


### PR DESCRIPTION
The sample.json file contained a typo