### PR TITLE
FPGA: Relace DPC++ with SYCL

### DIFF
--- a/DirectProgramming/DPC++FPGA/README.md
+++ b/DirectProgramming/DPC++FPGA/README.md
@@ -4,7 +4,7 @@ The folders in this area of the oneAPI-sample GitHub repository include tutorial
 
 You will need the following toolkits and add-ons:
 
-- [Intel® oneAPI Base Toolkit (Base Kit)](https://www.intel.com/content/www/us/en/developer/tools/oneapi/base-toolkit.html), specifically the Intel® oneAPI DPC++/C++ Compiler.
+- [Intel® oneAPI Base Toolkit (Base Kit)](https://www.intel.com/content/www/us/en/developer/tools/oneapi/base-toolkit.html), specifically the Intel® oneAPI SYCL Compiler.
 - [Intel® FPGA Add-On for oneAPI Base Toolkit](https://www.intel.com/content/www/us/en/developer/tools/oneapi/fpga.html).
 - Optionally, you might need access to [Intel® DevCloud for oneAPI](https://devcloud.intel.com/oneapi/get_started/).
 
@@ -262,7 +262,7 @@ Neither compiling nor executing programs on FPGA hardware are supported on the l
 
 ## Documentation:
 
-- The [DPC++ FPGA Code Samples Guide](https://software.intel.com/content/www/us/en/develop/articles/explore-dpcpp-through-intel-fpga-code-samples.html) helps you to navigate the samples and build your knowledge of DPC++ for FPGA.
+- The [DPC++ FPGA Code Samples Guide](https://software.intel.com/content/www/us/en/develop/articles/explore-dpcpp-through-intel-fpga-code-samples.html) helps you to navigate the samples and build your knowledge of SYCL for FPGA.
 - The [oneAPI DPC++ FPGA Optimization Guide](https://software.intel.com/content/www/us/en/develop/documentation/oneapi-fpga-optimization-guide) helps you understand how to target FPGAs using SYCL and Intel® oneAPI Toolkits.
 - The [Intel® oneAPI Programming Guide](https://software.intel.com/en-us/oneapi-programming-guide) helps you understand target-independent, SYCL-compliant programming using Intel® oneAPI Toolkits.
 - [Explore SYCL* Through Intel® FPGA Code Samples](https://software.intel.com/content/www/us/en/develop/articles/explore-dpcpp-through-intel-fpga-code-samples.html) helps you to navigate the samples and build your knowledge of FPGAs and SYCL by suggesting a series of samples.

--- a/DirectProgramming/DPC++FPGA/ReferenceDesigns/anr/README.md
+++ b/DirectProgramming/DPC++FPGA/ReferenceDesigns/anr/README.md
@@ -17,7 +17,7 @@ See [Key Implementation Details](#key-implementation-details) below for more inf
 |:---                               |:---
 | OS                                | Ubuntu* 18.04/20.04 <br> RHEL*/CentOS* 8 <br> SUSE* 15 <br> Windows* 10
 | Hardware                          | Intel® Programmable Acceleration Card (PAC) with Intel Arria® 10 GX FPGA <br> FPGA Programmable Acceleration Card (PAC) D5005 (with Intel Stratix® 10 SX) <br> Intel Xeon® CPU E5-1650 v2 @ 3.50GHz (host machine)
-| Software                          | Intel® oneAPI DPC++/C++ Compiler <br> Intel® FPGA Add-On for oneAPI Base Toolkit
+| Software                          | Intel® oneAPI SYCL Compiler <br> Intel® FPGA Add-On for oneAPI Base Toolkit
 
 ### Additional Documentation
 

--- a/DirectProgramming/DPC++FPGA/ReferenceDesigns/anr/src/CMakeLists.txt
+++ b/DirectProgramming/DPC++FPGA/ReferenceDesigns/anr/src/CMakeLists.txt
@@ -139,7 +139,7 @@ add_custom_target(fpga_emu DEPENDS ${EMULATOR_TARGET})
 ### Generate Report
 ###############################################################################
 set(FPGA_EARLY_IMAGE ${TARGET_NAME}_report.a)
-# The compile output is not an executable, but an intermediate compilation result unique to DPC++.
+# The compile output is not an executable, but an intermediate compilation result unique to SYCL.
 add_executable(${FPGA_EARLY_IMAGE} ${SOURCE_FILE})
 target_include_directories(${FPGA_EARLY_IMAGE} PRIVATE ../../../include)
 add_custom_target(report DEPENDS ${FPGA_EARLY_IMAGE})

--- a/DirectProgramming/DPC++FPGA/ReferenceDesigns/anr/src/CMakeLists.txt
+++ b/DirectProgramming/DPC++FPGA/ReferenceDesigns/anr/src/CMakeLists.txt
@@ -115,7 +115,7 @@ if(PIXEL_BITS)
   message(STATUS "  PIXEL_BITS=${PIXEL_BITS}")
 endif()
 
-# A DPC++ ahead-of-time (AoT) compile processes the device code in two stages.
+# A SYCL ahead-of-time (AoT) compile processes the device code in two stages.
 # 1. The "compile" stage compiles the device code to an intermediate representation (SPIR-V).
 # 2. The "link" stage invokes the compiler's FPGA backend before linking.
 #    For this reason, FPGA backend flags must be passed as link flags in CMake.

--- a/DirectProgramming/DPC++FPGA/ReferenceDesigns/board_test/README.md
+++ b/DirectProgramming/DPC++FPGA/ReferenceDesigns/board_test/README.md
@@ -20,11 +20,11 @@ This reference design implements tests to check FPGA board interfaces and measur
 |:---                     |:---
 | OS                      | Ubuntu* 18.04/20.04 <br> RHEL*/CentOS* 8 <br> SUSE* 15 <br> Windows* 10
 | Hardware                | Intel® Programmable Acceleration Card with Intel® Arria® 10 GX FPGA (Intel® PAC with Intel® Arria® 10 GX FPGA) <br> Intel® FPGA Programmable Acceleration Card (PAC) D5005 (with Intel Stratix® 10 SX FPGA) <br> Intel® FPGA 3rd party / custom platforms with oneAPI support <br> **Note**: Intel® FPGA PAC hardware is only compatible with Ubuntu 18.04*
-| Software                | Intel® oneAPI DPC++/C++ Compiler <br> Intel® FPGA Add-on for oneAPI Base Toolkit
+| Software                | Intel® oneAPI SYCL Compiler <br> Intel® FPGA Add-on for oneAPI Base Toolkit
 
 ## Key Implementation Details
 
-A oneAPI Board Support Package (BSP) consists of software layers and an FPGA hardware scaffold design, making it possible to target an FPGA through the Intel® oneAPI DPC++/C++ Compiler.
+A oneAPI Board Support Package (BSP) consists of software layers and an FPGA hardware scaffold design, making it possible to target an FPGA through the Intel® oneAPI SYCL Compiler.
 
 The compiler stitches the generated FPGA design into the oneAPI BSP framework. Refer to the [Intel® oneAPI Programming Guide](https://www.intel.com/content/www/us/en/develop/documentation/oneapi-programming-guide/top/programming-interface/fpga-flow/fpga-bsps-and-boards.html) for information about oneAPI BSPs.
 

--- a/DirectProgramming/DPC++FPGA/ReferenceDesigns/board_test/src/CMakeLists.txt
+++ b/DirectProgramming/DPC++FPGA/ReferenceDesigns/board_test/src/CMakeLists.txt
@@ -26,7 +26,7 @@ else()
     set(PLATFORM_SPECIFIC_LINK_FLAGS "")
 endif()
 
-# A DPC++ ahead-of-time (AoT) compile processes the device code in two stages.
+# A SYCL ahead-of-time (AoT) compile processes the device code in two stages.
 # 1. The "compile" stage compiles the device code to an intermediate representation (SPIR-V).
 # 2. The "link" stage invokes the compiler's FPGA backend before linking.
 #    For this reason, FPGA backend flags must be passed as link flags in CMake.

--- a/DirectProgramming/DPC++FPGA/ReferenceDesigns/board_test/src/CMakeLists.txt
+++ b/DirectProgramming/DPC++FPGA/ReferenceDesigns/board_test/src/CMakeLists.txt
@@ -58,7 +58,7 @@ add_custom_target(fpga_emu DEPENDS ${EMULATOR_TARGET})
 ###############################################################################
 # To compile manually:
 #   icpx -fsycl -fintelfpga -Xshardware -Xstarget=<FPGA_DEVICE> -Xsno-interleaving=default -fsycl-link=early board_test.cpp -o board_test.a
-# The compile output is not an executable, but an intermediate compilation result unique to DPC++.
+# The compile output is not an executable, but an intermediate compilation result unique to SYCL.
 add_executable(${FPGA_EARLY_IMAGE} ${SOURCE_FILE})
 target_include_directories(${FPGA_EARLY_IMAGE} PRIVATE ../../../include)
 add_custom_target(report DEPENDS ${FPGA_EARLY_IMAGE})

--- a/DirectProgramming/DPC++FPGA/ReferenceDesigns/cholesky/README.md
+++ b/DirectProgramming/DPC++FPGA/ReferenceDesigns/cholesky/README.md
@@ -24,7 +24,7 @@ You can set the template parameters to decompose custom-sized real or complex sq
 |:---                |:---
 | OS                 | Ubuntu* 18.04/20.04 <br> RHEL*/CentOS* 8 <br> SUSE* 15 <br> Windows* 10
 | Hardware           |Intel® Programmable Acceleration Card with Intel® Arria® 10 GX FPGA (Intel® PAC with Intel® Arria® 10 GX FPGA) <br> Intel® FPGA Programmable Acceleration Card (PAC) D5005 (with Intel Stratix® 10 SX) <br> Intel Xeon® CPU E5-1650 v2 @ 3.50GHz (host machine)
-| Software           | Intel® oneAPI DPC++/C++ Compiler  <br> Intel® FPGA Add-On for oneAPI Base Toolkit
+| Software           | Intel® oneAPI SYCL Compiler  <br> Intel® FPGA Add-On for oneAPI Base Toolkit
 
 
 ## Key Implementation Details

--- a/DirectProgramming/DPC++FPGA/ReferenceDesigns/cholesky/src/CMakeLists.txt
+++ b/DirectProgramming/DPC++FPGA/ReferenceDesigns/cholesky/src/CMakeLists.txt
@@ -96,7 +96,7 @@ add_custom_target(fpga_emu DEPENDS ${EMULATOR_TARGET})
 ###############################################################################
 ### Generate Report
 ###############################################################################
-# The compile output is not an executable, but an intermediate compilation result unique to DPC++.
+# The compile output is not an executable, but an intermediate compilation result unique to SYCL.
 add_executable(${FPGA_EARLY_IMAGE} EXCLUDE_FROM_ALL ${SOURCE_FILE})
 target_include_directories(${FPGA_EARLY_IMAGE} PRIVATE ../../../include)
 add_custom_target(report DEPENDS ${FPGA_EARLY_IMAGE})

--- a/DirectProgramming/DPC++FPGA/ReferenceDesigns/cholesky/src/CMakeLists.txt
+++ b/DirectProgramming/DPC++FPGA/ReferenceDesigns/cholesky/src/CMakeLists.txt
@@ -74,7 +74,7 @@ message(STATUS "COMPLEX=${COMPLEX}")
 message(STATUS "FIXED_ITERATIONS=${FIXED_ITERATIONS}")
 message(STATUS "SEED=${SEED}")
 
-# A DPC++ ahead-of-time (AoT) compile processes the device code in two stages.
+# A SYCL ahead-of-time (AoT) compile processes the device code in two stages.
 # 1. The "compile" stage compiles the device code to an intermediate representation (SPIR-V).
 # 2. The "link" stage invokes the compiler's FPGA backend before linking.
 #    For this reason, FPGA backend flags must be passed as link flags in CMake.

--- a/DirectProgramming/DPC++FPGA/ReferenceDesigns/cholesky_inversion/README.md
+++ b/DirectProgramming/DPC++FPGA/ReferenceDesigns/cholesky_inversion/README.md
@@ -37,7 +37,7 @@ Because $A^{-1}$  is going to be symmetric, one can also compute only half of th
 |:---                  |:---
 | OS                   | Ubuntu* 18.04/20.04 <br> RHEL*/CentOS* 8 <br> SUSE* 15 <br> Windows* 10
 | Hardware             | Intel® Programmable Acceleration Card with Intel® Arria® 10 GX FPGA (Intel® PAC with Intel® Arria® 10 GX FPGA) <br> Intel® FPGA Programmable Acceleration Card (PAC) D5005 (with Intel Stratix® 10 SX)
-| Software             | Intel® oneAPI DPC++/C++ Compiler <br> Intel® FPGA Add-on for oneAPI Base Toolkit
+| Software             | Intel® oneAPI SYCL Compiler <br> Intel® FPGA Add-on for oneAPI Base Toolkit
 
 ### Performance
 

--- a/DirectProgramming/DPC++FPGA/ReferenceDesigns/cholesky_inversion/src/CMakeLists.txt
+++ b/DirectProgramming/DPC++FPGA/ReferenceDesigns/cholesky_inversion/src/CMakeLists.txt
@@ -105,7 +105,7 @@ add_custom_target(fpga_emu DEPENDS ${EMULATOR_TARGET})
 ###############################################################################
 ### Generate Report
 ###############################################################################
-# The compile output is not an executable, but an intermediate compilation result unique to DPC++.
+# The compile output is not an executable, but an intermediate compilation result unique to SYCL.
 add_executable(${FPGA_EARLY_IMAGE} EXCLUDE_FROM_ALL ${SOURCE_FILE})
 target_include_directories(${FPGA_EARLY_IMAGE} PRIVATE ../../../include)
 add_custom_target(report DEPENDS ${FPGA_EARLY_IMAGE})

--- a/DirectProgramming/DPC++FPGA/ReferenceDesigns/cholesky_inversion/src/CMakeLists.txt
+++ b/DirectProgramming/DPC++FPGA/ReferenceDesigns/cholesky_inversion/src/CMakeLists.txt
@@ -83,7 +83,7 @@ message(STATUS "FIXED_ITERATIONS_DECOMPOSITION=${FIXED_ITERATIONS_DECOMPOSITION}
 message(STATUS "FIXED_ITERATIONS_INVERSION=${FIXED_ITERATIONS_INVERSION}")
 message(STATUS "SEED=${SEED}")
 
-# A DPC++ ahead-of-time (AoT) compile processes the device code in two stages.
+# A SYCL ahead-of-time (AoT) compile processes the device code in two stages.
 # 1. The "compile" stage compiles the device code to an intermediate representation (SPIR-V).
 # 2. The "link" stage invokes the compiler's FPGA backend before linking.
 #    For this reason, FPGA backend flags must be passed as link flags in CMake.

--- a/DirectProgramming/DPC++FPGA/ReferenceDesigns/crr/README.md
+++ b/DirectProgramming/DPC++FPGA/ReferenceDesigns/crr/README.md
@@ -9,7 +9,7 @@ This sample implements the Cox-Ross-Rubinstein (CRR) binomial tree model that is
 ---                                 |---
 | OS                                | Ubuntu* 18.04/20.04 <br>RHEL*/CentOS* 8 <br>SUSE* 15 <br>Windows* 10
 | Hardware                          | Intel&reg; Programmable Acceleration Card (PAC) with Intel Arria&reg; 10 GX FPGA; <br> Intel&reg; FPGA Programmable Acceleration Card (PAC) D5005 (with Intel Stratix&reg; 10 SX)
-| Software                          | Intel&reg; oneAPI DPC++ Compiler <br> Intel&reg; FPGA Add-On for oneAPI Base Toolkit
+| Software                          | Intel&reg; oneAPI SYCL Compiler <br> Intel&reg; FPGA Add-On for oneAPI Base Toolkit
 
 ### Performance
 > **Note**: Please refer to the [Performance Disclaimers](#performance-disclaimers) section below.

--- a/DirectProgramming/DPC++FPGA/ReferenceDesigns/crr/src/CMakeLists.txt
+++ b/DirectProgramming/DPC++FPGA/ReferenceDesigns/crr/src/CMakeLists.txt
@@ -49,7 +49,7 @@ message(STATUS "OUTER_UNROLL=${OUTER_UNROLL}")
 message(STATUS "INNER_UNROLL=${INNER_UNROLL}")
 message(STATUS "OUTER_UNROLL_POW2=${OUTER_UNROLL_POW2}")
 
-# A DPC++ ahead-of-time (AoT) compile processes the device code in two stages.
+# A SYCL ahead-of-time (AoT) compile processes the device code in two stages.
 # 1. The "compile" stage compiles the device code to an intermediate representation (SPIR-V).
 # 2. The "link" stage invokes the compiler's FPGA backend before linking.
 #    For this reason, FPGA backend flags must be passed as link flags in CMake.

--- a/DirectProgramming/DPC++FPGA/ReferenceDesigns/crr/src/CMakeLists.txt
+++ b/DirectProgramming/DPC++FPGA/ReferenceDesigns/crr/src/CMakeLists.txt
@@ -75,7 +75,7 @@ add_custom_target(fpga_emu DEPENDS ${EMULATOR_TARGET})
 ### Generate Report
 ###############################################################################
 set(FPGA_EARLY_IMAGE ${TARGET_NAME}_report.a)
-# The compile output is not an executable, but an intermediate compilation result unique to DPC++.
+# The compile output is not an executable, but an intermediate compilation result unique to SYCL.
 add_executable(${FPGA_EARLY_IMAGE} ${SOURCE_FILE})
 target_include_directories(${FPGA_EARLY_IMAGE} PRIVATE ../../../include)
 add_custom_target(report DEPENDS ${FPGA_EARLY_IMAGE})

--- a/DirectProgramming/DPC++FPGA/ReferenceDesigns/crr/src/CMakeLists.txt
+++ b/DirectProgramming/DPC++FPGA/ReferenceDesigns/crr/src/CMakeLists.txt
@@ -92,4 +92,3 @@ add_custom_target(fpga DEPENDS ${FPGA_TARGET})
 set_target_properties(${FPGA_TARGET} PROPERTIES COMPILE_FLAGS "${HARDWARE_COMPILE_FLAGS}")
 set_target_properties(${FPGA_TARGET} PROPERTIES LINK_FLAGS "${HARDWARE_LINK_FLAGS} -reuse-exe=${CMAKE_BINARY_DIR}/${FPGA_TARGET}")
 # The -reuse-exe flag enables rapid recompilation of host-only code changes.
-# See DPC++FPGA/GettingStarted/fast_recompile for details.

--- a/DirectProgramming/DPC++FPGA/ReferenceDesigns/db/README.md
+++ b/DirectProgramming/DPC++FPGA/ReferenceDesigns/db/README.md
@@ -5,7 +5,7 @@ This reference design demonstrates how to use an FPGA to accelerate database que
 ---                                 |---
 | OS                                | Linux* Ubuntu* 18.04/20.04 <br> RHEL*/CentOS* 8 <br> SUSE* 15 <br>Windows* 10
 | Hardware                          | Intel&reg; FPGA Programmable Acceleration Card (PAC) D5005 (with Intel Stratix&reg; 10 SX)
-| Software                          | Intel&reg; oneAPI DPC++ Compiler
+| Software                          | Intel&reg; oneAPI SYCL Compiler
 | What you will learn               | How to accelerate database queries using an Intel FPGA
 | Time to complete                  | 1 hour
 

--- a/DirectProgramming/DPC++FPGA/ReferenceDesigns/db/src/CMakeLists.txt
+++ b/DirectProgramming/DPC++FPGA/ReferenceDesigns/db/src/CMakeLists.txt
@@ -128,7 +128,7 @@ else()
     message(FATAL_ERROR "\tQUERY ${QUERY} not supported (supported queries are 1, 9, 11 and 12)")
 endif()
 
-# A DPC++ ahead-of-time (AoT) compile processes the device code in two stages.
+# A SYCL ahead-of-time (AoT) compile processes the device code in two stages.
 # 1. The "compile" stage compiles the device code to an intermediate representation (SPIR-V).
 # 2. The "link" stage invokes the compiler's FPGA backend before linking.
 #    For this reason, FPGA backend flags must be passed as link flags in CMake.

--- a/DirectProgramming/DPC++FPGA/ReferenceDesigns/db/src/CMakeLists.txt
+++ b/DirectProgramming/DPC++FPGA/ReferenceDesigns/db/src/CMakeLists.txt
@@ -153,7 +153,7 @@ add_custom_target(fpga_emu DEPENDS ${EMULATOR_TARGET})
 ### Generate Report
 ###############################################################################
 set(FPGA_EARLY_IMAGE ${TARGET_NAME}_report.a)
-# The compile output is not an executable, but an intermediate compilation result unique to DPC++.
+# The compile output is not an executable, but an intermediate compilation result unique to SYCL.
 add_executable(${FPGA_EARLY_IMAGE} ${SOURCE_FILE} ${DEVICE_SOURCE})
 target_include_directories(${FPGA_EARLY_IMAGE} PRIVATE ../../../include)
 add_custom_target(report DEPENDS ${FPGA_EARLY_IMAGE})

--- a/DirectProgramming/DPC++FPGA/ReferenceDesigns/decompress/README.md
+++ b/DirectProgramming/DPC++FPGA/ReferenceDesigns/decompress/README.md
@@ -5,7 +5,7 @@ This reference design can be compiled to implement either GZIP or Snappy decompr
 ---                                 |---
 | OS                                | Ubuntu* 18.04/20.04 <br>RHEL*/CentOS* 8 <br>SUSE* 15 <br> Windows* 10
 | Hardware                          | Intel&reg; Programmable Acceleration Card (PAC) with Intel Arria&reg; 10 GX FPGA <br> Intel&reg; FPGA Programmable Acceleration Card (PAC) D5005 (with Intel Stratix&reg; 10 SX) <br> Intel Xeon&reg; CPU E5-1650 v2 @ 3.50GHz (host machine)
-| Software                          | Intel&reg; oneAPI DPC++ Compiler <br> Intel&reg; FPGA Add-On for oneAPI Base Toolkit
+| Software                          | Intel&reg; oneAPI SYCL Compiler <br> Intel&reg; FPGA Add-On for oneAPI Base Toolkit
 | What you will learn               | How to implement an efficient GZIP and Snappy decompression engine on an FPGA.
 | Time to complete                  | 1 hour
 

--- a/DirectProgramming/DPC++FPGA/ReferenceDesigns/decompress/src/CMakeLists.txt
+++ b/DirectProgramming/DPC++FPGA/ReferenceDesigns/decompress/src/CMakeLists.txt
@@ -116,7 +116,7 @@ add_custom_target(fpga_emu DEPENDS ${EMULATOR_TARGET})
 ### Generate Report
 ###############################################################################
 set(FPGA_EARLY_IMAGE ${TARGET_NAME}_report.a)
-# The compile output is not an executable, but an intermediate compilation result unique to DPC++.
+# The compile output is not an executable, but an intermediate compilation result unique to SYCL.
 add_executable(${FPGA_EARLY_IMAGE} ${SOURCE_FILE})
 target_include_directories(${FPGA_EARLY_IMAGE} PRIVATE ../../../include)
 add_custom_target(report DEPENDS ${FPGA_EARLY_IMAGE})

--- a/DirectProgramming/DPC++FPGA/ReferenceDesigns/decompress/src/CMakeLists.txt
+++ b/DirectProgramming/DPC++FPGA/ReferenceDesigns/decompress/src/CMakeLists.txt
@@ -90,7 +90,7 @@ if(DEFINED LITERALS_PER_CYCLE)
 endif()
 
 
-# A DPC++ ahead-of-time (AoT) compile processes the device code in two stages.
+# A SYCL ahead-of-time (AoT) compile processes the device code in two stages.
 # 1. The "compile" stage compiles the device code to an intermediate representation (SPIR-V).
 # 2. The "link" stage invokes the compiler's FPGA backend before linking.
 #    For this reason, FPGA backend flags must be passed as link flags in CMake.

--- a/DirectProgramming/DPC++FPGA/ReferenceDesigns/gzip/README.md
+++ b/DirectProgramming/DPC++FPGA/ReferenceDesigns/gzip/README.md
@@ -5,7 +5,7 @@ This reference design demonstrates high-performance GZIP compression on FPGA.
 ---                                 |---
 | OS                                | Linux* Ubuntu* 18.04/20.04 <br> RHEL*/CentOS* 8 <br> SUSE* 15 <br>Windows* 10
 | Hardware                          | Intel&reg; Programmable Acceleration Card (PAC) with Intel Arria&reg; 10 GX FPGA; <br> Intel&reg; FPGA Programmable Acceleration Card (PAC) D5005 (with Intel Stratix&reg; 10 SX)
-| Software                          | Intel&reg; oneAPI DPC++ Compiler <br> Intel&reg; FPGA Add-On for oneAPI Base Toolkit
+| Software                          | Intel&reg; oneAPI SYCL Compiler <br> Intel&reg; FPGA Add-On for oneAPI Base Toolkit
 | What you will learn               | How to implement a high-performance multi-engine compression algorithm on FPGA
 | Time to complete                  | 1 hr (not including compile time)
 

--- a/DirectProgramming/DPC++FPGA/ReferenceDesigns/gzip/src/CMakeLists.txt
+++ b/DirectProgramming/DPC++FPGA/ReferenceDesigns/gzip/src/CMakeLists.txt
@@ -93,7 +93,7 @@ message(STATUS "NUM_ENGINES=${NUM_ENGINES}")
 message(STATUS "SEED=${SEED}")
 message(STATUS "NUM_REORDER=${NUM_REORDER}")
 
-# A DPC++ ahead-of-time (AoT) compile processes the device code in two stages.
+# A SYCL ahead-of-time (AoT) compile processes the device code in two stages.
 # 1. The "compile" stage compiles the device code to an intermediate representation (SPIR-V).
 # 2. The "link" stage invokes the compiler's FPGA backend before linking.
 #    For this reason, FPGA backend flags must be passed as link flags in CMake.

--- a/DirectProgramming/DPC++FPGA/ReferenceDesigns/gzip/src/CMakeLists.txt
+++ b/DirectProgramming/DPC++FPGA/ReferenceDesigns/gzip/src/CMakeLists.txt
@@ -116,7 +116,7 @@ add_custom_target(fpga_emu DEPENDS ${EMULATOR_TARGET})
 ### Generate Report
 ###############################################################################
 set(FPGA_EARLY_IMAGE ${TARGET_NAME}_report.a)
-# The compile output is not an executable, but an intermediate compilation result unique to DPC++.
+# The compile output is not an executable, but an intermediate compilation result unique to SYCL.
 add_executable(${FPGA_EARLY_IMAGE} ${SOURCE_FILE} ${DEVICE_SOURCE_FILE})
 target_include_directories(${FPGA_EARLY_IMAGE} PRIVATE ../../../include)
 add_custom_target(report DEPENDS ${FPGA_EARLY_IMAGE})

--- a/DirectProgramming/DPC++FPGA/ReferenceDesigns/merge_sort/README.md
+++ b/DirectProgramming/DPC++FPGA/ReferenceDesigns/merge_sort/README.md
@@ -5,7 +5,7 @@ This reference design demonstrates a highly paramaterizable merge sort algorithm
 ---                                 |---
 | OS                                | Ubuntu* 18.04/20.04 <br>RHEL*/CentOS* 8 <br>SUSE* 15 <br> Windows* 10
 | Hardware                          | Intel&reg; Programmable Acceleration Card (PAC) with Intel Arria&reg; 10 GX FPGA <br> Intel&reg; FPGA Programmable Acceleration Card (PAC) D5005 (with Intel Stratix&reg; 10 SX) <br> Intel Xeon&reg; CPU E5-1650 v2 @ 3.50GHz (host machine)
-| Software                          | Intel&reg; oneAPI DPC++ Compiler <br> Intel&reg; FPGA Add-On for oneAPI Base Toolkit
+| Software                          | Intel&reg; oneAPI SYCL Compiler <br> Intel&reg; FPGA Add-On for oneAPI Base Toolkit
 | What you will learn               | How to use the spatial compute of the FPGA to create a merge sort design that takes advantage of thread- and SIMD-level parallelism.
 | Time to complete                  | 1 hour
 

--- a/DirectProgramming/DPC++FPGA/ReferenceDesigns/merge_sort/src/CMakeLists.txt
+++ b/DirectProgramming/DPC++FPGA/ReferenceDesigns/merge_sort/src/CMakeLists.txt
@@ -84,7 +84,7 @@ add_custom_target(fpga_emu DEPENDS ${EMULATOR_TARGET})
 ### Generate Report
 ###############################################################################
 set(FPGA_EARLY_IMAGE ${TARGET_NAME}_report.a)
-# The compile output is not an executable, but an intermediate compilation result unique to DPC++.
+# The compile output is not an executable, but an intermediate compilation result unique to SYCL.
 add_executable(${FPGA_EARLY_IMAGE} ${SOURCE_FILE})
 target_include_directories(${FPGA_EARLY_IMAGE} PRIVATE ../../../include)
 add_custom_target(report DEPENDS ${FPGA_EARLY_IMAGE})

--- a/DirectProgramming/DPC++FPGA/ReferenceDesigns/merge_sort/src/CMakeLists.txt
+++ b/DirectProgramming/DPC++FPGA/ReferenceDesigns/merge_sort/src/CMakeLists.txt
@@ -61,7 +61,7 @@ else()
     set(SEED_FLAG "-Xsseed=${SEED}")
 endif()
 
-# A DPC++ ahead-of-time (AoT) compile processes the device code in two stages.
+# A SYCL ahead-of-time (AoT) compile processes the device code in two stages.
 # 1. The "compile" stage compiles the device code to an intermediate representation (SPIR-V).
 # 2. The "link" stage invokes the compiler's FPGA backend before linking.
 #    For this reason, FPGA backend flags must be passed as link flags in CMake.

--- a/DirectProgramming/DPC++FPGA/ReferenceDesigns/mvdr_beamforming/README.md
+++ b/DirectProgramming/DPC++FPGA/ReferenceDesigns/mvdr_beamforming/README.md
@@ -5,7 +5,7 @@ This reference design demonstrates IO streaming using SYCL* on an FPGA for a lar
 ---                                 |---
 | OS                                | Linux* Ubuntu* 18.04/20.04 <br> RHEL*/CentOS* 8 <br> SUSE* 15 <br> Windows* 10
 | Hardware                          | Intel&reg; Programmable Acceleration Card (PAC) with Intel Arria&reg; 10 GX FPGA <br> Intel&reg; FPGA Programmable Acceleration Card (PAC) D5005 (with Intel Stratix&reg; 10 SX) <br> Intel Xeon&reg; CPU E5-1650 v2 @ 3.50GHz (host machine)
-| Software                          | Intel&reg; oneAPI DPC++ Compiler <br> Intel&reg; FPGA Add-On for oneAPI Base Toolkit
+| Software                          | Intel&reg; oneAPI SYCL Compiler <br> Intel&reg; FPGA Add-On for oneAPI Base Toolkit
 | What you will learn               | How to create a full, complex system that performs IO streaming using SYCL*-compliant code.
 | Time to complete                  | 1 hour
 

--- a/DirectProgramming/DPC++FPGA/ReferenceDesigns/mvdr_beamforming/src/CMakeLists.txt
+++ b/DirectProgramming/DPC++FPGA/ReferenceDesigns/mvdr_beamforming/src/CMakeLists.txt
@@ -1,6 +1,3 @@
-# To see a Makefile equivalent of this build system:
-# https://github.com/oneapi-src/oneAPI-samples/blob/master/DirectProgramming/DPC++/ProjectTemplates/makefile-fpga
-
 set(SOURCE_FILE mvdr_beamforming.cpp)
 set(TARGET_NAME mvdr_beamforming)
 set(EMULATOR_TARGET ${TARGET_NAME}.fpga_emu)

--- a/DirectProgramming/DPC++FPGA/ReferenceDesigns/mvdr_beamforming/src/CMakeLists.txt
+++ b/DirectProgramming/DPC++FPGA/ReferenceDesigns/mvdr_beamforming/src/CMakeLists.txt
@@ -118,7 +118,7 @@ add_custom_target(fpga_emu DEPENDS ${EMULATOR_TARGET})
 # To compile manually:
 #   icpx -fsycl -fintelfpga -Xshardware -fbracket-depth=512 -qactypes -Xstarget=<FPGA_DEVICE> -fsycl-link=early mvdr_beamforming.cpp -o mvdr_beamforming_report.a
 set(FPGA_EARLY_IMAGE ${TARGET_NAME}_report.a)
-# The compile output is not an executable, but an intermediate compilation result unique to DPC++.
+# The compile output is not an executable, but an intermediate compilation result unique to SYCL.
 add_executable(${FPGA_EARLY_IMAGE} ${SOURCE_FILE})
 target_include_directories(${FPGA_EARLY_IMAGE} PRIVATE ../../../include)
 add_custom_target(report DEPENDS ${FPGA_EARLY_IMAGE})

--- a/DirectProgramming/DPC++FPGA/ReferenceDesigns/mvdr_beamforming/src/CMakeLists.txt
+++ b/DirectProgramming/DPC++FPGA/ReferenceDesigns/mvdr_beamforming/src/CMakeLists.txt
@@ -85,7 +85,7 @@ if(STREAMING_PIPE_WIDTH)
 endif()
 
 
-# A DPC++ ahead-of-time (AoT) compile processes the device code in two stages.
+# A SYCL ahead-of-time (AoT) compile processes the device code in two stages.
 # 1. The "compile" stage compiles the device code to an intermediate representation (SPIR-V).
 # 2. The "link" stage invokes the compiler's FPGA backend before linking.
 #    For this reason, FPGA backend flags must be passed as link flags in CMake.

--- a/DirectProgramming/DPC++FPGA/ReferenceDesigns/qrd/README.md
+++ b/DirectProgramming/DPC++FPGA/ReferenceDesigns/qrd/README.md
@@ -5,7 +5,7 @@ This reference design demonstrates high performance QR decomposition of complex/
 ---                                 |---
 | OS                                | Linux* Ubuntu* 18.04/20.04 <br>RHEL*/CentOS* 8 <br> SUSE* 15 <br> Windows* 10
 | Hardware                          | Intel&reg; Programmable Acceleration Card (PAC) with Intel Arria&reg; 10 GX FPGA <br> Intel&reg; FPGA Programmable Acceleration Card (PAC) D5005 (with Intel Stratix&reg; 10 SX) <br> Intel Xeon&reg; CPU E5-1650 v2 @ 3.50GHz (host machine)
-| Software                          | Intel&reg; oneAPI DPC++ Compiler <br> Intel&reg; FPGA Add-On for oneAPI Base Toolkit
+| Software                          | Intel&reg; oneAPI SYCL Compiler <br> Intel&reg; FPGA Add-On for oneAPI Base Toolkit
 | What you will learn               | Implementing a high performance FPGA version of the Gram-Schmidt QR decomposition algorithm.
 | Time to complete                  | 1 hr (not including compile time)
 

--- a/DirectProgramming/DPC++FPGA/ReferenceDesigns/qrd/src/CMakeLists.txt
+++ b/DirectProgramming/DPC++FPGA/ReferenceDesigns/qrd/src/CMakeLists.txt
@@ -104,7 +104,7 @@ add_custom_target(fpga_emu DEPENDS ${EMULATOR_TARGET})
 ###############################################################################
 ### Generate Report
 ###############################################################################
-# The compile output is not an executable, but an intermediate compilation result unique to DPC++.
+# The compile output is not an executable, but an intermediate compilation result unique to SYCL.
 add_executable(${FPGA_EARLY_IMAGE} EXCLUDE_FROM_ALL ${SOURCE_FILE})
 target_include_directories(${FPGA_EARLY_IMAGE} PRIVATE ../../../include)
 add_custom_target(report DEPENDS ${FPGA_EARLY_IMAGE})

--- a/DirectProgramming/DPC++FPGA/ReferenceDesigns/qrd/src/CMakeLists.txt
+++ b/DirectProgramming/DPC++FPGA/ReferenceDesigns/qrd/src/CMakeLists.txt
@@ -82,7 +82,7 @@ message(STATUS "COMPLEX=${COMPLEX}")
 message(STATUS "FIXED_ITERATIONS=${FIXED_ITERATIONS}")
 message(STATUS "SEED=${SEED}")
 
-# A DPC++ ahead-of-time (AoT) compile processes the device code in two stages.
+# A SYCL ahead-of-time (AoT) compile processes the device code in two stages.
 # 1. The "compile" stage compiles the device code to an intermediate representation (SPIR-V).
 # 2. The "link" stage invokes the compiler's FPGA backend before linking.
 #    For this reason, FPGA backend flags must be passed as link flags in CMake.

--- a/DirectProgramming/DPC++FPGA/ReferenceDesigns/qri/README.md
+++ b/DirectProgramming/DPC++FPGA/ReferenceDesigns/qri/README.md
@@ -6,7 +6,7 @@ This reference design demonstrates high performance QR-based inversion of comple
 ---                                 |---
 | OS                                | Linux* Ubuntu* 18.04/20.04 <br> RHEL*/CentOS* 8 <br> SUSE* 15 <br> Windows* 10
 | Hardware                          | Intel&reg; Programmable Acceleration Card (PAC) with Intel Arria&reg; 10 GX FPGA <br> Intel&reg; FPGA Programmable Acceleration Card (PAC) D5005 (with Intel Stratix&reg; 10 SX) <br> Intel Xeon&reg; CPU E5-1650 v2 @ 3.50GHz (host machine)
-| Software                          | Intel&reg; oneAPI DPC++ Compiler <br> Intel&reg; FPGA Add-On for oneAPI Base Toolkit
+| Software                          | Intel&reg; oneAPI SYCL Compiler <br> Intel&reg; FPGA Add-On for oneAPI Base Toolkit
 | What you will learn               | Implementing a high performance FPGA version of the Gram-Schmidt QR decomposition to compute a matrix inversion.
 | Time to complete                  | 1 hr (not including compile time)
 

--- a/DirectProgramming/DPC++FPGA/ReferenceDesigns/qri/src/CMakeLists.txt
+++ b/DirectProgramming/DPC++FPGA/ReferenceDesigns/qri/src/CMakeLists.txt
@@ -89,7 +89,7 @@ message(STATUS "FIXED_ITERATIONS_QRD=${FIXED_ITERATIONS_QRD}")
 message(STATUS "FIXED_ITERATIONS_QRI=${FIXED_ITERATIONS_QRI}")
 message(STATUS "SEED=${SEED}")
 
-# A DPC++ ahead-of-time (AoT) compile processes the device code in two stages.
+# A SYCL ahead-of-time (AoT) compile processes the device code in two stages.
 # 1. The "compile" stage compiles the device code to an intermediate representation (SPIR-V).
 # 2. The "link" stage invokes the compiler's FPGA backend before linking.
 #    For this reason, FPGA backend flags must be passed as link flags in CMake.

--- a/DirectProgramming/DPC++FPGA/ReferenceDesigns/qri/src/CMakeLists.txt
+++ b/DirectProgramming/DPC++FPGA/ReferenceDesigns/qri/src/CMakeLists.txt
@@ -128,4 +128,3 @@ add_custom_target(fpga DEPENDS ${FPGA_TARGET})
 set_target_properties(${FPGA_TARGET} PROPERTIES COMPILE_FLAGS "${HARDWARE_COMPILE_FLAGS}")
 set_target_properties(${FPGA_TARGET} PROPERTIES LINK_FLAGS "${HARDWARE_LINK_FLAGS} -reuse-exe=${CMAKE_BINARY_DIR}/${FPGA_TARGET}")
 # The -reuse-exe flag enables rapid recompilation of host-only code changes.
-# See DPC++FPGA/GettingStarted/fast_recompile for details.

--- a/DirectProgramming/DPC++FPGA/ReferenceDesigns/qri/src/CMakeLists.txt
+++ b/DirectProgramming/DPC++FPGA/ReferenceDesigns/qri/src/CMakeLists.txt
@@ -111,7 +111,7 @@ add_custom_target(fpga_emu DEPENDS ${EMULATOR_TARGET})
 ###############################################################################
 ### Generate Report
 ###############################################################################
-# The compile output is not an executable, but an intermediate compilation result unique to DPC++.
+# The compile output is not an executable, but an intermediate compilation result unique to SYCL.
 add_executable(${FPGA_EARLY_IMAGE} EXCLUDE_FROM_ALL ${HOST_SOURCE_FILE})
 target_include_directories(${FPGA_EARLY_IMAGE} PRIVATE ../../../include)
 add_custom_target(report DEPENDS ${FPGA_EARLY_IMAGE})

--- a/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/autorun/README.md
+++ b/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/autorun/README.md
@@ -6,7 +6,7 @@ This FPGA tutorial demonstrates how to create the equivalent of OpenCL `autorun`
 ---                                 |---
 | OS                                | Linux* Ubuntu* 18.04/20.04 <br> RHEL*/CentOS* 8 <br> SUSE* 15 <br> Windows* 10
 | Hardware                          | Intel&reg; Programmable Acceleration Card (PAC) with Intel Arria&reg; 10 GX FPGA <br> Intel&reg; FPGA Programmable Acceleration Card (PAC) D5005 (with Intel Stratix&reg; 10 SX) <br> Intel&reg; FPGA 3rd party / custom platforms with oneAPI support <br> *__Note__: Intel&reg; FPGA PAC hardware is only compatible with Ubuntu 18.04*
-| Software                          | Intel&reg; oneAPI DPC++ Compiler <br> Intel&reg; FPGA Add-On for oneAPI Base Toolkit
+| Software                          | Intel&reg; oneAPI SYCL Compiler <br> Intel&reg; FPGA Add-On for oneAPI Base Toolkit
 | What you will learn               | How and when to use autorun kernels
 | Time to complete                  | 15 minutes
 

--- a/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/autorun/src/CMakeLists.txt
+++ b/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/autorun/src/CMakeLists.txt
@@ -1,6 +1,3 @@
-# To see a Makefile equivalent of this build system:
-# https://github.com/oneapi-src/oneAPI-samples/blob/master/DirectProgramming/DPC++/ProjectTemplates/makefile-fpga
-
 set(SOURCE_FILE autorun.cpp)
 set(TARGET_NAME autorun)
 set(EMULATOR_TARGET ${TARGET_NAME}.fpga_emu)
@@ -76,7 +73,6 @@ add_custom_target(fpga_sim DEPENDS ${SIMULATOR_TARGET})
 set_target_properties(${SIMULATOR_TARGET} PROPERTIES COMPILE_FLAGS "${SIMULATOR_COMPILE_FLAGS}")
 set_target_properties(${SIMULATOR_TARGET} PROPERTIES LINK_FLAGS "${SIMULATOR_LINK_FLAGS} -reuse-exe=${CMAKE_BINARY_DIR}/${SIMULATOR_TARGET}")
 # The -reuse-exe flag enables rapid recompilation of host-only code changes.
-# See DPC++FPGA/GettingStarted/fast_recompile for details.
 
 ###############################################################################
 ### FPGA Hardware
@@ -92,4 +88,3 @@ add_custom_target(fpga DEPENDS ${FPGA_TARGET})
 set_target_properties(${FPGA_TARGET} PROPERTIES COMPILE_FLAGS "${HARDWARE_COMPILE_FLAGS}")
 set_target_properties(${FPGA_TARGET} PROPERTIES LINK_FLAGS "${HARDWARE_LINK_FLAGS} -reuse-exe=${CMAKE_BINARY_DIR}/${FPGA_TARGET}")
 # The -reuse-exe flag enables rapid recompilation of host-only code changes.
-# See DPC++FPGA/GettingStarted/fast_recompile for details.

--- a/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/autorun/src/CMakeLists.txt
+++ b/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/autorun/src/CMakeLists.txt
@@ -22,7 +22,7 @@ if(WIN32)
     set(WIN_FLAG "/EHsc")
 endif()
 
-# A DPC++ ahead-of-time (AoT) compile processes the device code in two stages.
+# A SYCL ahead-of-time (AoT) compile processes the device code in two stages.
 # 1. The "compile" stage compiles the device code to an intermediate representation (SPIR-V).
 # 2. The "link" stage invokes the compiler's FPGA backend before linking.
 #    For this reason, FPGA backend flags must be passed as link flags in CMake.

--- a/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/autorun/src/CMakeLists.txt
+++ b/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/autorun/src/CMakeLists.txt
@@ -54,7 +54,7 @@ add_custom_target(fpga_emu DEPENDS ${EMULATOR_TARGET})
 # To compile manually:
 #   icpx -fsycl -fintelfpga -Xshardware -Xstarget=<FPGA_DEVICE> -fsycl-link=early autorun.cpp -o autorun.a
 set(FPGA_EARLY_IMAGE ${TARGET_NAME}_report.a)
-# The compile output is not an executable, but an intermediate compilation result unique to DPC++.
+# The compile output is not an executable, but an intermediate compilation result unique to SYCL.
 add_executable(${FPGA_EARLY_IMAGE} ${SOURCE_FILE})
 target_include_directories(${FPGA_EARLY_IMAGE} PRIVATE ../../../../include)
 add_custom_target(report DEPENDS ${FPGA_EARLY_IMAGE})

--- a/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/buffered_host_streaming/README.md
+++ b/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/buffered_host_streaming/README.md
@@ -5,7 +5,7 @@ This tutorial demonstrates how to create a high-performance full system CPU-FPGA
 ---                                 |---
 | OS                                | Linux* Ubuntu* 18.04/20.04 <br> RHEL*/CentOS* 8 <br> SUSE* 15 <br> Windows* 10
 | Hardware                          | Intel® FPGA Programmable Acceleration Card (PAC) D5005 (with Intel Stratix® 10 SX) <br> Intel® FPGA 3rd party / custom platforms with oneAPI support (and SYCL USM support) <br> **Note**: Intel® FPGA PAC hardware is only compatible with Ubuntu 18.04*
-| Software                          | Intel® oneAPI DPC++ Compiler
+| Software                          | Intel® oneAPI SYCL Compiler
 | What you will learn               | How to optimally stream data between the host and device to maximize throughput
 | Time to complete                  | 45 minutes
 

--- a/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/buffered_host_streaming/src/CMakeLists.txt
+++ b/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/buffered_host_streaming/src/CMakeLists.txt
@@ -1,6 +1,3 @@
-# To see a Makefile equivalent of this build system:
-# https://github.com/oneapi-src/oneAPI-samples/blob/master/DirectProgramming/DPC++/ProjectTemplates/makefile-fpga
-
 set(SOURCE_FILE buffered_host_streaming.cpp)
 set(TARGET_NAME buffered_host_streaming)
 set(EMULATOR_TARGET ${TARGET_NAME}.fpga_emu)

--- a/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/buffered_host_streaming/src/CMakeLists.txt
+++ b/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/buffered_host_streaming/src/CMakeLists.txt
@@ -64,7 +64,7 @@ add_custom_target(fpga_emu DEPENDS ${EMULATOR_TARGET})
 # To compile manually:
 #   icpx -fsycl -fintelfpga -Xshardware -Xstarget=<FPGA_DEVICE> -fsycl-link=early buffered_host_streaming.cpp -o buffered_host_streaming_report.a
 set(FPGA_EARLY_IMAGE ${TARGET_NAME}_report.a)
-# The compile output is not an executable, but an intermediate compilation result unique to DPC++.
+# The compile output is not an executable, but an intermediate compilation result unique to SYCL.
 add_executable(${FPGA_EARLY_IMAGE} ${SOURCE_FILE})
 target_include_directories(${FPGA_EARLY_IMAGE} PRIVATE ../../../../include)
 add_custom_target(report DEPENDS ${FPGA_EARLY_IMAGE})

--- a/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/buffered_host_streaming/src/CMakeLists.txt
+++ b/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/buffered_host_streaming/src/CMakeLists.txt
@@ -34,7 +34,7 @@ else() # Windows
     set(WIN_FLAG "/EHsc") # This is a Windows-specific flag that enables exception handling in host code
 endif()
 
-# A DPC++ ahead-of-time (AoT) compile processes the device code in two stages.
+# A SYCL ahead-of-time (AoT) compile processes the device code in two stages.
 # 1. The "compile" stage compiles the device code to an intermediate representation (SPIR-V).
 # 2. The "link" stage invokes the compiler's FPGA backend before linking.
 #    For this reason, FPGA backend flags must be passed as link flags in CMake.

--- a/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/compute_units/README.md
+++ b/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/compute_units/README.md
@@ -209,7 +209,7 @@ dependencies and permissions errors.
 
  ### In Third-Party Integrated Development Environments (IDEs)
 
-You can compile and run this tutorial in the Eclipse* IDE (in Linux*) and the Visual Studio* IDE (in Windows*). For instructions, refer to the following link: [Intel&reg; oneAPI DPC++ FPGA Workflows on Third-Party IDEs](https://www.intel.com/content/www/us/en/developer/articles/technical/intel-oneapi-dpcpp-fpga-workflow-on-ide.html)
+You can compile and run this tutorial in the Eclipse* IDE (in Linux*) and the Visual Studio* IDE (in Windows*). For instructions, refer to the following link: [Intel&reg; oneAPI SYCL FPGA Workflows on Third-Party IDEs](https://www.intel.com/content/www/us/en/developer/articles/technical/intel-oneapi-dpcpp-fpga-workflow-on-ide.html)
 
 
 ## Examining the Reports

--- a/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/compute_units/README.md
+++ b/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/compute_units/README.md
@@ -6,7 +6,7 @@ This FPGA tutorial showcases a design pattern that allows you to make multiple c
 ---                                 |---
 | OS                                | Linux* Ubuntu* 18.04/20.04 <br> RHEL*/CentOS* 8 <br> SUSE* 15 <br> Windows* 10
 | Hardware                          | Intel&reg; Programmable Acceleration Card (PAC) with Intel Arria&reg; 10 GX FPGA <br> Intel&reg; FPGA Programmable Acceleration Card (PAC) D5005 (with Intel Stratix&reg; 10 SX) <br> Intel&reg; FPGA 3rd party / custom platforms with oneAPI support <br> **Note**: Intel&reg; FPGA PAC hardware is only compatible with Ubuntu 18.04*
-| Software                          | Intel&reg; oneAPI DPC++ Compiler <br> Intel&reg; FPGA Add-On for oneAPI Base Toolkit
+| Software                          | Intel&reg; oneAPI SYCL Compiler <br> Intel&reg; FPGA Add-On for oneAPI Base Toolkit
 | What you will learn               | A design pattern to generate multiple compute units using template metaprogramming
 | Time to complete                  | 15 minutes
 

--- a/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/compute_units/src/CMakeLists.txt
+++ b/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/compute_units/src/CMakeLists.txt
@@ -21,7 +21,7 @@ if(WIN32)
     set(WIN_FLAG "/EHsc")
 endif()
 
-# A DPC++ ahead-of-time (AoT) compile processes the device code in two stages.
+# A SYCL ahead-of-time (AoT) compile processes the device code in two stages.
 # 1. The "compile" stage compiles the device code to an intermediate representation (SPIR-V).
 # 2. The "link" stage invokes the compiler's FPGA backend before linking.
 #    For this reason, FPGA backend flags must be passed as link flags in CMake.

--- a/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/compute_units/src/CMakeLists.txt
+++ b/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/compute_units/src/CMakeLists.txt
@@ -1,6 +1,3 @@
-# To see a Makefile equivalent of this build system:
-# https://github.com/oneapi-src/oneAPI-samples/blob/master/DirectProgramming/DPC++/ProjectTemplates/makefile-fpga
-
 set(SOURCE_FILE compute_units.cpp)
 set(TARGET_NAME compute_units)
 set(EMULATOR_TARGET ${TARGET_NAME}.fpga_emu)

--- a/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/compute_units/src/CMakeLists.txt
+++ b/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/compute_units/src/CMakeLists.txt
@@ -52,7 +52,7 @@ add_custom_target(fpga_emu DEPENDS ${EMULATOR_TARGET})
 # To compile manually:
 #   icpx -fsycl -fintelfpga -Xshardware -Xstarget=<FPGA_DEVICE> -fsycl-link=early compute_units.cpp -o compute_units_report.a
 set(FPGA_EARLY_IMAGE ${TARGET_NAME}_report.a)
-# The compile output is not an executable, but an intermediate compilation result unique to DPC++.
+# The compile output is not an executable, but an intermediate compilation result unique to SYCL.
 add_executable(${FPGA_EARLY_IMAGE} ${SOURCE_FILE})
 target_include_directories(${FPGA_EARLY_IMAGE} PRIVATE ../../../../include)
 target_include_directories(${FPGA_EARLY_IMAGE} PRIVATE ../../../../include)

--- a/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/double_buffering/README.md
+++ b/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/double_buffering/README.md
@@ -5,7 +5,7 @@ This FPGA tutorial demonstrates how to parallelize host-side processing and buff
 ---                                 |---
 | OS                                | Linux* Ubuntu* 18.04/20.04 <br> RHEL*/CentOS* 8 <br> SUSE* 15 <br> Windows* 10
 | Hardware                          | Intel&reg; Programmable Acceleration Card (PAC) with Intel Arria&reg; 10 GX FPGA <br> Intel&reg; FPGA Programmable Acceleration Card (PAC) D5005 (with Intel Stratix&reg; 10 SX) <br> Intel&reg; FPGA 3rd party / custom platforms with oneAPI support <br> *__Note__: Intel&reg; FPGA PAC hardware is only compatible with Ubuntu 18.04*
-| Software                          | Intel&reg; oneAPI DPC++ Compiler <br> Intel&reg; FPGA Add-On for oneAPI Base Toolkit
+| Software                          | Intel&reg; oneAPI SYCL Compiler <br> Intel&reg; FPGA Add-On for oneAPI Base Toolkit
 | What you will learn               | How and when to implement the double buffering optimization technique
 | Time to complete                  | 30 minutes
 

--- a/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/double_buffering/src/CMakeLists.txt
+++ b/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/double_buffering/src/CMakeLists.txt
@@ -51,7 +51,7 @@ add_custom_target(fpga_emu DEPENDS ${EMULATOR_TARGET})
 # To compile manually:
 #   icpx -fsycl -fintelfpga -Xshardware -Xstarget=<FPGA_DEVICE> -fsycl-link=early double_buffering.cpp -o double_buffering_report.a
 set(FPGA_EARLY_IMAGE ${TARGET_NAME}_report.a)
-# The compile output is not an executable, but an intermediate compilation result unique to DPC++.
+# The compile output is not an executable, but an intermediate compilation result unique to SYCL.
 add_executable(${FPGA_EARLY_IMAGE} ${SOURCE_FILE})
 target_include_directories(${FPGA_EARLY_IMAGE} PRIVATE ../../../../include)
 add_custom_target(report DEPENDS ${FPGA_EARLY_IMAGE})

--- a/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/double_buffering/src/CMakeLists.txt
+++ b/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/double_buffering/src/CMakeLists.txt
@@ -1,6 +1,3 @@
-# To see a Makefile equivalent of this build system:
-# https://github.com/oneapi-src/oneAPI-samples/blob/master/DirectProgramming/DPC++/ProjectTemplates/makefile-fpga
-
 set(SOURCE_FILE double_buffering.cpp)
 set(TARGET_NAME double_buffering)
 set(EMULATOR_TARGET ${TARGET_NAME}.fpga_emu)

--- a/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/double_buffering/src/CMakeLists.txt
+++ b/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/double_buffering/src/CMakeLists.txt
@@ -21,7 +21,7 @@ if(WIN32)
     set(WIN_FLAG "/EHsc")
 endif()
 
-# A DPC++ ahead-of-time (AoT) compile processes the device code in two stages.
+# A SYCL ahead-of-time (AoT) compile processes the device code in two stages.
 # 1. The "compile" stage compiles the device code to an intermediate representation (SPIR-V).
 # 2. The "link" stage invokes the compiler's FPGA backend before linking.
 #    For this reason, FPGA backend flags must be passed as link flags in CMake.

--- a/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/explicit_data_movement/README.md
+++ b/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/explicit_data_movement/README.md
@@ -5,7 +5,7 @@ An FPGA tutorial demonstrating an alternative coding style, SYCL* Unified Shared
 ---                                 |---
 | OS                                | Linux* Ubuntu* 18.04/20.04 <br> RHEL*/CentOS* 8 <br> SUSE* 15 <br> Windows* 10
 | Hardware                          | Intel&reg; Programmable Acceleration Card (PAC) with Intel Arria&reg; 10 GX FPGA <br> Intel&reg; FPGA Programmable Acceleration Card (PAC) D5005 (with Intel Stratix&reg; 10 SX) <br> Intel&reg; FPGA 3rd party / custom platforms with oneAPI support <br> **Note**: Intel&reg; FPGA PAC hardware is only compatible with Ubuntu 18.04*
-| Software                          | Intel&reg; oneAPI DPC++ Compiler
+| Software                          | Intel&reg; oneAPI SYCL Compiler
 | What you will learn               | How to explicitly manage the movement of data for the FPGA
 | Time to complete                  | 15 minutes
 

--- a/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/explicit_data_movement/src/CMakeLists.txt
+++ b/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/explicit_data_movement/src/CMakeLists.txt
@@ -51,7 +51,7 @@ add_custom_target(fpga_emu DEPENDS ${EMULATOR_TARGET})
 # To compile manually:
 #   icpx -fsycl -fintelfpga -Xshardware -Xstarget=<FPGA_DEVICE> -fsycl-link=early explicit_data_movement.cpp -o explicit_data_movement_report.a
 set(FPGA_EARLY_IMAGE ${TARGET_NAME}_report.a)
-# The compile output is not an executable, but an intermediate compilation result unique to DPC++.
+# The compile output is not an executable, but an intermediate compilation result unique to SYCL.
 add_executable(${FPGA_EARLY_IMAGE} ${SOURCE_FILE})
 target_include_directories(${FPGA_EARLY_IMAGE} PRIVATE ../../../../include)
 add_custom_target(report DEPENDS ${FPGA_EARLY_IMAGE})

--- a/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/explicit_data_movement/src/CMakeLists.txt
+++ b/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/explicit_data_movement/src/CMakeLists.txt
@@ -21,7 +21,7 @@ if(WIN32)
     set(WIN_FLAG "/EHsc")
 endif()
 
-# A DPC++ ahead-of-time (AoT) compile processes the device code in two stages.
+# A SYCL ahead-of-time (AoT) compile processes the device code in two stages.
 # 1. The "compile" stage compiles the device code to an intermediate representation (SPIR-V).
 # 2. The "link" stage invokes the compiler's FPGA backend before linking.
 #    For this reason, FPGA backend flags must be passed as link flags in CMake.

--- a/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/explicit_data_movement/src/CMakeLists.txt
+++ b/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/explicit_data_movement/src/CMakeLists.txt
@@ -1,6 +1,3 @@
-# To see a Makefile equivalent of this build system:
-# https://github.com/oneapi-src/oneAPI-samples/blob/master/DirectProgramming/DPC++/ProjectTemplates/makefile-fpga
-
 set(SOURCE_FILE explicit_data_movement.cpp)
 set(TARGET_NAME explicit_data_movement)
 set(EMULATOR_TARGET ${TARGET_NAME}.fpga_emu)

--- a/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/io_streaming/README.md
+++ b/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/io_streaming/README.md
@@ -5,7 +5,7 @@ An FPGA code sample describing how to use SYCL* IO pipes to stream data through 
 ---                                 |---
 | OS                                | Linux* Ubuntu* 18.04/20.04 <br> RHEL*/CentOS* 8 <br> SUSE* 15 <br> Windows* 10
 | Hardware                          | Intel&reg; Programmable Acceleration Card (PAC) with Intel Arria&reg; 10 GX FPGA <br> Intel&reg; FPGA Programmable Acceleration Card (PAC) D5005 (with Intel Stratix&reg; 10 SX) <br> Intel&reg; FPGA 3rd party / custom platforms with oneAPI support <br> *__Note__: Intel&reg; FPGA PAC hardware is only compatible with Ubuntu 18.04*
-| Software                          | Intel&reg; oneAPI DPC++ Compiler <br> Intel&reg; FPGA Add-On for oneAPI Base Toolkit
+| Software                          | Intel&reg; oneAPI SYCL Compiler <br> Intel&reg; FPGA Add-On for oneAPI Base Toolkit
 | What you will learn               | How to stream data through the FPGA's IO using IO pipes.
 | Time to complete                  | 30 minutes
 

--- a/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/io_streaming/sample.json
+++ b/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/io_streaming/sample.json
@@ -1,8 +1,8 @@
 {
   "guid": "5C68CD75-C11E-47A4-B6AA-B5B42CD0941C",
-  "name": "IO streaming with DPC++ IO pipes",
+  "name": "IO streaming with SYCL IO pipes",
   "categories": ["Toolkit/oneAPI Direct Programming/DPC++ FPGA/Tutorials/Design Patterns"],
-  "description": "An FPGA tutorial describing how to stream data to and from DPC++ IO pipes.",
+  "description": "An FPGA tutorial describing how to stream data to and from SYCL IO pipes.",
   "toolchain": ["icpx"],
   "os": ["linux", "windows"],
   "targetDevice": ["FPGA"],

--- a/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/io_streaming/src/CMakeLists.txt
+++ b/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/io_streaming/src/CMakeLists.txt
@@ -27,7 +27,7 @@ if(FPGA_DEVICE MATCHES ".usm.*")
   message(STATUS "USM host allocations are enabled")
 endif()
 
-# A DPC++ ahead-of-time (AoT) compile processes the device code in two stages.
+# A SYCL ahead-of-time (AoT) compile processes the device code in two stages.
 # 1. The "compile" stage compiles the device code to an intermediate representation (SPIR-V).
 # 2. The "link" stage invokes the compiler's FPGA backend before linking.
 #    For this reason, FPGA backend flags must be passed as link flags in CMake.

--- a/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/io_streaming/src/CMakeLists.txt
+++ b/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/io_streaming/src/CMakeLists.txt
@@ -1,6 +1,3 @@
-# To see a Makefile equivalent of this build system:
-# https://github.com/oneapi-src/oneAPI-samples/blob/master/DirectProgramming/DPC++/ProjectTemplates/makefile-fpga
-
 set(SOURCE_FILE io_streaming.cpp)
 set(TARGET_NAME io_streaming)
 set(EMULATOR_TARGET ${TARGET_NAME}.fpga_emu)

--- a/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/io_streaming/src/CMakeLists.txt
+++ b/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/io_streaming/src/CMakeLists.txt
@@ -57,7 +57,7 @@ add_custom_target(fpga_emu DEPENDS ${EMULATOR_TARGET})
 # To compile manually:
 #   icpx -fsycl -fintelfpga -Xshardware -Xstarget=<FPGA_DEVICE> -fsycl-link=early explicit_data_movement.cpp -o explicit_data_movement_report.a
 set(FPGA_EARLY_IMAGE ${TARGET_NAME}_report.a)
-# The compile output is not an executable, but an intermediate compilation result unique to DPC++.
+# The compile output is not an executable, but an intermediate compilation result unique to SYCL.
 add_executable(${FPGA_EARLY_IMAGE} ${SOURCE_FILE})
 target_include_directories(${FPGA_EARLY_IMAGE} PRIVATE ../../../../include)
 add_custom_target(report DEPENDS ${FPGA_EARLY_IMAGE})

--- a/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/loop_carried_dependency/README.md
+++ b/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/loop_carried_dependency/README.md
@@ -5,7 +5,7 @@ This tutorial demonstrates how to remove a loop-carried dependency to improve th
 ---                                 |---
 | OS                                | Linux* Ubuntu* 18.04/20.04 <br> RHEL*/CentOS* 8 <br> SUSE* 15 <br> Windows* 10
 | Hardware                          | Intel&reg; Programmable Acceleration Card (PAC) with Intel Arria&reg; 10 GX FPGA <br> Intel&reg; FPGA Programmable Acceleration Card (PAC) D5005 (with Intel Stratix&reg; 10 SX) <br> Intel&reg; FPGA 3rd party / custom platforms with oneAPI support <br> **Note**: Intel&reg; FPGA PAC hardware is only compatible with Ubuntu 18.04*
-| Software                          | Intel&reg; oneAPI DPC++ Compiler <br> Intel&reg; FPGA Add-On for oneAPI Base Toolkit
+| Software                          | Intel&reg; oneAPI SYCL Compiler <br> Intel&reg; FPGA Add-On for oneAPI Base Toolkit
 | What you will learn               | A technique to remove loop carried dependencies from your FPGA device code, and when to apply it.
 | Time to complete                  | 25 minutes
 

--- a/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/loop_carried_dependency/src/CMakeLists.txt
+++ b/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/loop_carried_dependency/src/CMakeLists.txt
@@ -1,6 +1,3 @@
-# To see a Makefile equivalent of this build system:
-# https://github.com/oneapi-src/oneAPI-samples/blob/master/DirectProgramming/DPC++/ProjectTemplates/makefile-fpga
-
 set(SOURCE_FILE loop_carried_dependency.cpp)
 set(TARGET_NAME loop_carried_dependency)
 set(EMULATOR_TARGET ${TARGET_NAME}.fpga_emu)

--- a/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/loop_carried_dependency/src/CMakeLists.txt
+++ b/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/loop_carried_dependency/src/CMakeLists.txt
@@ -22,7 +22,7 @@ if(WIN32)
     set(WIN_FLAG "/EHsc")
 endif()
 
-# A DPC++ ahead-of-time (AoT) compile processes the device code in two stages.
+# A SYCL ahead-of-time (AoT) compile processes the device code in two stages.
 # 1. The "compile" stage compiles the device code to an intermediate representation (SPIR-V).
 # 2. The "link" stage invokes the compiler's FPGA backend before linking.
 #    For this reason, FPGA backend flags must be passed as link flags in CMake.

--- a/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/loop_carried_dependency/src/CMakeLists.txt
+++ b/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/loop_carried_dependency/src/CMakeLists.txt
@@ -67,7 +67,7 @@ add_custom_target(fpga_sim DEPENDS ${SIMULATOR_TARGET})
 # To compile manually:
 #   icpx -fsycl -fintelfpga -Xshardware -Xstarget=<FPGA_DEVICE> -fsycl-link=early loop_carried_dependency.cpp -o loop_carried_dependency_report.a
 set(FPGA_EARLY_IMAGE ${TARGET_NAME}_report.a)
-# The compile output is not an executable, but an intermediate compilation result unique to DPC++.
+# The compile output is not an executable, but an intermediate compilation result unique to SYCL.
 add_executable(${FPGA_EARLY_IMAGE} ${SOURCE_FILE})
 target_include_directories(${FPGA_EARLY_IMAGE} PRIVATE ../../../../include)
 add_custom_target(report DEPENDS ${FPGA_EARLY_IMAGE})

--- a/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/n_way_buffering/README.md
+++ b/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/n_way_buffering/README.md
@@ -7,7 +7,7 @@ This FPGA tutorial demonstrates how to parallelize host-side processing and buff
 |:--                                |:--
 | OS                                | Linux* Ubuntu* 18.04/20.04 <br> RHEL*/CentOS* 8 <br> SUSE* 15 <br> Windows* 10
 | Hardware                          | Intel&reg; Programmable Acceleration Card (PAC) with Intel Arria&reg; 10 GX FPGA <br> Intel&reg; FPGA Programmable Acceleration Card (PAC) D5005 (with Intel Stratix&reg; 10 SX) <br> Intel&reg; FPGA 3rd party / custom platforms with oneAPI support <br> **Note**: Intel&reg; FPGA PAC hardware is only compatible with Ubuntu 18.04*
-| Software                          | Intel&reg; oneAPI DPC++ Compiler <br> Intel&reg; FPGA Add-On for oneAPI Base Toolkit
+| Software                          | Intel&reg; oneAPI SYCL Compiler <br> Intel&reg; FPGA Add-On for oneAPI Base Toolkit
 | What you will learn               | How and when to apply the N-way buffering optimization technique
 | Time to complete                  | 30 minutes
 

--- a/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/n_way_buffering/src/CMakeLists.txt
+++ b/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/n_way_buffering/src/CMakeLists.txt
@@ -57,7 +57,7 @@ add_custom_target(fpga_emu DEPENDS ${EMULATOR_TARGET})
 # To compile manually:
 #   icpx -fsycl -fintelfpga -lpthread -Xshardware -Xstarget=<FPGA_DEVICE> -fsycl-link=early n_way_buffering.cpp -o n_way_buffering_report.a
 set(FPGA_EARLY_IMAGE ${TARGET_NAME}_report.a)
-# The compile output is not an executable, but an intermediate compilation result unique to DPC++.
+# The compile output is not an executable, but an intermediate compilation result unique to SYCL.
 add_executable(${FPGA_EARLY_IMAGE} ${SOURCE_FILE})
 target_include_directories(${FPGA_EARLY_IMAGE} PRIVATE ../../../../include)
 add_custom_target(report DEPENDS ${FPGA_EARLY_IMAGE})

--- a/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/n_way_buffering/src/CMakeLists.txt
+++ b/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/n_way_buffering/src/CMakeLists.txt
@@ -26,7 +26,7 @@ if(NOT WIN32)
     set(THREAD_LIB "-lpthread")
 endif()
 
-# A DPC++ ahead-of-time (AoT) compile processes the device code in two stages.
+# A SYCL ahead-of-time (AoT) compile processes the device code in two stages.
 # 1. The "compile" stage compiles the device code to an intermediate representation (SPIR-V).
 # 2. The "link" stage invokes the compiler's FPGA backend before linking.
 #    For this reason, FPGA backend flags must be passed as link flags in CMake.

--- a/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/n_way_buffering/src/CMakeLists.txt
+++ b/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/n_way_buffering/src/CMakeLists.txt
@@ -1,5 +1,3 @@
-# To see a Makefile equivalent of this build system:
-# https://github.com/oneapi-src/oneAPI-samples/blob/master/DirectProgramming/DPC++/ProjectTemplates/makefile-fpga
 set(SOURCE_FILE n_way_buffering.cpp)
 set(TARGET_NAME n_way_buffering)
 set(EMULATOR_TARGET ${TARGET_NAME}.fpga_emu)

--- a/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/onchip_memory_cache/README.md
+++ b/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/onchip_memory_cache/README.md
@@ -5,7 +5,7 @@ This FPGA tutorial demonstrates how to build a simple cache (implemented in FPGA
 ---                                 |---
 | OS                                | Linux* Ubuntu* 18.04/20.04 <br> RHEL*/CentOS* 8 <br> SUSE* 15 <br> Windows* 10
 | Hardware                          | Intel&reg; Programmable Acceleration Card (PAC) with Intel Arria&reg; 10 GX FPGA <br> Intel&reg; FPGA Programmable Acceleration Card (PAC) D5005 (with Intel Stratix&reg; 10 SX) <br> Intel&reg; FPGA 3rd party / custom platforms with oneAPI support <br> **Note**: Intel&reg; FPGA PAC hardware is only compatible with Ubuntu 18.04*
-| Software                          | Intel&reg; oneAPI DPC++ Compiler <br> Intel&reg; FPGA Add-On for oneAPI Base Toolkit
+| Software                          | Intel&reg; oneAPI SYCL Compiler <br> Intel&reg; FPGA Add-On for oneAPI Base Toolkit
 | What you will learn               | How and when to implement the on-chip memory cache optimization
 | Time to complete                  | 30 minutes
 

--- a/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/onchip_memory_cache/src/CMakeLists.txt
+++ b/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/onchip_memory_cache/src/CMakeLists.txt
@@ -68,7 +68,7 @@ add_custom_target(fpga_emu DEPENDS ${EMULATOR_TARGET})
 # To compile manually:
 #   icpx -fsycl -fintelfpga -Xshardware -Xstarget=<FPGA_DEVICE> -fsycl-link=early onchip_memory_cache.cpp -o onchip_memory_cache_report.a
 set(FPGA_EARLY_IMAGE ${TARGET_NAME}_report.a)
-# The compile output is not an executable, but an intermediate compilation result unique to DPC++.
+# The compile output is not an executable, but an intermediate compilation result unique to SYCL.
 add_executable(${FPGA_EARLY_IMAGE} ${SOURCE_FILE})
 target_include_directories(${FPGA_EARLY_IMAGE} PRIVATE ../../../../include)
 target_include_directories(${FPGA_EARLY_IMAGE} PRIVATE ../../../../include)

--- a/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/onchip_memory_cache/src/CMakeLists.txt
+++ b/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/onchip_memory_cache/src/CMakeLists.txt
@@ -1,6 +1,3 @@
-# To see a Makefile equivalent of this build system:
-# https://github.com/oneapi-src/oneAPI-samples/blob/master/DirectProgramming/DPC++/ProjectTemplates/makefile-fpga
-
 set(SOURCE_FILE onchip_memory_cache.cpp)
 set(TARGET_NAME onchip_memory_cache)
 set(EMULATOR_TARGET ${TARGET_NAME}.fpga_emu)

--- a/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/onchip_memory_cache/src/CMakeLists.txt
+++ b/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/onchip_memory_cache/src/CMakeLists.txt
@@ -36,7 +36,7 @@ endif()
 set(CACHE_DEPTH_FLAG "-DMAX_CACHE_DEPTH=${MAX_CACHE_DEPTH} -DMIN_CACHE_DEPTH=${MIN_CACHE_DEPTH}")
 
 
-# A DPC++ ahead-of-time (AoT) compile processes the device code in two stages.
+# A SYCL ahead-of-time (AoT) compile processes the device code in two stages.
 # 1. The "compile" stage compiles the device code to an intermediate representation (SPIR-V).
 # 2. The "link" stage invokes the compiler's FPGA backend before linking.
 #    For this reason, FPGA backend flags must be passed as link flags in CMake.

--- a/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/optimize_inner_loop/README.md
+++ b/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/optimize_inner_loop/README.md
@@ -5,7 +5,7 @@ This FPGA tutorial discusses optimizing the throughput of an inner loop with a l
 ---                                 |---
 | OS                                | Linux* Ubuntu* 18.04/20.04 <br> RHEL*/CentOS* 8 <br> SUSE* 15 <br> Windows* 10
 | Hardware                          | Intel&reg; Programmable Acceleration Card (PAC) with Intel Arria&reg; 10 GX FPGA <br> Intel&reg; FPGA Programmable Acceleration Card (PAC) D5005 (with Intel Stratix&reg; 10 SX) <br> Intel&reg; FPGA 3rd party / custom platforms with oneAPI support <br> *__Note__: Intel&reg; FPGA PAC hardware is only compatible with Ubuntu 18.04*
-| Software                          | Intel&reg; oneAPI DPC++ Compiler
+| Software                          | Intel&reg; oneAPI SYCL Compiler
 | What you will learn               | How to optimize the throughput of an inner loop with a low trip.
 | Time to complete                  | 45 minutes
 

--- a/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/optimize_inner_loop/src/CMakeLists.txt
+++ b/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/optimize_inner_loop/src/CMakeLists.txt
@@ -1,6 +1,3 @@
-# To see a Makefile equivalent of this build system:
-# https://github.com/oneapi-src/oneAPI-samples/blob/master/DirectProgramming/DPC++/ProjectTemplates/makefile-fpga
-
 set(SOURCE_FILE optimize_inner_loop.cpp)
 set(TARGET_NAME optimize_inner_loop)
 set(EMULATOR_TARGET ${TARGET_NAME}.fpga_emu)

--- a/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/optimize_inner_loop/src/CMakeLists.txt
+++ b/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/optimize_inner_loop/src/CMakeLists.txt
@@ -68,7 +68,7 @@ add_custom_target(fpga_sim DEPENDS ${SIMULATOR_TARGET})
 # To compile manually:
 #   icpx -fsycl -fintelfpga -Xshardware -Xstarget=<FPGA_DEVICE> -fsycl-link=early optimize_inner_loop.cpp -o optimize_inner_loop_report.a
 set(FPGA_EARLY_IMAGE ${TARGET_NAME}_report.a)
-# The compile output is not an executable, but an intermediate compilation result unique to DPC++.
+# The compile output is not an executable, but an intermediate compilation result unique to SYCL.
 add_executable(${FPGA_EARLY_IMAGE} ${SOURCE_FILE})
 target_include_directories(${FPGA_EARLY_IMAGE} PRIVATE ../../../../include)
 add_custom_target(report DEPENDS ${FPGA_EARLY_IMAGE})

--- a/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/optimize_inner_loop/src/CMakeLists.txt
+++ b/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/optimize_inner_loop/src/CMakeLists.txt
@@ -22,7 +22,7 @@ if(WIN32)
     set(WIN_FLAG "/EHsc")
 endif()
 
-# A DPC++ ahead-of-time (AoT) compile processes the device code in two stages.
+# A SYCL ahead-of-time (AoT) compile processes the device code in two stages.
 # 1. The "compile" stage compiles the device code to an intermediate representation (SPIR-V).
 # 2. The "link" stage invokes the compiler's FPGA backend before linking.
 #    For this reason, FPGA backend flags must be passed as link flags in CMake.
@@ -52,10 +52,10 @@ add_custom_target(fpga_emu DEPENDS ${EMULATOR_TARGET})
 ### FPGA Simulator
 ###############################################################################
 # To compile in a single command:
-#    dpcpp -fintelfpga -Xssimulation -Xstarget=<FPGA_DEVICE> -DFPGA_SIMULATOR loop_carried_dependency.cpp -o loop_carried_dependency.fpga_sim
+#    icpx -fintelfpga -Xssimulation -Xstarget=<FPGA_DEVICE> -DFPGA_SIMULATOR loop_carried_dependency.cpp -o loop_carried_dependency.fpga_sim
 # CMake executes:
-#    [compile] dpcpp -fintelfpga -Xssimulation -DFPGA_SIMULATOR -o loop_carried_dependency.cpp.o -c loop_carried_dependency.cpp
-#    [link]    dpcpp -fintelfpga -Xssimulation -Xstarget=<FPGA_DEVICE> loop_carried_dependency.cpp.o -o loop_carried_dependency.fpga_sim
+#    [compile] icpx -fintelfpga -Xssimulation -DFPGA_SIMULATOR -o loop_carried_dependency.cpp.o -c loop_carried_dependency.cpp
+#    [link]    icpx -fintelfpga -Xssimulation -Xstarget=<FPGA_DEVICE> loop_carried_dependency.cpp.o -o loop_carried_dependency.fpga_sim
 add_executable(${SIMULATOR_TARGET} ${SOURCE_FILE})
 target_include_directories(${SIMULATOR_TARGET} PRIVATE ../../../../include)
 set_target_properties(${SIMULATOR_TARGET} PROPERTIES COMPILE_FLAGS "${SIMULATOR_COMPILE_FLAGS}")

--- a/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/pipe_array/README.md
+++ b/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/pipe_array/README.md
@@ -6,7 +6,7 @@ This FPGA tutorial showcases a design pattern that makes it possible to create a
 ---                                 |---
 | OS                                | Linux* Ubuntu* 18.04/20.04 <br> RHEL*/CentOS* 8 <br> SUSE* 15 <br> Windows* 10
 | Hardware                          | Intel&reg; Programmable Acceleration Card (PAC) with Intel Arria&reg; 10 GX FPGA <br> Intel&reg; FPGA Programmable Acceleration Card (PAC) D5005 (with Intel Stratix&reg; 10 SX) <br> Intel&reg; FPGA 3rd party / custom platforms with oneAPI support <br> *__Note__: Intel&reg; FPGA PAC hardware is only compatible with Ubuntu 18.04*
-| Software                          | Intel&reg; oneAPI DPC++ Compiler <br> Intel&reg; FPGA Add-On for oneAPI Base Toolkit
+| Software                          | Intel&reg; oneAPI SYCL Compiler <br> Intel&reg; FPGA Add-On for oneAPI Base Toolkit
 | What you will learn               | A design pattern to generate an array of pipes using SYCL* <br> Static loop unrolling through template metaprogramming
 | Time to complete                  | 15 minutes
 

--- a/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/pipe_array/src/CMakeLists.txt
+++ b/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/pipe_array/src/CMakeLists.txt
@@ -1,6 +1,3 @@
-# To see a Makefile equivalent of this build system:
-# https://github.com/oneapi-src/oneAPI-samples/blob/master/DirectProgramming/DPC++/ProjectTemplates/makefile-fpga
-
 set(SOURCE_FILE pipe_array.cpp)
 set(TARGET_NAME pipe_array)
 set(EMULATOR_TARGET ${TARGET_NAME}.fpga_emu)

--- a/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/pipe_array/src/CMakeLists.txt
+++ b/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/pipe_array/src/CMakeLists.txt
@@ -21,7 +21,7 @@ if(WIN32)
     set(WIN_FLAG "/EHsc")
 endif()
 
-# A DPC++ ahead-of-time (AoT) compile processes the device code in two stages.
+# A SYCL ahead-of-time (AoT) compile processes the device code in two stages.
 # 1. The "compile" stage compiles the device code to an intermediate representation (SPIR-V).
 # 2. The "link" stage invokes the compiler's FPGA backend before linking.
 #    For this reason, FPGA backend flags must be passed as link flags in CMake.

--- a/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/pipe_array/src/CMakeLists.txt
+++ b/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/pipe_array/src/CMakeLists.txt
@@ -52,7 +52,7 @@ add_custom_target(fpga_emu DEPENDS ${EMULATOR_TARGET})
 # To compile manually:
 #   icpx -fsycl -fintelfpga -Xshardware -Xstarget=<FPGA_DEVICE> -fsycl-link=early pipe_array.cpp -o pipe_array_report.a
 set(FPGA_EARLY_IMAGE ${TARGET_NAME}_report.a)
-# The compile output is not an executable, but an intermediate compilation result unique to DPC++.
+# The compile output is not an executable, but an intermediate compilation result unique to SYCL.
 add_executable(${FPGA_EARLY_IMAGE} ${SOURCE_FILE})
 target_include_directories(${FPGA_EARLY_IMAGE} PRIVATE ../../../../include)
 target_include_directories(${FPGA_EARLY_IMAGE} PRIVATE ../../../../include)

--- a/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/shannonization/README.md
+++ b/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/shannonization/README.md
@@ -5,7 +5,7 @@ This tutorial describes the process of _Shannonization_ (named after [Claude Sha
 |:---                               |:---
 | OS                                | Linux* Ubuntu* 18.04/20.04 <br> RHEL*/CentOS* 8 <br> SUSE* 15 <br> Windows* 10
 | Hardware                          | Intel&reg; Programmable Acceleration Card (PAC) with Intel Arria&reg; 10 GX FPGA <br> Intel&reg; FPGA Programmable Acceleration Card (PAC) D5005 (with Intel Stratix&reg; 10 SX) <br> Intel&reg; FPGA 3rd party / custom platforms with oneAPI support <br> *__Note__: Intel&reg; FPGA PAC hardware is only compatible with Ubuntu 18.04*
-| Software                          | Intel&reg; oneAPI DPC++ Compiler
+| Software                          | Intel&reg; oneAPI SYCL Compiler
 | What you will learn               | How to make FPGA-specific optimizations to remove computation from the critical path and improve f<sub>MAX</sub>/II
 | Time to complete                  | 45 minutes
 

--- a/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/shannonization/src/CMakeLists.txt
+++ b/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/shannonization/src/CMakeLists.txt
@@ -35,7 +35,7 @@ if(WIN32)
     set(WIN_FLAG "/EHsc")
 endif()
 
-# A DPC++ ahead-of-time (AoT) compile processes the device code in two stages.
+# A SYCL ahead-of-time (AoT) compile processes the device code in two stages.
 # 1. The "compile" stage compiles the device code to an intermediate representation (SPIR-V).
 # 2. The "link" stage invokes the compiler's FPGA backend before linking.
 #    For this reason, FPGA backend flags must be passed as link flags in CMake.

--- a/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/shannonization/src/CMakeLists.txt
+++ b/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/shannonization/src/CMakeLists.txt
@@ -70,7 +70,7 @@ add_custom_target(fpga_emu DEPENDS ${EMULATOR_TARGET})
 # To compile manually:
 #   icpx -fsycl -fintelfpga -Xshardware -Xstarget=<FPGA_DEVICE> -fsycl-link=early shannonization.cpp -o shannonization_report.a
 set(FPGA_EARLY_IMAGE ${TARGET_NAME}_report.a)
-# The compile output is not an executable, but an intermediate compilation result unique to DPC++.
+# The compile output is not an executable, but an intermediate compilation result unique to SYCL.
 add_executable(${FPGA_EARLY_IMAGE} ${SOURCE_FILE})
 target_include_directories(${FPGA_EARLY_IMAGE} PRIVATE ../../../../include)
 add_custom_target(report DEPENDS ${FPGA_EARLY_IMAGE})

--- a/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/shannonization/src/CMakeLists.txt
+++ b/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/shannonization/src/CMakeLists.txt
@@ -1,6 +1,3 @@
-# To see a Makefile equivalent of this build system:
-# https://github.com/oneapi-src/oneAPI-samples/blob/master/DirectProgramming/DPC++/ProjectTemplates/makefile-fpga
-
 set(SOURCE_FILE shannonization.cpp)
 set(TARGET_NAME shannonization)
 set(EMULATOR_TARGET ${TARGET_NAME}.fpga_emu)

--- a/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/simple_host_streaming/README.md
+++ b/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/simple_host_streaming/README.md
@@ -6,7 +6,7 @@ This tutorial demonstrates how to use SYCL* Universal Shared Memory (USM) to str
 ---                                 |---
 | OS                                | Linux* Ubuntu* 18.04/20.04 <br> RHEL*/CentOS* 8 <br> SUSE* 15 <br> Windows* 10
 | Hardware                          | Intel&reg; FPGA Programmable Acceleration Card (PAC) D5005 (with Intel Stratix&reg; 10 SX) <br> Intel&reg; FPGA 3rd party / custom platforms with oneAPI support (and SYCL USM support) <br> **Note**: Intel&reg; FPGA PAC hardware is only compatible with Ubuntu 18.04*
-| Software                          | Intel&reg; oneAPI DPC++ Compiler
+| Software                          | Intel&reg; oneAPI SYCL Compiler
 | What you will learn               | How to achieve low-latency host-device streaming while maintaining throughput
 | Time to complete                  | 45 minutes
 

--- a/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/simple_host_streaming/src/CMakeLists.txt
+++ b/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/simple_host_streaming/src/CMakeLists.txt
@@ -33,7 +33,7 @@ if(WIN32)
     set(WIN_FLAG "/EHsc")
 endif()
 
-# A DPC++ ahead-of-time (AoT) compile processes the device code in two stages.
+# A SYCL ahead-of-time (AoT) compile processes the device code in two stages.
 # 1. The "compile" stage compiles the device code to an intermediate representation (SPIR-V).
 # 2. The "link" stage invokes the compiler's FPGA backend before linking.
 #    For this reason, FPGA backend flags must be passed as link flags in CMake.

--- a/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/simple_host_streaming/src/CMakeLists.txt
+++ b/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/simple_host_streaming/src/CMakeLists.txt
@@ -1,6 +1,3 @@
-# To see a Makefile equivalent of this build system:
-# https://github.com/oneapi-src/oneAPI-samples/blob/master/DirectProgramming/DPC++/ProjectTemplates/makefile-fpga
-
 set(SOURCE_FILE simple_host_streaming.cpp)
 set(TARGET_NAME simple_host_streaming)
 set(EMULATOR_TARGET ${TARGET_NAME}.fpga_emu)

--- a/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/simple_host_streaming/src/CMakeLists.txt
+++ b/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/simple_host_streaming/src/CMakeLists.txt
@@ -63,7 +63,7 @@ add_custom_target(fpga_emu DEPENDS ${EMULATOR_TARGET})
 # To compile manually:
 #   icpx -fsycl -fintelfpga -Xshardware -Xshyper-optimized-handshaking=off -Xstarget=<FPGA_DEVICE> -fsycl-link=early simple_host_streaming.cpp -o simple_host_streaming_report.a
 set(FPGA_EARLY_IMAGE ${TARGET_NAME}_report.a)
-# The compile output is not an executable, but an intermediate compilation result unique to DPC++.
+# The compile output is not an executable, but an intermediate compilation result unique to SYCL.
 add_executable(${FPGA_EARLY_IMAGE} ${SOURCE_FILE})
 target_include_directories(${FPGA_EARLY_IMAGE} PRIVATE ../../../../include)
 add_custom_target(report DEPENDS ${FPGA_EARLY_IMAGE})

--- a/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/triangular_loop/README.md
+++ b/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/triangular_loop/README.md
@@ -7,7 +7,7 @@ This FPGA tutorial demonstrates an advanced technique to improve the performance
 |:---                               |:---
 | OS                                | Linux* Ubuntu* 18.04/20.04 <br> RHEL*/CentOS* 8 <br> SUSE* 15 <br> Windows* 10
 | Hardware                          | Intel&reg; Programmable Acceleration Card (PAC) with Intel Arria&reg; 10 GX FPGA <br> Intel&reg; FPGA Programmable Acceleration Card (PAC) D5005 (with Intel Stratix&reg; 10 SX) <br> Intel&reg; FPGA 3rd party / custom platforms with oneAPI support <br> **Note**: Intel&reg; FPGA PAC hardware is only compatible with Ubuntu 18.04*
-| Software                          | Intel&reg; oneAPI DPC++ Compiler <br> Intel&reg; FPGA Add-On for oneAPI Base Toolkit
+| Software                          | Intel&reg; oneAPI SYCL Compiler <br> Intel&reg; FPGA Add-On for oneAPI Base Toolkit
 | What you will learn               | How and when to apply the triangular loop optimization technique
 | Time to complete                  | 30 minutes
 

--- a/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/triangular_loop/src/CMakeLists.txt
+++ b/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/triangular_loop/src/CMakeLists.txt
@@ -67,7 +67,7 @@ add_custom_target(fpga_sim DEPENDS ${SIMULATOR_TARGET})
 # To compile manually:
 #   icpx -fsycl -fintelfpga -Xshardware -Xstarget=<FPGA_DEVICE> -fsycl-link=early triangular_loop.cpp -o triangular_loop_report.a
 set(FPGA_EARLY_IMAGE ${TARGET_NAME}_report.a)
-# The compile output is not an executable, but an intermediate compilation result unique to DPC++.
+# The compile output is not an executable, but an intermediate compilation result unique to SYCL.
 add_executable(${FPGA_EARLY_IMAGE} ${SOURCE_FILE})
 target_include_directories(${FPGA_EARLY_IMAGE} PRIVATE ../../../../include)
 add_custom_target(report DEPENDS ${FPGA_EARLY_IMAGE})

--- a/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/triangular_loop/src/CMakeLists.txt
+++ b/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/triangular_loop/src/CMakeLists.txt
@@ -22,7 +22,7 @@ if(WIN32)
     set(WIN_FLAG "/EHsc")
 endif()
 
-# A DPC++ ahead-of-time (AoT) compile processes the device code in two stages.
+# A SYCL ahead-of-time (AoT) compile processes the device code in two stages.
 # 1. The "compile" stage compiles the device code to an intermediate representation (SPIR-V).
 # 2. The "link" stage invokes the compiler's FPGA backend before linking.
 #    For this reason, FPGA backend flags must be passed as link flags in CMake.

--- a/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/triangular_loop/src/CMakeLists.txt
+++ b/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/triangular_loop/src/CMakeLists.txt
@@ -1,6 +1,3 @@
-# To see a Makefile equivalent of this build system:
-# https://github.com/oneapi-src/oneAPI-samples/blob/master/DirectProgramming/DPC++/ProjectTemplates/makefile-fpga
-
 set(SOURCE_FILE triangular_loop.cpp)
 set(TARGET_NAME triangular_loop)
 set(EMULATOR_TARGET ${TARGET_NAME}.fpga_emu)

--- a/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/zero_copy_data_transfer/README.md
+++ b/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/zero_copy_data_transfer/README.md
@@ -5,7 +5,7 @@ This tutorial demonstrates how to use zero-copy host memory via the SYCL Unified
 |:---                               |:---
 | OS                                | Linux* Ubuntu* 18.04/20.04 <br> RHEL*/CentOS* 8 <br> SUSE* 15 <br> Windows* 10
 | Hardware                          | Intel&reg; FPGA Programmable Acceleration Card (PAC) D5005 (with Intel Stratix&reg; 10 SX) <br> Intel&reg; FPGA 3rd party / custom platforms with oneAPI support (and SYCL USM support) <br> *__Note__: Intel&reg; FPGA PAC hardware is only compatible with Ubuntu 18.04*
-| Software                          | Intel&reg; oneAPI DPC++ Compiler
+| Software                          | Intel&reg; oneAPI SYCL Compiler
 | What you will learn               | How to use SYCL USM host allocations for the FPGA
 | Time to complete                  | 15 minutes
 

--- a/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/zero_copy_data_transfer/src/CMakeLists.txt
+++ b/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/zero_copy_data_transfer/src/CMakeLists.txt
@@ -33,7 +33,7 @@ if(WIN32)
     set(WIN_FLAG "/EHsc")
 endif()
 
-# A DPC++ ahead-of-time (AoT) compile processes the device code in two stages.
+# A SYCL ahead-of-time (AoT) compile processes the device code in two stages.
 # 1. The "compile" stage compiles the device code to an intermediate representation (SPIR-V).
 # 2. The "link" stage invokes the compiler's FPGA backend before linking.
 #    For this reason, FPGA backend flags must be passed as link flags in CMake.

--- a/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/zero_copy_data_transfer/src/CMakeLists.txt
+++ b/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/zero_copy_data_transfer/src/CMakeLists.txt
@@ -1,6 +1,3 @@
-# To see a Makefile equivalent of this build system:
-# https://github.com/oneapi-src/oneAPI-samples/blob/master/DirectProgramming/DPC++/ProjectTemplates/makefile-fpga
-
 set(SOURCE_FILE zero_copy_data_transfer.cpp)
 set(TARGET_NAME zero_copy_data_transfer)
 set(EMULATOR_TARGET ${TARGET_NAME}.fpga_emu)

--- a/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/zero_copy_data_transfer/src/CMakeLists.txt
+++ b/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/zero_copy_data_transfer/src/CMakeLists.txt
@@ -63,7 +63,7 @@ add_custom_target(fpga_emu DEPENDS ${EMULATOR_TARGET})
 # To compile manually:
 #   icpx -fsycl -fintelfpga -Xshardware -Xstarget=<FPGA_DEVICE> -fsycl-link=early zero_copy_data_transfer.cpp -o zero_copy_data_transfer_report.a
 set(FPGA_EARLY_IMAGE ${TARGET_NAME}_report.a)
-# The compile output is not an executable, but an intermediate compilation result unique to DPC++.
+# The compile output is not an executable, but an intermediate compilation result unique to SYCL.
 add_executable(${FPGA_EARLY_IMAGE} ${SOURCE_FILE})
 target_include_directories(${FPGA_EARLY_IMAGE} PRIVATE ../../../../include)
 add_custom_target(report DEPENDS ${FPGA_EARLY_IMAGE})

--- a/DirectProgramming/DPC++FPGA/Tutorials/Features/ac_fixed/README.md
+++ b/DirectProgramming/DPC++FPGA/Tutorials/Features/ac_fixed/README.md
@@ -6,7 +6,7 @@ This FPGA tutorial demonstrates how to use the Algorithmic C (AC) data type `ac_
 |:---                               |:---
 | OS                                | CentOS*Linux 8 <br> Red Hat* Enterprise Linux*8 <br> SUSE* Linux Enterprise Server 15 <br> Ubuntu*18.04 LTS <br> Ubuntu 20.04 <br>Windows* 10
 | Hardware                          | Intel&reg; Programmable Acceleration Card (PAC) with Intel Arria&reg; 10 GX FPGA <br>Intel&reg; FPGA Programmable Acceleration Card (PAC) D5005 (with Intel Stratix&reg; 10 SX) <br>Intel&reg; FPGA 3rd party / custom platforms with oneAPI support <br> **Note**: Intel&reg; FPGA PAC hardware is only compatible with Ubuntu 18.04*
-| Software                          | Intel&reg; oneAPI DPC++ Compiler <br>Intel&reg; FPGA Add-On for oneAPI Base Toolkit
+| Software                          | Intel&reg; oneAPI SYCL Compiler <br>Intel&reg; FPGA Add-On for oneAPI Base Toolkit
 | What you will learn               | How different methods of `ac_fixed` number construction affect hardware resource utilization <br>Recommended method for constructing `ac_fixed` numbers in your kernel <br>Accessing and using the `ac_fixed` math library functions <br>Trading off accuracy of results for reduced resource usage on the FPGA
 | Time to complete                  | 30 minutes
 

--- a/DirectProgramming/DPC++FPGA/Tutorials/Features/ac_fixed/src/CMakeLists.txt
+++ b/DirectProgramming/DPC++FPGA/Tutorials/Features/ac_fixed/src/CMakeLists.txt
@@ -1,6 +1,3 @@
-# To see a Makefile equivalent of this build system:
-# https://github.com/oneapi-src/oneAPI-samples/blob/master/DirectProgramming/DPC++/ProjectTemplates/makefile-fpga
-
 set(SOURCE_FILE ac_fixed.cpp)
 set(TARGET_NAME ac_fixed)
 set(EMULATOR_TARGET ${TARGET_NAME}.fpga_emu)

--- a/DirectProgramming/DPC++FPGA/Tutorials/Features/ac_fixed/src/CMakeLists.txt
+++ b/DirectProgramming/DPC++FPGA/Tutorials/Features/ac_fixed/src/CMakeLists.txt
@@ -59,7 +59,7 @@ add_custom_target(fpga_emu DEPENDS ${EMULATOR_TARGET})
 # To compile manually:
 #   icpx -fsycl -fintelfpga ${AC_TYPES_FLAG} -Xshardware -Xstarget=<FPGA_DEVICE> -fsycl-link=early ac_fixed.cpp -o ac_fixed_report.a
 set(FPGA_EARLY_IMAGE ${TARGET_NAME}_report.a)
-# The compile output is not an executable, but an intermediate compilation result unique to DPC++.
+# The compile output is not an executable, but an intermediate compilation result unique to SYCL.
 add_executable(${FPGA_EARLY_IMAGE} ${SOURCE_FILE})
 target_include_directories(${FPGA_EARLY_IMAGE} PRIVATE ../../../../include)
 add_custom_target(report DEPENDS ${FPGA_EARLY_IMAGE})

--- a/DirectProgramming/DPC++FPGA/Tutorials/Features/ac_fixed/src/CMakeLists.txt
+++ b/DirectProgramming/DPC++FPGA/Tutorials/Features/ac_fixed/src/CMakeLists.txt
@@ -27,7 +27,7 @@ else()
     set(AC_TYPES_FLAG "-qactypes")
 endif()
 
-# A DPC++ ahead-of-time (AoT) compile processes the device code in two stages.
+# A SYCL ahead-of-time (AoT) compile processes the device code in two stages.
 # 1. The "compile" stage compiles the device code to an intermediate representation (SPIR-V).
 # 2. The "link" stage invokes the compiler's FPGA backend before linking.
 #    For this reason, FPGA backend flags must be passed as link flags in CMake.

--- a/DirectProgramming/DPC++FPGA/Tutorials/Features/ac_int/README.md
+++ b/DirectProgramming/DPC++FPGA/Tutorials/Features/ac_int/README.md
@@ -6,7 +6,7 @@ This FPGA tutorial demonstrates how to use the Algorithmic C (AC) data type `ac_
 |:---                               |:---
 | OS                                | Linux* Ubuntu* 18.04/20.04 <br> RHEL*/CentOS* 8 <br> SUSE* 15 <br> Windows* 10
 | Hardware                          | Intel&reg; Programmable Acceleration Card (PAC) with Intel Arria&reg; 10 GX FPGA <br> Intel&reg; FPGA Programmable Acceleration Card (PAC) D5005 (with Intel Stratix&reg; 10 SX) <br> Intel&reg; FPGA 3rd party / custom platforms with oneAPI support <br> **Note**: Intel&reg; FPGA PAC hardware is only compatible with Ubuntu 18.04*
-| Software                          | Intel&reg; oneAPI DPC++ Compiler <br> Intel&reg; FPGA Add-On for oneAPI Base Toolkit
+| Software                          | Intel&reg; oneAPI SYCL Compiler <br> Intel&reg; FPGA Add-On for oneAPI Base Toolkit
 | What you will learn               | Using the `ac_int` data type for basic operations <br> Efficiently using the left shift operation <br> Setting and reading certain bits of an `ac_int` number
 | Time to complete                  | 20 minutes
 

--- a/DirectProgramming/DPC++FPGA/Tutorials/Features/ac_int/src/CMakeLists.txt
+++ b/DirectProgramming/DPC++FPGA/Tutorials/Features/ac_int/src/CMakeLists.txt
@@ -27,7 +27,7 @@ else()
     set(AC_TYPES_FLAG "-qactypes")
 endif()
 
-# A DPC++ ahead-of-time (AoT) compile processes the device code in two stages.
+# A SYCL ahead-of-time (AoT) compile processes the device code in two stages.
 # 1. The "compile" stage compiles the device code to an intermediate representation (SPIR-V).
 # 2. The "link" stage invokes the compiler's FPGA backend before linking.
 #    For this reason, FPGA backend flags must be passed as link flags in CMake.

--- a/DirectProgramming/DPC++FPGA/Tutorials/Features/ac_int/src/CMakeLists.txt
+++ b/DirectProgramming/DPC++FPGA/Tutorials/Features/ac_int/src/CMakeLists.txt
@@ -62,7 +62,7 @@ add_custom_target(fpga_emu DEPENDS ${EMULATOR_TARGET})
 # To compile manually:
 #   icpx -fsycl -fintelfpga ${AC_TYPES_FLAG} -Xshardware -Xstarget=<FPGA_DEVICE> -fsycl-link=early ac_int.cpp -o ac_int_report.a
 set(FPGA_EARLY_IMAGE ${TARGET_NAME}_report.a)
-# The compile output is not an executable, but an intermediate compilation result unique to DPC++.
+# The compile output is not an executable, but an intermediate compilation result unique to SYCL.
 add_executable(${FPGA_EARLY_IMAGE} ${SOURCE_FILE})
 target_include_directories(${FPGA_EARLY_IMAGE} PRIVATE ../../../../include)
 add_custom_target(report DEPENDS ${FPGA_EARLY_IMAGE})

--- a/DirectProgramming/DPC++FPGA/Tutorials/Features/ac_int/src/CMakeLists.txt
+++ b/DirectProgramming/DPC++FPGA/Tutorials/Features/ac_int/src/CMakeLists.txt
@@ -1,6 +1,3 @@
-# To see a Makefile equivalent of this build system:
-# https://github.com/oneapi-src/oneAPI-samples/blob/master/DirectProgramming/DPC++/ProjectTemplates/makefile-fpga
-
 set(SOURCE_FILE ac_int.cpp)
 set(TARGET_NAME ac_int)
 set(EMULATOR_TARGET ${TARGET_NAME}.fpga_emu)

--- a/DirectProgramming/DPC++FPGA/Tutorials/Features/dsp_control/README.md
+++ b/DirectProgramming/DPC++FPGA/Tutorials/Features/dsp_control/README.md
@@ -6,7 +6,7 @@ This FPGA tutorial demonstrates how to set the implementation preference for cer
 |:---                                 |:---
 | OS                                | Linux* Ubuntu* 18.04/20.04 <br> RHEL*/CentOS* 8 <br> SUSE* 15 <br> Windows* 10
 | Hardware                          | Intel® Programmable Acceleration Card (PAC) with Intel Arria® 10 GX FPGA <br> Intel® FPGA Programmable Acceleration Card (PAC) D5005 (with Intel Stratix® 10 SX) <br> Intel® FPGA 3rd party / custom platforms with oneAPI support <br> **Note**: Intel® FPGA PAC hardware is only compatible with Ubuntu 18.04*
-| Software                          | Intel® oneAPI DPC++ Compiler <br> Intel® FPGA Add-On for oneAPI Base Toolkit
+| Software                          | Intel® oneAPI SYCL Compiler <br> Intel® FPGA Add-On for oneAPI Base Toolkit
 | What you will learn               |  How to apply global DSP control in command-line interface. <br> How to apply local DSP control in source code. <br> Scope of datatypes and math operations that support DSP control.
 | Time to complete                  | 15 minutes
 

--- a/DirectProgramming/DPC++FPGA/Tutorials/Features/dsp_control/src/CMakeLists.txt
+++ b/DirectProgramming/DPC++FPGA/Tutorials/Features/dsp_control/src/CMakeLists.txt
@@ -54,7 +54,7 @@ add_custom_target(fpga_emu DEPENDS ${EMULATOR_TARGET})
 # To compile manually:
 #   icpx -fsycl -fintelfpga -Xshardware -Xstarget=<FPGA_DEVICE> -fsycl-link=early -Xsdsp-mode=prefer-softlogic dsp_control.cpp -o dsp_control_report.a
 set(FPGA_EARLY_IMAGE ${TARGET_NAME}_report.a)
-# The compile output is not an executable, but an intermediate compilation result unique to DPC++.
+# The compile output is not an executable, but an intermediate compilation result unique to SYCL.
 add_executable(${FPGA_EARLY_IMAGE} ${SOURCE_FILE})
 target_include_directories(${FPGA_EARLY_IMAGE} PRIVATE ../../../../include)
 add_custom_target(report DEPENDS ${FPGA_EARLY_IMAGE})

--- a/DirectProgramming/DPC++FPGA/Tutorials/Features/dsp_control/src/CMakeLists.txt
+++ b/DirectProgramming/DPC++FPGA/Tutorials/Features/dsp_control/src/CMakeLists.txt
@@ -1,6 +1,3 @@
-# To see a Makefile equivalent of this build system:
-# https://github.com/oneapi-src/oneAPI-samples/blob/master/DirectProgramming/DPC++/ProjectTemplates/makefile-fpga
-
 set(SOURCE_FILE dsp_control.cpp)
 set(TARGET_NAME dsp_control)
 set(EMULATOR_TARGET ${TARGET_NAME}.fpga_emu)

--- a/DirectProgramming/DPC++FPGA/Tutorials/Features/dsp_control/src/CMakeLists.txt
+++ b/DirectProgramming/DPC++FPGA/Tutorials/Features/dsp_control/src/CMakeLists.txt
@@ -22,7 +22,7 @@ if(WIN32)
     set(WIN_FLAG "/EHsc")
 endif()
 
-# A DPC++ ahead-of-time (AoT) compile processes the device code in two stages.
+# A SYCL ahead-of-time (AoT) compile processes the device code in two stages.
 # 1. The "compile" stage compiles the device code to an intermediate representation (SPIR-V).
 # 2. The "link" stage invokes the compiler's FPGA backend before linking.
 #    For this reason, FPGA backend flags must be passed as link flags in CMake.

--- a/DirectProgramming/DPC++FPGA/Tutorials/Features/experimental/latency_control/README.md
+++ b/DirectProgramming/DPC++FPGA/Tutorials/Features/experimental/latency_control/README.md
@@ -6,7 +6,7 @@ This FPGA tutorial demonstrates how to set latency constraints to pipes and load
 |:---                                 |:---
 | OS                                | Linux* Ubuntu* 18.04/20.04 <br> RHEL*/CentOS* 8 <br> SUSE* 15 <br> Windows* 10
 | Hardware                          | Intel&reg; Programmable Acceleration Card (PAC) with Intel Arria&reg;10 GX FPGA <br> Intel&reg;FPGA Programmable Acceleration Card (PAC) D5005 (with Intel Stratix&reg;10 SX) <br> Intel&reg;FPGA 3rd party / custom platforms with oneAPI support <br> *__Note__: Intel&reg;FPGA PAC hardware is only compatible with Ubuntu 18.04*
-| Software                          | Intel&reg;oneAPI DPC++ Compiler <br> Intel&reg;FPGA Add-On for oneAPI Base Toolkit
+| Software                          | Intel&reg;oneAPI SYCL Compiler <br> Intel&reg;FPGA Add-On for oneAPI Base Toolkit
 | What you will learn               | How to set latency constraints to pipes and LSUs accesses.<br>How to confirm that the compiler respected the latency control directive.
 | Time to complete                  | 15 minutes
 

--- a/DirectProgramming/DPC++FPGA/Tutorials/Features/experimental/latency_control/src/CMakeLists.txt
+++ b/DirectProgramming/DPC++FPGA/Tutorials/Features/experimental/latency_control/src/CMakeLists.txt
@@ -1,6 +1,3 @@
-# To see a Makefile equivalent of this build system:
-# https://github.com/oneapi-src/oneAPI-samples/blob/master/DirectProgramming/DPC++/ProjectTemplates/makefile-fpga
-
 set(SOURCE_FILE latency_control.cpp)
 set(TARGET_NAME latency_control)
 set(EMULATOR_TARGET ${TARGET_NAME}.fpga_emu)

--- a/DirectProgramming/DPC++FPGA/Tutorials/Features/experimental/latency_control/src/CMakeLists.txt
+++ b/DirectProgramming/DPC++FPGA/Tutorials/Features/experimental/latency_control/src/CMakeLists.txt
@@ -30,7 +30,7 @@ else()
     set(HANDSHAKING "-Xshyper-optimized-handshaking=off")
 endif()
 
-# A DPC++ ahead-of-time (AoT) compile processes the device code in two stages.
+# A SYCL ahead-of-time (AoT) compile processes the device code in two stages.
 # 1. The "compile" stage compiles the device code to an intermediate representation (SPIR-V).
 # 2. The "link" stage invokes the compiler's FPGA backend before linking.
 #    For this reason, FPGA backend flags must be passed as link flags in CMake.

--- a/DirectProgramming/DPC++FPGA/Tutorials/Features/experimental/latency_control/src/CMakeLists.txt
+++ b/DirectProgramming/DPC++FPGA/Tutorials/Features/experimental/latency_control/src/CMakeLists.txt
@@ -62,7 +62,7 @@ add_custom_target(fpga_emu DEPENDS ${EMULATOR_TARGET})
 # To compile manually:
 #   icpx -fsycl -fintelfpga -Xshardware -Xstarget=<FPGA_DEVICE> -fsycl-link=early latency_control.cpp -o latency_control_report.a
 set(FPGA_EARLY_IMAGE ${TARGET_NAME}_report.a)
-# The compile output is not an executable, but an intermediate compilation result unique to DPC++.
+# The compile output is not an executable, but an intermediate compilation result unique to SYCL.
 add_executable(${FPGA_EARLY_IMAGE} ${SOURCE_FILE})
 target_include_directories(${FPGA_EARLY_IMAGE} PRIVATE ../../../../../include)
 add_custom_target(report DEPENDS ${FPGA_EARLY_IMAGE})

--- a/DirectProgramming/DPC++FPGA/Tutorials/Features/fpga_reg/README.md
+++ b/DirectProgramming/DPC++FPGA/Tutorials/Features/fpga_reg/README.md
@@ -8,7 +8,7 @@ This FPGA tutorial demonstrates how a power user can apply the SYCL*-compliant C
 ---                                 |---
 | OS                                | Linux* Ubuntu* 18.04/20.04 <br> RHEL*/CentOS* 8 <br> SUSE* 15 <br> Windows* 10
 | Hardware                          | Intel® Programmable Acceleration Card (PAC) with Intel Arria® 10 GX FPGA <br> Intel® FPGA 3rd party / custom platforms with oneAPI support <br> ***Note**: Intel® FPGA PAC hardware is only compatible with Ubuntu 18.04*
-| Software                          | Intel® oneAPI DPC++ Compiler <br> Intel® FPGA Add-On for oneAPI Base Toolkit
+| Software                          | Intel® oneAPI SYCL Compiler <br> Intel® FPGA Add-On for oneAPI Base Toolkit
 | What you will learn               | How to use the `ext::intel::fpga_reg` extension <br> How `ext::intel::fpga_reg` can be used to re-structure the compiler-generated hardware <br> Situations in which applying  `ext::intel::fpga_reg` might be beneficial
 | Time to complete                  | 20 minutes
 

--- a/DirectProgramming/DPC++FPGA/Tutorials/Features/fpga_reg/sample.json
+++ b/DirectProgramming/DPC++FPGA/Tutorials/Features/fpga_reg/sample.json
@@ -2,7 +2,7 @@
   "guid": "D661A5C2-5FE0-40F2-BFE7-70E3BA60F088",
   "name": "FPGA Reg",
   "categories": ["Toolkit/oneAPI Direct Programming/DPC++ FPGA/Tutorials/Features"],
-  "description": "An Intel® FPGA advanced tutorial demonstrating how to apply the Data Parallel C++ (DPC++) extension ext::intel::fpga_reg",
+  "description": "An Intel® FPGA advanced tutorial demonstrating how to apply the SYCL extension ext::intel::fpga_reg",
   "toolchain": ["icpx"],
   "os": ["linux", "windows"],
   "targetDevice": ["FPGA"],

--- a/DirectProgramming/DPC++FPGA/Tutorials/Features/fpga_reg/src/CMakeLists.txt
+++ b/DirectProgramming/DPC++FPGA/Tutorials/Features/fpga_reg/src/CMakeLists.txt
@@ -84,7 +84,6 @@ add_custom_target(fpga_sim DEPENDS ${SIMULATOR_TARGET} ${SIMULATOR_TARGET_REG})
 set_target_properties(${SIMULATOR_TARGET} PROPERTIES COMPILE_FLAGS "${SIMULATOR_COMPILE_FLAGS}")
 set_target_properties(${SIMULATOR_TARGET} PROPERTIES LINK_FLAGS "${SIMULATOR_LINK_FLAGS} -reuse-exe=${CMAKE_BINARY_DIR}/${SIMULATOR_TARGET}")
 # The -reuse-exe flag enables rapid recompilation of host-only code changes.
-# See DPC++FPGA/GettingStarted/fast_recompile for details.
 set_target_properties(${SIMULATOR_TARGET_REG} PROPERTIES COMPILE_FLAGS "${SIMULATOR_COMPILE_FLAGS} -DUSE_FPGA_REG")
 set_target_properties(${SIMULATOR_TARGET_REG} PROPERTIES LINK_FLAGS "${SIMULATOR_LINK_FLAGS} -reuse-exe=${CMAKE_BINARY_DIR}/${SIMULATOR_TARGET_REG}")
 
@@ -104,6 +103,5 @@ add_custom_target(fpga DEPENDS ${FPGA_TARGET} ${FPGA_TARGET_REG})
 set_target_properties(${FPGA_TARGET} PROPERTIES COMPILE_FLAGS "${HARDWARE_COMPILE_FLAGS}")
 set_target_properties(${FPGA_TARGET} PROPERTIES LINK_FLAGS "${HARDWARE_LINK_FLAGS} -reuse-exe=${CMAKE_BINARY_DIR}/${FPGA_TARGET}")
 # The -reuse-exe flag enables rapid recompilation of host-only code changes.
-# See DPC++FPGA/GettingStarted/fast_recompile for details.
 set_target_properties(${FPGA_TARGET_REG} PROPERTIES COMPILE_FLAGS "${HARDWARE_COMPILE_FLAGS} -DUSE_FPGA_REG")
 set_target_properties(${FPGA_TARGET_REG} PROPERTIES LINK_FLAGS "${HARDWARE_LINK_FLAGS} -reuse-exe=${CMAKE_BINARY_DIR}/${FPGA_TARGET_REG}")

--- a/DirectProgramming/DPC++FPGA/Tutorials/Features/fpga_reg/src/CMakeLists.txt
+++ b/DirectProgramming/DPC++FPGA/Tutorials/Features/fpga_reg/src/CMakeLists.txt
@@ -25,7 +25,7 @@ if(WIN32)
     set(WIN_FLAG "/EHsc")
 endif()
 
-# A DPC++ ahead-of-time (AoT) compile processes the device code in two stages.
+# A SYCL ahead-of-time (AoT) compile processes the device code in two stages.
 # 1. The "compile" stage compiles the device code to an intermediate representation (SPIR-V).
 # 2. The "link" stage invokes the compiler's FPGA backend before linking.
 #    For this reason, FPGA backend flags must be passed as link flags in CMake.

--- a/DirectProgramming/DPC++FPGA/Tutorials/Features/fpga_reg/src/CMakeLists.txt
+++ b/DirectProgramming/DPC++FPGA/Tutorials/Features/fpga_reg/src/CMakeLists.txt
@@ -1,6 +1,3 @@
-# To see a Makefile equivalent of this build system:
-# https://github.com/oneapi-src/oneAPI-samples/blob/master/DirectProgramming/DPC++/ProjectTemplates/makefile-fpga
-
 set(SOURCE_FILE fpga_reg.cpp)
 set(TARGET_NAME fpga_reg)
 set(TARGET_NAME_REG fpga_reg_registered)

--- a/DirectProgramming/DPC++FPGA/Tutorials/Features/fpga_reg/src/CMakeLists.txt
+++ b/DirectProgramming/DPC++FPGA/Tutorials/Features/fpga_reg/src/CMakeLists.txt
@@ -58,7 +58,7 @@ add_custom_target(fpga_emu DEPENDS ${EMULATOR_TARGET})
 #   icpx -fsycl -fintelfpga -Xshardware -Xstarget=<FPGA_DEVICE> -fsycl-link=early fpga_reg.cpp -o fpga_reg_report.a
 set(FPGA_EARLY_IMAGE ${TARGET_NAME}_report.a)
 set(FPGA_EARLY_IMAGE_REG ${TARGET_NAME_REG}_report.a)
-# The compile output is not an executable, but an intermediate compilation result unique to DPC++.
+# The compile output is not an executable, but an intermediate compilation result unique to SYCL.
 add_executable(${FPGA_EARLY_IMAGE} ${SOURCE_FILE})
 target_include_directories(${FPGA_EARLY_IMAGE} PRIVATE ../../../../include)
 add_executable(${FPGA_EARLY_IMAGE_REG} ${SOURCE_FILE})

--- a/DirectProgramming/DPC++FPGA/Tutorials/Features/fpga_reg/src/fpga_reg.cpp
+++ b/DirectProgramming/DPC++FPGA/Tutorials/Features/fpga_reg/src/fpga_reg.cpp
@@ -107,7 +107,7 @@ void RunKernel(const std::vector<int> &vec_a,
 
           // Fully unroll the accumulator loop.
           // All of the unrolled operations can be freely scheduled by the
-          // oneAPI DPC++ Compiler's FPGA backend as part of a common data pipeline.
+          // oneAPI SYCL Compiler's FPGA backend as part of a common data pipeline.
           #pragma unroll
           for (size_t j = 0; j < kSize; j++) {
 #ifdef USE_FPGA_REG
@@ -134,7 +134,7 @@ void RunKernel(const std::vector<int> &vec_a,
 
           // Rotate the values of the coefficient array.
           // The loop is fully unrolled. This is a canonical code structure;
-          // the oneAPI DPC++ Compiler's FPGA backend infers a shift register here.
+          // the oneAPI SYCL Compiler's FPGA backend infers a shift register here.
           int tmp = coeff[0];
           #pragma unroll
           for (size_t j = 0; j < kSize - 1; j++) {

--- a/DirectProgramming/DPC++FPGA/Tutorials/Features/kernel_args_restrict/README.md
+++ b/DirectProgramming/DPC++FPGA/Tutorials/Features/kernel_args_restrict/README.md
@@ -6,7 +6,7 @@ This tutorial explains the  `kernel_args_restrict` attribute and its effect on t
 |:---                               |:---
 | OS                                | Linux* Ubuntu* 18.04/20.04 <br> RHEL*/CentOS* 8 <br> SUSE* 15 <br> Windows* 10
 | Hardware                          | Intel&reg; Programmable Acceleration Card (PAC) with Intel Arria&reg; 10 GX FPGA <br> Intel&reg; FPGA Programmable Acceleration Card (PAC) D5005 (with Intel Stratix&reg; 10 SX) <br> Intel&reg; FPGA 3rd party / custom platforms with oneAPI support <br> **Note**: Intel&reg; FPGA PAC hardware is only compatible with Ubuntu 18.04*
-| Software                          | Intel&reg; oneAPI DPC++ Compiler <br> Intel&reg; FPGA Add-On for oneAPI Base Toolkit
+| Software                          | Intel&reg; oneAPI SYCL Compiler <br> Intel&reg; FPGA Add-On for oneAPI Base Toolkit
 | What you will learn               |  The problem of *pointer aliasing* and its impact on compiler optimizations. <br> The behavior of the `kernel_args_restrict` attribute and when to use it on your kernel. <br> The effect this attribute can have on your kernel's performance on FPGA.
 | Time to complete                  | 20 minutes
 

--- a/DirectProgramming/DPC++FPGA/Tutorials/Features/kernel_args_restrict/src/CMakeLists.txt
+++ b/DirectProgramming/DPC++FPGA/Tutorials/Features/kernel_args_restrict/src/CMakeLists.txt
@@ -1,6 +1,3 @@
-# To see a Makefile equivalent of this build system:
-# https://github.com/oneapi-src/oneAPI-samples/blob/master/DirectProgramming/DPC++/ProjectTemplates/makefile-fpga
-
 set(SOURCE_FILE kernel_args_restrict.cpp)
 set(TARGET_NAME kernel_args_restrict)
 set(EMULATOR_TARGET ${TARGET_NAME}.fpga_emu)
@@ -76,7 +73,6 @@ add_custom_target(fpga_sim DEPENDS ${SIMULATOR_TARGET})
 set_target_properties(${SIMULATOR_TARGET} PROPERTIES COMPILE_FLAGS "${SIMULATOR_COMPILE_FLAGS}")
 set_target_properties(${SIMULATOR_TARGET} PROPERTIES LINK_FLAGS "${SIMULATOR_LINK_FLAGS} -reuse-exe=${CMAKE_BINARY_DIR}/${SIMULATOR_TARGET}")
 # The -reuse-exe flag enables rapid recompilation of host-only code changes.
-# See DPC++FPGA/GettingStarted/fast_recompile for details.
 
 ###############################################################################
 ### FPGA Hardware
@@ -92,4 +88,3 @@ add_custom_target(fpga DEPENDS ${FPGA_TARGET})
 set_target_properties(${FPGA_TARGET} PROPERTIES COMPILE_FLAGS "${HARDWARE_COMPILE_FLAGS}")
 set_target_properties(${FPGA_TARGET} PROPERTIES LINK_FLAGS "${HARDWARE_LINK_FLAGS} -reuse-exe=${CMAKE_BINARY_DIR}/${FPGA_TARGET}")
 # The -reuse-exe flag enables rapid recompilation of host-only code changes.
-# See DPC++FPGA/GettingStarted/fast_recompile for details.

--- a/DirectProgramming/DPC++FPGA/Tutorials/Features/kernel_args_restrict/src/CMakeLists.txt
+++ b/DirectProgramming/DPC++FPGA/Tutorials/Features/kernel_args_restrict/src/CMakeLists.txt
@@ -54,7 +54,7 @@ add_custom_target(fpga_emu DEPENDS ${EMULATOR_TARGET})
 # To compile manually:
 #   icpx -fsycl -fintelfpga -Xshardware -Xstarget=<FPGA_DEVICE> -fsycl-link=early kernel_args_restrict.cpp -o kernel_args_restrict_report.a
 set(FPGA_EARLY_IMAGE ${TARGET_NAME}_report.a)
-# The compile output is not an executable, but an intermediate compilation result unique to DPC++.
+# The compile output is not an executable, but an intermediate compilation result unique to SYCL.
 add_executable(${FPGA_EARLY_IMAGE} ${SOURCE_FILE})
 target_include_directories(${FPGA_EARLY_IMAGE} PRIVATE ../../../../include)
 add_custom_target(report DEPENDS ${FPGA_EARLY_IMAGE})

--- a/DirectProgramming/DPC++FPGA/Tutorials/Features/kernel_args_restrict/src/CMakeLists.txt
+++ b/DirectProgramming/DPC++FPGA/Tutorials/Features/kernel_args_restrict/src/CMakeLists.txt
@@ -22,7 +22,7 @@ if(WIN32)
     set(WIN_FLAG "/EHsc")
 endif()
 
-# A DPC++ ahead-of-time (AoT) compile processes the device code in two stages.
+# A SYCL ahead-of-time (AoT) compile processes the device code in two stages.
 # 1. The "compile" stage compiles the device code to an intermediate representation (SPIR-V).
 # 2. The "link" stage invokes the compiler's FPGA backend before linking.
 #    For this reason, FPGA backend flags must be passed as link flags in CMake.

--- a/DirectProgramming/DPC++FPGA/Tutorials/Features/loop_coalesce/README.md
+++ b/DirectProgramming/DPC++FPGA/Tutorials/Features/loop_coalesce/README.md
@@ -6,7 +6,7 @@ This FPGA tutorial demonstrates applying the `loop_coalesce` attribute to a nest
 ---                                 |---
 | OS                                | Linux* Ubuntu* 18.04/20.04 <br> RHEL*/CentOS* 8 <br> SUSE* 15 <br> Windows* 10
 | Hardware                          | Intel&reg; Programmable Acceleration Card (PAC) with Intel Arria&reg; 10 GX FPGA <br> Intel&reg; FPGA Programmable Acceleration Card (PAC) D5005 (with Intel Stratix&reg; 10 SX) <br> Intel&reg; FPGA 3rd party / custom platforms with oneAPI support <br> *__Note__: Intel&reg; FPGA PAC hardware is only compatible with Ubuntu 18.04*
-| Software                          | Intel&reg; oneAPI DPC++ Compiler <br> Intel&reg; FPGA Add-On for oneAPI Base Toolkit
+| Software                          | Intel&reg; oneAPI SYCL Compiler <br> Intel&reg; FPGA Add-On for oneAPI Base Toolkit
 | What you will learn               |  What the `loop_coalesce` attribute does <br> How `loop_coalesce` attribute affects resource usage and loop throughput <br> How to apply the `loop_coalesce` attribute to loops in your program <br> Which loops make good candidates for coalescing
 | Time to complete                  | 15 minutes
 

--- a/DirectProgramming/DPC++FPGA/Tutorials/Features/loop_coalesce/src/CMakeLists.txt
+++ b/DirectProgramming/DPC++FPGA/Tutorials/Features/loop_coalesce/src/CMakeLists.txt
@@ -54,7 +54,7 @@ add_custom_target(fpga_emu DEPENDS ${EMULATOR_TARGET})
 # To compile manually:
 #   icpx -fsycl -fintelfpga -Xshardware -Xstarget=<FPGA_DEVICE> -fsycl-link=early loop_coalesce.cpp -o loop_coalesce_report.a
 set(FPGA_EARLY_IMAGE ${TARGET_NAME}_report.a)
-# The compile output is not an executable, but an intermediate compilation result unique to DPC++.
+# The compile output is not an executable, but an intermediate compilation result unique to SYCL.
 add_executable(${FPGA_EARLY_IMAGE} ${SOURCE_FILE})
 target_include_directories(${FPGA_EARLY_IMAGE} PRIVATE ../../../../include)
 add_custom_target(report DEPENDS ${FPGA_EARLY_IMAGE})

--- a/DirectProgramming/DPC++FPGA/Tutorials/Features/loop_coalesce/src/CMakeLists.txt
+++ b/DirectProgramming/DPC++FPGA/Tutorials/Features/loop_coalesce/src/CMakeLists.txt
@@ -22,7 +22,7 @@ if(WIN32)
     set(WIN_FLAG "/EHsc")
 endif()
 
-# A DPC++ ahead-of-time (AoT) compile processes the device code in two stages.
+# A SYCL ahead-of-time (AoT) compile processes the device code in two stages.
 # 1. The "compile" stage compiles the device code to an intermediate representation (SPIR-V).
 # 2. The "link" stage invokes the compiler's FPGA backend before linking.
 #    For this reason, FPGA backend flags must be passed as link flags in CMake.

--- a/DirectProgramming/DPC++FPGA/Tutorials/Features/loop_coalesce/src/CMakeLists.txt
+++ b/DirectProgramming/DPC++FPGA/Tutorials/Features/loop_coalesce/src/CMakeLists.txt
@@ -1,6 +1,3 @@
-# To see a Makefile equivalent of this build system:
-# https://github.com/oneapi-src/oneAPI-samples/blob/master/DirectProgramming/DPC++/ProjectTemplates/makefile-fpga
-
 set(SOURCE_FILE loop_coalesce.cpp)
 set(TARGET_NAME loop_coalesce)
 set(EMULATOR_TARGET ${TARGET_NAME}.fpga_emu)

--- a/DirectProgramming/DPC++FPGA/Tutorials/Features/loop_fusion/README.md
+++ b/DirectProgramming/DPC++FPGA/Tutorials/Features/loop_fusion/README.md
@@ -5,7 +5,7 @@ This FPGA tutorial demonstrates how loop fusion is used and how it affects perfo
 |:---                               |:---
 | OS                                | Linux* Ubuntu* 18.04/20.04, RHEL*/CentOS* 8, SUSE* 15; Windows* 10
 | Hardware                          | Intel&reg; Programmable Acceleration Card (PAC) with Intel Arria&reg; 10 GX FPGA <br> Intel&reg; FPGA Programmable Acceleration Card (PAC) D5005 (with Intel Stratix&reg; 10 SX) <br> Intel&reg; FPGA 3rd party / custom platforms with oneAPI support <br> *__Note__: Intel&reg; FPGA PAC hardware is only compatible with Ubuntu 18.04*
-| Software                          | Intel&reg; oneAPI DPC++ Compiler <br> Intel&reg; FPGA Add-On for oneAPI Base Toolkit
+| Software                          | Intel&reg; oneAPI SYCL Compiler <br> Intel&reg; FPGA Add-On for oneAPI Base Toolkit
 | What you will learn               |  Basics of loop fusion<br/>The reasons for loop fusion<br/>How to use loop fusion to increase performance<br/>Understanding safe application of loop fusion
 | Time to complete                  | 20 minutes
 

--- a/DirectProgramming/DPC++FPGA/Tutorials/Features/loop_fusion/src/CMakeLists.txt
+++ b/DirectProgramming/DPC++FPGA/Tutorials/Features/loop_fusion/src/CMakeLists.txt
@@ -1,6 +1,3 @@
-# To see a Makefile equivalent of this build system:
-# https://github.com/oneapi-src/oneAPI-samples/blob/master/DirectProgramming/DPC++/ProjectTemplates/makefile-fpga
-
 set(SOURCE_FILE loop_fusion.cpp)
 set(TARGET_NAME loop_fusion)
 set(EMULATOR_TARGET ${TARGET_NAME}.fpga_emu)

--- a/DirectProgramming/DPC++FPGA/Tutorials/Features/loop_fusion/src/CMakeLists.txt
+++ b/DirectProgramming/DPC++FPGA/Tutorials/Features/loop_fusion/src/CMakeLists.txt
@@ -22,7 +22,7 @@ if(WIN32)
     set(WIN_FLAG "/EHsc")
 endif()
 
-# A DPC++ ahead-of-time (AoT) compile processes the device code in two stages.
+# A SYCL ahead-of-time (AoT) compile processes the device code in two stages.
 # 1. The "compile" stage compiles the device code to an intermediate representation (SPIR-V).
 # 2. The "link" stage invokes the compiler's FPGA backend before linking.
 #    For this reason, FPGA backend flags must be passed as link flags in CMake.
@@ -52,10 +52,10 @@ add_custom_target(fpga_emu DEPENDS ${EMULATOR_TARGET})
 ### FPGA Simulator
 ###############################################################################
 # To compile in a single command:
-#    dpcpp -fintelfpga -Xssimulation -Xstarget=<FPGA_DEVICE> -DFPGA_SIMULATOR loop_carried_dependency.cpp -o loop_carried_dependency.fpga_sim
+#    icpx -fintelfpga -Xssimulation -Xstarget=<FPGA_DEVICE> -DFPGA_SIMULATOR loop_carried_dependency.cpp -o loop_carried_dependency.fpga_sim
 # CMake executes:
-#    [compile] dpcpp -fintelfpga -Xssimulation -DFPGA_SIMULATOR -o loop_carried_dependency.cpp.o -c loop_carried_dependency.cpp
-#    [link]    dpcpp -fintelfpga -Xssimulation -Xstarget=<FPGA_DEVICE> loop_carried_dependency.cpp.o -o loop_carried_dependency.fpga_sim
+#    [compile] icpx -fintelfpga -Xssimulation -DFPGA_SIMULATOR -o loop_carried_dependency.cpp.o -c loop_carried_dependency.cpp
+#    [link]    icpx -fintelfpga -Xssimulation -Xstarget=<FPGA_DEVICE> loop_carried_dependency.cpp.o -o loop_carried_dependency.fpga_sim
 add_executable(${SIMULATOR_TARGET} ${SOURCE_FILE})
 target_include_directories(${SIMULATOR_TARGET} PRIVATE ../../../../include)
 set_target_properties(${SIMULATOR_TARGET} PROPERTIES COMPILE_FLAGS "${SIMULATOR_COMPILE_FLAGS}")

--- a/DirectProgramming/DPC++FPGA/Tutorials/Features/loop_fusion/src/CMakeLists.txt
+++ b/DirectProgramming/DPC++FPGA/Tutorials/Features/loop_fusion/src/CMakeLists.txt
@@ -68,7 +68,7 @@ add_custom_target(fpga_sim DEPENDS ${SIMULATOR_TARGET})
 # To compile manually:
 #   icpx -fsycl -fintelfpga -Xshardware -Xstarget=<FPGA_DEVICE> -fsycl-link=early loop_fusion.cpp -o loop_fusion_report.a
 set(FPGA_EARLY_IMAGE ${TARGET_NAME}_report.a)
-# The compile output is not an executable, but an intermediate compilation result unique to DPC++.
+# The compile output is not an executable, but an intermediate compilation result unique to SYCL.
 add_executable(${FPGA_EARLY_IMAGE} ${SOURCE_FILE})
 target_include_directories(${FPGA_EARLY_IMAGE} PRIVATE ../../../../include)
 add_custom_target(report DEPENDS ${FPGA_EARLY_IMAGE})

--- a/DirectProgramming/DPC++FPGA/Tutorials/Features/loop_initiation_interval/README.md
+++ b/DirectProgramming/DPC++FPGA/Tutorials/Features/loop_initiation_interval/README.md
@@ -6,7 +6,7 @@ This FPGA tutorial demonstrates how a user can use the `intel::initiation_interv
 |:---                               |:---
 | OS                                | Linux* Ubuntu* 18.04/20.04 <br> RHEL*/CentOS* 8 <br> SUSE* 15 <br> Windows* 10
 | Hardware                          | Intel&reg; Programmable Acceleration Card (PAC) with Intel Arria&reg; 10 GX FPGA <br> Intel&reg; FPGA Programmable Acceleration Card (PAC) D5005 (with Intel Stratix&reg; 10 SX) <br> Intel&reg; FPGA 3rd party / custom platforms with oneAPI support <br> **Note**: Intel&reg; FPGA PAC hardware is only compatible with Ubuntu 18.04*
-| Software                          | Intel&reg; oneAPI DPC++ Compiler <br> Intel&reg; FPGA Add-On for oneAPI Base Toolkit
+| Software                          | Intel&reg; oneAPI SYCL Compiler <br> Intel&reg; FPGA Add-On for oneAPI Base Toolkit
 | What you will learn               | The f<sub>MAX</sub>-II tradeoff <br>Default behavior of the compiler when scheduling loops <br> How to use `intel::initiation_interval` to attempt to set the II for a loop <br> Scenarios in which `intel::initiation_interval` can be helpful in optimizing kernel performance
 | Time to complete                  | 20 minutes
 

--- a/DirectProgramming/DPC++FPGA/Tutorials/Features/loop_initiation_interval/src/CMakeLists.txt
+++ b/DirectProgramming/DPC++FPGA/Tutorials/Features/loop_initiation_interval/src/CMakeLists.txt
@@ -1,6 +1,3 @@
-# To see a Makefile equivalent of this build system:
-# https://github.com/oneapi-src/oneAPI-samples/blob/master/DirectProgramming/DPC++/ProjectTemplates/makefile-fpga
-
 set(SOURCE_FILE loop_initiation_interval.cpp)
 set(TARGET_NAME loop_ii)
 set(TARGET_NAME_ENABLE_II loop_ii_enable_ii)

--- a/DirectProgramming/DPC++FPGA/Tutorials/Features/loop_initiation_interval/src/CMakeLists.txt
+++ b/DirectProgramming/DPC++FPGA/Tutorials/Features/loop_initiation_interval/src/CMakeLists.txt
@@ -39,7 +39,7 @@ if(WIN32)
     set(WIN_FLAG "/EHsc")
 endif()
 
-# A DPC++ ahead-of-time (AoT) compile processes the device code in two stages.
+# A SYCL ahead-of-time (AoT) compile processes the device code in two stages.
 # 1. The "compile" stage compiles the device code to an intermediate representation (SPIR-V).
 # 2. The "link" stage invokes the compiler's FPGA backend before linking.
 #    For this reason, FPGA backend flags must be passed as link flags in CMake.

--- a/DirectProgramming/DPC++FPGA/Tutorials/Features/loop_initiation_interval/src/CMakeLists.txt
+++ b/DirectProgramming/DPC++FPGA/Tutorials/Features/loop_initiation_interval/src/CMakeLists.txt
@@ -72,7 +72,7 @@ add_custom_target(fpga_emu DEPENDS ${EMULATOR_TARGET})
 #   icpx -fsycl -fintelfpga -Xshardware -Xstarget=<FPGA_DEVICE> -DA10 -fsycl-link=early loop_initiation_interval.cpp -o loop_ii_report.a
 set(FPGA_EARLY_IMAGE ${TARGET_NAME}_report.a)
 set(FPGA_EARLY_IMAGE_ENABLE_II ${TARGET_NAME_ENABLE_II}_report.a)
-# The compile output is not an executable, but an intermediate compilation result unique to DPC++.
+# The compile output is not an executable, but an intermediate compilation result unique to SYCL.
 add_executable(${FPGA_EARLY_IMAGE} ${SOURCE_FILE})
 target_include_directories(${FPGA_EARLY_IMAGE} PRIVATE ../../../../include)
 add_executable(${FPGA_EARLY_IMAGE_ENABLE_II} ${SOURCE_FILE})

--- a/DirectProgramming/DPC++FPGA/Tutorials/Features/loop_ivdep/README.md
+++ b/DirectProgramming/DPC++FPGA/Tutorials/Features/loop_ivdep/README.md
@@ -5,7 +5,7 @@ This FPGA tutorial demonstrates how to apply the `ivdep` attribute to a loop to 
 |:---                               |:---
 | OS                                | Linux* Ubuntu* 18.04/20.04 <br> RHEL*/CentOS* 8 <br> SUSE* 15 <br> Windows* 10
 | Hardware                          | Intel&reg; Programmable Acceleration Card (PAC) with Intel Arria&reg; 10 GX FPGA <br> Intel&reg; FPGA Programmable Acceleration Card (PAC) D5005 (with Intel Stratix&reg; 10 SX) <br> Intel&reg; FPGA 3rd party / custom platforms with oneAPI support <br> *__Note__: Intel&reg; FPGA PAC hardware is only compatible with Ubuntu 18.04*
-| Software                          | Intel&reg; oneAPI DPC++ Compiler <br> Intel&reg; FPGA Add-On for oneAPI Base Toolkit
+| Software                          | Intel&reg; oneAPI SYCL Compiler <br> Intel&reg; FPGA Add-On for oneAPI Base Toolkit
 | What you will learn               |  Basics of loop-carried dependencies <br> The notion of a loop-carried dependence distance <br> What constitutes a *safe* dependence distance <br> How to aid the compiler's dependence analysis to maximize performance
 | Time to complete                  | 30 minutes
 
@@ -308,7 +308,7 @@ PASSED: The results are correct
 
 ### Discussion of Results
 
-The following table summarizes the execution time (in ms) and throughput (in MFlops) for `safelen` parameters of 1 (redundant attribute) and 128 (`kRowLength`) for a default input matrix size of 128 x 128 floats on Intel&reg; Programmable Acceleration Card with Intel&reg; Arria&reg; 10 GX FPGA and the Intel&reg; oneAPI DPC++ Compiler.
+The following table summarizes the execution time (in ms) and throughput (in MFlops) for `safelen` parameters of 1 (redundant attribute) and 128 (`kRowLength`) for a default input matrix size of 128 x 128 floats on Intel&reg; Programmable Acceleration Card with Intel&reg; Arria&reg; 10 GX FPGA and the Intel&reg; oneAPI SYCL Compiler.
 
 |Safelen | Kernel Time (ms) | Throughput (KB/s)
 |:---  |:--- |:---

--- a/DirectProgramming/DPC++FPGA/Tutorials/Features/loop_ivdep/src/CMakeLists.txt
+++ b/DirectProgramming/DPC++FPGA/Tutorials/Features/loop_ivdep/src/CMakeLists.txt
@@ -22,7 +22,7 @@ if(WIN32)
     set(WIN_FLAG "/EHsc")
 endif()
 
-# A DPC++ ahead-of-time (AoT) compile processes the device code in two stages.
+# A SYCL ahead-of-time (AoT) compile processes the device code in two stages.
 # 1. The "compile" stage compiles the device code to an intermediate representation (SPIR-V).
 # 2. The "link" stage invokes the compiler's FPGA backend before linking.
 #    For this reason, FPGA backend flags must be passed as link flags in CMake.
@@ -52,10 +52,10 @@ add_custom_target(fpga_emu DEPENDS ${EMULATOR_TARGET})
 ### FPGA Simulator
 ###############################################################################
 # To compile in a single command:
-#    dpcpp -fintelfpga -Xssimulation -Xsghdl -Xstarget=<FPGA_DEVICE> -DFPGA_SIMULATOR loop_ivdep.cpp -o loop_ivdep.fpga_sim
+#    icpx -fintelfpga -Xssimulation -Xsghdl -Xstarget=<FPGA_DEVICE> -DFPGA_SIMULATOR loop_ivdep.cpp -o loop_ivdep.fpga_sim
 # CMake executes:
-#    [compile] dpcpp -fintelfpga -Xssimulation -DFPGA_SIMULATOR -o loop_ivdep.cpp.o -c loop_ivdep.cpp
-#    [link]    dpcpp -fintelfpga -Xssimulation -Xsghdl -Xstarget=<FPGA_DEVICE> loop_ivdep.cpp.o -o loop_ivdep.fpga_sim
+#    [compile] icpx -fintelfpga -Xssimulation -DFPGA_SIMULATOR -o loop_ivdep.cpp.o -c loop_ivdep.cpp
+#    [link]    icpx -fintelfpga -Xssimulation -Xsghdl -Xstarget=<FPGA_DEVICE> loop_ivdep.cpp.o -o loop_ivdep.fpga_sim
 add_executable(${SIMULATOR_TARGET} ${SOURCE_FILE})
 target_include_directories(${SIMULATOR_TARGET} PRIVATE ../../../../include)
 set_target_properties(${SIMULATOR_TARGET} PROPERTIES COMPILE_FLAGS "${SIMULATOR_COMPILE_FLAGS}")

--- a/DirectProgramming/DPC++FPGA/Tutorials/Features/loop_ivdep/src/CMakeLists.txt
+++ b/DirectProgramming/DPC++FPGA/Tutorials/Features/loop_ivdep/src/CMakeLists.txt
@@ -68,7 +68,7 @@ add_custom_target(fpga_sim DEPENDS ${SIMULATOR_TARGET})
 # To compile manually:
 #   icpx -fsycl -fintelfpga -Xshardware -Xstarget=<FPGA_DEVICE> -fsycl-link=early loop_ivdep.cpp -o loop_ivdep_report.a
 set(FPGA_EARLY_IMAGE ${TARGET_NAME}_report.a)
-# The compile output is not an executable, but an intermediate compilation result unique to DPC++.
+# The compile output is not an executable, but an intermediate compilation result unique to SYCL.
 add_executable(${FPGA_EARLY_IMAGE} ${SOURCE_FILE})
 target_include_directories(${FPGA_EARLY_IMAGE} PRIVATE ../../../../include)
 add_custom_target(report DEPENDS ${FPGA_EARLY_IMAGE})

--- a/DirectProgramming/DPC++FPGA/Tutorials/Features/loop_ivdep/src/CMakeLists.txt
+++ b/DirectProgramming/DPC++FPGA/Tutorials/Features/loop_ivdep/src/CMakeLists.txt
@@ -1,6 +1,3 @@
-# To see a Makefile equivalent of this build system:
-# https://github.com/oneapi-src/oneAPI-samples/blob/master/DirectProgramming/DPC++/ProjectTemplates/makefile-fpga
-
 set(SOURCE_FILE loop_ivdep.cpp)
 set(TARGET_NAME loop_ivdep)
 set(EMULATOR_TARGET ${TARGET_NAME}.fpga_emu)

--- a/DirectProgramming/DPC++FPGA/Tutorials/Features/loop_unroll/README.md
+++ b/DirectProgramming/DPC++FPGA/Tutorials/Features/loop_unroll/README.md
@@ -5,7 +5,7 @@ This tutorial demonstrates a simple example of unrolling loops to improve throug
 |:---                                 |:---
 | OS                                | Linux* Ubuntu* 18.04/20.04 <br> RHEL*/CentOS* 8 <br> SUSE* 15 <br> Windows* 10
 | Hardware                          | Intel&reg; Programmable Acceleration Card (PAC) with Intel Arria&reg; 10 GX FPGA <br> Intel&reg; FPGA Programmable Acceleration Card (PAC) D5005 (with Intel Stratix&reg; 10 SX) <br> Intel&reg; FPGA 3rd party / custom platforms with oneAPI support <br> **Note**: Intel&reg; FPGA PAC hardware is only compatible with Ubuntu 18.04*
-| Software                          | Intel&reg; oneAPI DPC++ Compiler <br> Intel&reg; FPGA Add-On for oneAPI Base Toolkit
+| Software                          | Intel&reg; oneAPI SYCL Compiler <br> Intel&reg; FPGA Add-On for oneAPI Base Toolkit
 | What you will learn               |  Basics of loop unrolling. <br> How to unroll loops in your program. <br> Determining the optimal unroll factor for your program.
 | Time to complete                  | 15 minutes
 

--- a/DirectProgramming/DPC++FPGA/Tutorials/Features/loop_unroll/src/CMakeLists.txt
+++ b/DirectProgramming/DPC++FPGA/Tutorials/Features/loop_unroll/src/CMakeLists.txt
@@ -1,6 +1,3 @@
-# To see a Makefile equivalent of this build system:
-# https://github.com/oneapi-src/oneAPI-samples/blob/master/DirectProgramming/DPC++/ProjectTemplates/makefile-fpga
-
 set(SOURCE_FILE loop_unroll.cpp)
 set(TARGET_NAME loop_unroll)
 set(EMULATOR_TARGET ${TARGET_NAME}.fpga_emu)

--- a/DirectProgramming/DPC++FPGA/Tutorials/Features/loop_unroll/src/CMakeLists.txt
+++ b/DirectProgramming/DPC++FPGA/Tutorials/Features/loop_unroll/src/CMakeLists.txt
@@ -22,7 +22,7 @@ if(WIN32)
     set(WIN_FLAG "/EHsc")
 endif()
 
-# A DPC++ ahead-of-time (AoT) compile processes the device code in two stages.
+# A SYCL ahead-of-time (AoT) compile processes the device code in two stages.
 # 1. The "compile" stage compiles the device code to an intermediate representation (SPIR-V).
 # 2. The "link" stage invokes the compiler's FPGA backend before linking.
 #    For this reason, FPGA backend flags must be passed as link flags in CMake.
@@ -52,10 +52,10 @@ add_custom_target(fpga_emu DEPENDS ${EMULATOR_TARGET})
 ### FPGA Simulator
 ###############################################################################
 # To compile in a single command:
-#    dpcpp -fintelfpga -Xssimulation -Xsghdl -Xstarget=<FPGA_DEVICE> -DFPGA_SIMULATOR loop_unroll.cpp -o loop_unroll.fpga_sim
+#    icpx -fintelfpga -Xssimulation -Xsghdl -Xstarget=<FPGA_DEVICE> -DFPGA_SIMULATOR loop_unroll.cpp -o loop_unroll.fpga_sim
 # CMake executes:
-#    [compile] dpcpp -fintelfpga -Xssimulation -DFPGA_SIMULATOR -o loop_unroll.cpp.o -c loop_unroll.cpp
-#    [link]    dpcpp -fintelfpga -Xssimulation -Xsghdl -Xstarget=<FPGA_DEVICE> loop_unroll.cpp.o -o loop_unroll.fpga_sim
+#    [compile] icpx -fintelfpga -Xssimulation -DFPGA_SIMULATOR -o loop_unroll.cpp.o -c loop_unroll.cpp
+#    [link]    icpx -fintelfpga -Xssimulation -Xsghdl -Xstarget=<FPGA_DEVICE> loop_unroll.cpp.o -o loop_unroll.fpga_sim
 add_executable(${SIMULATOR_TARGET} ${SOURCE_FILE})
 target_include_directories(${SIMULATOR_TARGET} PRIVATE ../../../../include)
 set_target_properties(${SIMULATOR_TARGET} PROPERTIES COMPILE_FLAGS "${SIMULATOR_COMPILE_FLAGS}")

--- a/DirectProgramming/DPC++FPGA/Tutorials/Features/loop_unroll/src/CMakeLists.txt
+++ b/DirectProgramming/DPC++FPGA/Tutorials/Features/loop_unroll/src/CMakeLists.txt
@@ -68,7 +68,7 @@ add_custom_target(fpga_sim DEPENDS ${SIMULATOR_TARGET})
 # To compile manually:
 #   icpx -fsycl -fintelfpga -Xshardware -Xstarget=<FPGA_DEVICE> -fsycl-link=early loop_unroll.cpp -o loop_unroll_report.a
 set(FPGA_EARLY_IMAGE ${TARGET_NAME}_report.a)
-# The compile output is not an executable, but an intermediate compilation result unique to DPC++.
+# The compile output is not an executable, but an intermediate compilation result unique to SYCL.
 add_executable(${FPGA_EARLY_IMAGE} ${SOURCE_FILE})
 target_include_directories(${FPGA_EARLY_IMAGE} PRIVATE ../../../../include)
 add_custom_target(report DEPENDS ${FPGA_EARLY_IMAGE})

--- a/DirectProgramming/DPC++FPGA/Tutorials/Features/lsu_control/README.md
+++ b/DirectProgramming/DPC++FPGA/Tutorials/Features/lsu_control/README.md
@@ -6,7 +6,7 @@ This FPGA tutorial demonstrates how to configure the load-store units (LSU) in S
 |:---                               |:---
 | OS                                | Linux* Ubuntu* 18.04/20.04 <br> RHEL*/CentOS* 8 <br> SUSE* 15 <br> Windows* 10
 | Hardware                          | Intel&reg; Programmable Acceleration Card (PAC) with Intel Arria&reg; 10 GX FPGA <br> Intel&reg; FPGA Programmable Acceleration Card (PAC) D5005 (with Intel Stratix&reg; 10 SX) <br> Intel&reg; FPGA 3rd party / custom platforms with oneAPI support <br> *__Note__: Intel&reg; FPGA PAC hardware is only compatible with Ubuntu 18.04*
-| Software                          | Intel&reg; oneAPI DPC++ Compiler <br> Intel&reg; FPGA Add-On for oneAPI Base Toolkit
+| Software                          | Intel&reg; oneAPI SYCL Compiler <br> Intel&reg; FPGA Add-On for oneAPI Base Toolkit
 | What you will learn               | The basic concepts of LSU styles and LSU modifiers <br>  How to use the LSU controls extension to request specific configurations <br>  How to confirm what LSU configurations are implemented <br> A case study of the type of area trade-offs enabled by LSU
 | Time to complete                  | 30 minutes
 

--- a/DirectProgramming/DPC++FPGA/Tutorials/Features/lsu_control/sample.json
+++ b/DirectProgramming/DPC++FPGA/Tutorials/Features/lsu_control/sample.json
@@ -2,7 +2,7 @@
   "guid": "C3B945F8-D3CC-47E8-A094-D8A0B0DBA22C",
   "name": "LSU Control",
   "categories": ["Toolkit/oneAPI Direct Programming/DPC++ FPGA/Tutorials/Features"],
-  "description": "An Intel® FPGA tutorial demonstrating how to configure the load-store units (LSU) in Data Parallel C++ (DPC++) program using the LSU controls extension",
+  "description": "An Intel® FPGA tutorial demonstrating how to configure the load-store units (LSU) in a SYCL program using the LSU controls extension",
   "toolchain": ["icpx"],
   "os": ["linux", "windows"],
   "targetDevice": ["FPGA"],

--- a/DirectProgramming/DPC++FPGA/Tutorials/Features/lsu_control/src/CMakeLists.txt
+++ b/DirectProgramming/DPC++FPGA/Tutorials/Features/lsu_control/src/CMakeLists.txt
@@ -1,6 +1,3 @@
-# To see a Makefile equivalent of this build system:
-# https://github.com/oneapi-src/oneAPI-samples/blob/master/DirectProgramming/DPC++/ProjectTemplates/makefile-fpga
-
 set(SOURCE_FILE lsu_control.cpp)
 set(TARGET_NAME lsu_control)
 set(EMULATOR_TARGET ${TARGET_NAME}.fpga_emu)

--- a/DirectProgramming/DPC++FPGA/Tutorials/Features/lsu_control/src/CMakeLists.txt
+++ b/DirectProgramming/DPC++FPGA/Tutorials/Features/lsu_control/src/CMakeLists.txt
@@ -56,7 +56,7 @@ add_custom_target(fpga_emu DEPENDS ${EMULATOR_TARGET})
 # To compile manually:
 #   icpx -fsycl -fintelfpga -Xshardware -Xstarget=<FPGA_DEVICE> -fsycl-link=early lsu_control.cpp -o lsu_control_report.a
 set(FPGA_EARLY_IMAGE ${TARGET_NAME}_report.a)
-# The compile output is not an executable, but an intermediate compilation result unique to DPC++.
+# The compile output is not an executable, but an intermediate compilation result unique to SYCL.
 add_executable(${FPGA_EARLY_IMAGE} ${SOURCE_FILE})
 target_include_directories(${FPGA_EARLY_IMAGE} PRIVATE ../../../../include)
 add_custom_target(report DEPENDS ${FPGA_EARLY_IMAGE})

--- a/DirectProgramming/DPC++FPGA/Tutorials/Features/lsu_control/src/CMakeLists.txt
+++ b/DirectProgramming/DPC++FPGA/Tutorials/Features/lsu_control/src/CMakeLists.txt
@@ -21,7 +21,7 @@ if(WIN32)
     set(WIN_FLAG "/EHsc")
 endif()
 
-# A DPC++ ahead-of-time (AoT) compile processes the device code in two stages.
+# A SYCL ahead-of-time (AoT) compile processes the device code in two stages.
 # 1. The "compile" stage compiles the device code to an intermediate representation (SPIR-V).
 # 2. The "link" stage invokes the compiler's FPGA backend before linking.
 #    For this reason, FPGA backend flags must be passed as link flags in CMake.

--- a/DirectProgramming/DPC++FPGA/Tutorials/Features/max_interleaving/README.md
+++ b/DirectProgramming/DPC++FPGA/Tutorials/Features/max_interleaving/README.md
@@ -5,7 +5,7 @@ This FPGA tutorial explains how to use the `max_interleaving` attribute for loop
 |:---                                 |:---
 | OS                                | Linux* Ubuntu* 18.04/20.04 <br> RHEL*/CentOS* 8 <br> SUSE* 15 <br> Windows* 10
 | Hardware                          | Intel&reg; Programmable Acceleration Card (PAC) with Intel Arria&reg; 10 GX FPGA <br> Intel&reg; FPGA Programmable Acceleration Card (PAC) D5005 (with Intel Stratix&reg; 10 SX) <br> Intel&reg; FPGA 3rd party / custom platforms with oneAPI support <br> **Note**: Intel&reg; FPGA PAC hardware is only compatible with Ubuntu 18.04*
-| Software                          | Intel&reg; oneAPI DPC++ Compiler
+| Software                          | Intel&reg; oneAPI SYCL Compiler
 | What you will learn               | The basic usage of the `max_interleaving` attribute <br> How the `max_interleaving` attribute affects loop resource use <br> How to apply the `max_interleaving` attribute to loops in your program
 | Time to complete                  | 15 minutes
 

--- a/DirectProgramming/DPC++FPGA/Tutorials/Features/max_interleaving/src/CMakeLists.txt
+++ b/DirectProgramming/DPC++FPGA/Tutorials/Features/max_interleaving/src/CMakeLists.txt
@@ -69,7 +69,7 @@ add_custom_target(fpga_sim DEPENDS ${SIMULATOR_TARGET})
 # To compile manually:
 #   icpx -fsycl -fintelfpga -Xshardware -Xstarget=<FPGA_DEVICE> -fsycl-link=early max_interleaving.cpp -o max_interleaving_report.a
 set(FPGA_EARLY_IMAGE ${TARGET_NAME}_report.a)
-# The compile output is not an executable, but an intermediate compilation result unique to DPC++.
+# The compile output is not an executable, but an intermediate compilation result unique to SYCL.
 add_executable(${FPGA_EARLY_IMAGE} ${SOURCE_FILE})
 target_include_directories(${FPGA_EARLY_IMAGE} PRIVATE ../../../../include)
 add_custom_target(report DEPENDS ${FPGA_EARLY_IMAGE})

--- a/DirectProgramming/DPC++FPGA/Tutorials/Features/max_interleaving/src/CMakeLists.txt
+++ b/DirectProgramming/DPC++FPGA/Tutorials/Features/max_interleaving/src/CMakeLists.txt
@@ -22,7 +22,7 @@ if(WIN32)
     set(WIN_FLAG "/EHsc")
 endif()
 
-# A DPC++ ahead-of-time (AoT) compile processes the device code in two stages.
+# A SYCL ahead-of-time (AoT) compile processes the device code in two stages.
 # 1. The "compile" stage compiles the device code to an intermediate representation (SPIR-V).
 # 2. The "link" stage invokes the compiler's FPGA backend before linking.
 #    For this reason, FPGA backend flags must be passed as link flags in CMake.
@@ -53,10 +53,10 @@ add_custom_target(fpga_emu DEPENDS ${EMULATOR_TARGET})
 ### FPGA Simulator
 ###############################################################################
 # To compile in a single command:
-#    dpcpp -fintelfpga -Xssimulation -Xsghdl -Xstarget=<FPGA_DEVICE> -DFPGA_SIMULATOR max_interleaving.cpp -o max_interleaving.fpga_sim
+#    icpx -fintelfpga -Xssimulation -Xsghdl -Xstarget=<FPGA_DEVICE> -DFPGA_SIMULATOR max_interleaving.cpp -o max_interleaving.fpga_sim
 # CMake executes:
-#    [compile] dpcpp -fintelfpga -Xssimulation -DFPGA_SIMULATOR -o max_interleaving.cpp.o -c max_interleaving.cpp
-#    [link]    dpcpp -fintelfpga -Xssimulation -Xsghdl -Xstarget=<FPGA_DEVICE> max_interleaving.cpp.o -o max_interleaving.fpga_sim
+#    [compile] icpx -fintelfpga -Xssimulation -DFPGA_SIMULATOR -o max_interleaving.cpp.o -c max_interleaving.cpp
+#    [link]    icpx -fintelfpga -Xssimulation -Xsghdl -Xstarget=<FPGA_DEVICE> max_interleaving.cpp.o -o max_interleaving.fpga_sim
 add_executable(${SIMULATOR_TARGET} ${SOURCE_FILE})
 target_include_directories(${SIMULATOR_TARGET} PRIVATE ../../../../include)
 set_target_properties(${SIMULATOR_TARGET} PROPERTIES COMPILE_FLAGS "${SIMULATOR_COMPILE_FLAGS}")

--- a/DirectProgramming/DPC++FPGA/Tutorials/Features/max_interleaving/src/CMakeLists.txt
+++ b/DirectProgramming/DPC++FPGA/Tutorials/Features/max_interleaving/src/CMakeLists.txt
@@ -1,6 +1,3 @@
-# To see a Makefile equivalent of this build system:
-# https://github.com/oneapi-src/oneAPI-samples/blob/master/DirectProgramming/DPC++/ProjectTemplates/makefile-fpga
-
 set(SOURCE_FILE max_interleaving.cpp)
 set(TARGET_NAME max_interleaving)
 set(EMULATOR_TARGET ${TARGET_NAME}.fpga_emu)

--- a/DirectProgramming/DPC++FPGA/Tutorials/Features/mem_channel/README.md
+++ b/DirectProgramming/DPC++FPGA/Tutorials/Features/mem_channel/README.md
@@ -8,7 +8,7 @@ SYCL*-compliant FPGA design.
 |:---                               |:---
 | OS                                | Linux* Ubuntu* 18.04/20.04 <br> RHEL*/CentOS* 8 <br> SUSE* 15 <br> Windows* 10
 | Hardware                          | Intel&reg; Programmable Acceleration Card (PAC) with Intel Arria&reg; 10 GX FPGA <br> Intel&reg; FPGA Programmable Acceleration Card (PAC) D5005 (with Intel Stratix&reg; 10 SX) <br> Intel&reg; FPGA 3rd party / custom platforms with oneAPI support <br> **Note**: Intel&reg; FPGA PAC hardware is only compatible with Ubuntu 18.04*
-| Software                          | Intel&reg; oneAPI DPC++ Compiler <br> Intel&reg; FPGA Add-On for oneAPI Base Toolkit
+| Software                          | Intel&reg; oneAPI SYCL Compiler <br> Intel&reg; FPGA Add-On for oneAPI Base Toolkit
 | What you will learn               | How and when to use the `mem_channel` buffer property and the `-Xsno-interleaving` flag
 | Time to complete                  | 30 minutes
 

--- a/DirectProgramming/DPC++FPGA/Tutorials/Features/mem_channel/src/CMakeLists.txt
+++ b/DirectProgramming/DPC++FPGA/Tutorials/Features/mem_channel/src/CMakeLists.txt
@@ -1,6 +1,3 @@
-# To see a Makefile equivalent of this build system:
-# https://github.com/oneapi-src/oneAPI-samples/blob/master/DirectProgramming/DPC++/ProjectTemplates/makefile-fpga
-
 set(SOURCE_FILE mem_channel.cpp)
 set(TARGET_NAME mem_channel)
 set(EMULATOR_TARGET ${TARGET_NAME}.fpga_emu)

--- a/DirectProgramming/DPC++FPGA/Tutorials/Features/mem_channel/src/CMakeLists.txt
+++ b/DirectProgramming/DPC++FPGA/Tutorials/Features/mem_channel/src/CMakeLists.txt
@@ -22,7 +22,7 @@ if(WIN32)
     set(WIN_FLAG "/EHsc")
 endif()
 
-# A DPC++ ahead-of-time (AoT) compile processes the device code in two stages.
+# A SYCL ahead-of-time (AoT) compile processes the device code in two stages.
 # 1. The "compile" stage compiles the device code to an intermediate representation (SPIR-V).
 # 2. The "link" stage invokes the compiler's FPGA backend before linking.
 #    For this reason, FPGA backend flags must be passed as link flags in CMake.

--- a/DirectProgramming/DPC++FPGA/Tutorials/Features/mem_channel/src/CMakeLists.txt
+++ b/DirectProgramming/DPC++FPGA/Tutorials/Features/mem_channel/src/CMakeLists.txt
@@ -60,7 +60,7 @@ add_custom_target(fpga_emu DEPENDS ${EMULATOR_TARGET})
 #   icpx -fsycl -fintelfpga -Xshardware -Xstarget=<FPGA_DEVICE> -fsycl-link=early mem_channel.cpp -o mem_channel_report.a
 set(FPGA_EARLY_IMAGE_INTERLEAVING ${TARGET_NAME}_interleaving_report.a)
 set(FPGA_EARLY_IMAGE_NO_INTERLEAVING ${TARGET_NAME}_no_interleaving_report.a)
-# The compile output is not an executable, but an intermediate compilation result unique to DPC++.
+# The compile output is not an executable, but an intermediate compilation result unique to SYCL.
 add_executable(${FPGA_EARLY_IMAGE_INTERLEAVING} ${SOURCE_FILE})
 target_include_directories(${FPGA_EARLY_IMAGE_INTERLEAVING} PRIVATE ../../../../include)
 add_executable(${FPGA_EARLY_IMAGE_NO_INTERLEAVING} ${SOURCE_FILE})

--- a/DirectProgramming/DPC++FPGA/Tutorials/Features/memory_attributes/README.md
+++ b/DirectProgramming/DPC++FPGA/Tutorials/Features/memory_attributes/README.md
@@ -5,7 +5,7 @@ This FPGA tutorial demonstrates how to use on-chip memory attributes to control 
 |:---                               |:---
 | OS                                | Linux* Ubuntu* 18.04/20.04 <br> RHEL*/CentOS* 8 <br> SUSE* 15 <br> Windows* 10
 | Hardware                          | Intel&reg; Programmable Acceleration Card (PAC) with Intel Arria&reg; 10 GX FPGA <br> Intel&reg; FPGA Programmable Acceleration Card (PAC) D5005 (with Intel Stratix&reg; 10 SX) <br> Intel&reg; FPGA 3rd party / custom platforms with oneAPI support <br> *__Note__: Intel&reg; FPGA PAC hardware is only compatible with Ubuntu 18.04*
-| Software                          | Intel&reg; oneAPI DPC++ Compiler <br> Intel&reg; FPGA Add-On for oneAPI Base Toolkit
+| Software                          | Intel&reg; oneAPI SYCL Compiler <br> Intel&reg; FPGA Add-On for oneAPI Base Toolkit
 | What you will learn               |  The basic concepts of on-chip memory attributes <br> How to apply memory attributes in your program <br> How to confirm that the memory attributes were respected by the compiler <br> A case study of the type of performance/area trade-offs enabled by memory attributes
 | Time to complete                  | 30 minutes
 

--- a/DirectProgramming/DPC++FPGA/Tutorials/Features/memory_attributes/sample.json
+++ b/DirectProgramming/DPC++FPGA/Tutorials/Features/memory_attributes/sample.json
@@ -2,7 +2,7 @@
   "guid": "31BCA673-F514-4E2E-A8B3-A0B42D63884C",
   "name": "Memory Attributes",
   "categories": ["Toolkit/oneAPI Direct Programming/DPC++ FPGA/Tutorials/Features"],
-  "description": "An Intel® FPGA tutorial demonstrating the use of on-chip memory attributes to control memory structures in a Data Parallel C++ (DPC++) program",
+  "description": "An Intel® FPGA tutorial demonstrating the use of on-chip memory attributes to control memory structures in a SYCL program",
   "toolchain": ["icpx"],
   "os": ["linux", "windows"],
   "targetDevice": ["FPGA"],

--- a/DirectProgramming/DPC++FPGA/Tutorials/Features/memory_attributes/src/CMakeLists.txt
+++ b/DirectProgramming/DPC++FPGA/Tutorials/Features/memory_attributes/src/CMakeLists.txt
@@ -21,7 +21,7 @@ if(WIN32)
     set(WIN_FLAG "/EHsc")
 endif()
 
-# A DPC++ ahead-of-time (AoT) compile processes the device code in two stages.
+# A SYCL ahead-of-time (AoT) compile processes the device code in two stages.
 # 1. The "compile" stage compiles the device code to an intermediate representation (SPIR-V).
 # 2. The "link" stage invokes the compiler's FPGA backend before linking.
 #    For this reason, FPGA backend flags must be passed as link flags in CMake.

--- a/DirectProgramming/DPC++FPGA/Tutorials/Features/memory_attributes/src/CMakeLists.txt
+++ b/DirectProgramming/DPC++FPGA/Tutorials/Features/memory_attributes/src/CMakeLists.txt
@@ -1,6 +1,3 @@
-# To see a Makefile equivalent of this build system:
-# https://github.com/oneapi-src/oneAPI-samples/blob/master/DirectProgramming/DPC++/ProjectTemplates/makefile-fpga
-
 set(SOURCE_FILE memory_attributes.cpp)
 set(TARGET_NAME memory_attributes)
 set(EMULATOR_TARGET ${TARGET_NAME}.fpga_emu)

--- a/DirectProgramming/DPC++FPGA/Tutorials/Features/memory_attributes/src/CMakeLists.txt
+++ b/DirectProgramming/DPC++FPGA/Tutorials/Features/memory_attributes/src/CMakeLists.txt
@@ -51,7 +51,7 @@ add_custom_target(fpga_emu DEPENDS ${EMULATOR_TARGET})
 # To compile manually:
 #   icpx -fsycl -fintelfpga -Xshardware -Xstarget=<FPGA_DEVICE> -fsycl-link=early memory_attributes.cpp -o memory_attributes_report.a
 set(FPGA_EARLY_IMAGE ${TARGET_NAME}_report.a)
-# The compile output is not an executable, but an intermediate compilation result unique to DPC++.
+# The compile output is not an executable, but an intermediate compilation result unique to SYCL.
 add_executable(${FPGA_EARLY_IMAGE} ${SOURCE_FILE})
 target_include_directories(${FPGA_EARLY_IMAGE} PRIVATE ../../../../include)
 add_custom_target(report DEPENDS ${FPGA_EARLY_IMAGE})

--- a/DirectProgramming/DPC++FPGA/Tutorials/Features/pipes/README.md
+++ b/DirectProgramming/DPC++FPGA/Tutorials/Features/pipes/README.md
@@ -65,7 +65,7 @@ SYCL*-compliant pipes are defined as a class with static members. To declare a p
 transfers integer data and has  `capacity=4`, use a type alias:
 
 ```c++
-using ProducerToConsumerPipe = pipe<  // Defined in the DPC++ headers.
+using ProducerToConsumerPipe = pipe<  // Defined in the SYCL headers.
   class ProducerConsumerPipe,         // An identifier for the pipe.
   int,                                // The type of data in the pipe.
   4>;                                 // The capacity of the pipe.
@@ -76,7 +76,7 @@ uniqueness of the pipe. This class need not be defined but must be distinct
 for each pipe. Consider another type alias with the exact same parameters:
 
 ```c++
-using ProducerToConsumerPipe2 = pipe<  // Defined in the DPC++ headers.
+using ProducerToConsumerPipe2 = pipe<  // Defined in the SYCL headers.
   class ProducerConsumerPipe,          // An identifier for the pipe.
   int,                                 // The type of data in the pipe.
   4>;                                  // The capacity of the pipe.

--- a/DirectProgramming/DPC++FPGA/Tutorials/Features/pipes/README.md
+++ b/DirectProgramming/DPC++FPGA/Tutorials/Features/pipes/README.md
@@ -5,7 +5,7 @@ This FPGA tutorial shows how to use pipes to transfer data between kernels.
 ---                                 |---
 | OS                                | Linux* Ubuntu* 18.04/20.04 <br> RHEL*/CentOS* 8 <br> SUSE* 15 <br> Windows* 10
 | Hardware                          | Intel&reg; Programmable Acceleration Card (PAC) with Intel Arria&reg; 10 GX FPGA <br> Intel&reg; FPGA Programmable Acceleration Card (PAC) D5005 (with Intel Stratix&reg; 10 SX) <br> Intel&reg; FPGA 3rd party / custom platforms with oneAPI support <br> ***Note**: Intel&reg; FPGA PAC hardware is only compatible with Ubuntu 18.04*
-| Software                          | Intel&reg; oneAPI DPC++ Compiler <br> Intel&reg; FPGA Add-On for oneAPI Base Toolkit
+| Software                          | Intel&reg; oneAPI SYCL Compiler <br> Intel&reg; FPGA Add-On for oneAPI Base Toolkit
 | What you will learn               | The basics of using SYCL*-compliant pipes extension for FPGA<br> How to declare and use pipes
 | Time to complete                  | 15 minutes
 

--- a/DirectProgramming/DPC++FPGA/Tutorials/Features/pipes/src/CMakeLists.txt
+++ b/DirectProgramming/DPC++FPGA/Tutorials/Features/pipes/src/CMakeLists.txt
@@ -1,6 +1,3 @@
-# To see a Makefile equivalent of this build system:
-# https://github.com/oneapi-src/oneAPI-samples/blob/master/DirectProgramming/DPC++/ProjectTemplates/makefile-fpga
-
 set(SOURCE_FILE pipes.cpp)
 set(TARGET_NAME pipes)
 set(EMULATOR_TARGET ${TARGET_NAME}.fpga_emu)

--- a/DirectProgramming/DPC++FPGA/Tutorials/Features/pipes/src/CMakeLists.txt
+++ b/DirectProgramming/DPC++FPGA/Tutorials/Features/pipes/src/CMakeLists.txt
@@ -21,7 +21,7 @@ if(WIN32)
     set(WIN_FLAG "/EHsc")
 endif()
 
-# A DPC++ ahead-of-time (AoT) compile processes the device code in two stages.
+# A SYCL ahead-of-time (AoT) compile processes the device code in two stages.
 # 1. The "compile" stage compiles the device code to an intermediate representation (SPIR-V).
 # 2. The "link" stage invokes the compiler's FPGA backend before linking.
 #    For this reason, FPGA backend flags must be passed as link flags in CMake.

--- a/DirectProgramming/DPC++FPGA/Tutorials/Features/pipes/src/CMakeLists.txt
+++ b/DirectProgramming/DPC++FPGA/Tutorials/Features/pipes/src/CMakeLists.txt
@@ -51,7 +51,7 @@ add_custom_target(fpga_emu DEPENDS ${EMULATOR_TARGET})
 # To compile manually:
 #   icpx -fsycl -fintelfpga -Xshardware -Xstarget=<FPGA_DEVICE> -fsycl-link=early pipes.cpp -o pipes_report.a
 set(FPGA_EARLY_IMAGE ${TARGET_NAME}_report.a)
-# The compile output is not an executable, but an intermediate compilation result unique to DPC++.
+# The compile output is not an executable, but an intermediate compilation result unique to SYCL.
 add_executable(${FPGA_EARLY_IMAGE} ${SOURCE_FILE})
 target_include_directories(${FPGA_EARLY_IMAGE} PRIVATE ../../../../include)
 add_custom_target(report DEPENDS ${FPGA_EARLY_IMAGE})

--- a/DirectProgramming/DPC++FPGA/Tutorials/Features/printf/README.md
+++ b/DirectProgramming/DPC++FPGA/Tutorials/Features/printf/README.md
@@ -6,7 +6,7 @@ This FPGA tutorial explains how to use the `sycl::ext::oneapi::experimental::pri
 |:---                                 |:---
 | OS                                | Linux* Ubuntu* 18.04/20.04 <br> RHEL*/CentOS* 8 <br> SUSE* 15 <br> Windows* 10
 | Hardware                          | Intel&reg; Programmable Acceleration Card (PAC) with Intel Arria&reg; 10 GX FPGA <br> Intel&reg; FPGA Programmable Acceleration Card (PAC) D5005 (with Intel Stratix&reg; 10 SX) <br> Intel&reg; FPGA 3rd party / custom platforms with oneAPI support <br> *__Note__: Intel&reg; FPGA PAC hardware is only compatible with Ubuntu 18.04*
-| Software                          | Intel&reg; oneAPI DPC++ Compiler <br> Intel&reg; FPGA Add-On for oneAPI Base Toolkit
+| Software                          | Intel&reg; oneAPI SYCL Compiler <br> Intel&reg; FPGA Add-On for oneAPI Base Toolkit
 | What you will learn               | How to declare and use printf in program
 | Time to complete                  | 10 minutes
 

--- a/DirectProgramming/DPC++FPGA/Tutorials/Features/printf/sample.json
+++ b/DirectProgramming/DPC++FPGA/Tutorials/Features/printf/sample.json
@@ -2,7 +2,7 @@
   "guid": "7D431C27-AC4C-4AFF-9566-5B978C3D1F5D",
   "name": "Printf",
   "categories": ["Toolkit/oneAPI Direct Programming/DPC++ FPGA/Tutorials/Features"],
-  "description": "This FPGA tutorial explains how to use the printf() to print in a DPC++ FPGA program",
+  "description": "This FPGA tutorial explains how to use the printf() to print in a SYCL FPGA program",
   "toolchain": ["icpx"],
   "os": ["linux", "windows"],
   "targetDevice": ["FPGA"],

--- a/DirectProgramming/DPC++FPGA/Tutorials/Features/printf/src/CMakeLists.txt
+++ b/DirectProgramming/DPC++FPGA/Tutorials/Features/printf/src/CMakeLists.txt
@@ -1,6 +1,3 @@
-# To see a Makefile equivalent of this build system:
-# https://github.com/oneapi-src/oneAPI-samples/blob/master/DirectProgramming/DPC++/ProjectTemplates/makefile-fpga
-
 set(SOURCE_FILE printf.cpp)
 set(TARGET_NAME printf)
 set(EMULATOR_TARGET ${TARGET_NAME}.fpga_emu)

--- a/DirectProgramming/DPC++FPGA/Tutorials/Features/printf/src/CMakeLists.txt
+++ b/DirectProgramming/DPC++FPGA/Tutorials/Features/printf/src/CMakeLists.txt
@@ -21,7 +21,7 @@ if(WIN32)
     set(WIN_FLAG "/EHsc")
 endif()
 
-# A DPC++ ahead-of-time (AoT) compile processes the device code in two stages.
+# A SYCL ahead-of-time (AoT) compile processes the device code in two stages.
 # 1. The "compile" stage compiles the device code to an intermediate representation (SPIR-V).
 # 2. The "link" stage invokes the compiler's FPGA backend before linking.
 #    For this reason, FPGA backend flags must be passed as link flags in CMake.

--- a/DirectProgramming/DPC++FPGA/Tutorials/Features/printf/src/CMakeLists.txt
+++ b/DirectProgramming/DPC++FPGA/Tutorials/Features/printf/src/CMakeLists.txt
@@ -51,7 +51,7 @@ add_custom_target(fpga_emu DEPENDS ${EMULATOR_TARGET})
 # To compile manually:
 #   icpx -fsycl -fintelfpga -Xshardware -Xstarget=<FPGA_DEVICE> -fsycl-link=early printf.cpp -o printf_report.a
 set(FPGA_EARLY_IMAGE ${TARGET_NAME}_report.a)
-# The compile output is not an executable, but an intermediate compilation result unique to DPC++.
+# The compile output is not an executable, but an intermediate compilation result unique to SYCL.
 add_executable(${FPGA_EARLY_IMAGE} ${SOURCE_FILE})
 target_include_directories(${FPGA_EARLY_IMAGE} PRIVATE ../../../../include)
 add_custom_target(report DEPENDS ${FPGA_EARLY_IMAGE})

--- a/DirectProgramming/DPC++FPGA/Tutorials/Features/private_copies/README.md
+++ b/DirectProgramming/DPC++FPGA/Tutorials/Features/private_copies/README.md
@@ -5,7 +5,7 @@ This FPGA tutorial explains how to use the `private_copies` attribute to trade o
 |:---                                 |:---
 | OS                                | Linux* Ubuntu* 18.04/20.04 <br> RHEL*/CentOS* 8 <br> SUSE* 15 <br> Windows* 10
 | Hardware                          | Intel&reg; Programmable Acceleration Card (PAC) with Intel Arria&reg; 10 GX FPGA; <br> Intel&reg; FPGA Programmable Acceleration Card (PAC) D5005 (with Intel Stratix&reg; 10 SX) <br> Intel&reg; FPGA 3rd party / custom platforms with oneAPI support <br> **Note**: Intel&reg; FPGA PAC hardware is only compatible with Ubuntu 18.04*
-| Software                          | Intel&reg; oneAPI DPC++ Compiler <br> Intel&reg; FPGA Add-On for oneAPI Base Toolkit
+| Software                          | Intel&reg; oneAPI SYCL Compiler <br> Intel&reg; FPGA Add-On for oneAPI Base Toolkit
 | What you will learn               | The basic usage of the `private_copies` attribute <br> How the `private_copies` attribute affects the throughput and resource use of your FPGA program <br> How to apply the `private_copies` attribute to variables or arrays in your program <br> How to identify the correct `private_copies` factor for your program
 | Time to complete                  | 15 minutes
 

--- a/DirectProgramming/DPC++FPGA/Tutorials/Features/private_copies/sample.json
+++ b/DirectProgramming/DPC++FPGA/Tutorials/Features/private_copies/sample.json
@@ -2,7 +2,7 @@
   "guid": "CDC9540F-B89F-499E-BC27-E8EC9EA3B2D7",
   "name": "Private Copies",
   "categories": ["Toolkit/oneAPI Direct Programming/DPC++ FPGA/Tutorials/Features"],
-  "description": "An Intel® FPGA tutorial demonstrating how to use the private_copies attribute to trade off the resource use and the throughput of a DPC++ FPGA program",
+  "description": "An Intel® FPGA tutorial demonstrating how to use the private_copies attribute to trade off the resource use and the throughput of a SYCL FPGA program",
   "toolchain": ["icpx"],
   "os": ["linux", "windows"],
   "targetDevice": ["FPGA"],

--- a/DirectProgramming/DPC++FPGA/Tutorials/Features/private_copies/src/CMakeLists.txt
+++ b/DirectProgramming/DPC++FPGA/Tutorials/Features/private_copies/src/CMakeLists.txt
@@ -51,7 +51,7 @@ add_custom_target(fpga_emu DEPENDS ${EMULATOR_TARGET})
 # To compile manually:
 #   icpx -fsycl -fintelfpga -Xshardware -Xstarget=<FPGA_DEVICE> -fsycl-link=early private_copies.cpp -o private_copies_report.a
 set(FPGA_EARLY_IMAGE ${TARGET_NAME}_report.a)
-# The compile output is not an executable, but an intermediate compilation result unique to DPC++.
+# The compile output is not an executable, but an intermediate compilation result unique to SYCL.
 add_executable(${FPGA_EARLY_IMAGE} ${SOURCE_FILE})
 target_include_directories(${FPGA_EARLY_IMAGE} PRIVATE ../../../../include)
 add_custom_target(report DEPENDS ${FPGA_EARLY_IMAGE})

--- a/DirectProgramming/DPC++FPGA/Tutorials/Features/private_copies/src/CMakeLists.txt
+++ b/DirectProgramming/DPC++FPGA/Tutorials/Features/private_copies/src/CMakeLists.txt
@@ -1,6 +1,3 @@
-# To see a Makefile equivalent of this build system:
-# https://github.com/oneapi-src/oneAPI-samples/blob/master/DirectProgramming/DPC++/ProjectTemplates/makefile-fpga
-
 set(SOURCE_FILE private_copies.cpp)
 set(TARGET_NAME private_copies)
 set(EMULATOR_TARGET ${TARGET_NAME}.fpga_emu)

--- a/DirectProgramming/DPC++FPGA/Tutorials/Features/private_copies/src/CMakeLists.txt
+++ b/DirectProgramming/DPC++FPGA/Tutorials/Features/private_copies/src/CMakeLists.txt
@@ -21,7 +21,7 @@ if(WIN32)
     set(WIN_FLAG "/EHsc")
 endif()
 
-# A DPC++ ahead-of-time (AoT) compile processes the device code in two stages.
+# A SYCL ahead-of-time (AoT) compile processes the device code in two stages.
 # 1. The "compile" stage compiles the device code to an intermediate representation (SPIR-V).
 # 2. The "link" stage invokes the compiler's FPGA backend before linking.
 #    For this reason, FPGA backend flags must be passed as link flags in CMake.

--- a/DirectProgramming/DPC++FPGA/Tutorials/Features/read_only_cache/README.md
+++ b/DirectProgramming/DPC++FPGA/Tutorials/Features/read_only_cache/README.md
@@ -7,7 +7,7 @@ memory in a non-contiguous manner.
 |:---                                |:---
 | OS                                | Linux* Ubuntu* 18.04/20.04 <br> RHEL*/CentOS* 8 <br> SUSE* 15 <br> Windows* 10
 | Hardware                          | Intel&reg; Programmable Acceleration Card (PAC) with Intel Arria&reg; 10 GX FPGA <br> Intel&reg; FPGA Programmable Acceleration Card (PAC) D5005 (with Intel Stratix&reg; 10 SX) <br> Intel&reg; FPGA 3rd party / custom platforms with oneAPI support <br> **Note**: Intel&reg; FPGA PAC hardware is only compatible with Ubuntu 18.04*
-| Software                          | Intel&reg; oneAPI DPC++ Compiler <br> Intel&reg; FPGA Add-On for oneAPI Base Toolkit
+| Software                          | Intel&reg; oneAPI SYCL Compiler <br> Intel&reg; FPGA Add-On for oneAPI Base Toolkit
 | What you will learn               | How and when to use the read-only cache feature
 | Time to complete                  | 30 minutes
 

--- a/DirectProgramming/DPC++FPGA/Tutorials/Features/read_only_cache/sample.json
+++ b/DirectProgramming/DPC++FPGA/Tutorials/Features/read_only_cache/sample.json
@@ -2,7 +2,7 @@
   "guid": "4A9A5E59-D877-4FFF-A44C-0B96491840C0",
   "name": "Read-Only Cache",
   "categories": ["Toolkit/oneAPI Direct Programming/DPC++ FPGA/Tutorials/Features"],
-  "description": "An Intel® FPGA tutorial demonstrating how to use the read-only cache feature to boost the throughput of a DPC++ FPGA program",
+  "description": "An Intel® FPGA tutorial demonstrating how to use the read-only cache feature to boost the throughput of a SYCL FPGA program",
   "toolchain": ["icpx"],
   "os": ["linux", "windows"],
   "targetDevice": ["FPGA"],

--- a/DirectProgramming/DPC++FPGA/Tutorials/Features/read_only_cache/src/CMakeLists.txt
+++ b/DirectProgramming/DPC++FPGA/Tutorials/Features/read_only_cache/src/CMakeLists.txt
@@ -22,7 +22,7 @@ if(WIN32)
     set(WIN_FLAG "/EHsc")
 endif()
 
-# A DPC++ ahead-of-time (AoT) compile processes the device code in two stages.
+# A SYCL ahead-of-time (AoT) compile processes the device code in two stages.
 # 1. The "compile" stage compiles the device code to an intermediate representation (SPIR-V).
 # 2. The "link" stage invokes the compiler's FPGA backend before linking.
 #    For this reason, FPGA backend flags must be passed as link flags in CMake.

--- a/DirectProgramming/DPC++FPGA/Tutorials/Features/read_only_cache/src/CMakeLists.txt
+++ b/DirectProgramming/DPC++FPGA/Tutorials/Features/read_only_cache/src/CMakeLists.txt
@@ -53,7 +53,7 @@ add_custom_target(fpga_emu DEPENDS ${EMULATOR_TARGET})
 #   icpx -fsycl -fintelfpga -Xshardware -Xstarget=<FPGA_DEVICE> -fsycl-link=early read_only_cache.cpp -o read_only_cache_report.a
 set(FPGA_EARLY_IMAGE_CACHE_DISABLED ${TARGET_NAME}_disabled_report.a)
 set(FPGA_EARLY_IMAGE_CACHE_ENABLED ${TARGET_NAME}_enabled_report.a)
-# The compile output is not an executable, but an intermediate compilation result unique to DPC++.
+# The compile output is not an executable, but an intermediate compilation result unique to SYCL.
 add_executable(${FPGA_EARLY_IMAGE_CACHE_DISABLED} ${SOURCE_FILE})
 target_include_directories(${FPGA_EARLY_IMAGE_CACHE_DISABLED} PRIVATE ../../../../include)
 add_executable(${FPGA_EARLY_IMAGE_CACHE_ENABLED} ${SOURCE_FILE})

--- a/DirectProgramming/DPC++FPGA/Tutorials/Features/read_only_cache/src/CMakeLists.txt
+++ b/DirectProgramming/DPC++FPGA/Tutorials/Features/read_only_cache/src/CMakeLists.txt
@@ -1,6 +1,3 @@
-# To see a Makefile equivalent of this build system:
-# https://github.com/oneapi-src/oneAPI-samples/blob/master/DirectProgramming/DPC++/ProjectTemplates/makefile-fpga
-
 set(SOURCE_FILE read_only_cache.cpp)
 set(TARGET_NAME read_only_cache)
 set(EMULATOR_TARGET ${TARGET_NAME}.fpga_emu)

--- a/DirectProgramming/DPC++FPGA/Tutorials/Features/scheduler_target_fmax/README.md
+++ b/DirectProgramming/DPC++FPGA/Tutorials/Features/scheduler_target_fmax/README.md
@@ -6,7 +6,7 @@ This tutorial explains the `scheduler_target_fmax_mhz` attribute and its effect 
 |:---                               |:---
 | OS                                | Linux* Ubuntu* 18.04/20.04 <br> RHEL*/CentOS* 8 <br> SUSE* 15 <br> Windows* 10
 | Hardware                          | Intel&reg; Programmable Acceleration Card (PAC) with Intel Arria&reg; 10 GX FPGA <br> Intel&reg; FPGA Programmable Acceleration Card (PAC) D5005 (with Intel Stratix&reg; 10 SX) <br> Intel&reg; FPGA 3rd party / custom platforms with oneAPI support <br> *__Note__: Intel&reg; FPGA PAC hardware is only compatible with Ubuntu 18.04*
-| Software                          | Intel&reg; oneAPI DPC++ Compiler <br> Intel&reg; FPGA Add-On for oneAPI Base Toolkit
+| Software                          | Intel&reg; oneAPI SYCL Compiler <br> Intel&reg; FPGA Add-On for oneAPI Base Toolkit
 | What you will learn               |  The behavior of the `scheduler_target_fmax_mhz` attribute and when to use it. <br> The effect this attribute can have on kernel performance on FPGA.
 | Time to complete                  | 15 minutes
 

--- a/DirectProgramming/DPC++FPGA/Tutorials/Features/scheduler_target_fmax/src/CMakeLists.txt
+++ b/DirectProgramming/DPC++FPGA/Tutorials/Features/scheduler_target_fmax/src/CMakeLists.txt
@@ -1,6 +1,3 @@
-# To see a Makefile equivalent of this build system:
-# https://github.com/oneapi-src/oneAPI-samples/blob/master/DirectProgramming/DPC++/ProjectTemplates/makefile-fpga
-
 set(SOURCE_FILE scheduler_target_fmax.cpp)
 set(TARGET_NAME scheduler_target_fmax)
 set(EMULATOR_TARGET ${TARGET_NAME}.fpga_emu)

--- a/DirectProgramming/DPC++FPGA/Tutorials/Features/scheduler_target_fmax/src/CMakeLists.txt
+++ b/DirectProgramming/DPC++FPGA/Tutorials/Features/scheduler_target_fmax/src/CMakeLists.txt
@@ -54,7 +54,7 @@ add_custom_target(fpga_emu DEPENDS ${EMULATOR_TARGET})
 # To compile manually:
 #   icpx -fsycl -fintelfpga -Xshardware -Xstarget=<FPGA_DEVICE> -fsycl-link=early scheduler_target_fmax.cpp -o scheduler_target_fmax_report.a
 set(FPGA_EARLY_IMAGE ${TARGET_NAME}_report.a)
-# The compile output is not an executable, but an intermediate compilation result unique to DPC++.
+# The compile output is not an executable, but an intermediate compilation result unique to SYCL.
 add_executable(${FPGA_EARLY_IMAGE} ${SOURCE_FILE})
 target_include_directories(${FPGA_EARLY_IMAGE} PRIVATE ../../../../include)
 add_custom_target(report DEPENDS ${FPGA_EARLY_IMAGE})

--- a/DirectProgramming/DPC++FPGA/Tutorials/Features/scheduler_target_fmax/src/CMakeLists.txt
+++ b/DirectProgramming/DPC++FPGA/Tutorials/Features/scheduler_target_fmax/src/CMakeLists.txt
@@ -22,7 +22,7 @@ if(WIN32)
     set(WIN_FLAG "/EHsc")
 endif()
 
-# A DPC++ ahead-of-time (AoT) compile processes the device code in two stages.
+# A SYCL ahead-of-time (AoT) compile processes the device code in two stages.
 # 1. The "compile" stage compiles the device code to an intermediate representation (SPIR-V).
 # 2. The "link" stage invokes the compiler's FPGA backend before linking.
 #    For this reason, FPGA backend flags must be passed as link flags in CMake.

--- a/DirectProgramming/DPC++FPGA/Tutorials/Features/speculated_iterations/README.md
+++ b/DirectProgramming/DPC++FPGA/Tutorials/Features/speculated_iterations/README.md
@@ -6,7 +6,7 @@ This FPGA tutorial demonstrates applying the `speculated_iterations` attribute t
 |:---                               |:---
 | OS                                | Linux* Ubuntu* 18.04/20.04 <br> RHEL*/CentOS* 8 <br> SUSE* 15 <br> Windows* 10
 | Hardware                          | Intel&reg; Programmable Acceleration Card (PAC) with Intel Arria&reg; 10 GX FPGA <br> Intel&reg; FPGA Programmable Acceleration Card (PAC) D5005 (with Intel Stratix&reg; 10 SX) <br> Intel&reg; FPGA 3rd party / custom platforms with oneAPI support <br> *__Note__: Intel&reg; FPGA PAC hardware is only compatible with Ubuntu 18.04*
-| Software                          | Intel&reg; oneAPI DPC++ Compiler <br> Intel&reg; FPGA Add-On for oneAPI Base Toolkit
+| Software                          | Intel&reg; oneAPI SYCL Compiler <br> Intel&reg; FPGA Add-On for oneAPI Base Toolkit
 | What you will learn               |  What the `speculated_iterations` attribute does <br> How to apply the `speculated_iterations` attribute to loops in your program <br> How to determine the optimal number of speculated iterations
 | Time to complete                  | 15 minutes
 

--- a/DirectProgramming/DPC++FPGA/Tutorials/Features/speculated_iterations/src/CMakeLists.txt
+++ b/DirectProgramming/DPC++FPGA/Tutorials/Features/speculated_iterations/src/CMakeLists.txt
@@ -1,6 +1,3 @@
-# To see a Makefile equivalent of this build system:
-# https://github.com/oneapi-src/oneAPI-samples/blob/master/DirectProgramming/DPC++/ProjectTemplates/makefile-fpga
-
 set(SOURCE_FILE speculated_iterations.cpp)
 set(TARGET_NAME speculated_iterations)
 set(EMULATOR_TARGET ${TARGET_NAME}.fpga_emu)

--- a/DirectProgramming/DPC++FPGA/Tutorials/Features/speculated_iterations/src/CMakeLists.txt
+++ b/DirectProgramming/DPC++FPGA/Tutorials/Features/speculated_iterations/src/CMakeLists.txt
@@ -69,7 +69,7 @@ add_custom_target(fpga_emu DEPENDS ${EMULATOR_TARGET})
 # To compile manually:
 #   icpx -fsycl -fintelfpga -Xshardware -Xstarget=<FPGA_DEVICE> -DA10 -fsycl-link=early speculated_iterations.cpp -o speculated_iterations_report.a
 set(FPGA_EARLY_IMAGE ${TARGET_NAME}_report.a)
-# The compile output is not an executable, but an intermediate compilation result unique to DPC++.
+# The compile output is not an executable, but an intermediate compilation result unique to SYCL.
 add_executable(${FPGA_EARLY_IMAGE} ${SOURCE_FILE})
 target_include_directories(${FPGA_EARLY_IMAGE} PRIVATE ../../../../include)
 add_custom_target(report DEPENDS ${FPGA_EARLY_IMAGE})

--- a/DirectProgramming/DPC++FPGA/Tutorials/Features/speculated_iterations/src/CMakeLists.txt
+++ b/DirectProgramming/DPC++FPGA/Tutorials/Features/speculated_iterations/src/CMakeLists.txt
@@ -37,7 +37,7 @@ if(WIN32)
     set(WIN_FLAG "/EHsc")
 endif()
 
-# A DPC++ ahead-of-time (AoT) compile processes the device code in two stages.
+# A SYCL ahead-of-time (AoT) compile processes the device code in two stages.
 # 1. The "compile" stage compiles the device code to an intermediate representation (SPIR-V).
 # 2. The "link" stage invokes the compiler's FPGA backend before linking.
 #    For this reason, FPGA backend flags must be passed as link flags in CMake.

--- a/DirectProgramming/DPC++FPGA/Tutorials/Features/stall_enable/README.md
+++ b/DirectProgramming/DPC++FPGA/Tutorials/Features/stall_enable/README.md
@@ -5,7 +5,7 @@ This FPGA tutorial demonstrates how to use the `use_stall_enable_clusters` attri
 |:---                               |:---
 | OS                                | Linux* Ubuntu* 18.04/20.04 <br> RHEL*/CentOS* 8 <br> SUSE* 15 <br> Windows* 10
 | Hardware                          | Intel&reg; Programmable Acceleration Card (PAC) with Intel Arria&reg; 10 GX FPGA <br> Intel&reg; FPGA Programmable Acceleration Card (PAC) D5005 (with Intel Stratix&reg; 10 SX) <br> Intel&reg; FPGA 3rd party / custom platforms with oneAPI support <br> **Note**: Intel&reg; FPGA PAC hardware is only compatible with Ubuntu 18.04*
-| Software                          | Intel&reg; oneAPI DPC++ Compiler <br> Intel&reg; FPGA Add-On for oneAPI Base Toolkit
+| Software                          | Intel&reg; oneAPI SYCL Compiler <br> Intel&reg; FPGA Add-On for oneAPI Base Toolkit
 | What you will learn               |  What the `use_stall_enable_clusters` attribute does <br> How `use_stall_enable_clusters` attribute affects resource usage and latency <br> How to apply the `use_stall_enable_clusters` attribute to kernels in your program
 | Time to complete                  | 15 minutes (emulator and report) <br> several hours (fpga bitstream generation)
 

--- a/DirectProgramming/DPC++FPGA/Tutorials/Features/stall_enable/src/CMakeLists.txt
+++ b/DirectProgramming/DPC++FPGA/Tutorials/Features/stall_enable/src/CMakeLists.txt
@@ -33,7 +33,7 @@ if(WIN32)
     set(WIN_FLAG "/EHsc")
 endif()
 
-# A DPC++ ahead-of-time (AoT) compile processes the device code in two stages.
+# A SYCL ahead-of-time (AoT) compile processes the device code in two stages.
 # 1. The "compile" stage compiles the device code to an intermediate representation (SPIR-V).
 # 2. The "link" stage invokes the compiler's FPGA backend before linking.
 #    For this reason, FPGA backend flags must be passed as link flags in CMake.

--- a/DirectProgramming/DPC++FPGA/Tutorials/Features/stall_enable/src/CMakeLists.txt
+++ b/DirectProgramming/DPC++FPGA/Tutorials/Features/stall_enable/src/CMakeLists.txt
@@ -1,6 +1,3 @@
-# To see a Makefile equivalent of this build system:
-# https://github.com/oneapi-src/oneAPI-samples/blob/master/DirectProgramming/DPC++/ProjectTemplates/makefile-fpga
-
 set(SOURCE_FILE stall_enable.cpp)
 set(STALL_ENABLE_TARGET_NAME stall_enable)
 set(EMULATOR_TARGET ${STALL_ENABLE_TARGET_NAME}.fpga_emu)

--- a/DirectProgramming/DPC++FPGA/Tutorials/Features/stall_enable/src/CMakeLists.txt
+++ b/DirectProgramming/DPC++FPGA/Tutorials/Features/stall_enable/src/CMakeLists.txt
@@ -87,7 +87,7 @@ add_custom_target(fpga_sim DEPENDS ${SIMULATOR_TARGET} ${STALL_FREE_SIMULATOR_TA
 # To compile manually (Stall Enable):
 #   icpx -fsycl -fintelfpga -Xshardware -Xstarget=<FPGA_DEVICE> -fsycl-link=early stall_enable.cpp -o stall_enable.a
 set(FPGA_EARLY_IMAGE ${STALL_ENABLE_TARGET_NAME}_report.a)
-# The compile output is not an executable, but an intermediate compilation result unique to DPC++.
+# The compile output is not an executable, but an intermediate compilation result unique to SYCL.
 add_executable(${FPGA_EARLY_IMAGE} ${SOURCE_FILE})
 target_include_directories(${FPGA_EARLY_IMAGE} PRIVATE ../../../../include)
 set_target_properties(${FPGA_EARLY_IMAGE} PROPERTIES COMPILE_FLAGS "${HARDWARE_COMPILE_FLAGS}")
@@ -97,7 +97,7 @@ set_target_properties(${FPGA_EARLY_IMAGE} PROPERTIES LINK_FLAGS "${HARDWARE_LINK
 # To compile manually (Stall Free):
 #   icpx -DSTALL_FREE -fsycl -fintelfpga -Xshardware -Xstarget=<FPGA_DEVICE> -fsycl-link=early stall_enable.cpp -o stall_enable.a
 set(FPGA_STALL_FREE_EARLY_IMAGE ${STALL_FREE_TARGET_NAME}_report.a)
-# The compile output is not an executable, but an intermediate compilation result unique to DPC++.
+# The compile output is not an executable, but an intermediate compilation result unique to SYCL.
 add_executable(${FPGA_STALL_FREE_EARLY_IMAGE} ${SOURCE_FILE})
 target_include_directories(${FPGA_STALL_FREE_EARLY_IMAGE} PRIVATE ../../../../include)
 add_custom_target(report DEPENDS ${FPGA_EARLY_IMAGE} ${FPGA_STALL_FREE_EARLY_IMAGE})

--- a/DirectProgramming/DPC++FPGA/Tutorials/GettingStarted/fast_recompile/README.md
+++ b/DirectProgramming/DPC++FPGA/Tutorials/GettingStarted/fast_recompile/README.md
@@ -6,14 +6,14 @@ This FPGA tutorial demonstrates how to separate the compilation of a program's h
 ---                                 |---
 | OS                                | Linux* Ubuntu* 18.04/20.04 <br> RHEL*/CentOS* 8 <br> SUSE* 15 <br> Windows* 10
 | Hardware                          | Intel® Programmable Acceleration Card (PAC) with Intel Arria® 10 GX FPGA <br> Intel® FPGA Programmable Acceleration Card (PAC) D5005 (with Intel Stratix® 10 SX) <br> Intel® FPGA 3rd party / custom platforms with oneAPI support <br> *__Note__: Intel® FPGA PAC hardware is only compatible with Ubuntu 18.04*
-| Software                          | Intel® oneAPI DPC++ Compiler <br> Intel® FPGA Add-On for oneAPI Base Toolkit
+| Software                          | Intel® oneAPI SYCL Compiler <br> Intel® FPGA Add-On for oneAPI Base Toolkit
 | What you will learn               | Why to separate host and device code compilation in your FPGA project <br> How to use the `-reuse-exe` and device link methods <br> Which method to choose for your project
 | Time to complete                  | 15 minutes
 
 
 
 ## Purpose
-Intel® oneAPI DPC++ Compiler only supports ahead-of-time (AoT) compilation for FPGA, which means that an FPGA device image is generated at compile time. The FPGA device image generation process can take hours to complete. Suppose you make a change that is exclusive to the host code. In that case, it is more efficient to recompile your host code only, re-using the existing FPGA device image and circumventing the time-consuming device compilation process.
+Intel® oneAPI SYCL Compiler only supports ahead-of-time (AoT) compilation for FPGA, which means that an FPGA device image is generated at compile time. The FPGA device image generation process can take hours to complete. Suppose you make a change that is exclusive to the host code. In that case, it is more efficient to recompile your host code only, re-using the existing FPGA device image and circumventing the time-consuming device compilation process.
 
 **NOTE:** In this sample, the compiler is refered to as `icpx`. On Windows, you should use `icx-cl`.
 

--- a/DirectProgramming/DPC++FPGA/Tutorials/GettingStarted/fast_recompile/src/CMakeLists.txt
+++ b/DirectProgramming/DPC++FPGA/Tutorials/GettingStarted/fast_recompile/src/CMakeLists.txt
@@ -20,7 +20,7 @@ if(WIN32)
     set(WIN_FLAG "/EHsc")
 endif()
 
-# A DPC++ ahead-of-time (AoT) compile processes the device code in two stages.
+# A SYCL ahead-of-time (AoT) compile processes the device code in two stages.
 # 1. The "compile" stage compiles the device code to an intermediate representation (SPIR-V).
 # 2. The "link" stage invokes the compiler's FPGA backend before linking.
 #    For this reason, FPGA backend flags must be passed as link flags in CMake.

--- a/DirectProgramming/DPC++FPGA/Tutorials/GettingStarted/fast_recompile/src/CMakeLists.txt
+++ b/DirectProgramming/DPC++FPGA/Tutorials/GettingStarted/fast_recompile/src/CMakeLists.txt
@@ -51,7 +51,7 @@ add_custom_target(fpga_emu DEPENDS ${EMULATOR_TARGET})
 # To compile manually:
 #   icpx -fsycl -fintelfpga -Xshardware -Xstarget=<FPGA_DEVICE> -fsycl-link=early host.cpp kernel.cpp -o fast_compile_report.a
 set(FPGA_EARLY_IMAGE ${TARGET_NAME}_report.a)
-# The compile output is not an executable, but an intermediate compilation result unique to DPC++.
+# The compile output is not an executable, but an intermediate compilation result unique to SYCL.
 add_executable(${FPGA_EARLY_IMAGE} ${HOST_SOURCE_FILE} ${DEVICE_SOURCE_FILE})
 target_include_directories(${FPGA_EARLY_IMAGE} PRIVATE ../../../../include)
 add_custom_target(report DEPENDS ${FPGA_EARLY_IMAGE})

--- a/DirectProgramming/DPC++FPGA/Tutorials/GettingStarted/fpga_compile/README.md
+++ b/DirectProgramming/DPC++FPGA/Tutorials/GettingStarted/fpga_compile/README.md
@@ -5,7 +5,7 @@ This FPGA tutorial introduces how to compile SYCL*-compliant code for FPGA throu
 |:---                                 |:---
 | OS                                | Linux* Ubuntu* 18.04/20.04 <br> RHEL*/CentOS* 8 <br> SUSE* 15 <br> Windows* 10
 | Hardware                          | Intel® Programmable Acceleration Card (PAC) with Intel Arria® 10 GX FPGA <br> Intel® FPGA Programmable Acceleration Card (PAC) D5005 (with Intel Stratix® 10 SX) <br> Intel® FPGA 3rd party / custom platforms with oneAPI support <br> *__Note__: Intel® FPGA PAC hardware is only compatible with Ubuntu 18.04*
-| Software                          | Intel® oneAPI DPC++ Compiler <br> Intel® FPGA Add-On for oneAPI Base Toolkit
+| Software                          | Intel® oneAPI SYCL Compiler <br> Intel® FPGA Add-On for oneAPI Base Toolkit
 | What you will learn               | How and why compiling SYCL* code for FPGA differs from CPU or GPU <br> FPGA device image types and when to use them <br> The compile options used to target FPGA
 | Time to complete                  | 15 minutes
 
@@ -19,7 +19,7 @@ FPGAs differ from CPUs and GPUs in many interesting ways. However, in this tutor
 
 For this reason, only ahead-of-time (or "offline") kernel compilation mode is supported for FPGA. The long compile time for FPGA hardware makes just-in-time (or "online") compilation impractical.
 
-Long compile times are detrimental to developer productivity. The Intel® oneAPI DPC++ Compiler provides several mechanisms that enable developers targeting FPGA to iterate quickly on their designs. By circumventing the time-consuming process of full FPGA compilation wherever possible, SYCL for FPGA developers can enjoy the fast compile times familiar to CPU and GPU developers.
+Long compile times are detrimental to developer productivity. The Intel® oneAPI SYCL Compiler provides several mechanisms that enable developers targeting FPGA to iterate quickly on their designs. By circumventing the time-consuming process of full FPGA compilation wherever possible, SYCL for FPGA developers can enjoy the fast compile times familiar to CPU and GPU developers.
 
 
 ### Three types of SYCL for FPGA compilation
@@ -33,7 +33,7 @@ The three types of FPGA compilation are summarized in the table below.
 
 The typical FPGA development workflow is to iterate in each of these stages, refining the code using the feedback provided by that stage. Intel® recommends relying on emulation and the optimization report whenever possible.
 
-- Compiling for FPGA emulation or generating the FPGA optimization report requires only the Intel® oneAPI DPC++ Compiler (part of the Intel® oneAPI Base Toolkit).
+- Compiling for FPGA emulation or generating the FPGA optimization report requires only the Intel® oneAPI SYCL Compiler (part of the Intel® oneAPI Base Toolkit).
 - An FPGA hardware compile requires the Intel® FPGA Add-On for oneAPI Base Toolkit.
 
 #### FPGA Emulator

--- a/DirectProgramming/DPC++FPGA/Tutorials/GettingStarted/fpga_compile/sample.json
+++ b/DirectProgramming/DPC++FPGA/Tutorials/GettingStarted/fpga_compile/sample.json
@@ -2,7 +2,7 @@
   "guid": "A211FDE2-B037-4069-BD84-C45E354798B7",
   "name": "FPGA Compile",
   "categories": ["Toolkit/oneAPI Direct Programming/DPC++ FPGA/Getting Started Tutorials"],
-  "description": "Intel® FPGA tutorial introducing how to compile Data Parallel C++ (DPC++) for Intel® FPGA",
+  "description": "Intel® FPGA tutorial introducing how to SYCL for Intel® FPGA",
   "toolchain": ["icpx"],
   "os": ["linux", "windows"],
   "targetDevice": ["FPGA"],

--- a/DirectProgramming/DPC++FPGA/Tutorials/GettingStarted/fpga_compile/src/CMakeLists.txt
+++ b/DirectProgramming/DPC++FPGA/Tutorials/GettingStarted/fpga_compile/src/CMakeLists.txt
@@ -21,7 +21,7 @@ if(WIN32)
     set(WIN_FLAG "/EHsc")
 endif()
 
-# A DPC++ ahead-of-time (AoT) compile processes the device code in two stages.
+# A SYCL ahead-of-time (AoT) compile processes the device code in two stages.
 # 1. The "compile" stage compiles the device code to an intermediate representation (SPIR-V).
 # 2. The "link" stage invokes the compiler's FPGA backend before linking.
 #    For this reason, FPGA backend flags must be passed as link flags in CMake.

--- a/DirectProgramming/DPC++FPGA/Tutorials/GettingStarted/fpga_compile/src/CMakeLists.txt
+++ b/DirectProgramming/DPC++FPGA/Tutorials/GettingStarted/fpga_compile/src/CMakeLists.txt
@@ -51,7 +51,7 @@ add_custom_target(fpga_emu DEPENDS ${EMULATOR_TARGET})
 # To compile manually:
 #   icpx -fsycl -fintelfpga -Xshardware -Xstarget=<FPGA_DEVICE> -fsycl-link=early fpga_compile.cpp -o fpga_compile_report.a
 set(FPGA_EARLY_IMAGE ${TARGET_NAME}_report.a)
-# The compile output is not an executable, but an intermediate compilation result unique to DPC++.
+# The compile output is not an executable, but an intermediate compilation result unique to SYCL.
 add_executable(${FPGA_EARLY_IMAGE} ${SOURCE_FILE})
 target_include_directories(${FPGA_EARLY_IMAGE} PRIVATE ../../../../include)
 add_custom_target(report DEPENDS ${FPGA_EARLY_IMAGE})

--- a/DirectProgramming/DPC++FPGA/Tutorials/GettingStarted/fpga_compile/src/CMakeLists.txt
+++ b/DirectProgramming/DPC++FPGA/Tutorials/GettingStarted/fpga_compile/src/CMakeLists.txt
@@ -1,6 +1,3 @@
-# To see a Makefile equivalent of this build system:
-# https://github.com/oneapi-src/oneAPI-samples/blob/master/DirectProgramming/DPC++/ProjectTemplates/makefile-fpga
-
 set(SOURCE_FILE fpga_compile.cpp)
 set(TARGET_NAME fpga_compile)
 set(EMULATOR_TARGET ${TARGET_NAME}.fpga_emu)

--- a/DirectProgramming/DPC++FPGA/Tutorials/Tools/dynamic_profiler/README.md
+++ b/DirectProgramming/DPC++FPGA/Tutorials/Tools/dynamic_profiler/README.md
@@ -8,7 +8,7 @@ This FPGA tutorial demonstrates how to use the Intel&reg; FPGA Dynamic Profiler 
 |:---                               |:---
 | OS                                | Linux* Ubuntu* 18.04/20.04 <br> RHEL*/CentOS* 8 <br> SUSE* 15
 | Hardware                          | Intel&reg; Programmable Acceleration Card (PAC) with Intel Arria&reg; 10 GX FPGA <br> Intel&reg; FPGA Programmable Acceleration Card (PAC) D5005 (with Intel Stratix&reg; 10 SX) <br> Intel&reg; FPGA 3rd party / custom platforms with oneAPI support <br> *__Note__: Intel&reg; FPGA PAC hardware is only compatible with Ubuntu 18.04*
-| Software                          | Intel&reg; oneAPI SYCL Compiler <br> Intel&reg; FPGA Add-On for oneAPI Base Toolkit
+| Software                          | Intel&reg; oneAPI DPC++ Compiler <br> Intel&reg; FPGA Add-On for oneAPI Base Toolkit
 | What you will learn               | About the Intel&reg; FPGA Dynamic Profiler for DPC++ <br> How to set up and use this tool <br> A case study of using this tool to identify performance bottlenecks in pipes.
 | Time to complete                  | 15 minutes
 
@@ -67,7 +67,7 @@ There are two ways of obtaining data from a program containing performance count
     Instructions on installing, configure and opening the Intel&reg; VTune™ Profiler can be found in the [Intel&reg; VTune™ Profiler User Guide](https://software.intel.com/content/www/us/en/develop/documentation/vtune-help/top/installation.html). Further instructions on setting up the Dynamic Profiler via the CPU/FPGA Interaction View can be found in the [CPU/FPGA Interaction Analysis](https://software.intel.com/content/www/us/en/develop/documentation/vtune-help/top/analyze-performance/accelerators-group/cpu-fpga-interaction-analysis-preview.html) section of the Intel&reg; VTune™ Profiler User Guide. To extract device performance counter data, please ensure the source for the FPGA profiling data is set to "AOCL Profiler".
 
 2. Run the design from the command line using the Profiler Runtime Wrapper.
-  The Profiler Runtime Wrapper comes as part of the Intel&reg; oneAPI SYCL Compiler and can be run as follows:
+  The Profiler Runtime Wrapper comes as part of the Intel&reg; oneAPI DPC++ Compiler and can be run as follows:
    ```
    aocl profile <executable>
    ```

--- a/DirectProgramming/DPC++FPGA/Tutorials/Tools/dynamic_profiler/README.md
+++ b/DirectProgramming/DPC++FPGA/Tutorials/Tools/dynamic_profiler/README.md
@@ -8,7 +8,7 @@ This FPGA tutorial demonstrates how to use the Intel&reg; FPGA Dynamic Profiler 
 |:---                               |:---
 | OS                                | Linux* Ubuntu* 18.04/20.04 <br> RHEL*/CentOS* 8 <br> SUSE* 15
 | Hardware                          | Intel&reg; Programmable Acceleration Card (PAC) with Intel Arria&reg; 10 GX FPGA <br> Intel&reg; FPGA Programmable Acceleration Card (PAC) D5005 (with Intel Stratix&reg; 10 SX) <br> Intel&reg; FPGA 3rd party / custom platforms with oneAPI support <br> *__Note__: Intel&reg; FPGA PAC hardware is only compatible with Ubuntu 18.04*
-| Software                          | Intel&reg; oneAPI DPC++ Compiler <br> Intel&reg; FPGA Add-On for oneAPI Base Toolkit
+| Software                          | Intel&reg; oneAPI SYCL Compiler <br> Intel&reg; FPGA Add-On for oneAPI Base Toolkit
 | What you will learn               | About the Intel&reg; FPGA Dynamic Profiler for DPC++ <br> How to set up and use this tool <br> A case study of using this tool to identify performance bottlenecks in pipes.
 | Time to complete                  | 15 minutes
 
@@ -19,7 +19,7 @@ This FPGA tutorial demonstrates how to use the Intel&reg; FPGA Dynamic Profiler 
 
 ###  Profiling Tools
 
-Intel&reg; oneAPI provides two runtime profiling tools to help you analyze your DPC++ design for FPGA:
+Intel&reg; oneAPI provides two runtime profiling tools to help you analyze your SYCL design for FPGA:
 
 1. The **Intel&reg; FPGA Dynamic Profiler for DPC++** is a profiling tool used to collect fine-grained device side data during SYCL* kernel execution. When used within the Intel&reg; VTune™ Profiler, some host side performance data is also collected. However, note that the VTune Profiler is not designed to collect detailed system level host-side data.
 
@@ -67,7 +67,7 @@ There are two ways of obtaining data from a program containing performance count
     Instructions on installing, configure and opening the Intel&reg; VTune™ Profiler can be found in the [Intel&reg; VTune™ Profiler User Guide](https://software.intel.com/content/www/us/en/develop/documentation/vtune-help/top/installation.html). Further instructions on setting up the Dynamic Profiler via the CPU/FPGA Interaction View can be found in the [CPU/FPGA Interaction Analysis](https://software.intel.com/content/www/us/en/develop/documentation/vtune-help/top/analyze-performance/accelerators-group/cpu-fpga-interaction-analysis-preview.html) section of the Intel&reg; VTune™ Profiler User Guide. To extract device performance counter data, please ensure the source for the FPGA profiling data is set to "AOCL Profiler".
 
 2. Run the design from the command line using the Profiler Runtime Wrapper.
-  The Profiler Runtime Wrapper comes as part of the Intel&reg; oneAPI DPC++ Compiler and can be run as follows:
+  The Profiler Runtime Wrapper comes as part of the Intel&reg; oneAPI SYCL Compiler and can be run as follows:
    ```
    aocl profile <executable>
    ```

--- a/DirectProgramming/DPC++FPGA/Tutorials/Tools/dynamic_profiler/README.md
+++ b/DirectProgramming/DPC++FPGA/Tutorials/Tools/dynamic_profiler/README.md
@@ -8,7 +8,7 @@ This FPGA tutorial demonstrates how to use the Intel&reg; FPGA Dynamic Profiler 
 |:---                               |:---
 | OS                                | Linux* Ubuntu* 18.04/20.04 <br> RHEL*/CentOS* 8 <br> SUSE* 15
 | Hardware                          | Intel&reg; Programmable Acceleration Card (PAC) with Intel Arria&reg; 10 GX FPGA <br> Intel&reg; FPGA Programmable Acceleration Card (PAC) D5005 (with Intel Stratix&reg; 10 SX) <br> Intel&reg; FPGA 3rd party / custom platforms with oneAPI support <br> *__Note__: Intel&reg; FPGA PAC hardware is only compatible with Ubuntu 18.04*
-| Software                          | Intel&reg; oneAPI DPC++ Compiler <br> Intel&reg; FPGA Add-On for oneAPI Base Toolkit
+| Software                          | Intel&reg; oneAPI SYCL Compiler <br> Intel&reg; FPGA Add-On for oneAPI Base Toolkit
 | What you will learn               | About the Intel&reg; FPGA Dynamic Profiler for DPC++ <br> How to set up and use this tool <br> A case study of using this tool to identify performance bottlenecks in pipes.
 | Time to complete                  | 15 minutes
 
@@ -67,7 +67,7 @@ There are two ways of obtaining data from a program containing performance count
     Instructions on installing, configure and opening the Intel&reg; VTune™ Profiler can be found in the [Intel&reg; VTune™ Profiler User Guide](https://software.intel.com/content/www/us/en/develop/documentation/vtune-help/top/installation.html). Further instructions on setting up the Dynamic Profiler via the CPU/FPGA Interaction View can be found in the [CPU/FPGA Interaction Analysis](https://software.intel.com/content/www/us/en/develop/documentation/vtune-help/top/analyze-performance/accelerators-group/cpu-fpga-interaction-analysis-preview.html) section of the Intel&reg; VTune™ Profiler User Guide. To extract device performance counter data, please ensure the source for the FPGA profiling data is set to "AOCL Profiler".
 
 2. Run the design from the command line using the Profiler Runtime Wrapper.
-  The Profiler Runtime Wrapper comes as part of the Intel&reg; oneAPI DPC++ Compiler and can be run as follows:
+  The Profiler Runtime Wrapper comes as part of the Intel&reg; oneAPI SYCL Compiler and can be run as follows:
    ```
    aocl profile <executable>
    ```

--- a/DirectProgramming/DPC++FPGA/Tutorials/Tools/dynamic_profiler/sample.json
+++ b/DirectProgramming/DPC++FPGA/Tutorials/Tools/dynamic_profiler/sample.json
@@ -2,7 +2,7 @@
   "guid": "51713811-2E33-43D8-A064-4D711160EA05",
   "name": "Dynamic Profiler",
   "categories": ["Toolkit/oneAPI Direct Programming/DPC++ FPGA/Tutorials/Tools"],
-  "description": "An Intel® FPGA tutorial demonstrating how to use the Intel® FPGA Dynamic Profiler for Data Parallel C++ (DPC++) to dynamically collect performance data and reveal areas for optimization",
+  "description": "An tutorial demonstrating how to use the Intel® FPGA Dynamic Profiler for Data Parallel C++ (DPC++) to dynamically collect performance data and reveal areas for optimization",
   "toolchain": ["icpx"],
   "os": ["linux"],
   "targetDevice": ["FPGA"],

--- a/DirectProgramming/DPC++FPGA/Tutorials/Tools/dynamic_profiler/src/CMakeLists.txt
+++ b/DirectProgramming/DPC++FPGA/Tutorials/Tools/dynamic_profiler/src/CMakeLists.txt
@@ -17,7 +17,7 @@ else()
     message(STATUS "Configuring the design to run on FPGA board ${FPGA_DEVICE}")
 endif()
 
-# A DPC++ ahead-of-time (AoT) compile processes the device code in two stages.
+# A SYCL ahead-of-time (AoT) compile processes the device code in two stages.
 # 1. The "compile" stage compiles the device code to an intermediate representation (SPIR-V).
 # 2. The "link" stage invokes the compiler's FPGA backend before linking.
 #    For this reason, FPGA backend flags must be passed as link flags in CMake.

--- a/DirectProgramming/DPC++FPGA/Tutorials/Tools/dynamic_profiler/src/CMakeLists.txt
+++ b/DirectProgramming/DPC++FPGA/Tutorials/Tools/dynamic_profiler/src/CMakeLists.txt
@@ -1,6 +1,3 @@
-# To see a Makefile equivalent of this build system:
-# https://github.com/oneapi-src/oneAPI-samples/blob/master/DirectProgramming/DPC++/ProjectTemplates/makefile-fpga
-
 set(SOURCE_FILE dynamic_profiler.cpp)
 set(TARGET_NAME dynamic_profiler)
 set(EMULATOR_TARGET ${TARGET_NAME}.fpga_emu)

--- a/DirectProgramming/DPC++FPGA/Tutorials/Tools/dynamic_profiler/src/CMakeLists.txt
+++ b/DirectProgramming/DPC++FPGA/Tutorials/Tools/dynamic_profiler/src/CMakeLists.txt
@@ -17,7 +17,7 @@ else()
     message(STATUS "Configuring the design to run on FPGA board ${FPGA_DEVICE}")
 endif()
 
-# A SYCL ahead-of-time (AoT) compile processes the device code in two stages.
+# A DPC++ ahead-of-time (AoT) compile processes the device code in two stages.
 # 1. The "compile" stage compiles the device code to an intermediate representation (SPIR-V).
 # 2. The "link" stage invokes the compiler's FPGA backend before linking.
 #    For this reason, FPGA backend flags must be passed as link flags in CMake.

--- a/DirectProgramming/DPC++FPGA/Tutorials/Tools/system_profiling/README.md
+++ b/DirectProgramming/DPC++FPGA/Tutorials/Tools/system_profiling/README.md
@@ -10,7 +10,7 @@ The [Intercept Layer for OpenCL™ Applications](https://github.com/intel/opencl
 ---                                 |---
 | OS                                | Linux* Ubuntu* 18.04/20.04 <br> RHEL*/CentOS* 8 <br> SUSE* 15
 | Hardware                          | Intel&reg; Programmable Acceleration Card (PAC) with Intel Arria&reg; 10 GX FPGA <br> Intel&reg; FPGA Programmable Acceleration Card (PAC) D5005 (with Intel Stratix&reg; 10 SX) <br> Intel&reg; FPGA 3rd party / custom platforms with oneAPI support <br> *__Note__: Intel&reg; FPGA PAC hardware is only compatible with Ubuntu 18.04*
-| Software                          | Intel&reg; oneAPI DPC++ Compiler <br> Intel&reg; FPGA Add-On for oneAPI Base Toolkit
+| Software                          | Intel&reg; oneAPI SYCL Compiler <br> Intel&reg; FPGA Add-On for oneAPI Base Toolkit
 | What you will learn               | Summary of profiling tools available for performance optimization <br> About the Intercept Layer for OpenCL™ Applications <br> How to set up and use this tool <br> A case study of using this tool to identify when the double buffering system-level optimization is beneficial
 | Time to complete                  | 30 minutes
 

--- a/DirectProgramming/DPC++FPGA/Tutorials/Tools/system_profiling/README.md
+++ b/DirectProgramming/DPC++FPGA/Tutorials/Tools/system_profiling/README.md
@@ -10,7 +10,7 @@ The [Intercept Layer for OpenCL™ Applications](https://github.com/intel/opencl
 ---                                 |---
 | OS                                | Linux* Ubuntu* 18.04/20.04 <br> RHEL*/CentOS* 8 <br> SUSE* 15
 | Hardware                          | Intel&reg; Programmable Acceleration Card (PAC) with Intel Arria&reg; 10 GX FPGA <br> Intel&reg; FPGA Programmable Acceleration Card (PAC) D5005 (with Intel Stratix&reg; 10 SX) <br> Intel&reg; FPGA 3rd party / custom platforms with oneAPI support <br> *__Note__: Intel&reg; FPGA PAC hardware is only compatible with Ubuntu 18.04*
-| Software                          | Intel&reg; oneAPI SYCL Compiler <br> Intel&reg; FPGA Add-On for oneAPI Base Toolkit
+| Software                          | Intel&reg; oneAPI DPC++ Compiler <br> Intel&reg; FPGA Add-On for oneAPI Base Toolkit
 | What you will learn               | Summary of profiling tools available for performance optimization <br> About the Intercept Layer for OpenCL™ Applications <br> How to set up and use this tool <br> A case study of using this tool to identify when the double buffering system-level optimization is beneficial
 | Time to complete                  | 30 minutes
 

--- a/DirectProgramming/DPC++FPGA/Tutorials/Tools/system_profiling/src/CMakeLists.txt
+++ b/DirectProgramming/DPC++FPGA/Tutorials/Tools/system_profiling/src/CMakeLists.txt
@@ -17,7 +17,7 @@ else()
     message(STATUS "Configuring the design to run on FPGA board ${FPGA_DEVICE}")
 endif()
 
-# A DPC++ ahead-of-time (AoT) compile processes the device code in two stages.
+# A SYCL ahead-of-time (AoT) compile processes the device code in two stages.
 # 1. The "compile" stage compiles the device code to an intermediate representation (SPIR-V).
 # 2. The "link" stage invokes the compiler's FPGA backend before linking.
 #    For this reason, FPGA backend flags must be passed as link flags in CMake.

--- a/DirectProgramming/DPC++FPGA/Tutorials/Tools/system_profiling/src/CMakeLists.txt
+++ b/DirectProgramming/DPC++FPGA/Tutorials/Tools/system_profiling/src/CMakeLists.txt
@@ -17,7 +17,7 @@ else()
     message(STATUS "Configuring the design to run on FPGA board ${FPGA_DEVICE}")
 endif()
 
-# A SYCL ahead-of-time (AoT) compile processes the device code in two stages.
+# A DPC++ ahead-of-time (AoT) compile processes the device code in two stages.
 # 1. The "compile" stage compiles the device code to an intermediate representation (SPIR-V).
 # 2. The "link" stage invokes the compiler's FPGA backend before linking.
 #    For this reason, FPGA backend flags must be passed as link flags in CMake.

--- a/DirectProgramming/DPC++FPGA/Tutorials/Tools/system_profiling/src/CMakeLists.txt
+++ b/DirectProgramming/DPC++FPGA/Tutorials/Tools/system_profiling/src/CMakeLists.txt
@@ -1,6 +1,3 @@
-# To see a Makefile equivalent of this build system:
-# https://github.com/oneapi-src/oneAPI-samples/blob/master/DirectProgramming/DPC++/ProjectTemplates/makefile-fpga
-
 set(SOURCE_FILE double_buffering.cpp)
 set(TARGET_NAME double_buffering)
 set(EMULATOR_TARGET ${TARGET_NAME}.fpga_emu)
@@ -17,7 +14,7 @@ else()
     message(STATUS "Configuring the design to run on FPGA board ${FPGA_DEVICE}")
 endif()
 
-# A DPC++ ahead-of-time (AoT) compile processes the device code in two stages.
+# A SYCL ahead-of-time (AoT) compile processes the device code in two stages.
 # 1. The "compile" stage compiles the device code to an intermediate representation (SPIR-V).
 # 2. The "link" stage invokes the compiler's FPGA backend before linking.
 #    For this reason, FPGA backend flags must be passed as link flags in CMake.

--- a/DirectProgramming/DPC++FPGA/include/pipe_utils.hpp
+++ b/DirectProgramming/DPC++FPGA/include/pipe_utils.hpp
@@ -12,7 +12,7 @@
 
 /*
 
-This header defines the following utilities for use with pipes in DPC++ FPGA
+This header defines the following utilities for use with pipes in SYCL FPGA
 designs.
 
 1. PipeArray


### PR DESCRIPTION
This PR replaces all relevant occurrences of DPC++ with SYCL in the DPC++FPGA folder.
This change is the first step before changing the name of the DPC++FPGA folder to C++SYCL_FPGA.