### PR TITLE
[oneTBB] Move project(...) call to the top of CMakeLists.txt file

### DIFF
--- a/Libraries/oneTBB/tbb-async-sycl/CMakeLists.txt
+++ b/Libraries/oneTBB/tbb-async-sycl/CMakeLists.txt
@@ -1,4 +1,5 @@
 cmake_minimum_required (VERSION 3.4)
+project (TBB-ASYNC-SYCL LANGUAGES CXX)
 
 if (${CMAKE_HOST_SYSTEM_NAME} STREQUAL "Windows")
     set(CMAKE_CXX_COMPILER "dpcpp-cl")
@@ -7,5 +8,4 @@ else()
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fsycl")
 endif()
 
-project (TBB-ASYNC-SYCL LANGUAGES CXX)
 add_subdirectory (src)

--- a/Libraries/oneTBB/tbb-resumable-tasks-sycl/CMakeLists.txt
+++ b/Libraries/oneTBB/tbb-resumable-tasks-sycl/CMakeLists.txt
@@ -1,4 +1,5 @@
 cmake_minimum_required (VERSION 3.4)
+project (TBB-RESUMABLE-TASKS-SYCL LANGUAGES CXX)
 
 if (${CMAKE_HOST_SYSTEM_NAME} STREQUAL "Windows")
     set(CMAKE_CXX_COMPILER "dpcpp-cl")
@@ -7,5 +8,4 @@ else()
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fsycl")
 endif()
 
-project (TBB-RESUMABLE-TASKS-SYCL LANGUAGES CXX)
 add_subdirectory (src)

--- a/Libraries/oneTBB/tbb-task-sycl/CMakeLists.txt
+++ b/Libraries/oneTBB/tbb-task-sycl/CMakeLists.txt
@@ -1,4 +1,5 @@
 cmake_minimum_required (VERSION 3.4)
+project (TBB-TASK-SYCL LANGUAGES CXX)
 
 if (${CMAKE_HOST_SYSTEM_NAME} STREQUAL "Windows")
     set(CMAKE_CXX_COMPILER "dpcpp-cl")
@@ -7,5 +8,4 @@ else()
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fsycl")
 endif()
 
-project (TBB-TASK-SYCL LANGUAGES CXX)
 add_subdirectory (src)


### PR DESCRIPTION
Signed-off-by: Isaev, Ilya <ilya.isaev@intel.com>

# Existing Sample Changes
## Description

Regarding to https://cmake.org/cmake/help/latest/command/project.html:

> Call the project() command near the top of the top-level CMakeLists.txt, but after calling [cmake_minimum_required()](https://cmake.org/cmake/help/latest/command/cmake_minimum_required.html#command:cmake_minimum_required). It is important to establish version and policy settings before invoking other commands whose behavior they may affect

Otherwise it can override variables set before. In oneTBB case it overrides CMAKE_CXX_FLAGS variable on Ubuntu 18.04 and leads to following error:
```bash
[ 50%] Building CXX object src/CMakeFiles/tbb-task-sycl.dir/tbb-task-sycl.cpp.o
cd /tmp/oneAPI-samples/Libraries/oneTBB/tbb-task-sycl/build/src && /mnt/tbbusers/tbbtest/tools/linux/oneapi_compiler/nightly/build/linux_prod/compiler/linux/bin/icpx    -O2 -g -DNDEBUG   -o CMakeFiles/tbb-task-sycl.dir/tbb-task-sycl.cpp.o -c /tmp/oneAPI-samples/Libraries/oneTBB/tbb-task-sycl/src/tbb-task-sycl.cpp
/tmp/oneAPI-samples/Libraries/oneTBB/tbb-task-sycl/src/tbb-task-sycl.cpp:11:10: fatal error: 'sycl/sycl.hpp' file not found
#include <sycl/sycl.hpp>
         ^~~~~~~~~~~~~~~
1 error generated.
src/CMakeFiles/tbb-task-sycl.dir/build.make:62: recipe for target 'src/CMakeFiles/tbb-task-sycl.dir/tbb-task-sycl.cpp.o' failed
```

Fixes Issue# 

## External Dependencies

List any external dependencies created as a result of this change.

## Type of change

Please delete options that are not relevant. Add a 'X' to the one that is applicable. 

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Implement fixes for ONSAM Jiras

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Command Line
- [ ] oneapi-cli
- [ ] Visual Studio
- [ ] Eclipse IDE
- [ ] VSCode
- [ ] When compiling the compliler flag "-Wall -Wformat-security -Werror=format-security" was used
