### PR TITLE
Updated README - added dpcpp for windows support

### DIFF
--- a/Libraries/oneDNN/getting_started/README.md
+++ b/Libraries/oneDNN/getting_started/README.md
@@ -14,7 +14,7 @@ in Intel® DevCloud for oneAPI environment.
 
 | Optimized for                      | Description
 | :---                               | :---
-| OS                                 | Linux* Ubuntu* 18.04
+| OS                                 | Linux* Ubuntu* 18.04; Windows
 | Hardware                           | Skylake with GEN9 or newer
 | Software                           | Intel® oneAPI Deep Neural Network Library (oneDNN) <br> Intel® oneAPI DPC++/C++ Compiler <br> Intel® oneAPI Threading Building Blocks (oneTBB) <br> GNU Compiler Collection <br> Intel® C++ Compiler
 | What you will learn                | Running a simple convolutional model on Intel CPU or Intel GPU
@@ -123,6 +123,35 @@ mkdir build
 cd build
 cmake -G "Visual Studio 16 2019" ..
 cmake --build .
+```
+
+#### oneAPI DPC++ Compiler
+
+##### 1. Setup oneAPI development environment
+
+```
+C:\Program Files (x86)\Intel\oneAPI\setvars.bat 
+```
+##### or open `Intel oneAPI Commmand Prompt` instead. 
+
+##### 2. Download [oneAPI Level Zero headers](https://github.com/oneapi-src/level-zero/releases/tag/v1.0) from Github and unpack the archive.
+
+
+> NOTE: Intel oneAPI DPC++/C++ Compiler on Windows requires __CMake v3.21__ or later
+
+
+
+##### 3. Generate Ninja project
+```
+mkdir build
+cd build
+
+set CC=icx
+set CXX=icx
+
+cmake .. -G Ninja -DDNNL_CPU_RUNTIME=DPCPP 
+                  -DDNNL_GPU_RUNTIME=DPCPP 
+                  -DCMAKE_PREFIX_PATH=<path to Level Zero headers> 
 ```
 ##### 3. Run the sample
 You can get additional information during the execution of this sample by setting


### PR DESCRIPTION
# Existing Sample Changes
## Description

Verified that DPCPP compiler works on windows (CMake v3.21+), and updated the getting_started sample readme to include instructions for dpcpp build.


## External Dependencies
N/A

## Type of change

- [ X] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Used oneDNN instructions to build and compile using DPC++ on windows, works for CMake versions 3.21 and above.

- [X] Command Line
- [ ] oneapi-cli
- [X] Visual Studio
- [ ] Eclipse IDE
- [ ] VSCode
- [ ] When compiling the compliler flag "-Wall -Wformat-security -Werror=format-security" was used
