### PR TITLE
Update printf readme and fixed some typos

### DIFF
--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/printf/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/printf/README.md
@@ -124,6 +124,10 @@ PRINTF("Hello: %d\n", 123);
       ```
       make fpga_emu
       ```
+   * Compile for simulation (medium compile time, targets simulated FPGA device):
+      ```
+      make fpga_sim
+      ```
    * Generate the optimization report:
      ```
      make report
@@ -160,6 +164,10 @@ PRINTF("Hello: %d\n", 123);
      ```
      nmake fpga_emu
      ```
+   * Compile for simulation (medium compile time, targets simulated FPGA device):
+     ```
+     nmake fpga_sim
+     ```
    * Generate the optimization report:
      ```
      nmake report
@@ -185,7 +193,12 @@ From the report, you can find the compilation information of the design and the 
      ./printf.fpga_emu     (Linux)
      printf.fpga_emu.exe   (Windows)
      ```
-2. Run the sample on the FPGA device:
+2. Run the sample on the FPGA simulator:
+     ```
+     ./printf.fpga_sim     (Linux)
+     printf.fpga_sim.exe   (Windows)
+     ```
+3. Run the sample on the FPGA device:
      ```
      ./printf.fpga         (Linux)
      printf.fpga.exe       (Windows)
@@ -208,7 +221,7 @@ Result11: ABCD
 
 ## Known issues and limitations
 
-There are some known issues with the `experimental::printf()` and that's why the function is in the experimental namespace. The following limitations exist when using `experimental::printf()` on FPGA hardware:
+There are some known issues with the `experimental::printf()` and that's why the function is in the experimental namespace. The following limitations exist when using `experimental::printf()` on FPGA simulation and hardware:
 
 * Printing string literals %s is not supported yet. You can put the string directly in the format as a workaround. For example: `PRINTF("Hello, World!\n")`.
 * Printing pointer address %p is not supported yet.

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/printf/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/printf/README.md
@@ -194,10 +194,16 @@ From the report, you can find the compilation information of the design and the 
      printf.fpga_emu.exe   (Windows)
      ```
 2. Run the sample on the FPGA simulator:
-     ```
-     ./printf.fpga_sim     (Linux)
-     printf.fpga_sim.exe   (Windows)
-     ```
+    * On Linux
+        ```
+        CL_CONTEXT_MPSIM_DEVICE_INTELFPGA=1 ./printf.fpga_sim
+        ```
+    * On Windows
+        ```
+        set CL_CONTEXT_MPSIM_DEVICE_INTELFPGA=1
+        printf.fpga_sim.exe
+        set CL_CONTEXT_MPSIM_DEVICE_INTELFPGA=
+        ```
 3. Run the sample on the FPGA device:
      ```
      ./printf.fpga         (Linux)


### PR DESCRIPTION
# Existing Sample Changes
DirectProgramming/C++SYCL_FPGA/Tutorials/Features/printf

## Description

The simulator instructions have been removed from the README of the printf code sample because it was generating a warning in the 2023.0 release.
This has been fixed in 2023.1 and we shoud re-add these instructions for the 2023.1 release of the code samples.

## Type of change

Please delete options that are not relevant. Add a 'X' to the one that is applicable. 

- [X] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [X] Command Line
- [ ] oneapi-cli
- [ ] Visual Studio
- [ ] Eclipse IDE
- [ ] VSCode
- [ ] When compiling the compliler flag "-Wall -Wformat-security -Werror=format-security" was used