### PR TITLE
removed dpc_common.hpp dependency

### DIFF
--- a/DirectProgramming/C++SYCL/Jupyter/oneapi-essentials-training/02_SYCL_Program_Structure/src/complex_mult_solution.cpp
+++ b/DirectProgramming/C++SYCL/Jupyter/oneapi-essentials-training/02_SYCL_Program_Structure/src/complex_mult_solution.cpp
@@ -6,9 +6,6 @@
 #include <sycl/sycl.hpp>
 #include <iomanip>
 #include <vector>
-// dpc_common.hpp can be found in the dev-utilities include folder.
-// e.g., $ONEAPI_ROOT/dev-utilities/<version>/include/dpc_common.hpp
-#include "dpc_common.hpp"
 #include "Complex.hpp"
 
 using namespace sycl;

--- a/DirectProgramming/C++SYCL/Jupyter/oneapi-essentials-training/11_Intel_Distribution_for_GDB/src/array-transform.cpp
+++ b/DirectProgramming/C++SYCL/Jupyter/oneapi-essentials-training/11_Intel_Distribution_for_GDB/src/array-transform.cpp
@@ -12,8 +12,6 @@
 
 #include <sycl/sycl.hpp>
 #include <iostream>
-// Location of file: <oneapi-root>/dev-utilities/<version>/include
-#include "dpc_common.hpp"
 #include "selector.hpp"
 
 using namespace std;


### PR DESCRIPTION
# Existing Sample Changes
## Description

removed dpc_common.hpp dependency which was throwing errors with 2023.0 release

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [X] Command Line

