### PR TITLE
updated notebooks for user clarifications

### DIFF
--- a/AI-and-Analytics/Jupyter/Predictive_Modeling_Training/AI_Kit_XGBoost_Predictive_Modeling/01_Decision_Trees/Decision_Trees.ipynb
+++ b/AI-and-Analytics/Jupyter/Predictive_Modeling_Training/AI_Kit_XGBoost_Predictive_Modeling/01_Decision_Trees/Decision_Trees.ipynb
@@ -77,7 +77,8 @@
     "## Exercise 1\n",
     "\n",
     "* Import the data and examine the features.\n",
-    "* We will be using all of them to predict __`color`__ (white or red), but the colors feature will need to be integer encoded."
+    "* We will be using all of them to predict __`color`__ (white or red), but the colors feature will need to be integer encoded.\n",
+	"* Note: you are expected to solve this exercise by replacing the 'xxx' in the following cells."
    ]
   },
   {
@@ -175,7 +176,8 @@
     "## Exercise 2\n",
     "\n",
     "* The amount of data is small so we will use a __`StratifiedShuffleSplit`__ to split data into train and test sets that are stratified by wine quality. Stratified ShuffleSplit cross-validator provides train/test indices to split data in train/test sets.  This cross-validation object is a merge of StratifiedKFold and ShuffleSplit, which returns stratified randomized folds. The folds are made by preserving the percentage of samples for each class.  Note: like the ShuffleSplit strategy, stratified random splits do not guarantee that all folds will be different, although this is still very likely for sizeable datasets.\n",
-    "* Check the percent composition of each quality level for both the train and test data sets."
+    "* Check the percent composition of each quality level for both the train and test data sets.\n",
+	"* Note: you are expected to solve this exercise by replacing the 'xxx' in the following cells."
    ]
   },
   {
@@ -262,7 +264,8 @@
     "\n",
     "* Fit a __DecisionTreeClassifier__ with no set limits on maximum depth, features, or leaves.\n",
     "* Determine how many nodes are present and what the depth of this (very large) tree is.\n",
-    "* Using this tree, measure the prediction error in the train and test data sets. What do you think is going on here based on the differences in prediction error?"
+    "* Using this tree, measure the prediction error in the train and test data sets. What do you think is going on here based on the differences in prediction error?\n",
+	"* Note: you are expected to solve this exercise by replacing the 'xxx' in the following cells."
    ]
   },
   {
@@ -364,7 +367,8 @@
     "\n",
     "* Using __`GridSearchCV`__ with cross validation, find a decision tree that performs well on the test data set. Use a different variable name for this decision tree model than in question 3 so that both can be used in question 6.\n",
     "* Determine the number of nodes and the depth of this tree.\n",
-    "* Measure the errors on the training and test sets as before and compare them to those from the tree in question 3."
+    "* Measure the errors on the training and test sets as before and compare them to those from the tree in question 3.\n",
+	"* Note: you are expected to solve this exercise by replacing the 'xxx' in the following cells."
    ]
   },
   {
@@ -459,7 +463,8 @@
     "* Re-split the data into `X` and `y` parts, this time with __`residual_sugar`__ being the predicted (`y`) data. *Note:* if the indices were preserved from the `StratifiedShuffleSplit` output in question 2, they can be used again to split the data.\n",
     "* Using grid search with cross validation, find a decision tree **regression** model that performs well on the test data set.\n",
     "* Measure the errors on the training and test sets using mean squared error.\n",
-    "* Make a plot of actual *vs* predicted residual sugar."
+    "* Make a plot of actual *vs* predicted residual sugar.\n",
+	"* Note: you are expected to solve this exercise by replacing the 'xxx' in the following cells."
    ]
   },
   {

--- a/AI-and-Analytics/Jupyter/Predictive_Modeling_Training/AI_Kit_XGBoost_Predictive_Modeling/02_Bagging/Bagging_RF.ipynb
+++ b/AI-and-Analytics/Jupyter/Predictive_Modeling_Training/AI_Kit_XGBoost_Predictive_Modeling/02_Bagging/Bagging_RF.ipynb
@@ -150,7 +150,8 @@
     "## Exercise 2\n",
     "\n",
     "* Examine distribution of the predicted variable (`color`).\n",
-    "* Split the data into train and test sets. Again use __StratefiedShuffleSplit__"
+    "* Split the data into train and test sets. Again use __StratefiedShuffleSplit__\n",
+	"* Note: you are expected to solve this exercise by replacing the 'xxx' in the following cells."
    ]
   },
   {
@@ -342,7 +343,8 @@
     "## Exercise 4\n",
     "\n",
     "* Repeat question 3 using extra randomized trees __ExtraTreesClassifier__. Note that the `bootstrap` parameter will have to be set to `True` for this model.\n",
-    "* Compare the out-of-bag errors for the two different types of models."
+    "* Compare the out-of-bag errors for the two different types of models.\n",
+	"* Note: you are expected to solve this exercise by replacing the 'xxx' in the following cells."
    ]
   },
   {
@@ -433,7 +435,8 @@
     "## Exercise 5\n",
     "\n",
     "* Select one of the models that performs well and calculate error metrics and a confusion matrix on the test data set. \n",
-    "* Given the distribution of the predicted class, which metric is most important? Which could be deceiving?"
+    "* Given the distribution of the predicted class, which metric is most important? Which could be deceiving?\n",
+	"* Note: you are expected to solve this exercise by replacing the 'xxx' in the following cells."
    ]
   },
   {

--- a/AI-and-Analytics/Jupyter/Predictive_Modeling_Training/README.md
+++ b/AI-and-Analytics/Jupyter/Predictive_Modeling_Training/README.md
@@ -2,7 +2,9 @@
 
 The purpose of this repo is to be the central aggregation, curation, and
 distribution point for Juypter notebooks that are developed in support of
-the Intel AI Kit. These initial hands-on exercises introduce you to predictive modeling using decision trees, bagging and XGBoost.  
+the Intel AI Kit. These initial hands-on exercises introduce you to predictive modeling using decision trees, bagging and XGBoost.
+The notebooks for the exercises are stored under AI_Kit_XGBoost_Predictive_Modeling and the answers to these exercises are stored
+under AI_Kit_XGBoost_Predictive_Modeling.complete.
 
 The Jupyter notebooks are tested and can be run on the Intel Devcloud. Below
 are the steps to access these Jupyter notebooks on the Intel Devcloud:


### PR DESCRIPTION
# Existing Sample Changes
## Description

Users were recently facing two issues in terms of clarification for some Jupyter exercises:
1. The Jupyter exercises in Predictive_Modeling_Training had 'xxx' in exercises that were meant to be solved and replaced by an actual function by the user. This was not made explicit anywhere. Resolution: state it explicitly for the user under every exercise, specifically in Decision_Trees.ipynb and Bagging_RF.ipynb.
2. The exercises are stored in "AI_Kit_XGBoost_Predictive_Modeling" and the answers to these exercises are stored in "AI_Kit_XGBoost_Predictive_Modeling.complete". This is not stated anywhere in README. Resolution: state it in Predictive_Modeling_Training README explicitly.

## External Dependencies

n/a

## Type of change

Please delete options that are not relevant. Add a 'X' to the one that is applicable. 

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Implement fixes for ONSAM Jiras

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Command Line
- [ ] oneapi-cli
- [ ] Visual Studio
- [ ] Eclipse IDE
- [ ] VSCode
- [ ] When compiling the compliler flag "-Wall -Wformat-security -Werror=format-security" was used
- [X] JetBrains PyCharm