### PR TITLE
Private copies warn

### DIFF
--- a/DirectProgramming/DPC++FPGA/Tutorials/Features/private_copies/README.md
+++ b/DirectProgramming/DPC++FPGA/Tutorials/Features/private_copies/README.md
@@ -25,7 +25,7 @@ for (size_t i = 0; i < kMaxIter; i++) {
   for (size_t j = 0; j < kSize; j++) {
     a[j] = accessor_array[(i * 4 + j) % kSize] * shift;
   }
-  for (size_t j = 0; j < kSize; j++)
+  for (size_t j = 0; j < kSize / 2; j++)
     r += a[j];
 }
 ```

--- a/DirectProgramming/DPC++FPGA/Tutorials/Features/private_copies/README.md
+++ b/DirectProgramming/DPC++FPGA/Tutorials/Features/private_copies/README.md
@@ -25,7 +25,7 @@ for (size_t i = 0; i < kMaxIter; i++) {
   for (size_t j = 0; j < kSize; j++) {
     a[j] = accessor_array[(i * 4 + j) % kSize] * shift;
   }
-  for (size_t j = 0; j < kSize/2; j++)
+  for (size_t j = 0; j < kSize; j++)
     r += a[j];
 }
 ```
@@ -122,10 +122,6 @@ When compiling for FPGA hardware, it is recommended to increase the job timeout 
      ```
      make report
      ```
-  * Compile for simulation (fast compile time, targets simulated FPGA device, reduced data size):
-     ```
-     make fpga_sim
-     ```
    * Compile for FPGA hardware (longer compile time, targets FPGA device):
      ```
      make fpga
@@ -163,10 +159,6 @@ When compiling for FPGA hardware, it is recommended to increase the job timeout 
      ```
      nmake report
      ```
-  * Compile for simulation (fast compile time, targets simulated FPGA device, reduced data size):
-     ```
-     nmake fpga_sim
-     ```
    * Compile for FPGA hardware (longer compile time, targets FPGA device):
      ```
      nmake fpga
@@ -202,12 +194,7 @@ On the main report page, scroll down to the section titled "Estimated Resource U
      ./private_copies.fpga_emu     (Linux)
      private_copies.fpga_emu.exe   (Windows)
      ```
-2. Run the sample on the FPGA simulator device:
-     ```
-     ./private_copies.fpga         (Linux)
-     private_copies.fpga.exe       (Windows)
-     ```
-3. Run the sample on the FPGA device:
+2. Run the sample on the FPGA device:
      ```
      ./private_copies.fpga         (Linux)
      private_copies.fpga.exe       (Windows)
@@ -238,7 +225,7 @@ When run on the Intel&reg; PAC with Intel Arria10&reg; 10 GX FPGA hardware board
 
 Setting the `private_copies` attribute to 0 (or equivalently omitting the attribute entirely) produced good throughput, and the reports show us that the compiler selected 3 private copies. This does produce the optimal throughput, but in this case it probably makes sense to save some area in exchange for a very small throughput loss by specifying 2 private copies instead.
 
-When run on the FPGA emulator or simulator, the `private_copies` attribute has no effect on kernel time. You may actually notice that the emulator achieved higher throughput than the FPGA in this example. This is because this trivial example uses only a tiny fraction of the spatial compute resources available on the FPGA.
+When run on the FPGA emulator, the `private_copies` attribute has no effect on kernel time. You may actually notice that the emulator achieved higher throughput than the FPGA in this example. This is because this trivial example uses only a tiny fraction of the spatial compute resources available on the FPGA.
 
 ## License
 Code samples are licensed under the MIT license. See

--- a/DirectProgramming/DPC++FPGA/Tutorials/Features/private_copies/src/CMakeLists.txt
+++ b/DirectProgramming/DPC++FPGA/Tutorials/Features/private_copies/src/CMakeLists.txt
@@ -1,7 +1,6 @@
 set(SOURCE_FILE private_copies.cpp)
 set(TARGET_NAME private_copies)
 set(EMULATOR_TARGET ${TARGET_NAME}.fpga_emu)
-set(SIMULATOR_TARGET ${TARGET_NAME}.fpga_sim)
 set(FPGA_TARGET ${TARGET_NAME}.fpga)
 
 # FPGA board selection
@@ -25,8 +24,6 @@ endif()
 #    For this reason, FPGA backend flags must be passed as link flags in CMake.
 set(EMULATOR_COMPILE_FLAGS "-Wall ${WIN_FLAG} -fsycl -fintelfpga -DFPGA_EMULATOR")
 set(EMULATOR_LINK_FLAGS "-fsycl -fintelfpga")
-set(SIMULATOR_COMPILE_FLAGS "-Wall ${WIN_FLAG} -fsycl -fintelfpga -Xssimulation -DFPGA_SIMULATOR")
-set(SIMULATOR_LINK_FLAGS "-fsycl -fintelfpga -Xssimulation -Xstarget=${FPGA_DEVICE} ${USER_HARDWARE_FLAGS}")
 set(HARDWARE_COMPILE_FLAGS "-Wall ${WIN_FLAG} -fsycl -fintelfpga")
 set(HARDWARE_LINK_FLAGS "-fsycl -fintelfpga -Xshardware -Xstarget=${FPGA_DEVICE} ${USER_HARDWARE_FLAGS}")
 # use cmake -D USER_HARDWARE_FLAGS=<flags> to set extra flags for FPGA backend compilation
@@ -58,20 +55,6 @@ add_custom_target(report DEPENDS ${FPGA_EARLY_IMAGE})
 set_target_properties(${FPGA_EARLY_IMAGE} PROPERTIES COMPILE_FLAGS "${HARDWARE_COMPILE_FLAGS}")
 set_target_properties(${FPGA_EARLY_IMAGE} PROPERTIES LINK_FLAGS "${HARDWARE_LINK_FLAGS} -fsycl-link=early")
 # fsycl-link=early stops the compiler after RTL generation, before invoking Quartus®
-
-###############################################################################
-### FPGA Simulator
-###############################################################################
-# To compile in a single command:
-#   icpx -fsycl -fintelfpga -Xssimulation -DFPGA_SIMULATOR -Xstarget=<FPGA_DEVICE> private_copies.cpp -o private_copies.fpga
-# CMake executes:
-#   [compile] icpx -fsycl -fintelfpga -Xssimulation -DFPGA_SIMULATOR -o private_copies.cpp.o -c private_copies.cpp
-#   [link]    icpx -fsycl -fintelfpga -Xssimulation -Xstarget=<FPGA_DEVICE> private_copies.cpp.o -o private_copies.fpga
-add_executable(${SIMULATOR_TARGET} EXCLUDE_FROM_ALL ${SOURCE_FILE})
-target_include_directories(${SIMULATOR_TARGET} PRIVATE ../../../../include)
-add_custom_target(fpga_sim DEPENDS ${SIMULATOR_TARGET})
-set_target_properties(${SIMULATOR_TARGET} PROPERTIES COMPILE_FLAGS "${SIMULATOR_COMPILE_FLAGS}")
-set_target_properties(${SIMULATOR_TARGET} PROPERTIES LINK_FLAGS "${SIMULATOR_LINK_FLAGS}")
 
 ###############################################################################
 ### FPGA Hardware

--- a/DirectProgramming/DPC++FPGA/Tutorials/Features/private_copies/src/private_copies.cpp
+++ b/DirectProgramming/DPC++FPGA/Tutorials/Features/private_copies/src/private_copies.cpp
@@ -15,14 +15,8 @@
 
 using namespace sycl;
 
-#if defined(FPGA_SIMULATOR)
-// Smaller size to keep the runtime reasonable
-constexpr size_t kSize = 512; //2^9
-constexpr size_t kMaxIter = 100;
-#else
-constexpr size_t kSize = 8192; //2^13
+constexpr size_t kSize = 8192;
 constexpr size_t kMaxIter = 50000;
-#endif
 constexpr size_t kTotalOps = 2 * kMaxIter * kSize;
 constexpr size_t kMaxValue = 128;
 
@@ -40,8 +34,6 @@ template <int num_copies>
 void SimpleMathWithShift(const IntArray &array, int shift, IntScalar &result) {
 #if defined(FPGA_EMULATOR)
   ext::intel::fpga_emulator_selector selector;
-#elif defined(FPGA_SIMULATOR)
-  ext::intel::fpga_simulator_selector selector;
 #else
   ext::intel::fpga_selector selector;
 #endif
@@ -70,9 +62,7 @@ void SimpleMathWithShift(const IntArray &array, int shift, IntScalar &result) {
           for (size_t j = 0; j < kSize; j++) {
             a[j] = accessor_array[(i * 4 + j) % kSize] * shift;
           }
-          // The trip count of this loop is different from the loop above to
-          // prevent the compiler optimizing array `a` out.
-          for (size_t j = 0; j < kSize/2; j++)
+          for (size_t j = 0; j < kSize; j++)
             r += a[j];
         }
 
@@ -122,7 +112,7 @@ int GoldenResult(const IntArray &input_arr, int shift) {
     for (size_t j = 0; j < kSize; j++) {
       a[j] = input_arr[(i * 4 + j) % kSize] * shift;
     }
-    for (size_t j = 0; j < kSize/2; j++)
+    for (size_t j = 0; j < kSize; j++)
       gr += a[j];
   }
 

--- a/DirectProgramming/DPC++FPGA/Tutorials/Features/private_copies/src/private_copies.cpp
+++ b/DirectProgramming/DPC++FPGA/Tutorials/Features/private_copies/src/private_copies.cpp
@@ -62,7 +62,9 @@ void SimpleMathWithShift(const IntArray &array, int shift, IntScalar &result) {
           for (size_t j = 0; j < kSize; j++) {
             a[j] = accessor_array[(i * 4 + j) % kSize] * shift;
           }
-          for (size_t j = 0; j < kSize; j++)
+          // The trip count of this loop is different from the loop above to
+          // prevent the compiler optimizing array `a` out.
+          for (size_t j = 0; j < kSize / 2; j++)
             r += a[j];
         }
 
@@ -112,7 +114,7 @@ int GoldenResult(const IntArray &input_arr, int shift) {
     for (size_t j = 0; j < kSize; j++) {
       a[j] = input_arr[(i * 4 + j) % kSize] * shift;
     }
-    for (size_t j = 0; j < kSize; j++)
+    for (size_t j = 0; j < kSize / 2; j++)
       gr += a[j];
   }
 


### PR DESCRIPTION
Reverted change c2e5673ce20b478413f1075330c47f58a28575d5 as 2023.0 release cannot support simulation flow for this design. 

This change does keep the fix to prevent a warning being issued about the compiler optimizing away a key array of the design.