### PR TITLE
Reverted PR#1265 and PR#1266

### DIFF
--- a/DirectProgramming/C++SYCL/CombinationalLogic/mandelbrot/src/main.cpp
+++ b/DirectProgramming/C++SYCL/CombinationalLogic/mandelbrot/src/main.cpp
@@ -7,12 +7,10 @@
 #include <chrono>
 #include <iomanip>
 #include <iostream>
-#include <CL/sycl.hpp>
 // dpc_common.hpp can be found in the dev-utilities include folder.
 // e.g., $ONEAPI_ROOT/dev-utilities/<version>/include/dpc_common.hpp
 #include "dpc_common.hpp"
 #include "mandel.hpp"
-
 
 using namespace std;
 using namespace sycl;

--- a/DirectProgramming/C++SYCL/DenseLinearAlgebra/complex_mult/src/complex_mult.cpp
+++ b/DirectProgramming/C++SYCL/DenseLinearAlgebra/complex_mult/src/complex_mult.cpp
@@ -4,7 +4,7 @@
 //
 // SPDX-License-Identifier: MIT
 // =============================================================
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 #include <iomanip>
 #include <vector>
 // dpc_common.hpp can be found in the dev-utilities include folder.

--- a/DirectProgramming/C++SYCL/DenseLinearAlgebra/matrix_mul/src/matrix_mul_sycl.cpp
+++ b/DirectProgramming/C++SYCL/DenseLinearAlgebra/matrix_mul/src/matrix_mul_sycl.cpp
@@ -14,7 +14,7 @@
  * relevant terms noted in the comments.
  */
 
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 #include <iostream>
 #include <limits>
 

--- a/DirectProgramming/C++SYCL/GraphAlgorithms/all-pairs-shortest-paths/src/apsp.cpp
+++ b/DirectProgramming/C++SYCL/GraphAlgorithms/all-pairs-shortest-paths/src/apsp.cpp
@@ -7,7 +7,7 @@
 // SPDX-License-Identifier: MIT
 // =============================================================
 
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 #include <chrono>
 #include <cstdlib>
 #include <iostream>

--- a/DirectProgramming/C++SYCL/GraphTraversal/bitonic-sort/src/bitonic-sort.cpp
+++ b/DirectProgramming/C++SYCL/GraphTraversal/bitonic-sort/src/bitonic-sort.cpp
@@ -38,7 +38,6 @@
 #include <iostream>
 #include <string>
 #include <optional>
-#include <CL/sycl.hpp>
 
 // dpc_common.hpp can be found in the dev-utilities include folder.
 // e.g., $ONEAPI_ROOT/dev-utilities/<version>/include/dpc_common.hpp

--- a/DirectProgramming/C++SYCL/GraphTraversal/hidden-markov-models/src/hidden-markov-models.cpp
+++ b/DirectProgramming/C++SYCL/GraphTraversal/hidden-markov-models/src/hidden-markov-models.cpp
@@ -24,7 +24,7 @@
 // Note: The implementation uses logarithms of the probabilities to process small numbers correctly
 // and to replace multiplication operations with addition operations.
 
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 #include <iostream>
 #include <limits>
 #include <math.h>

--- a/DirectProgramming/C++SYCL/MapReduce/MonteCarloPi/src/monte_carlo_pi.cpp
+++ b/DirectProgramming/C++SYCL/MapReduce/MonteCarloPi/src/monte_carlo_pi.cpp
@@ -1,4 +1,4 @@
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 #include <iostream>
 #include <math.h>
 #include <stdlib.h>

--- a/DirectProgramming/C++SYCL/N-BodyMethods/Nbody/src/GSimulation.hpp
+++ b/DirectProgramming/C++SYCL/N-BodyMethods/Nbody/src/GSimulation.hpp
@@ -7,7 +7,7 @@
 #ifndef _GSIMULATION_HPP
 #define _GSIMULATION_HPP
 
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 #include <cstdlib>
 #include <fstream>
 #include <iomanip>

--- a/DirectProgramming/C++SYCL/ParallelPatterns/PrefixSum/src/PrefixSum.cpp
+++ b/DirectProgramming/C++SYCL/ParallelPatterns/PrefixSum/src/PrefixSum.cpp
@@ -34,7 +34,6 @@
 
 #include <iostream>
 #include <string>
-#include <CL/sycl.hpp>
 // dpc_common.hpp can be found in the dev-utilities include folder.
 // e.g., $ONEAPI_ROOT/dev-utilities/<version>/include/dpc_common.hpp
 #include "dpc_common.hpp"

--- a/DirectProgramming/C++SYCL/ParallelPatterns/loop-unroll/src/loop-unroll.cpp
+++ b/DirectProgramming/C++SYCL/ParallelPatterns/loop-unroll/src/loop-unroll.cpp
@@ -7,7 +7,7 @@
 // SPDX-License-Identifier: MIT
 // =============================================================
 
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 #include <iomanip>
 #include <iostream>
 #include <vector>

--- a/DirectProgramming/C++SYCL/SparseLinearAlgebra/merge-spmv/src/spmv.cpp
+++ b/DirectProgramming/C++SYCL/SparseLinearAlgebra/merge-spmv/src/spmv.cpp
@@ -8,7 +8,7 @@
 // SPDX-License-Identifier: MIT
 // =============================================================
 
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 #include <iostream>
 #include <map>
 #include <set>

--- a/DirectProgramming/C++SYCL/SpectralMethods/DiscreteCosineTransform/src/DCT.cpp
+++ b/DirectProgramming/C++SYCL/SpectralMethods/DiscreteCosineTransform/src/DCT.cpp
@@ -1,6 +1,6 @@
 #include "DCT.hpp"
 
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 #include <cmath>
 #include <cstdio>
 #include <cstdlib>

--- a/DirectProgramming/C++SYCL/StructuredGrids/1d_HeatTransfer/src/1d_HeatTransfer.cpp
+++ b/DirectProgramming/C++SYCL/StructuredGrids/1d_HeatTransfer/src/1d_HeatTransfer.cpp
@@ -33,7 +33,7 @@
 //   1d_HeatTransfer.cpp
 //
 //******************************************************************************
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 #include <algorithm>
 #include <fstream>
 #include <iomanip>

--- a/DirectProgramming/C++SYCL/StructuredGrids/guided_HSOpticalflow_SYCLMigration/02_sycl_dpct_migrated/src/derivativesKernel.hpp
+++ b/DirectProgramming/C++SYCL/StructuredGrids/guided_HSOpticalflow_SYCLMigration/02_sycl_dpct_migrated/src/derivativesKernel.hpp
@@ -31,7 +31,7 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 #include <dpct/dpct.hpp>
 
 #include "common.h"

--- a/DirectProgramming/C++SYCL/StructuredGrids/iso2dfd_dpcpp/src/iso2dfd.cpp
+++ b/DirectProgramming/C++SYCL/StructuredGrids/iso2dfd_dpcpp/src/iso2dfd.cpp
@@ -31,7 +31,7 @@
 #include <fstream>
 #include <iostream>
 #include <string>
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 #include <cmath>
 #include <cstring>
 #include <stdio.h>

--- a/DirectProgramming/C++SYCL/StructuredGrids/iso3dfd_dpcpp/src/iso3dfd.cpp
+++ b/DirectProgramming/C++SYCL/StructuredGrids/iso3dfd_dpcpp/src/iso3dfd.cpp
@@ -33,7 +33,6 @@
 #include "iso3dfd.h"
 #include <iostream>
 #include <string>
-#include <CL/sycl.hpp>
 #include "device_selector.hpp"
 #include "dpc_common.hpp"
 

--- a/DirectProgramming/C++SYCL/StructuredGrids/particle-diffusion/src/motionsim.hpp
+++ b/DirectProgramming/C++SYCL/StructuredGrids/particle-diffusion/src/motionsim.hpp
@@ -22,7 +22,7 @@ constexpr float sigma = 0.03f;  // Standard Deviation
 #include <unistd.h>
 #endif  // !WINDOWS
 
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 #include <cmath>
 #include <iomanip>
 #include <iostream>


### PR DESCRIPTION
# Existing Sample Changes
## Description

Reverted PR#1265 and PR#1266 so that code samples will work with the latest dpc_common.hpp namespace changes and uses the right headers for the 2023.0 compilers.

Fixes Issue# 

## External Dependencies

List any external dependencies created as a result of this change.

## Type of change

Please delete options that are not relevant. Add a 'X' to the one that is applicable. 

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Implement fixes for ONSAM Jiras

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [X] Command Line
- [ ] oneapi-cli
- [ ] Visual Studio
- [ ] Eclipse IDE
- [ ] VSCode
- [ ] When compiling the compliler flag "-Wall -Wformat-security -Werror=format-security" was used
