### PR TITLE
FPGA: add a warning when compiling the CRR design in the simulation flow

### DIFF
--- a/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/crr/src/CMakeLists.txt
+++ b/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/crr/src/CMakeLists.txt
@@ -94,6 +94,11 @@ add_custom_target(fpga_emu DEPENDS ${EMULATOR_TARGET})
 ### FPGA Simulator
 ###############################################################################
 add_executable(${SIMULATOR_TARGET} ${SOURCE_FILE})
+add_custom_command(TARGET ${SIMULATOR_TARGET} PRE_BUILD
+                     COMMAND ${CMAKE_COMMAND} -E cmake_echo_color --cyan
+                     ""
+                     COMMENT "Running the simulation flow on the CRR design is very long and is therefore not recommended"
+                    )
 target_include_directories(${SIMULATOR_TARGET} PRIVATE ../../../include)
 set_target_properties(${SIMULATOR_TARGET} PROPERTIES COMPILE_FLAGS "${SIMULATOR_COMPILE_FLAGS}")
 set_target_properties(${SIMULATOR_TARGET} PROPERTIES LINK_FLAGS "${SIMULATOR_LINK_FLAGS}")


### PR DESCRIPTION
The simulation runtime of the CRR design is very long.
This PR adds a message that the users can see when they compile for simulation warning them about this long runtime.