### PR TITLE
Bug fix to the functionality of the dynamic_profiler tutorial

### DIFF
--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Tools/dynamic_profiler/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Tools/dynamic_profiler/README.md
@@ -139,7 +139,7 @@ When analyzing performance data to optimize a design, the goal is to get as clos
 
 #### Analyzing Stall and Occupancy Metrics
 
-In this tutorial, there are two design scenarios defined in dynamic_profiler.cpp. One showing a naive pre-optimized design, and a second showing the same design optimized based on data collected through the Intel® FPGA Dynamic Profiler for DPC++.
+In this tutorial, there are two design scenarios defined in dynamic_profiler.cpp. One showing a naive pre-optimized design, and a second showing the same design optimized based on data collected through the Intel® FPGA Dynamic Profiler for DPC++ on an Arria 10 device.
 
 ##### Pre-optimization Version #####
 
@@ -155,7 +155,7 @@ The second scenario is an example of what the design might look like after being
 - a producer SYCL kernel (ProducerAfter) that reads data from a buffer, performs the first computation on the data and writes this value to a pipe (ProducerToConsumerAfterPipe), and
 - a consumer SYCL kernel (ConsumerAfter) that reads from the pipe (ProducerToConsumerAfterPipe), does the second set of computations and fills up the output buffer.
 
-When looking at the performance data for the two "after optimization" kernels in the Bottom-Up view, you should see that ProducerAfter's pipe write (on line 105) and the ConsumerAfter's pipe read (line 120) both have stall percentages near 0%. This indicates the pipe is being used more effectively - now the read and write side of the pipe are being used at similar rates, so the pipe operations are not creating stalls in the pipeline. This also speeds up the overall design execution - the two "after" kernels take less time to execute than the two before kernels.
+When looking at the performance data for the two "after optimization" kernels in the Bottom-Up view, you should see that ProducerAfter's pipe write (on line 126) and the ConsumerAfter's pipe read (line 139) both have stall percentages near 0%. This indicates the pipe is being used more effectively - now the read and write side of the pipe are being used at similar rates, so the pipe operations are not creating stalls in the pipeline. This also speeds up the overall design execution - the two "after" kernels take less time to execute than the two before kernels.
 
 ![](profiler_pipe_tutorial_bottom_up.png)
 

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Tools/dynamic_profiler/src/dynamic_profiler.cpp
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Tools/dynamic_profiler/src/dynamic_profiler.cpp
@@ -41,8 +41,8 @@ constexpr int kSize = 262144;
 
 // Number of iterations performed in the consumer kernels
 // This controls the amount of work done by the Consumer.
-// Part of the work moves to the Producer in the "after" case.
-constexpr int kComplexity1 = 1000;
+// After the optimization, the Producer and Consumer split the work.
+constexpr int kComplexity1 = 1900;
 constexpr int kComplexity2 = 2000;
 
 // Perform two stages of processing on the input data.

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Tools/dynamic_profiler/src/dynamic_profiler.cpp
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Tools/dynamic_profiler/src/dynamic_profiler.cpp
@@ -33,9 +33,7 @@ class ProducerAfterKernel;
 class ConsumerAfterKernel;
 
 // kSize = # of floats to process on each kernel execution.
-#if defined(FPGA_EMULATOR)
-constexpr int kSize = 4096;
-#elif defined(FPGA_SIMULATOR)
+#if defined(FPGA_EMULATOR) or defined(FPGA_SIMULATOR)
 constexpr int kSize = 64;
 #else
 constexpr int kSize = 262144;
@@ -43,11 +41,9 @@ constexpr int kSize = 262144;
 
 // Number of iterations performed in the consumer kernels
 // This controls the amount of work done by the Consumer.
-#if defined(FPGA_SIMULATOR)
-constexpr int kComplexity = 2000;
-#else
-constexpr int kComplexity = 32;
-#endif
+// Part of the work moves to the Producer in the "after" case.
+constexpr int kComplexity1 = 1000;
+constexpr int kComplexity2 = 2000;
 
 // Perform two stages of processing on the input data.
 // The output of ConsumerWork1 needs to go to the input
@@ -56,7 +52,7 @@ constexpr int kComplexity = 32;
 // can be replaced with more useful operations.
 float ConsumerWork1(float f) {
   float output = f;
-  for (int j = 0; j < kComplexity; j++) {
+  for (int j = 0; j < kComplexity1; j++) {
     output = 20 * f + j - output;
   }
   return output;
@@ -64,7 +60,7 @@ float ConsumerWork1(float f) {
 
 float ConsumerWork2(float f) {
   auto output = f;
-  for (int j = 0; j < kComplexity; j++) {
+  for (int j = 0; j < kComplexity2; j++) {
     output = output + f * j;
   }
   return output;


### PR DESCRIPTION
## Description

The dynamic_profiler code sample currently does not demonstrate the change in stalls that the README explains. This is due to a change in the behaviour of pipes, resulting in a different stall balance between the consumer and producer sides. This change to the tutorial slightly rebalances the work on the consumer and producer side to allow the code sample to demonstrate the intended feature. There are also a few small README updates for correctness and clarity.

Fixes Issue# 

## Type of change

Please delete options that are not relevant. Add a 'X' to the one that is applicable. 

- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Used the internal test framework to run the code sample to all valuable flows (simulation and hardware) on the supported devices, and confirmed the code sample works as claimed in the README after the change. Also re-opened the sample results in VTune to confirm the screenshots in the README are accurate after the code change.

- [X] Command Line
- [ ] oneapi-cli
- [ ] Visual Studio
- [ ] Eclipse IDE
- [ ] VSCode
- [ ] When compiling the compliler flag "-Wall -Wformat-security -Werror=format-security" was used
