### PR TITLE
2023.1 ai kit itex get started example fix

### DIFF
--- a/AI-and-Analytics/Getting-Started-Samples/Intel_Extension_For_TensorFlow_GettingStarted/README.md
+++ b/AI-and-Analytics/Getting-Started-Samples/Intel_Extension_For_TensorFlow_GettingStarted/README.md
@@ -38,7 +38,7 @@ Please follow bellow steps to setup GPU environment.
 3. Activate the created conda env:  ```$source activate user-tensorflow-gpu ```
 4. Install the required packages:  ```(user-tensorflow-gpu) $pip install tensorflow_hub ipykernel ```
 5. Deactivate conda env:  ```(user-tensorflow-gpu)$conda deactivate ```
-6. Register the kernel to Jupyter NB: ``` $~/.conda/envs/user-tensorflowgpu/bin/python  -m ipykernel install --user --name=user-tensorflow-gpu ```  
+6. Register the kernel to Jupyter NB: ``` $~/.conda/envs/user-tensorflow-gpu/bin/python  -m ipykernel install --user --name=user-tensorflow-gpu ```  
 
 Once users finish GPU environment setup, please do the same steps but remove "-gpu" from above steps. 
 In the end, you will have two new conda environments which are user-tensorflow-gpu and user-tensorflow

--- a/AI-and-Analytics/Getting-Started-Samples/Intel_Extension_For_TensorFlow_GettingStarted/ResNet50_Inference.ipynb
+++ b/AI-and-Analytics/Getting-Started-Samples/Intel_Extension_For_TensorFlow_GettingStarted/ResNet50_Inference.ipynb
@@ -51,7 +51,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%env ONEAPI_INSTALL=~/intel/oneapi"
+    "%env ONEAPI_INSTALL=/opt/intel/oneapi"
    ]
   },
   {
@@ -124,7 +124,7 @@
     "%%writefile run.sh\n",
     "#!/bin/bash\n",
     "source $ONEAPI_INSTALL/setvars.sh --force > /dev/null 2>&1\n",
-    "source activate tensorflow-gpu\n",
+    "source activate user-tensorflow-gpu\n",
     "echo \"########## Executing the run\"\n",
     "DNNL_VERBOSE=1 python infer_resnet50.py > infer_rn50_gpu.csv\n",
     "echo \"########## Done with the run\""
@@ -156,7 +156,7 @@
    "metadata": {},
    "source": [
     "#### Run on CPU via Intel TensorFlow\n",
-    "Users also can run the same infer_resnet50.py on CPU with intel tensorflow or stock tensorflow."
+    "Users also can run the same infer_resnet50.py on CPU with intel tensorflow or stock tensorflow. Please switch to the user-tensorflow jupyter kernel and execute again from prerequisites for CPU run"
    ]
   },
   {
@@ -168,7 +168,7 @@
     "%%writefile run.sh\n",
     "#!/bin/bash\n",
     "source $ONEAPI_INSTALL/setvars.sh --force > /dev/null 2>&1\n",
-    "source activate tensorflow\n",
+    "source activate user-tensorflow\n",
     "echo \"########## Executing the run\"\n",
     "DNNL_VERBOSE=1 python infer_resnet50.py > infer_rn50_cpu.csv\n",
     "echo \"########## Done with the run\""
@@ -269,7 +269,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "FdIndex=2"
+    "FdIndex=0"
    ]
   },
   {
@@ -325,7 +325,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "onednn.breakdown(data,\"arch\",\"time\")"
+    "onednn.breakdown(exec_data,\"arch\",\"time\")"
    ]
   },
   {
@@ -382,7 +382,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "os.chdir(initial_cwd)\n",
     "print('[CODE_SAMPLE_COMPLETED_SUCCESFULLY]')"
    ]
   }


### PR DESCRIPTION
# Existing Sample Changes
## Description

For README file, fix a typo in the command of registering the jupyter kernel for gpu environment.

For ResNet50_Inference.ipynb, there are 6 items to be fixed:

    1. align the default ONEAPI_INSTALL path with the one in README.
    2. correct the conda environment name for both CPU and GPU.
    3. add notes to switch jupyter kernel and run prerequisites again in the section running on CPU.
    4. Modify the default FdIndex from 2 to 0 because there are only 2 indexes available in this example (i.e. 0 and 1).
    5. Modify the code of showing the time breakdown for architecture type, to fix the "exception" error.
    6. remove the unnecessary code of changing the directory to the initial path, in the end.

Fixes Issue# 

## External Dependencies

List any external dependencies created as a result of this change.

## Type of change

Please delete options that are not relevant. Add a 'X' to the one that is applicable. 

- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [X] Command Line
- [ ] oneapi-cli
- [ ] Visual Studio
- [ ] Eclipse IDE
- [ ] VSCode
- [ ] When compiling the compliler flag "-Wall -Wformat-security -Werror=format-security" was used
