### PR TITLE
Added USM_HOST_ALLOCATIONS_ENABLED to gzip

### DIFF
--- a/DirectProgramming/DPC++FPGA/ReferenceDesigns/gzip/src/CMakeLists.txt
+++ b/DirectProgramming/DPC++FPGA/ReferenceDesigns/gzip/src/CMakeLists.txt
@@ -82,12 +82,14 @@ endif()
 
 # Presence of USM host allocations (and whether to turn on enable the low-latency target) is detected automatically by
 # looking at the name of the BSP, or manually by the user when running CMake.
-# E.g., cmake .. -DUSER_ENABLE_USM=1
-if(FPGA_DEVICE MATCHES ".*usm.*" OR USER_ENABLE_USM)
-    set(USM_ENABLED 1)
-elseif(LOW_LATENCY)
+# E.g., cmake .. -DUSM_HOST_ALLOCATIONS_ENABLED=1
+if(LOW_LATENCY AND NOT FPGA_DEVICE MATCHES ".usm.*" AND (NOT DEFINED USM_HOST_ALLOCATIONS_ENABLED OR USM_HOST_ALLOCATIONS_ENABLED STREQUAL "0"))
     # Low latency design requires USM, so error out
     message(FATAL_ERROR "Error: The Low Latency variant of the design requires USM host allocations")
+endif()
+
+if(USM_HOST_ALLOCATIONS_ENABLED)
+    message(STATUS "USM_HOST_ALLOCATIONS_ENABLED set manually!")
 endif()
 
 message(STATUS "NUM_ENGINES=${NUM_ENGINES}")


### PR DESCRIPTION
# Existing Sample Changes
- DirectProgramming/DPC++FPGA/ReferenceDesigns/gzip

## Description
Changed the USER_ENABLE_USM flag to USM_HOST_ALLOCATIONS_ENABLED to accommodate the intel testing infrastructure. The setup is now similar to Tutorial/DesignPatterns/simple_host_streaming.
Removed the USM_ENABLED flag since it is no longer used in the Makefile.

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [X] Command Line
- [ ] oneapi-cli
- [ ] Visual Studio
- [ ] Eclipse IDE
- [ ] VSCode
- [ ] When compiling the compliler flag "-Wall -Wformat-security -Werror=format-security" was used
