### PR TITLE
Fixes for AMX bfloat16 transformer and numba vs numpy samples

### DIFF
--- a/AI-and-Analytics/Features-and-Functionality/IntelPython_Numpy_Numba_dpex_kNN/IntelPython_Numpy_Numba_dpex_kNN.py
+++ b/AI-and-Analytics/Features-and-Functionality/IntelPython_Numpy_Numba_dpex_kNN/IntelPython_Numpy_Numba_dpex_kNN.py
@@ -217,7 +217,7 @@ def knn_numba(X_train, y_train, X_test, k):
 predictions = knn_numba(X_train.values, y_train.values, X_test.values, 3)
 true_values = y_test.to_numpy()
 accuracy = np.mean(predictions == true_values)
-print('Numba accuracy:' + accuracy)
+print('Numba accuracy:', accuracy)
 
 
 # ## Numba_dpex k-NN
@@ -335,7 +335,7 @@ with dpctl.device_context("opencl:cpu:0"):
 
 true_values = y_test.to_numpy()
 accuracy = np.mean(predictions_numba == true_values)
-print('Numba_dpex accuracy:' + accuracy)
+print('Numba_dpex accuracy:', accuracy)
 
 
 # In[ ]:

--- a/AI-and-Analytics/Features-and-Functionality/IntelTensorFlow_Transformer_AMX_bfloat16_MixedPrecision/IntelTensorFlow_Transformer_AMX_bfloat16_MixedPrecision.ipynb
+++ b/AI-and-Analytics/Features-and-Functionality/IntelTensorFlow_Transformer_AMX_bfloat16_MixedPrecision/IntelTensorFlow_Transformer_AMX_bfloat16_MixedPrecision.ipynb
@@ -20,7 +20,7 @@
    "id": "1bdd8c5b-209e-4a7d-9d98-2b552c987039",
    "metadata": {},
    "source": [
-    "# Tensorflow Transformer with AMX bfoat16 Mixed Precision Learning\n",
+    "# Tensorflow Transformer with AMX bfloat16 Mixed Precision Learning\n",
     "\n",
     "In this example we will be learning Transformer block for text classification using **IMBD dataset**. And then we will modify the code to use mixed precision learning with **bfloat16**. The example based on the [Text classification with Transformer Keras code example](https://keras.io/examples/nlp/text_classification_with_transformer/).\n",
     "\n",

--- a/AI-and-Analytics/Features-and-Functionality/IntelTensorFlow_Transformer_AMX_bfloat16_MixedPrecision/README.md
+++ b/AI-and-Analytics/Features-and-Functionality/IntelTensorFlow_Transformer_AMX_bfloat16_MixedPrecision/README.md
@@ -1,4 +1,4 @@
-# `TensorFlow (TF) Transformer with Intel® Advanced Matrix Extensions (Intel® AMX) bfoat16 Mixed Precision Learning` 
+# `TensorFlow (TF) Transformer with Intel® Advanced Matrix Extensions (Intel® AMX) bfloat16 Mixed Precision Learning` 
 
 This sample code demonstrates optimizing a TensorFlow model with Intel® Advanced Matrix Extensions (Intel® AMX) using bfloat16 (Brain Floating Point) on  4th Gen Intel® Xeon® Scalable Processors (Sapphire Rapids).
 

--- a/AI-and-Analytics/Features-and-Functionality/IntelTensorFlow_Transformer_AMX_bfloat16_MixedPrecision/sample.json
+++ b/AI-and-Analytics/Features-and-Functionality/IntelTensorFlow_Transformer_AMX_bfloat16_MixedPrecision/sample.json
@@ -1,6 +1,6 @@
 {
   "guid": "60A68888-6099-414E-999B-EDC7310A01EA",
-  "name": "TensorFlow Transformer with Advanced Matrix Extensions bfoat16 Mixed Precision Learning",
+  "name": "TensorFlow Transformer with Advanced Matrix Extensions bfloat16 Mixed Precision Learning",
   "categories": ["Toolkit/oneAPI AI And Analytics/AI Getting Started Samples"],
   "description": "This sample code demonstrates optimizing a TensorFlow model with Intel® Advanced Matrix Extensions (Intel® AMX) using bfloat16 (Brain Floating Point) on Sapphire Rapids",
   "builder": ["cli"],


### PR DESCRIPTION
# Existing Sample Changes
## Description

There was a spelling mistake in AMX bfloat16 mixed precision Transformer sample (Readme.md, sample.json and *.ipynb files).
There was a error printing results for *.py files in numpy vs numba vs numba_dpex sample. 

Fixes Issue# 

## External Dependencies

List any external dependencies created as a result of this change.

## Type of change

Please delete options that are not relevant. Add a 'X' to the one that is applicable. 

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Implement fixes for ONSAM Jiras (ONSAM-1559, ONSAM-1557)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [X] Command Line
- [ ] oneapi-cli
- [ ] Visual Studio
- [ ] Eclipse IDE
- [ ] VSCode
- [ ] When compiling the compliler flag "-Wall -Wformat-security -Werror=format-security" was used
