### PR TITLE
Update the oneMKL sample with mcg59 as a default engine

### DIFF
--- a/Libraries/oneMKL/monte_carlo_european_opt/GNUmakefile
+++ b/Libraries/oneMKL/monte_carlo_european_opt/GNUmakefile
@@ -1,6 +1,21 @@
 all: montecarlo
 
-MKL_COPTS = -DMKL_ILP64  -I"${MKLROOT}/include"
+# setting non-default generator
+generator ?= mcg59
+
+ifeq ($(generator), mrg)
+	GENERATOR = -DUSE_MRG
+endif
+
+ifeq ($(generator), philox)
+	GENERATOR = -DUSE_PHILOX
+endif
+
+ifneq ($(generator), $(filter $(generator),mrg philox mcg59))
+ 	$(error "You use unknown generator. Please, use mrg philox or mcg59 (default)")
+endif
+
+MKL_COPTS = -DMKL_ILP64 $(GENERATOR) -I"${MKLROOT}/include" -Wall -Wformat-security -Werror=format-security
 MKL_LIBS = -L${MKLROOT}/lib/intel64 -lmkl_sycl -lmkl_intel_ilp64 -lmkl_sequential -lmkl_core -lpthread -lm -ldl
 
 DPCPP_OPTS = $(MKL_COPTS) -fsycl -fsycl-device-code-split=per_kernel $(MKL_LIBS)

--- a/Libraries/oneMKL/monte_carlo_european_opt/README.md
+++ b/Libraries/oneMKL/monte_carlo_european_opt/README.md
@@ -21,7 +21,8 @@ based on a stochastic stock price model. A large number of possible implementati
 price over time are generated, and an estimation of the call and put options is made by averaging
 their values in each realization.
 
-This sample performs its computations on the default SYCL* device. You can set the `SYCL_DEVICE_TYPE` environment variable to `cpu` or `gpu` to select the device to use.
+This sample performs its computations on the default SYCL* device. You can set
+the `SYCL_DEVICE_TYPE` environment variable to `cpu` or `gpu` to select the device to use.
 
 ## Key Implementation Details
 
@@ -30,7 +31,7 @@ a distribution object (specifying the desired probability distribution), and fin
 the random numbers themselves. Random number generation can be done from the host,
 storing the results in a SYCL-compliant buffer or USM pointer, or directly in a kernel.
 
-In this sample, a Philox 4x32x10 generator is used, and a gaussian distribution
+In this sample, the MCG59 generator is used by default, and a gaussian distribution
 is the basis for the Monte Carlo simulation. oneMKL provides many other generators
 and distributions to suit a range of applications. After generating the random number
 input for the simulation, prices are calculated and then averaged using reduction functions.
@@ -67,7 +68,10 @@ To learn more about the extensions, see the
 > For more information on configuring environment variables, see [Use the setvars Script with Linux* or MacOS*](https://www.intel.com/content/www/us/en/develop/documentation/oneapi-programming-guide/top/oneapi-development-environment-setup/use-the-setvars-script-with-linux-or-macos.html) or [Use the setvars Script with Windows*](https://www.intel.com/content/www/us/en/develop/documentation/oneapi-programming-guide/top/oneapi-development-environment-setup/use-the-setvars-script-with-windows.html).
 
 ### Running Samples In Intel® DevCloud
-If running a sample in the Intel® DevCloud, remember that you must specify the compute node (CPU, GPU, FPGA) as well whether to run in batch or interactive mode. For more information see the Intel® oneAPI Base Toolkit Get Started Guide (https://devcloud.intel.com/oneapi/get-started/base-toolkit/).
+If running a sample in the Intel® DevCloud, remember that you must specify the
+compute node (CPU, GPU, FPGA) as well whether to run in batch or interactive mode.
+For more information see the Intel® oneAPI Base Toolkit Get Started Guide
+(https://devcloud.intel.com/oneapi/get-started/base-toolkit/).
 
 ### On a Linux* System
 Run `make` to build the sample. Then run the sample calling generated execution file.
@@ -78,6 +82,20 @@ You can remove all generated files with `make clean`.
 Run `nmake` to build and run the sample programs. `nmake clean` removes temporary files.
 
 > **Warning**: On Windows, static linking with oneMKL currently takes a very long time, due to a known compiler issue. This will be addressed in an upcoming release.
+
+#### Build a sample using others generators
+To use the MRG32k3a generator or the Philox4x32x10 generator use `generator=mrg`
+or `generator=philox` correspondingly when building the sample, e.g.
+```
+make generator=mrg
+```
+for Linux* system or
+
+```
+nmake generator=mrg
+```
+
+for Windows* System.
 
 ## Running the Monte Carlo European Options Sample
 If everything is working correctly, the program will run the Monte Carlo simulation.

--- a/Libraries/oneMKL/monte_carlo_european_opt/makefile
+++ b/Libraries/oneMKL/monte_carlo_european_opt/makefile
@@ -1,6 +1,20 @@
 all: montecarlo
 
-DPCPP_OPTS=/I$(MKLROOT)\include /DMKL_ILP64 -fsycl -fsycl-device-code-split=per_kernel -qmkl
+generator ?= mcg59
+
+ifeq ($(generator), mrg)
+	GENERATOR = /DUSE_MRG
+endif
+
+ifeq ($(generator), philox)
+	GENERATOR = /DUSE_PHILOX
+endif
+
+ifneq ($(generator), $(filter $(generator),mrg philox mcg59))
+ 	$(error "You use unknown generator. Please, use mrg philox or mcg59 (default)")
+endif
+
+DPCPP_OPTS=/I$(MKLROOT)\include /DMKL_ILP64 $(GENERATOR) -fsycl -fsycl-device-code-split=per_kernel -qmkl
 
 montecarlo: src/montecarlo_main.cpp
 	icpx src/montecarlo_main.cpp /omontecarlo.exe $(DPCPP_OPTS)

--- a/Libraries/oneMKL/monte_carlo_european_opt/src/montecarlo_main.cpp
+++ b/Libraries/oneMKL/monte_carlo_european_opt/src/montecarlo_main.cpp
@@ -20,10 +20,21 @@ int main(int argc, char** argv)
 {
     try {
         std::cout << "MonteCarlo European Option Pricing in " <<
-            (std::is_same_v<DataType, double> ? "Double" : "Single") << " precision" << std::endl;
+            (std::is_same_v<DataType, double> ? "Double" : "Single") <<
+            " precision using " <<
+#if USE_PHILOX
+            "PHILOX4x32x10" <<
+#elif USE_MRG
+            "MRG32k3a" <<
+#else
+            "MCG59" <<
+#endif
+            " generator." <<
+        std::endl;
+
         std::cout <<
-            "Pricing "<< num_options <<
-            " Options with Path Length = "<< path_length <<
+            "Pricing " << num_options <<
+            " Options with Path Length = " << path_length <<
             ", sycl::vec size = " << VEC_SIZE <<
             ", Options Per Work Item = " << ITEMS_PER_WORK_ITEM <<
             " and Iterations = " << num_iterations <<
@@ -57,19 +68,19 @@ int main(int argc, char** argv)
 
         namespace mkl_rng = oneapi::mkl::rng;
 
-        mkl_rng::philox4x32x10 engine(my_queue, rand_seed); // random number generator object
+        mkl_rng::mcg59 engine(my_queue, rand_seed); // random number generator object
         auto rng_event_1 = mkl_rng::generate(mkl_rng::uniform<DataType>(5.0, 50.0), engine, num_options, h_stock_price_ptr);
         auto rng_event_2 = mkl_rng::generate(mkl_rng::uniform<DataType>(10.0, 25.0), engine, num_options, h_option_strike_ptr);
         auto rng_event_3 = mkl_rng::generate(mkl_rng::uniform<DataType>(1.0, 5.0), engine, num_options, h_option_years_ptr);
 
         std::size_t n_states = global_size;
         using EngineType =
-#if USE_MCG59
-            mkl_rng::device::mcg59<VEC_SIZE>;
+#if USE_PHILOX
+            mkl_rng::device::philox4x32x10<VEC_SIZE>;
 #elif USE_MRG
             mkl_rng::device::mrg32k3a<VEC_SIZE>;
 #else
-            mkl_rng::device::philox4x32x10<VEC_SIZE>;
+            mkl_rng::device::mcg59<VEC_SIZE>;
 #endif
 
         // initialization needs only on first step
@@ -159,4 +170,5 @@ int main(int argc, char** argv)
         std::cout << e.what();
         exit(1);
     }
+    return 0;
 }


### PR DESCRIPTION
## Description

These changes fix the default random number generator for the european Monte-Carlo oneMKL sample.

## Type of change

- [X] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [X] Command Line
- [x] oneapi-cli
- [ ] Visual Studio
- [ ] Eclipse IDE
- [ ] VSCode
- [X] When compiling the compliler flag "-Wall -Wformat-security -Werror=format-security" was used

Signed-off-by: Fedorov, Andrey <andrey.fedorov@intel.com>
