### PR TITLE
FPGA: fix latency_control sample.json

### DIFF
--- a/DirectProgramming/DPC++FPGA/Tutorials/Features/experimental/latency_control/sample.json
+++ b/DirectProgramming/DPC++FPGA/Tutorials/Features/experimental/latency_control/sample.json
@@ -11,7 +11,7 @@
   "commonFolder": {
     "base": "../../../..",
     "include": [
-      "Tutorials/Features/latency_control",
+      "Tutorials/Features/experimental/latency_control",
       "include"
     ],
     "exclude": []


### PR DESCRIPTION
The sample.json of the latency_control had an incorrect path.