### PR TITLE
FPGA: Update throughput numbers for mvdr_beamforming design for 2023.1 release

### DIFF
--- a/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/mvdr_beamforming/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/mvdr_beamforming/README.md
@@ -336,7 +336,7 @@ Training matrix rows          : 48
 Data rows per training matrix : 48
 Steering vectors              : 25
 Streaming pipe width          : 4
-Throughput: 233793 matrices/second
+Throughput: 177299 matrices/second
 Checking output data against ../data/small_expected_out_real.txt and ../data/small_expected_out_imag.txt
 Output data check succeeded
 PASSED


### PR DESCRIPTION
# Existing Sample Changes
## Description

This change updates the throughput numbers observed for the mvdr_beamforming design to be accurate for the 2023.1 release.

Fixes Issue# 

## External Dependencies

* N/A

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Since this is a README change I checked to see if the new .md file looks as intended.

- [X] Command Line
- [ ] oneapi-cli
- [ ] Visual Studio
- [ ] Eclipse IDE
- [ ] VSCode
- [ ] When compiling the compliler flag "-Wall -Wformat-security -Werror=format-security" was used
