### PR TITLE
[oneDNN] Sample Update: getting_started

### DIFF
--- a/Libraries/oneDNN/tutorials/tutorial_getting_started.ipynb
+++ b/Libraries/oneDNN/tutorials/tutorial_getting_started.ipynb
@@ -152,7 +152,8 @@
    "source": [
     "!cp $ONEAPI_INSTALL/dnnl/latest/cpu_dpcpp_gpu_dpcpp/examples/example_utils.hpp lab/\n",
     "!cp $ONEAPI_INSTALL/dnnl/latest/cpu_dpcpp_gpu_dpcpp/examples/example_utils.h lab/\n",
-    "!cp $ONEAPI_INSTALL/dnnl/latest/cpu_dpcpp_gpu_dpcpp/examples/CMakeLists.txt lab/"
+    "!cp $ONEAPI_INSTALL/dnnl/latest/cpu_dpcpp_gpu_dpcpp/examples/CMakeLists.txt lab/\n",
+    "!cp $ONEAPI_INSTALL/dnnl/latest/cpu_dpcpp_gpu_dpcpp/examples/dpcpp_driver_check.cmake lab/"
    ]
   },
   {
@@ -272,6 +273,15 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!cp $ONEAPI_INSTALL/dnnl/latest/cpu_gomp/examples/CMakeLists.txt lab/"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -379,6 +389,15 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!cp $ONEAPI_INSTALL/dnnl/latest/cpu_iomp/examples/CMakeLists.txt lab/"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -410,7 +429,7 @@
     "export EXAMPLE_ROOT=./lab/\n",
     "mkdir cpu_iomp\n",
     "cd cpu_iomp\n",
-    "cmake .. -DCMAKE_C_COMPILER=icc -DCMAKE_CXX_COMPILER=icpc -DDNNL_CPU_RUNTIME=OMP -DDNNL_GPU_RUNTIME=NONE\n",
+    "cmake .. -DCMAKE_C_COMPILER=icx -DCMAKE_CXX_COMPILER=icpx -DDNNL_CPU_RUNTIME=OMP -DDNNL_GPU_RUNTIME=NONE\n",
     "make getting-started-cpp\n",
     "\n"
    ]
@@ -491,6 +510,15 @@
     "# Build and Run with GNU Compiler and oneTBB \n",
     "One of the oneDNN configurations supports Intel® oneAPI Threading bBuilding block Blocks (oneTBB) as its threading library, but it can run only on CPU.\n",
     "The following section shows you how to build with oneTBB and run on CPU."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!cp $ONEAPI_INSTALL/dnnl/latest/cpu_tbb/examples/CMakeLists.txt lab/"
    ]
   },
   {
@@ -619,21 +647,21 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 2",
    "language": "python",
-   "name": "python3"
+   "name": "python2"
   },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
-    "version": 3
+    "version": 2
    },
    "file_extension": ".py",
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.6.9"
+   "pygments_lexer": "ipython2",
+   "version": "2.7.17"
   },
   "toc": {
    "base_numbering": 1,


### PR DESCRIPTION
# Existing Sample Changes
## Description

Made modifications needed for 2023.0 Base Toolkit release
- Modified the right CMake directory for getting_started sample
- Added dpcpp driver check file to getting_started sample
- changed icc to icx compiler 


Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes Issue# 

## External Dependencies

List any external dependencies created as a result of this change.

## Type of change

- [ X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Tested the samples in a Linux environment with 2023.0 base Toolkit using jupyter notebook

- [X] Command Line 
