### PR TITLE
FPGA: fix missing -fsycl flag in loop_fusion

### DIFF
--- a/DirectProgramming/DPC++FPGA/Tutorials/Features/loop_fusion/src/CMakeLists.txt
+++ b/DirectProgramming/DPC++FPGA/Tutorials/Features/loop_fusion/src/CMakeLists.txt
@@ -23,13 +23,13 @@ endif()
 # 1. The "compile" stage compiles the device code to an intermediate representation (SPIR-V).
 # 2. The "link" stage invokes the compiler's FPGA backend before linking.
 #    For this reason, FPGA backend flags must be passed as link flags in CMake.
-set(EMULATOR_COMPILE_FLAGS "-Wall -fintelfpga -DFPGA_EMULATOR")
-set(EMULATOR_LINK_FLAGS "-fintelfpga")
+set(EMULATOR_COMPILE_FLAGS "-fsycl -Wall -fintelfpga -DFPGA_EMULATOR")
+set(EMULATOR_LINK_FLAGS "-fsycl -fintelfpga")
 set(SIMULATOR_COMPILE_FLAGS "-fsycl -Wall -fintelfpga -Xssimulation -DFPGA_SIMULATOR ${USER_SIMULATOR_FLAGS}")
 set(SIMULATOR_LINK_FLAGS "-fsycl -fintelfpga -Xssimulation -Xstarget=${FPGA_DEVICE} ${USER_SIMULATOR_FLAGS}")
 # use cmake -D USER_SIMULATOR_FLAGS=<flags> to set extra flags for FPGA simulator compilation
-set(HARDWARE_COMPILE_FLAGS "-Wall -fintelfpga")
-set(HARDWARE_LINK_FLAGS "-fintelfpga -Xshardware -Xstarget=${FPGA_DEVICE} ${USER_HARDWARE_FLAGS}")
+set(HARDWARE_COMPILE_FLAGS "-fsycl -Wall -fintelfpga")
+set(HARDWARE_LINK_FLAGS "-fsycl -fintelfpga -Xshardware -Xstarget=${FPGA_DEVICE} ${USER_HARDWARE_FLAGS}")
 # use cmake -D USER_HARDWARE_FLAGS=<flags> to set extra flags for FPGA backend compilation
 
 ###############################################################################
@@ -49,10 +49,10 @@ add_custom_target(fpga_emu DEPENDS ${EMULATOR_TARGET})
 ### FPGA Simulator
 ###############################################################################
 # To compile in a single command:
-#    icpx -fintelfpga -Xssimulation -Xstarget=<FPGA_DEVICE> -DFPGA_SIMULATOR loop_carried_dependency.cpp -o loop_carried_dependency.fpga_sim
+#    icpx -fsycl -fintelfpga -Xssimulation -Xstarget=<FPGA_DEVICE> -DFPGA_SIMULATOR loop_carried_dependency.cpp -o loop_carried_dependency.fpga_sim
 # CMake executes:
-#    [compile] icpx -fintelfpga -Xssimulation -DFPGA_SIMULATOR -o loop_carried_dependency.cpp.o -c loop_carried_dependency.cpp
-#    [link]    icpx -fintelfpga -Xssimulation -Xstarget=<FPGA_DEVICE> loop_carried_dependency.cpp.o -o loop_carried_dependency.fpga_sim
+#    [compile] icpx -fsycl -fintelfpga -Xssimulation -DFPGA_SIMULATOR -o loop_carried_dependency.cpp.o -c loop_carried_dependency.cpp
+#    [link]    icpx -fsycl -fintelfpga -Xssimulation -Xstarget=<FPGA_DEVICE> loop_carried_dependency.cpp.o -o loop_carried_dependency.fpga_sim
 add_executable(${SIMULATOR_TARGET} ${SOURCE_FILE})
 target_include_directories(${SIMULATOR_TARGET} PRIVATE ../../../../include)
 set_target_properties(${SIMULATOR_TARGET} PROPERTIES COMPILE_FLAGS "${SIMULATOR_COMPILE_FLAGS}")


### PR DESCRIPTION
The loop_fusion tutorial was missing the -fsycl compiler flag for its emulation and hw targets.