### PR TITLE
FPGA: update qrd seed

### DIFF
--- a/DirectProgramming/DPC++FPGA/ReferenceDesigns/qrd/src/CMakeLists.txt
+++ b/DirectProgramming/DPC++FPGA/ReferenceDesigns/qrd/src/CMakeLists.txt
@@ -49,7 +49,7 @@ elseif(FPGA_DEVICE MATCHES ".*s10.*")
     set(COMPLEX 1)
     set(FIXED_ITERATIONS 110)
     set(CLOCK_TARGET 480MHz)
-    set(SEED "-Xsseed=22")
+    set(SEED "-Xsseed=9")
 elseif(FPGA_DEVICE MATCHES ".*agilex.*")
     # Agilex™ parameters
     set(ROWS_COMPONENT 256)


### PR DESCRIPTION
The QRD design needs a seed update to match the expected performance with the 2023.0 version of the compiler.