### PR TITLE
Fix proposal for CI scripts

### DIFF
--- a/AI-and-Analytics/Features-and-Functionality/IntelPython_XGBoost_daal4pyPrediction/ci_test.py
+++ b/AI-and-Analytics/Features-and-Functionality/IntelPython_XGBoost_daal4pyPrediction/ci_test.py
@@ -1,10 +1,13 @@
+import os
+
+
 def runJupyterNotebook(input_notebook_filename, output_notebook_filename, conda_env, fdpath='./'):
     import nbformat
     import os
     from nbconvert.preprocessors import ExecutePreprocessor
     from nbconvert.preprocessors import CellExecutionError
     if os.path.isfile(input_notebook_filename) is False:
-        print("No Jupyter notebook found : ",input_notebook_filename)
+        print("No Jupyter notebook found : ", input_notebook_filename)
     try:
         with open(input_notebook_filename) as f:
             nb = nbformat.read(f, as_version=4)
@@ -18,4 +21,6 @@ def runJupyterNotebook(input_notebook_filename, output_notebook_filename, conda_
         return -1
 
 
-runJupyterNotebook('IntelPython_XGBoost_daal4pyPrediction.ipynb', 'IntelPython_XGBoost_daal4pyPrediction_result.ipynb', 'xgboost')
+runJupyterNotebook(os.path.join(os.path.dirname(os.path.realpath(__file__)),
+                                'IntelPython_XGBoost_daal4pyPrediction.ipynb'),
+                   'IntelPython_XGBoost_daal4pyPrediction_result.ipynb', 'xgboost')

--- a/AI-and-Analytics/Features-and-Functionality/IntelTensorFlow_InferenceOptimization/scripts/ci_test.py
+++ b/AI-and-Analytics/Features-and-Functionality/IntelTensorFlow_InferenceOptimization/scripts/ci_test.py
@@ -1,3 +1,6 @@
+import os
+
+
 def runJupyterNotebook(input_notebook_filename, output_notebook_filename, conda_env, fdpath='./'):
     import nbformat
     import os
@@ -18,4 +21,6 @@ def runJupyterNotebook(input_notebook_filename, output_notebook_filename, conda_
         return -1
 
 
-runJupyterNotebook('tutorial_optimize_TensorFlow_pretrained_model.ipynb', 'tutorial_optimize_TensorFlow_pretrained_model_result.ipynb', 'tensorflow')
+runJupyterNotebook(os.path.join(os.path.dirname(os.path.realpath(__file__)),
+                                'tutorial_optimize_TensorFlow_pretrained_model.ipynb'),
+                   'tutorial_optimize_TensorFlow_pretrained_model_result.ipynb', 'tensorflow')


### PR DESCRIPTION
# Existing Sample Changes
## Description

Updated CI scripts for AI Kit samples so they could find Jupyter notebooks to run from any pytest execution location. This is needed for samples validation automation.

Fixes Issue ONSAM-1538

## External Dependencies

List any external dependencies created as a result of this change.

## Type of change

Please delete options that are not relevant. Add a 'X' to the one that is applicable. 

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] Implement fixes for ONSAM Jiras

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [X] Command Line
- [ ] oneapi-cli
- [ ] Visual Studio
- [ ] Eclipse IDE
- [ ] VSCode
- [ ] When compiling the compliler flag "-Wall -Wformat-security -Werror=format-security" was used
