### PR TITLE
FPGA: add Windows flags to the compile options of `loop_fusion` and `optimize_inner_loop`

### DIFF
--- a/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/optimize_inner_loop/src/CMakeLists.txt
+++ b/DirectProgramming/DPC++FPGA/Tutorials/DesignPatterns/optimize_inner_loop/src/CMakeLists.txt
@@ -23,12 +23,12 @@ endif()
 # 1. The "compile" stage compiles the device code to an intermediate representation (SPIR-V).
 # 2. The "link" stage invokes the compiler's FPGA backend before linking.
 #    For this reason, FPGA backend flags must be passed as link flags in CMake.
-set(EMULATOR_COMPILE_FLAGS "-fsycl -Wall -fintelfpga -DFPGA_EMULATOR")
+set(EMULATOR_COMPILE_FLAGS "-fsycl -Wall -fintelfpga ${WIN_FLAG} -DFPGA_EMULATOR")
 set(EMULATOR_LINK_FLAGS "-fsycl -fintelfpga")
-set(SIMULATOR_COMPILE_FLAGS "-fsycl -Wall -fintelfpga -Xssimulation -DFPGA_SIMULATOR ${USER_SIMULATOR_FLAGS}")
+set(SIMULATOR_COMPILE_FLAGS "-fsycl -Wall -fintelfpga ${WIN_FLAG} -Xssimulation -DFPGA_SIMULATOR ${USER_SIMULATOR_FLAGS}")
 set(SIMULATOR_LINK_FLAGS "-fsycl -fintelfpga -Xssimulation -Xstarget=${FPGA_DEVICE} ${USER_SIMULATOR_FLAGS}")
 # use cmake -D USER_SIMULATOR_FLAGS=<flags> to set extra flags for FPGA simulator compilation
-set(HARDWARE_COMPILE_FLAGS "-fsycl -Wall -fintelfpga")
+set(HARDWARE_COMPILE_FLAGS "-fsycl -Wall -fintelfpga ${WIN_FLAG}")
 set(HARDWARE_LINK_FLAGS "-fsycl -fintelfpga -Xshardware -Xstarget=${FPGA_DEVICE} ${USER_HARDWARE_FLAGS}")
 # use cmake -D USER_HARDWARE_FLAGS=<flags> to set extra flags for FPGA backend compilation
 

--- a/DirectProgramming/DPC++FPGA/Tutorials/Features/loop_fusion/src/CMakeLists.txt
+++ b/DirectProgramming/DPC++FPGA/Tutorials/Features/loop_fusion/src/CMakeLists.txt
@@ -23,12 +23,12 @@ endif()
 # 1. The "compile" stage compiles the device code to an intermediate representation (SPIR-V).
 # 2. The "link" stage invokes the compiler's FPGA backend before linking.
 #    For this reason, FPGA backend flags must be passed as link flags in CMake.
-set(EMULATOR_COMPILE_FLAGS "-fsycl -Wall -fintelfpga -DFPGA_EMULATOR")
+set(EMULATOR_COMPILE_FLAGS "-fsycl -Wall -fintelfpga ${WIN_FLAG} -DFPGA_EMULATOR")
 set(EMULATOR_LINK_FLAGS "-fsycl -fintelfpga")
-set(SIMULATOR_COMPILE_FLAGS "-fsycl -Wall -fintelfpga -Xssimulation -DFPGA_SIMULATOR ${USER_SIMULATOR_FLAGS}")
+set(SIMULATOR_COMPILE_FLAGS "-fsycl -Wall -fintelfpga ${WIN_FLAG} -Xssimulation -DFPGA_SIMULATOR ${USER_SIMULATOR_FLAGS}")
 set(SIMULATOR_LINK_FLAGS "-fsycl -fintelfpga -Xssimulation -Xstarget=${FPGA_DEVICE} ${USER_SIMULATOR_FLAGS}")
 # use cmake -D USER_SIMULATOR_FLAGS=<flags> to set extra flags for FPGA simulator compilation
-set(HARDWARE_COMPILE_FLAGS "-fsycl -Wall -fintelfpga")
+set(HARDWARE_COMPILE_FLAGS "-fsycl -Wall -fintelfpga ${WIN_FLAG}")
 set(HARDWARE_LINK_FLAGS "-fsycl -fintelfpga -Xshardware -Xstarget=${FPGA_DEVICE} ${USER_HARDWARE_FLAGS}")
 # use cmake -D USER_HARDWARE_FLAGS=<flags> to set extra flags for FPGA backend compilation
 


### PR DESCRIPTION
These two samples were missing the `/EHsc` Windows flags which was making the Windows compiles to fail.
