### PR TITLE
Sample.json fix for IntelTensorFlow_Transformer_AMX_bfloat16_MixedPrecision sample

### DIFF
--- a/AI-and-Analytics/Features-and-Functionality/IntelTensorFlow_Transformer_AMX_bfloat16_MixedPrecision/sample.json
+++ b/AI-and-Analytics/Features-and-Functionality/IntelTensorFlow_Transformer_AMX_bfloat16_MixedPrecision/sample.json
@@ -1,6 +1,6 @@
 {
   "guid": "60A68888-6099-414E-999B-EDC7310A01EA",
-  "name": "TensorFlow (TF) Transformer with Intel® Advanced Matrix Extensions (Intel® AMX) bfoat16 Mixed Precision Learning",
+  "name": "TensorFlow Transformer with Advanced Matrix Extensions bfoat16 Mixed Precision Learning",
   "categories": ["Toolkit/oneAPI AI And Analytics/AI Getting Started Samples"],
   "description": "This sample code demonstrates optimizing a TensorFlow model with Intel® Advanced Matrix Extensions (Intel® AMX) using bfloat16 (Brain Floating Point) on Sapphire Rapids",
   "builder": ["cli"],


### PR DESCRIPTION
# Existing Sample Changes
## Description

Updated title field in sample.json in TF Transformer AMX bfloat16 Mixed Precision sample to fit within character length range

## External Dependencies

List any external dependencies created as a result of this change.

## Type of change

Please delete options that are not relevant. Add a 'X' to the one that is applicable. 

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Implement fixes for ONSAM Jiras

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Command Line
- [ ] oneapi-cli
- [ ] Visual Studio
- [ ] Eclipse IDE
- [ ] VSCode
- [ ] When compiling the compliler flag "-Wall -Wformat-security -Werror=format-security" was used