### PR TITLE
fix resnet inference demo link from ipex repo

### DIFF
--- a/AI-and-Analytics/Getting-Started-Samples/Intel_Extension_For_PyTorch_GettingStarted/ResNet50_Inference.ipynb
+++ b/AI-and-Analytics/Getting-Started-Samples/Intel_Extension_For_PyTorch_GettingStarted/ResNet50_Inference.ipynb
@@ -65,7 +65,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!wget https://raw.githubusercontent.com/intel/intel-extension-for-pytorch/master/examples/resnet50.py"
+    "!wget https://raw.githubusercontent.com/intel/intel-extension-for-pytorch/master/examples/cpu/inference/resnet50_general_inference_script.py"
    ]
   },
   {
@@ -111,7 +111,7 @@
     "source $ONEAPI_INSTALL/setvars.sh --force > /dev/null 2>&1\n",
     "source activate pytorch\n",
     "echo \"########## Executing the run\"\n",
-    "DNNL_VERBOSE=1 python resnet50.py > infer_rn50_cpu.csv\n",
+    "DNNL_VERBOSE=1 python resnet50_general_inference_script.py > infer_rn50_cpu.csv\n",
     "echo \"########## Done with the run\""
    ]
   },
@@ -175,7 +175,7 @@
     "source $ONEAPI_INSTALL/setvars.sh --force > /dev/null 2>&1\n",
     "source activate pytorch\n",
     "echo \"########## Executing the run\"\n",
-    "DNNL_VERBOSE=1 python resnet50.py > infer_rn50_gpu.csv\n",
+    "DNNL_VERBOSE=1 python resnet50_general_inference_script_gpu.py > infer_rn50_gpu.csv\n",
     "echo \"########## Done with the run\""
    ]
   },

--- a/AI-and-Analytics/Getting-Started-Samples/Intel_Extension_For_PyTorch_GettingStarted/codes_for_ipynb/gpu.patch
+++ b/AI-and-Analytics/Getting-Started-Samples/Intel_Extension_For_PyTorch_GettingStarted/codes_for_ipynb/gpu.patch
@@ -1,32 +1,18 @@
-diff --git a/AI-and-Analytics/Getting-Started-Samples/Intel_Extension_For_PyTorch_GettingStarted/Intel_Extension_For_PyTorch_Hello_World.py b/AI-and-Analytics/Getting-Started-Samples/Intel_Extension_For_PyTorch_GettingStarted/Intel_Extension_For_PyTorch_Hello_World.py
-index 00eb371b..a3ded045 100755
---- a/AI-and-Analytics/Getting-Started-Samples/Intel_Extension_For_PyTorch_GettingStarted/Intel_Extension_For_PyTorch_Hello_World.py
-+++ b/AI-and-Analytics/Getting-Started-Samples/Intel_Extension_For_PyTorch_GettingStarted/Intel_Extension_For_PyTorch_Hello_World.py
-@@ -75,7 +75,7 @@ def main():
-     3. crite: Criterion function to minimize loss
-     '''
-     model = TestModel()
--    model = model.to(memory_format=torch.channels_last)
-+    model = model.to("xpu", memory_format=torch.channels_last)
-     optim = torch.optim.SGD(model.parameters(), lr=0.01)
-     crite = nn.MSELoss(reduction='sum')
+diff --git a/AI-and-Analytics/Getting-Started-Samples/Intel_Extension_For_PyTorch_GettingStarted/resnet50_general_inference_script.py b/AI-and-Analytics/Getting-Started-Samples/Intel_Extension_For_PyTorch_GettingStarted/resnet50_general_inference_script_gpu.py
+similarity index 92%
+rename from AI-and-Analytics/Getting-Started-Samples/Intel_Extension_For_PyTorch_GettingStarted/resnet50_general_inference_script.py
+rename to AI-and-Analytics/Getting-Started-Samples/Intel_Extension_For_PyTorch_GettingStarted/resnet50_general_inference_script_gpu.py
+index dae594af..edd0fcb3 100644
+--- a/AI-and-Analytics/Getting-Started-Samples/Intel_Extension_For_PyTorch_GettingStarted/resnet50_general_inference_script.py
++++ b/AI-and-Analytics/Getting-Started-Samples/Intel_Extension_For_PyTorch_GettingStarted/resnet50_general_inference_script_gpu.py
+@@ -23,8 +23,8 @@ def main(args):
  
-@@ -104,7 +104,8 @@ def main():
-         '''
-         model.train()
-         for batch_index, (data, y_ans) in enumerate(trainLoader):
--            data = data.to(memory_format=torch.channels_last)
-+            data = data.to("xpu", memory_format=torch.channels_last)
-+            y_ans = y_ans.to("xpu", memory_format=torch.channels_last)
-             optim.zero_grad()
-             y = model(data)
-             loss = crite(y, y_ans)
-@@ -116,7 +117,7 @@ def main():
-         '''
-         model.eval()
-         for batch_index, data in enumerate(testLoader):
--            data = data.to(memory_format=torch.channels_last)
-+            data = data.to("xpu", memory_format=torch.channels_last)
-             y = model(data)
+   import intel_extension_for_pytorch as ipex
  
- if __name__ == '__main__':
+-  model = model.to(memory_format=torch.channels_last)
+-  data = data.to(memory_format=torch.channels_last)
++  model = model.to("xpu",memory_format=torch.channels_last)
++  data = data.to("xpu",memory_format=torch.channels_last)
+ 
+   if args.dtype == 'float32':
+     model = ipex.optimize(model, dtype=torch.float32)

--- a/AI-and-Analytics/Getting-Started-Samples/Intel_Extension_For_PyTorch_GettingStarted/codes_for_py/gpu.patch
+++ b/AI-and-Analytics/Getting-Started-Samples/Intel_Extension_For_PyTorch_GettingStarted/codes_for_py/gpu.patch
@@ -1,0 +1,32 @@
+diff --git a/AI-and-Analytics/Getting-Started-Samples/Intel_Extension_For_PyTorch_GettingStarted/Intel_Extension_For_PyTorch_Hello_World.py b/AI-and-Analytics/Getting-Started-Samples/Intel_Extension_For_PyTorch_GettingStarted/Intel_Extension_For_PyTorch_Hello_World.py
+index 00eb371b..a3ded045 100755
+--- a/AI-and-Analytics/Getting-Started-Samples/Intel_Extension_For_PyTorch_GettingStarted/Intel_Extension_For_PyTorch_Hello_World.py
++++ b/AI-and-Analytics/Getting-Started-Samples/Intel_Extension_For_PyTorch_GettingStarted/Intel_Extension_For_PyTorch_Hello_World.py
+@@ -75,7 +75,7 @@ def main():
+     3. crite: Criterion function to minimize loss
+     '''
+     model = TestModel()
+-    model = model.to(memory_format=torch.channels_last)
++    model = model.to("xpu", memory_format=torch.channels_last)
+     optim = torch.optim.SGD(model.parameters(), lr=0.01)
+     crite = nn.MSELoss(reduction='sum')
+ 
+@@ -104,7 +104,8 @@ def main():
+         '''
+         model.train()
+         for batch_index, (data, y_ans) in enumerate(trainLoader):
+-            data = data.to(memory_format=torch.channels_last)
++            data = data.to("xpu", memory_format=torch.channels_last)
++            y_ans = y_ans.to("xpu", memory_format=torch.channels_last)
+             optim.zero_grad()
+             y = model(data)
+             loss = crite(y, y_ans)
+@@ -116,7 +117,7 @@ def main():
+         '''
+         model.eval()
+         for batch_index, data in enumerate(testLoader):
+-            data = data.to(memory_format=torch.channels_last)
++            data = data.to("xpu", memory_format=torch.channels_last)
+             y = model(data)
+ 
+ if __name__ == '__main__':


### PR DESCRIPTION
# Existing Sample Changes
## Description

The original demo file used in ipynb for this get started samples link changed by ipex repo.
updated demo link is https://github.com/intel/intel-extension-for-pytorch/blob/master/examples/cpu/training/single_instance_training_fp32.py
Need change in the ipynb code to wget the right link.

Fixes Issue# 

## External Dependencies

List any external dependencies created as a result of this change.

## Type of change

Please delete options that are not relevant. Add a 'X' to the one that is applicable. 

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Command Line
- [ ] oneapi-cli
- [ ] Visual Studio
- [ ] Eclipse IDE
- [x] VSCode
- [ ] When compiling the compliler flag "-Wall -Wformat-security -Werror=format-security" was used

