### PR TITLE
Update readme since simulation is not fully supported for printf

### DIFF
--- a/DirectProgramming/DPC++FPGA/Tutorials/Features/printf/README.md
+++ b/DirectProgramming/DPC++FPGA/Tutorials/Features/printf/README.md
@@ -116,10 +116,6 @@ When compiling for FPGA hardware, it is recommended to increase the job timeout 
       ```
       make fpga_emu
       ```
-   * Compile for simulation (medium compile time, targets simulated FPGA device):
-      ```
-      make fpga_sim
-      ```
    * Generate the optimization report:
      ```
      make report
@@ -155,10 +151,6 @@ When compiling for FPGA hardware, it is recommended to increase the job timeout 
    * Compile for emulation (fast compile time, targets emulated FPGA device):
      ```
      nmake fpga_emu
-     ```
-   * Compile for simulation (medium compile time, targets simulated FPGA device):
-     ```
-     nmake fpga_sim
      ```
    * Generate the optimization report:
      ```
@@ -199,12 +191,7 @@ From the report, you can find the compilation information of the design and the 
      ./printf.fpga_emu     (Linux)
      printf.fpga_emu.exe   (Windows)
      ```
-2. Run the sample on the FPGA simulator:
-     ```
-     ./printf.fpga_sim     (Linux)
-     printf.fpga_sim.exe   (Windows)
-     ```
-3. Run the sample on the FPGA device:
+2. Run the sample on the FPGA device:
      ```
      ./printf.fpga         (Linux)
      printf.fpga.exe       (Windows)
@@ -227,7 +214,7 @@ Result11: ABCD
 
 ## Known issues and limitations
 
-There are some known issues with the `experimental::printf()` and that's why the function is in the experimental namespace. The following limitations exist when using `experimental::printf()` on FPGA simulation and hardware:
+There are some known issues with the `experimental::printf()` and that's why the function is in the experimental namespace. The following limitations exist when using `experimental::printf()` on FPGA hardware:
 
 * Printing string literals %s is not supported yet. You can put the string directly in the format as a workaround. For example: `PRINTF("Hello, World!\n")`.
 * Printing pointer address %p is not supported yet.


### PR DESCRIPTION
# Existing Sample Changes
DirectProgramming/DPC++FPGA/Tutorials/Features/printf

## Description

Printf generates a warning "compiler warning: argument 'llvm_fpga_printf_buffer_start' on component 'zts11basickernel' is never used by the component" that is not useful to the user. It is fixed for 2023.1, but the problem is still in 2023.0. The instruction would be added back in 2023.1.

## Type of change

Please delete options that are not relevant. Add a 'X' to the one that is applicable. 

- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Command Line
- [ ] oneapi-cli
- [ ] Visual Studio
- [ ] Eclipse IDE
- [ ] VSCode
- [ ] When compiling the compliler flag "-Wall -Wformat-security -Werror=format-security" was used
