### PR TITLE
Revert PR#1265 and PR#1266

### DIFF
--- a/DirectProgramming/C++SYCL/CombinationalLogic/mandelbrot/src/main.cpp
+++ b/DirectProgramming/C++SYCL/CombinationalLogic/mandelbrot/src/main.cpp
@@ -7,7 +7,6 @@
 #include <chrono>
 #include <iomanip>
 #include <iostream>
-#include <CL/sycl.hpp>
 // dpc_common.hpp can be found in the dev-utilities include folder.
 // e.g., $ONEAPI_ROOT/dev-utilities/<version>/include/dpc_common.hpp
 #include "dpc_common.hpp"

--- a/DirectProgramming/C++SYCL/DenseLinearAlgebra/complex_mult/src/complex_mult.cpp
+++ b/DirectProgramming/C++SYCL/DenseLinearAlgebra/complex_mult/src/complex_mult.cpp
@@ -81,7 +81,7 @@ void Scalar(std::vector<Complex2> &in_vect1,
   if ((in_vect2.size() != in_vect1.size()) || (out_vect.size() != in_vect1.size())){
 	  std::cout<<"ERROR: Vector sizes do not match"<<"\n";
 	  return;
-  }              
+  }		
   for (int i = 0; i < in_vect1.size(); i++) {
     out_vect[i] = in_vect1[i].complex_mul(in_vect2[i]);
   }

--- a/DirectProgramming/C++SYCL/DenseLinearAlgebra/complex_mult/src/complex_mult.cpp
+++ b/DirectProgramming/C++SYCL/DenseLinearAlgebra/complex_mult/src/complex_mult.cpp
@@ -47,7 +47,7 @@ void SYCLParallel(queue &q, std::vector<Complex2> &in_vect1,
                    std::vector<Complex2> &in_vect2,
                    std::vector<Complex2> &out_vect) {
   auto R = range(in_vect1.size());
-  if (in_vect2.size() != in_vect1.size() || out_vect.size() != in_vect1.size()){
+  if (in_vect2.size() != in_vect1.size() || out_vect.size() != in_vect1.size()){ 
 	  std::cout << "ERROR: Vector sizes do not  match"<< "\n";
 	  return;
   }
@@ -55,7 +55,7 @@ void SYCLParallel(queue &q, std::vector<Complex2> &in_vect1,
   buffer bufin_vect1(in_vect1);
   buffer bufin_vect2(in_vect2);
 
-  // Setup Output buffers
+  // Setup Output buffers 
   buffer bufout_vect(out_vect);
 
   std::cout << "Target Device: "
@@ -81,7 +81,7 @@ void Scalar(std::vector<Complex2> &in_vect1,
   if ((in_vect2.size() != in_vect1.size()) || (out_vect.size() != in_vect1.size())){
 	  std::cout<<"ERROR: Vector sizes do not match"<<"\n";
 	  return;
-  }
+  }              
   for (int i = 0; i < in_vect1.size(); i++) {
     out_vect[i] = in_vect1[i].complex_mul(in_vect2[i]);
   }

--- a/DirectProgramming/C++SYCL/DenseLinearAlgebra/complex_mult/src/complex_mult.cpp
+++ b/DirectProgramming/C++SYCL/DenseLinearAlgebra/complex_mult/src/complex_mult.cpp
@@ -81,7 +81,7 @@ void Scalar(std::vector<Complex2> &in_vect1,
   if ((in_vect2.size() != in_vect1.size()) || (out_vect.size() != in_vect1.size())){
 	  std::cout<<"ERROR: Vector sizes do not match"<<"\n";
 	  return;
-  }		
+  }		 
   for (int i = 0; i < in_vect1.size(); i++) {
     out_vect[i] = in_vect1[i].complex_mul(in_vect2[i]);
   }

--- a/DirectProgramming/C++SYCL/DenseLinearAlgebra/complex_mult/src/complex_mult.cpp
+++ b/DirectProgramming/C++SYCL/DenseLinearAlgebra/complex_mult/src/complex_mult.cpp
@@ -81,7 +81,7 @@ void Scalar(std::vector<Complex2> &in_vect1,
   if ((in_vect2.size() != in_vect1.size()) || (out_vect.size() != in_vect1.size())){
 	  std::cout<<"ERROR: Vector sizes do not match"<<"\n";
 	  return;
-  }		 
+  }		
   for (int i = 0; i < in_vect1.size(); i++) {
     out_vect[i] = in_vect1[i].complex_mul(in_vect2[i]);
   }

--- a/DirectProgramming/C++SYCL/DenseLinearAlgebra/complex_mult/src/complex_mult.cpp
+++ b/DirectProgramming/C++SYCL/DenseLinearAlgebra/complex_mult/src/complex_mult.cpp
@@ -4,7 +4,7 @@
 //
 // SPDX-License-Identifier: MIT
 // =============================================================
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 #include <iomanip>
 #include <vector>
 // dpc_common.hpp can be found in the dev-utilities include folder.
@@ -47,7 +47,7 @@ void SYCLParallel(queue &q, std::vector<Complex2> &in_vect1,
                    std::vector<Complex2> &in_vect2,
                    std::vector<Complex2> &out_vect) {
   auto R = range(in_vect1.size());
-  if (in_vect2.size() != in_vect1.size() || out_vect.size() != in_vect1.size()){ 
+  if (in_vect2.size() != in_vect1.size() || out_vect.size() != in_vect1.size()){
 	  std::cout << "ERROR: Vector sizes do not  match"<< "\n";
 	  return;
   }
@@ -55,7 +55,7 @@ void SYCLParallel(queue &q, std::vector<Complex2> &in_vect1,
   buffer bufin_vect1(in_vect1);
   buffer bufin_vect2(in_vect2);
 
-  // Setup Output buffers 
+  // Setup Output buffers
   buffer bufout_vect(out_vect);
 
   std::cout << "Target Device: "
@@ -81,7 +81,7 @@ void Scalar(std::vector<Complex2> &in_vect1,
   if ((in_vect2.size() != in_vect1.size()) || (out_vect.size() != in_vect1.size())){
 	  std::cout<<"ERROR: Vector sizes do not match"<<"\n";
 	  return;
-  }		 
+  }
   for (int i = 0; i < in_vect1.size(); i++) {
     out_vect[i] = in_vect1[i].complex_mul(in_vect2[i]);
   }

--- a/DirectProgramming/C++SYCL/DenseLinearAlgebra/matrix_mul/src/matrix_mul_sycl.cpp
+++ b/DirectProgramming/C++SYCL/DenseLinearAlgebra/matrix_mul/src/matrix_mul_sycl.cpp
@@ -14,7 +14,7 @@
  * relevant terms noted in the comments.
  */
 
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 #include <iostream>
 #include <limits>
 

--- a/DirectProgramming/C++SYCL/GraphAlgorithms/all-pairs-shortest-paths/src/apsp.cpp
+++ b/DirectProgramming/C++SYCL/GraphAlgorithms/all-pairs-shortest-paths/src/apsp.cpp
@@ -7,7 +7,7 @@
 // SPDX-License-Identifier: MIT
 // =============================================================
 
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 #include <chrono>
 #include <cstdlib>
 #include <iostream>

--- a/DirectProgramming/C++SYCL/GraphTraversal/bitonic-sort/src/bitonic-sort.cpp
+++ b/DirectProgramming/C++SYCL/GraphTraversal/bitonic-sort/src/bitonic-sort.cpp
@@ -38,6 +38,7 @@
 #include <iostream>
 #include <string>
 #include <optional>
+
 // dpc_common.hpp can be found in the dev-utilities include folder.
 // e.g., $ONEAPI_ROOT/dev-utilities/<version>/include/dpc_common.hpp
 #include "dpc_common.hpp"

--- a/DirectProgramming/C++SYCL/GraphTraversal/bitonic-sort/src/bitonic-sort.cpp
+++ b/DirectProgramming/C++SYCL/GraphTraversal/bitonic-sort/src/bitonic-sort.cpp
@@ -38,8 +38,6 @@
 #include <iostream>
 #include <string>
 #include <optional>
-#include <CL/sycl.hpp>
-
 // dpc_common.hpp can be found in the dev-utilities include folder.
 // e.g., $ONEAPI_ROOT/dev-utilities/<version>/include/dpc_common.hpp
 #include "dpc_common.hpp"

--- a/DirectProgramming/C++SYCL/GraphTraversal/hidden-markov-models/src/hidden-markov-models.cpp
+++ b/DirectProgramming/C++SYCL/GraphTraversal/hidden-markov-models/src/hidden-markov-models.cpp
@@ -4,27 +4,27 @@
 // SPDX-License-Identifier: MIT
 // =============================================================
 //
-// Hidden Markov Models: this code sample implements the Viterbi algorithm which is a dynamic
+// Hidden Markov Models: this code sample implements the Viterbi algorithm which is a dynamic 
 // programming algorithm for finding the most likely sequence of hidden states—
 // called the Viterbi path—that results in a sequence of observed events,
 // especially in the context of Markov information sources and HMM.
 //
 // The sample can use GPU offload to compute sequential steps of multiple graph traversals simultaneously.
 //
-// - Initially, the dataset for algorithm processing is generated : initial states probability
-// distribution Pi, transition matrix A, emission matrix B and the sequence or the observations
+// - Initially, the dataset for algorithm processing is generated : initial states probability 
+// distribution Pi, transition matrix A, emission matrix B and the sequence or the observations 
 // produced by hidden Markov process.
-// - First, the matrix of Viterbi values on the first states are initialized using distribution Pi
+// - First, the matrix of Viterbi values on the first states are initialized using distribution Pi 
 // and emission matrix B. The matrix of back pointers is initialized with default values -1.
 // - Then, for each time step the Viterbi matrix is set to the maximal possible value using A, B and Pi.
-// - Finally, the state with maximum Viterbi value on the last step is set as a final state of
-// the Viterbi path and the previous nodes of this path are detemined using the correspondent rows
+// - Finally, the state with maximum Viterbi value on the last step is set as a final state of 
+// the Viterbi path and the previous nodes of this path are detemined using the correspondent rows 
 // of back pointers matrix for each of the steps except the last one.
 //
 // Note: The implementation uses logarithms of the probabilities to process small numbers correctly
 // and to replace multiplication operations with addition operations.
 
-#include <sycl/sycl.hpp>
+#include <sycl/sycl.hpp> 
 #include <iostream>
 #include <limits>
 #include <math.h>
@@ -111,16 +111,16 @@ int main() {
             h.parallel_for(range<2>(N, T), [=](id<2> index) {
                 int i = index[0];
                 int j = index[1];
-                // At starting point only the first Viterbi values are defined and these Values are substituted
+                // At starting point only the first Viterbi values are defined and these Values are substituted 
                 // with logarithms  due to the following equation: log(x*y) = log(x) + log(y).
                 v_acc[index] = (j != 0) ? MIN_DOUBLE : pi_acc[i] + b_acc[i][seq_acc[0]];
-                // Default values of all the back pointers are (-1) to show that they are not determined yet.
+                // Default values of all the back pointers are (-1) to show that they are not determined yet. 
                 b_ptr_acc[index] = -1;
             });
-        });
+        }); 
 
-        // The sequential steps of the Viterbi algorithm that define the Viterbi matrix and the matrix
-        // of back pointers. The product of the Viterbi values and the probabilities is substituted with the sum of
+        // The sequential steps of the Viterbi algorithm that define the Viterbi matrix and the matrix 
+        // of back pointers. The product of the Viterbi values and the probabilities is substituted with the sum of 
         // the logarithms due to the following equation: log (x*y*z) = log(x) + log(y) + log(z).
         for (int j = 0; j < T - 1; ++j) {
             q.submit([&](handler& h) {
@@ -132,7 +132,7 @@ int main() {
 
                 h.parallel_for(range<2>(N, N), [=](id<2> index) {
                     int i = index[0], k = index[1];
-                    // This conditional block finds the maximum possible Viterbi value on
+                    // This conditional block finds the maximum possible Viterbi value on 
                     // the current step j for the state i.
                     if (ViterbiCondition(v_acc[k][j], b_acc[i][seq_acc[j + 1]], a_acc[k][i], v_acc[i][j + 1])) {
                         v_acc[i][j + 1] = v_acc[k][j] + a_acc[k][i] + b_acc[i][seq_acc[j + 1]];
@@ -148,7 +148,7 @@ int main() {
         auto b_ptr_acc = back_pointer.get_access<access::mode::read>();
         auto vit_path_acc = vit_path.get_access<access::mode::read_write>();
         double v_max = MIN_DOUBLE;
-        // Constructing the Viterbi path. The last state of this path is the one with
+        // Constructing the Viterbi path. The last state of this path is the one with 
         // the biggest Viterbi value (the most likely state).
         for (int i = 0; i < N; ++i) {
             if (v_acc[i][T - 1] > v_max) {
@@ -179,8 +179,8 @@ int main() {
     return 0;
 }
 
-// The method checks if all three components of the sum are not equivalent to logarithm of zero
-// (that is incorrect value and is substituted with minimal possible value of double) and that
+// The method checks if all three components of the sum are not equivalent to logarithm of zero 
+// (that is incorrect value and is substituted with minimal possible value of double) and that 
 // the Viterbi value on the new step exceeds the current one.
 bool ViterbiCondition(double x, double y, double z, double compare) {
     return (x > MIN_DOUBLE) && (y > MIN_DOUBLE) && (z > MIN_DOUBLE) && (x + y + z > compare);

--- a/DirectProgramming/C++SYCL/GraphTraversal/hidden-markov-models/src/hidden-markov-models.cpp
+++ b/DirectProgramming/C++SYCL/GraphTraversal/hidden-markov-models/src/hidden-markov-models.cpp
@@ -4,27 +4,27 @@
 // SPDX-License-Identifier: MIT
 // =============================================================
 //
-// Hidden Markov Models: this code sample implements the Viterbi algorithm which is a dynamic 
+// Hidden Markov Models: this code sample implements the Viterbi algorithm which is a dynamic
 // programming algorithm for finding the most likely sequence of hidden states—
 // called the Viterbi path—that results in a sequence of observed events,
 // especially in the context of Markov information sources and HMM.
 //
 // The sample can use GPU offload to compute sequential steps of multiple graph traversals simultaneously.
 //
-// - Initially, the dataset for algorithm processing is generated : initial states probability 
-// distribution Pi, transition matrix A, emission matrix B and the sequence or the observations 
+// - Initially, the dataset for algorithm processing is generated : initial states probability
+// distribution Pi, transition matrix A, emission matrix B and the sequence or the observations
 // produced by hidden Markov process.
-// - First, the matrix of Viterbi values on the first states are initialized using distribution Pi 
+// - First, the matrix of Viterbi values on the first states are initialized using distribution Pi
 // and emission matrix B. The matrix of back pointers is initialized with default values -1.
 // - Then, for each time step the Viterbi matrix is set to the maximal possible value using A, B and Pi.
-// - Finally, the state with maximum Viterbi value on the last step is set as a final state of 
-// the Viterbi path and the previous nodes of this path are detemined using the correspondent rows 
+// - Finally, the state with maximum Viterbi value on the last step is set as a final state of
+// the Viterbi path and the previous nodes of this path are detemined using the correspondent rows
 // of back pointers matrix for each of the steps except the last one.
 //
 // Note: The implementation uses logarithms of the probabilities to process small numbers correctly
 // and to replace multiplication operations with addition operations.
 
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 #include <iostream>
 #include <limits>
 #include <math.h>
@@ -111,16 +111,16 @@ int main() {
             h.parallel_for(range<2>(N, T), [=](id<2> index) {
                 int i = index[0];
                 int j = index[1];
-                // At starting point only the first Viterbi values are defined and these Values are substituted 
+                // At starting point only the first Viterbi values are defined and these Values are substituted
                 // with logarithms  due to the following equation: log(x*y) = log(x) + log(y).
                 v_acc[index] = (j != 0) ? MIN_DOUBLE : pi_acc[i] + b_acc[i][seq_acc[0]];
-                // Default values of all the back pointers are (-1) to show that they are not determined yet. 
+                // Default values of all the back pointers are (-1) to show that they are not determined yet.
                 b_ptr_acc[index] = -1;
             });
-        });    
+        });
 
-        // The sequential steps of the Viterbi algorithm that define the Viterbi matrix and the matrix 
-        // of back pointers. The product of the Viterbi values and the probabilities is substituted with the sum of 
+        // The sequential steps of the Viterbi algorithm that define the Viterbi matrix and the matrix
+        // of back pointers. The product of the Viterbi values and the probabilities is substituted with the sum of
         // the logarithms due to the following equation: log (x*y*z) = log(x) + log(y) + log(z).
         for (int j = 0; j < T - 1; ++j) {
             q.submit([&](handler& h) {
@@ -132,7 +132,7 @@ int main() {
 
                 h.parallel_for(range<2>(N, N), [=](id<2> index) {
                     int i = index[0], k = index[1];
-                    // This conditional block finds the maximum possible Viterbi value on 
+                    // This conditional block finds the maximum possible Viterbi value on
                     // the current step j for the state i.
                     if (ViterbiCondition(v_acc[k][j], b_acc[i][seq_acc[j + 1]], a_acc[k][i], v_acc[i][j + 1])) {
                         v_acc[i][j + 1] = v_acc[k][j] + a_acc[k][i] + b_acc[i][seq_acc[j + 1]];
@@ -148,7 +148,7 @@ int main() {
         auto b_ptr_acc = back_pointer.get_access<access::mode::read>();
         auto vit_path_acc = vit_path.get_access<access::mode::read_write>();
         double v_max = MIN_DOUBLE;
-        // Constructing the Viterbi path. The last state of this path is the one with 
+        // Constructing the Viterbi path. The last state of this path is the one with
         // the biggest Viterbi value (the most likely state).
         for (int i = 0; i < N; ++i) {
             if (v_acc[i][T - 1] > v_max) {
@@ -179,8 +179,8 @@ int main() {
     return 0;
 }
 
-// The method checks if all three components of the sum are not equivalent to logarithm of zero 
-// (that is incorrect value and is substituted with minimal possible value of double) and that 
+// The method checks if all three components of the sum are not equivalent to logarithm of zero
+// (that is incorrect value and is substituted with minimal possible value of double) and that
 // the Viterbi value on the new step exceeds the current one.
 bool ViterbiCondition(double x, double y, double z, double compare) {
     return (x > MIN_DOUBLE) && (y > MIN_DOUBLE) && (z > MIN_DOUBLE) && (x + y + z > compare);

--- a/DirectProgramming/C++SYCL/MapReduce/MonteCarloPi/src/monte_carlo_pi.cpp
+++ b/DirectProgramming/C++SYCL/MapReduce/MonteCarloPi/src/monte_carlo_pi.cpp
@@ -1,4 +1,4 @@
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 #include <iostream>
 #include <math.h>
 #include <stdlib.h>
@@ -8,7 +8,7 @@
 // e.g., $ONEAPI_ROOT/dev-utilities/<version>/include/dpc_common.hpp
 #include "dpc_common.hpp"
 #include "monte_carlo_pi.hpp"
-#define STB_IMAGE_IMPLEMENTATION 
+#define STB_IMAGE_IMPLEMENTATION
 #include "stb/stb_image.h"
 #define STB_IMAGE_WRITE_IMPLEMENTATION
 #include "stb/stb_image_write.h"

--- a/DirectProgramming/C++SYCL/N-BodyMethods/Nbody/src/GSimulation.hpp
+++ b/DirectProgramming/C++SYCL/N-BodyMethods/Nbody/src/GSimulation.hpp
@@ -7,7 +7,7 @@
 #ifndef _GSIMULATION_HPP
 #define _GSIMULATION_HPP
 
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 #include <cstdlib>
 #include <fstream>
 #include <iomanip>

--- a/DirectProgramming/C++SYCL/ParallelPatterns/PrefixSum/src/PrefixSum.cpp
+++ b/DirectProgramming/C++SYCL/ParallelPatterns/PrefixSum/src/PrefixSum.cpp
@@ -34,7 +34,6 @@
 
 #include <iostream>
 #include <string>
-#include <CL/sycl.hpp>
 // dpc_common.hpp can be found in the dev-utilities include folder.
 // e.g., $ONEAPI_ROOT/dev-utilities/<version>/include/dpc_common.hpp
 #include "dpc_common.hpp"

--- a/DirectProgramming/C++SYCL/ParallelPatterns/loop-unroll/src/loop-unroll.cpp
+++ b/DirectProgramming/C++SYCL/ParallelPatterns/loop-unroll/src/loop-unroll.cpp
@@ -7,7 +7,7 @@
 // SPDX-License-Identifier: MIT
 // =============================================================
 
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 #include <iomanip>
 #include <iostream>
 #include <vector>

--- a/DirectProgramming/C++SYCL/SparseLinearAlgebra/merge-spmv/src/spmv.cpp
+++ b/DirectProgramming/C++SYCL/SparseLinearAlgebra/merge-spmv/src/spmv.cpp
@@ -8,7 +8,7 @@
 // SPDX-License-Identifier: MIT
 // =============================================================
 
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 #include <iostream>
 #include <map>
 #include <set>

--- a/DirectProgramming/C++SYCL/SpectralMethods/DiscreteCosineTransform/src/DCT.cpp
+++ b/DirectProgramming/C++SYCL/SpectralMethods/DiscreteCosineTransform/src/DCT.cpp
@@ -1,6 +1,6 @@
 #include "DCT.hpp"
 
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 #include <cmath>
 #include <cstdio>
 #include <cstdlib>

--- a/DirectProgramming/C++SYCL/StructuredGrids/1d_HeatTransfer/src/1d_HeatTransfer.cpp
+++ b/DirectProgramming/C++SYCL/StructuredGrids/1d_HeatTransfer/src/1d_HeatTransfer.cpp
@@ -33,7 +33,7 @@
 //   1d_HeatTransfer.cpp
 //
 //******************************************************************************
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 #include <algorithm>
 #include <fstream>
 #include <iomanip>

--- a/DirectProgramming/C++SYCL/StructuredGrids/guided_HSOpticalflow_SYCLMigration/02_sycl_dpct_migrated/src/derivativesKernel.hpp
+++ b/DirectProgramming/C++SYCL/StructuredGrids/guided_HSOpticalflow_SYCLMigration/02_sycl_dpct_migrated/src/derivativesKernel.hpp
@@ -31,7 +31,7 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 #include <dpct/dpct.hpp>
 
 #include "common.h"

--- a/DirectProgramming/C++SYCL/StructuredGrids/iso2dfd_dpcpp/src/iso2dfd.cpp
+++ b/DirectProgramming/C++SYCL/StructuredGrids/iso2dfd_dpcpp/src/iso2dfd.cpp
@@ -31,7 +31,7 @@
 #include <fstream>
 #include <iostream>
 #include <string>
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 #include <cmath>
 #include <cstring>
 #include <stdio.h>

--- a/DirectProgramming/C++SYCL/StructuredGrids/iso3dfd_dpcpp/src/iso3dfd.cpp
+++ b/DirectProgramming/C++SYCL/StructuredGrids/iso3dfd_dpcpp/src/iso3dfd.cpp
@@ -33,7 +33,7 @@
 #include "iso3dfd.h"
 #include <iostream>
 #include <string>
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 #include "device_selector.hpp"
 #include "dpc_common.hpp"
 

--- a/DirectProgramming/C++SYCL/StructuredGrids/particle-diffusion/src/motionsim.hpp
+++ b/DirectProgramming/C++SYCL/StructuredGrids/particle-diffusion/src/motionsim.hpp
@@ -22,7 +22,7 @@ constexpr float sigma = 0.03f;  // Standard Deviation
 #include <unistd.h>
 #endif  // !WINDOWS
 
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 #include <cmath>
 #include <iomanip>
 #include <iostream>


### PR DESCRIPTION
# Existing Sample Changes
## Description

Reverts PR#1265 and #1266 so that samples will compile with the latest version of dpc_common.hpp and the latest version of the compilers.

Fixes Issue# 

## External Dependencies

List any external dependencies created as a result of this change.

## Type of change

Please delete options that are not relevant. Add a 'X' to the one that is applicable. 

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Implement fixes for ONSAM Jiras

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [X] Command Line
- [ ] oneapi-cli
- [ ] Visual Studio
- [ ] Eclipse IDE
- [ ] VSCode
- [ ] When compiling the compliler flag "-Wall -Wformat-security -Werror=format-security" was used