### PR TITLE
FPGA: Update QRD s10 default seed

### DIFF
--- a/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/qrd/src/CMakeLists.txt
+++ b/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/qrd/src/CMakeLists.txt
@@ -70,7 +70,7 @@ elseif(DEVICE_FLAG MATCHES "S10")
     set(COMPLEX 1)
     set(FIXED_ITERATIONS 110)
     set(CLOCK_TARGET "-Xsclock=480MHz")
-    set(SEED "-Xsseed=9")
+    set(SEED "-Xsseed=2")
 elseif(DEVICE_FLAG MATCHES "Agilex")
     # Agilex™ parameters
     set(ROWS_COMPONENT 256)


### PR DESCRIPTION
This PR updates the PAC S10 default seed of the QRD design in order to meet the expected performance for 2023.1