### PR TITLE
 add some comments and also set oneapi path to default path

### DIFF
--- a/Libraries/oneDNN/tutorials/tutorial_analyze_isa_with_dispatcher_control.ipynb
+++ b/Libraries/oneDNN/tutorials/tutorial_analyze_isa_with_dispatcher_control.ipynb
@@ -65,7 +65,7 @@
    "outputs": [],
    "source": [
     "# default path: /opt/intel/oneapi\n",
-    "%env ONEAPI_INSTALL=/home/tce/intel/oneapi"
+    "%env ONEAPI_INSTALL=/opt/intel/oneapi"
    ]
   },
   {
@@ -337,7 +337,7 @@
     "|AVX512 vs AVX2 |cnn-inference-f32-cpp| show the usage of zmm instruction and avx512 JIT kernel | \n",
     "|AVX512 VNNI vs AVX512 |cnn-inference-int8-cpp| show the usage of VNNI instruction and VNNI JIT kernel|\n",
     "|AVX512 BF16 vs AVX512| cnn-training-bf16-cpp| show the usage of BF16 instruction and BF16 JIT kernel| \n",
-    "|AVX512 BF16 vs AVX512 AMX| cnn-training-bf16-cpp| show the usage of AMX BF16 instruction and AMX BF16 JIT kernel| \n",
+    "|AVX512 AMX vs AVX512 BF16| cnn-training-bf16-cpp| show the usage of AMX BF16 instruction and AMX BF16 JIT kernel| \n",
     "\n",
     "Those comparisons can be conducted on the same CPU microarchitecture with the help of oneDNN CPU dispatcher control.  \n",
     "Users can also conduct similiar comparisons for TensorFlow or PyTorch workloads by replacing the oneDNN sample with other workloads.  \n",
@@ -744,8 +744,8 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "> NOTE: users should be able to see **avx512_core_vnni** JIT Kernel if the sample run with **VNNI** instruction  \n",
-    "> NOTE: users should be able to see **avx512_core_bf16** JIT Kernel if the sample run with **BF16** instruction  \n",
+    "> NOTE: users should be able to see **avx512_core_vnni** or **avx512_core_amx_int8** JIT Kernel if the sample run with **VNNI** instruction  \n",
+    "> NOTE: users should be able to see **avx512_core_bf16** or **avx512_core_amx_bf16** JIT Kernel if the sample run with **BF16** instruction  \n",
     "> NOTE: users should be able to see **avx512** JIT Kernel if the sample run with **AVX512** instructions  "
    ]
   },
@@ -895,7 +895,10 @@
     "Users should see usage of **vpdpbusd** in AVX512_VNNI JIT dump files. \n",
     "\n",
     "> NOTE: **vdpbf16ps**, **vcvtne2ps2bf16**, and **vcvtneps2bf16** are introduced by AVX512_BF16 ISA.  \n",
-    "Users should see usage of vdpbf16ps, vcvtne2ps2bf16 or vcvtneps2bf16 in AVX512_BF16 JIT dump files. "
+    "Users should see usage of vdpbf16ps, vcvtne2ps2bf16 or vcvtneps2bf16 in AVX512_BF16 JIT dump files. \n",
+    "\n",
+    "> NOTE: **tdpbf16ps**, **tdpbssd**, **tdpbsud**, **tdpbusd**, and **tdpbuud** are introduced by AVX512_AMX ISA.  \n",
+    "Users should see usage of tdpbf16ps, tdpbssd, tdpbsud, tdpbusd, or tdpbuud in AVX512_AMX JIT dump files. "
    ]
   },
   {
@@ -935,7 +938,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "Python 3",
    "language": "python",
    "name": "python3"
   },
@@ -949,7 +952,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.12"
+   "version": "3.6.9"
   },
   "toc": {
    "base_numbering": 1,


### PR DESCRIPTION
# Existing Sample Changes
## Description

add some comments and also set oneapi path to default path

## Type of change

Please delete options that are not relevant. Add a 'X' to the one that is applicable. 

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Implement fixes for ONSAM Jiras

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Command Line
- [ ] oneapi-cli
- [ ] Visual Studio
- [ ] Eclipse IDE
- [ ] VSCode
- [ ] When compiling the compliler flag "-Wall -Wformat-security -Werror=format-security" was used

