### PR TITLE
2023.1 ai kit ipex get started, gpu patch fix

### DIFF
--- a/AI-and-Analytics/Getting-Started-Samples/Intel_Extension_For_PyTorch_GettingStarted/codes_for_ipynb/gpu.patch
+++ b/AI-and-Analytics/Getting-Started-Samples/Intel_Extension_For_PyTorch_GettingStarted/codes_for_ipynb/gpu.patch
@@ -1,13 +1,32 @@
---- resnet50.py	2023-01-24 14:40:21.570401244 +0900
-+++ resnet50_xpu.py	2023-01-24 14:43:31.170393594 +0900
-@@ -23,8 +23,8 @@
+diff --git a/AI-and-Analytics/Getting-Started-Samples/Intel_Extension_For_PyTorch_GettingStarted/Intel_Extension_For_PyTorch_Hello_World.py b/AI-and-Analytics/Getting-Started-Samples/Intel_Extension_For_PyTorch_GettingStarted/Intel_Extension_For_PyTorch_Hello_World.py
+index 00eb371b..a3ded045 100755
+--- a/AI-and-Analytics/Getting-Started-Samples/Intel_Extension_For_PyTorch_GettingStarted/Intel_Extension_For_PyTorch_Hello_World.py
++++ b/AI-and-Analytics/Getting-Started-Samples/Intel_Extension_For_PyTorch_GettingStarted/Intel_Extension_For_PyTorch_Hello_World.py
+@@ -75,7 +75,7 @@ def main():
+     3. crite: Criterion function to minimize loss
+     '''
+     model = TestModel()
+-    model = model.to(memory_format=torch.channels_last)
++    model = model.to("xpu", memory_format=torch.channels_last)
+     optim = torch.optim.SGD(model.parameters(), lr=0.01)
+     crite = nn.MSELoss(reduction='sum')
  
-   import intel_extension_for_pytorch as ipex
+@@ -104,7 +104,8 @@ def main():
+         '''
+         model.train()
+         for batch_index, (data, y_ans) in enumerate(trainLoader):
+-            data = data.to(memory_format=torch.channels_last)
++            data = data.to("xpu", memory_format=torch.channels_last)
++            y_ans = y_ans.to("xpu", memory_format=torch.channels_last)
+             optim.zero_grad()
+             y = model(data)
+             loss = crite(y, y_ans)
+@@ -116,7 +117,7 @@ def main():
+         '''
+         model.eval()
+         for batch_index, data in enumerate(testLoader):
+-            data = data.to(memory_format=torch.channels_last)
++            data = data.to("xpu", memory_format=torch.channels_last)
+             y = model(data)
  
--  model = model.to(memory_format=torch.channels_last)
--  data = data.to(memory_format=torch.channels_last)
-+  model = model.to("xpu", memory_format=torch.channels_last)
-+  data = data.to("xpu", memory_format=torch.channels_last)
- 
-   if args.dtype == 'float32':
-     model = ipex.optimize(model, dtype=torch.float32)
+ if __name__ == '__main__':


### PR DESCRIPTION
# Existing Sample Changes
## Description

In the original gpu.patch, there are two point to be fixed
1. file name not match
2. y_ans stay on cpu not convert to gpu

Fixes Issue# 

## External Dependencies
None

## Type of change

Please delete options that are not relevant. Add a 'X' to the one that is applicable. 

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Command Line
- [ ] oneapi-cli
- [ ] Visual Studio
- [ ] Eclipse IDE
- [x] VSCode
- [ ] When compiling the compliler flag "-Wall -Wformat-security -Werror=format-security" was used
