### PR TITLE
FPGA: Fix typo

### DIFF
--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/autorun/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/autorun/README.md
@@ -15,7 +15,7 @@ The purpose of this tutorial is to demonstrate how to create autorun kernels in 
 ## Prerequisites
 
 This sample is part of the FPGA code samples.
-It is categorized as a Tier 3 sample that demonstatres a design pattern.
+It is categorized as a Tier 3 sample that demonstrates a design pattern.
 
 ```mermaid
 flowchart LR

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/buffered_host_streaming/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/buffered_host_streaming/README.md
@@ -24,7 +24,7 @@ The concepts explained in these tutorials will be used in this tutorial to creat
 ## Prerequisites
 
 This sample is part of the FPGA code samples.
-It is categorized as a Tier 3 sample that demonstatres a design pattern.
+It is categorized as a Tier 3 sample that demonstrates a design pattern.
 
 ```mermaid
 flowchart LR

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/compute_units/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/compute_units/README.md
@@ -18,7 +18,7 @@ This tutorial provides a header file that defines an abstraction for making mult
 ## Prerequisites
 
 This sample is part of the FPGA code samples.
-It is categorized as a Tier 3 sample that demonstatres a design pattern.
+It is categorized as a Tier 3 sample that demonstrates a design pattern.
 
 ```mermaid
 flowchart LR

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/double_buffering/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/double_buffering/README.md
@@ -19,7 +19,7 @@ This sample demonstrates double buffering to overlap kernel execution with buffe
 ## Prerequisites
 
 This sample is part of the FPGA code samples.
-It is categorized as a Tier 2 sample that demonstatres a design pattern.
+It is categorized as a Tier 2 sample that demonstrates a design pattern.
 
 ```mermaid
 flowchart LR

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/explicit_data_movement/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/explicit_data_movement/README.md
@@ -15,7 +15,7 @@ The purpose of this tutorial is to demonstrate an alternative coding style that 
 ## Prerequisites
 
 This sample is part of the FPGA code samples.
-It is categorized as a Tier 2 sample that demonstatres a design pattern.
+It is categorized as a Tier 2 sample that demonstrates a design pattern.
 
 ```mermaid
 flowchart LR

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/io_streaming/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/io_streaming/README.md
@@ -15,7 +15,7 @@ The purpose of this code sample is to demonstrate how to do trivial I/O streamin
 ## Prerequisites
 
 This sample is part of the FPGA code samples.
-It is categorized as a Tier 3 sample that demonstatres a design pattern.
+It is categorized as a Tier 3 sample that demonstrates a design pattern.
 
 ```mermaid
 flowchart LR

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/loop_carried_dependency/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/loop_carried_dependency/README.md
@@ -18,7 +18,7 @@ This tutorial sample demonstrates the following concepts:
 ## Prerequisites
 
 This sample is part of the FPGA code samples.
-It is categorized as a Tier 3 sample that demonstatres a design pattern.
+It is categorized as a Tier 3 sample that demonstrates a design pattern.
 
 ```mermaid
 flowchart LR

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/n_way_buffering/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/n_way_buffering/README.md
@@ -16,7 +16,7 @@ This system-level optimization enables kernel execution to occur in parallel wit
 ## Prerequisites
 
 This sample is part of the FPGA code samples.
-It is categorized as a Tier 3 sample that demonstatres a design pattern.
+It is categorized as a Tier 3 sample that demonstrates a design pattern.
 
 ```mermaid
 flowchart LR

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/onchip_memory_cache/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/onchip_memory_cache/README.md
@@ -23,7 +23,7 @@ This FPGA tutorial demonstrates how to build a simple cache (implemented in FPGA
 ## Prerequisites
 
 This sample is part of the FPGA code samples.
-It is categorized as a Tier 3 sample that demonstatres a design pattern.
+It is categorized as a Tier 3 sample that demonstrates a design pattern.
 
 ```mermaid
 flowchart LR

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/optimize_inner_loop/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/optimize_inner_loop/README.md
@@ -23,7 +23,7 @@ This FPGA tutorial discusses optimizing the throughput of an inner loop with a l
 ## Prerequisites
 
 This sample is part of the FPGA code samples.
-It is categorized as a Tier 3 sample that demonstatres a design pattern.
+It is categorized as a Tier 3 sample that demonstrates a design pattern.
 
 ```mermaid
 flowchart LR

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/pipe_array/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/pipe_array/README.md
@@ -24,7 +24,7 @@ This FPGA tutorial showcases a design pattern that makes it possible to create a
 ## Prerequisites
 
 This sample is part of the FPGA code samples.
-It is categorized as a Tier 3 sample that demonstatres a design pattern.
+It is categorized as a Tier 3 sample that demonstrates a design pattern.
 
 ```mermaid
 flowchart LR

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/shannonization/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/shannonization/README.md
@@ -23,7 +23,7 @@ This tutorial describes the process of _Shannonization_ (named after [Claude Sha
 ## Prerequisites
 
 This sample is part of the FPGA code samples.
-It is categorized as a Tier 3 sample that demonstatres a design pattern.
+It is categorized as a Tier 3 sample that demonstrates a design pattern.
 
 ```mermaid
 flowchart LR

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/simple_host_streaming/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/simple_host_streaming/README.md
@@ -29,7 +29,7 @@ This tutorial demonstrates how to use SYCL* Universal Shared Memory (USM) to str
 ## Prerequisites
 
 This sample is part of the FPGA code samples.
-It is categorized as a Tier 3 sample that demonstatres a design pattern.
+It is categorized as a Tier 3 sample that demonstrates a design pattern.
 
 ```mermaid
 flowchart LR

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/triangular_loop/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/triangular_loop/README.md
@@ -25,7 +25,7 @@ This FPGA tutorial demonstrates an advanced technique to improve the performance
 ## Prerequisites
 
 This sample is part of the FPGA code samples.
-It is categorized as a Tier 3 sample that demonstatres a design pattern.
+It is categorized as a Tier 3 sample that demonstrates a design pattern.
 
 ```mermaid
 flowchart LR

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/zero_copy_data_transfer/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/zero_copy_data_transfer/README.md
@@ -26,7 +26,7 @@ This tutorial demonstrates how to use zero-copy host memory via the SYCL Unified
 ## Prerequisites
 
 This sample is part of the FPGA code samples.
-It is categorized as a Tier 3 sample that demonstatres a design pattern.
+It is categorized as a Tier 3 sample that demonstrates a design pattern.
 
 ```mermaid
 flowchart LR

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/ac_fixed/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/ac_fixed/README.md
@@ -24,7 +24,7 @@ This FPGA tutorial demonstrates how to use the Algorithmic C (AC) data type `ac_
 ## Prerequisites
 
 This sample is part of the FPGA code samples.
-It is categorized as a Tier 2 sample that demonstatres a compiler feature.
+It is categorized as a Tier 2 sample that demonstrates a compiler feature.
 
 ```mermaid
 flowchart LR

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/ac_int/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/ac_int/README.md
@@ -24,7 +24,7 @@ This FPGA tutorial demonstrates how to use the Algorithmic C (AC) data type `ac_
 ## Prerequisites
 
 This sample is part of the FPGA code samples.
-It is categorized as a Tier 2 sample that demonstatres a compiler feature.
+It is categorized as a Tier 2 sample that demonstrates a compiler feature.
 
 ```mermaid
 flowchart LR

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/dsp_control/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/dsp_control/README.md
@@ -24,7 +24,7 @@ This FPGA tutorial demonstrates how to set the implementation preference for cer
 ## Prerequisites
 
 This sample is part of the FPGA code samples.
-It is categorized as a Tier 3 sample that demonstatres a compiler feature.
+It is categorized as a Tier 3 sample that demonstrates a compiler feature.
 
 ```mermaid
 flowchart LR

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/experimental/hostpipes/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/experimental/hostpipes/README.md
@@ -24,7 +24,7 @@ This FPGA tutorial demonstrates how to use pipes to send and receive data betwee
 ## Prerequisites
 
 This sample is part of the FPGA code samples.
-It is categorized as a Tier 2 sample that demonstatres a compiler feature.
+It is categorized as a Tier 2 sample that demonstrates a compiler feature.
 
 ```mermaid
 flowchart LR

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/experimental/invocation_interfaces/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/experimental/invocation_interfaces/README.md
@@ -25,7 +25,7 @@ This FPGA tutorial demonstrates how to specify the kernel invocation interfaces 
 ## Prerequisites
 
 This sample is part of the FPGA code samples.
-It is categorized as a Tier 2 sample that demonstatres a compiler feature.
+It is categorized as a Tier 2 sample that demonstrates a compiler feature.
 
 ```mermaid
 flowchart LR

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/experimental/latency_control/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/experimental/latency_control/README.md
@@ -24,7 +24,7 @@ This FPGA tutorial demonstrates how to set latency constraints to pipes and load
 ## Prerequisites
 
 This sample is part of the FPGA code samples.
-It is categorized as a Tier 3 sample that demonstatres a compiler feature.
+It is categorized as a Tier 3 sample that demonstrates a compiler feature.
 
 ```mermaid
 flowchart LR

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/fpga_reg/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/fpga_reg/README.md
@@ -26,7 +26,7 @@ This FPGA tutorial demonstrates how a power user can apply the SYCL*-compliant C
 ## Prerequisites
 
 This sample is part of the FPGA code samples.
-It is categorized as a Tier 3 sample that demonstatres a compiler feature.
+It is categorized as a Tier 3 sample that demonstrates a compiler feature.
 
 ```mermaid
 flowchart LR

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/kernel_args_restrict/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/kernel_args_restrict/README.md
@@ -24,7 +24,7 @@ This tutorial explains the  `kernel_args_restrict` attribute and its effect on t
 ## Prerequisites
 
 This sample is part of the FPGA code samples.
-It is categorized as a Tier 2 sample that demonstatres a compiler feature.
+It is categorized as a Tier 2 sample that demonstrates a compiler feature.
 
 ```mermaid
 flowchart LR

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/loop_coalesce/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/loop_coalesce/README.md
@@ -24,7 +24,7 @@ This FPGA tutorial demonstrates applying the `loop_coalesce` attribute to a nest
 ## Prerequisites
 
 This sample is part of the FPGA code samples.
-It is categorized as a Tier 2 sample that demonstatres a compiler feature.
+It is categorized as a Tier 2 sample that demonstrates a compiler feature.
 
 ```mermaid
 flowchart LR

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/loop_fusion/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/loop_fusion/README.md
@@ -23,7 +23,7 @@ This FPGA tutorial demonstrates how loop fusion is used and how it affects perfo
 ## Prerequisites
 
 This sample is part of the FPGA code samples.
-It is categorized as a Tier 2 sample that demonstatres a compiler feature.
+It is categorized as a Tier 2 sample that demonstrates a compiler feature.
 
 ```mermaid
 flowchart LR

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/loop_initiation_interval/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/loop_initiation_interval/README.md
@@ -24,7 +24,7 @@ This FPGA tutorial demonstrates how a user can use the `intel::initiation_interv
 ## Prerequisites
 
 This sample is part of the FPGA code samples.
-It is categorized as a Tier 2 sample that demonstatres a compiler feature.
+It is categorized as a Tier 2 sample that demonstrates a compiler feature.
 
 ```mermaid
 flowchart LR

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/loop_ivdep/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/loop_ivdep/README.md
@@ -23,7 +23,7 @@ This FPGA tutorial demonstrates how to apply the `ivdep` attribute to a loop to 
 ## Prerequisites
 
 This sample is part of the FPGA code samples.
-It is categorized as a Tier 2 sample that demonstatres a compiler feature.
+It is categorized as a Tier 2 sample that demonstrates a compiler feature.
 
 ```mermaid
 flowchart LR

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/loop_unroll/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/loop_unroll/README.md
@@ -23,7 +23,7 @@ This tutorial demonstrates a simple example of unrolling loops to improve throug
 ## Prerequisites
 
 This sample is part of the FPGA code samples.
-It is categorized as a Tier 2 sample that demonstatres a compiler feature.
+It is categorized as a Tier 2 sample that demonstrates a compiler feature.
 
 ```mermaid
 flowchart LR

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/lsu_control/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/lsu_control/README.md
@@ -24,7 +24,7 @@ This FPGA tutorial demonstrates how to configure the load-store units (LSU) in S
 ## Prerequisites
 
 This sample is part of the FPGA code samples.
-It is categorized as a Tier 3 sample that demonstatres a compiler feature.
+It is categorized as a Tier 3 sample that demonstrates a compiler feature.
 
 ```mermaid
 flowchart LR

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/max_interleaving/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/max_interleaving/README.md
@@ -23,7 +23,7 @@ This FPGA tutorial explains how to use the `max_interleaving` attribute for loop
 ## Prerequisites
 
 This sample is part of the FPGA code samples.
-It is categorized as a Tier 2 sample that demonstatres a compiler feature.
+It is categorized as a Tier 2 sample that demonstrates a compiler feature.
 
 ```mermaid
 flowchart LR

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/mem_channel/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/mem_channel/README.md
@@ -26,7 +26,7 @@ SYCL*-compliant FPGA design.
 ## Prerequisites
 
 This sample is part of the FPGA code samples.
-It is categorized as a Tier 3 sample that demonstatres a compiler feature.
+It is categorized as a Tier 3 sample that demonstrates a compiler feature.
 
 ```mermaid
 flowchart LR

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/memory_attributes/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/memory_attributes/README.md
@@ -23,7 +23,7 @@ This FPGA tutorial demonstrates how to use on-chip memory attributes to control 
 ## Prerequisites
 
 This sample is part of the FPGA code samples.
-It is categorized as a Tier 2 sample that demonstatres a compiler feature.
+It is categorized as a Tier 2 sample that demonstrates a compiler feature.
 
 ```mermaid
 flowchart LR

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/pipes/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/pipes/README.md
@@ -23,7 +23,7 @@ This FPGA tutorial shows how to use pipes to transfer data between kernels.
 ## Prerequisites
 
 This sample is part of the FPGA code samples.
-It is categorized as a Tier 2 sample that demonstatres a compiler feature.
+It is categorized as a Tier 2 sample that demonstrates a compiler feature.
 
 ```mermaid
 flowchart LR

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/printf/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/printf/README.md
@@ -24,7 +24,7 @@ This FPGA tutorial explains how to use the `sycl::ext::oneapi::experimental::pri
 ## Prerequisites
 
 This sample is part of the FPGA code samples.
-It is categorized as a Tier 2 sample that demonstatres a compiler feature.
+It is categorized as a Tier 2 sample that demonstrates a compiler feature.
 
 ```mermaid
 flowchart LR

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/private_copies/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/private_copies/README.md
@@ -23,7 +23,7 @@ This FPGA tutorial explains how to use the `private_copies` attribute to trade o
 ## Prerequisites
 
 This sample is part of the FPGA code samples.
-It is categorized as a Tier 3 sample that demonstatres a compiler feature.
+It is categorized as a Tier 3 sample that demonstrates a compiler feature.
 
 ```mermaid
 flowchart LR

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/read_only_cache/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/read_only_cache/README.md
@@ -25,7 +25,7 @@ memory in a non-contiguous manner.
 ## Prerequisites
 
 This sample is part of the FPGA code samples.
-It is categorized as a Tier 3 sample that demonstatres a compiler feature.
+It is categorized as a Tier 3 sample that demonstrates a compiler feature.
 
 ```mermaid
 flowchart LR

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/scheduler_target_fmax/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/scheduler_target_fmax/README.md
@@ -24,7 +24,7 @@ This tutorial explains the `scheduler_target_fmax_mhz` attribute and its effect 
 ## Prerequisites
 
 This sample is part of the FPGA code samples.
-It is categorized as a Tier 3 sample that demonstatres a compiler feature.
+It is categorized as a Tier 3 sample that demonstrates a compiler feature.
 
 ```mermaid
 flowchart LR

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/speculated_iterations/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/speculated_iterations/README.md
@@ -24,7 +24,7 @@ This FPGA tutorial demonstrates applying the `speculated_iterations` attribute t
 ## Prerequisites
 
 This sample is part of the FPGA code samples.
-It is categorized as a Tier 3 sample that demonstatres a compiler feature.
+It is categorized as a Tier 3 sample that demonstrates a compiler feature.
 
 ```mermaid
 flowchart LR

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/stall_enable/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/stall_enable/README.md
@@ -23,7 +23,7 @@ This FPGA tutorial demonstrates how to use the `use_stall_enable_clusters` attri
 ## Prerequisites
 
 This sample is part of the FPGA code samples.
-It is categorized as a Tier 3 sample that demonstatres a compiler feature.
+It is categorized as a Tier 3 sample that demonstrates a compiler feature.
 
 ```mermaid
 flowchart LR

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Tools/dynamic_profiler/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Tools/dynamic_profiler/README.md
@@ -26,7 +26,7 @@ This FPGA tutorial demonstrates how to use the Intel® FPGA Dynamic Profiler for
 ## Prerequisites
 
 This sample is part of the FPGA code samples.
-It is categorized as a Tier 3 sample that demonstatres the usage of a tool.
+It is categorized as a Tier 3 sample that demonstrates the usage of a tool.
 
 ```mermaid
 flowchart LR

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Tools/system_profiling/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Tools/system_profiling/README.md
@@ -27,7 +27,7 @@ The [Intercept Layer for OpenCL™ Applications](https://github.com/intel/opencl
 ## Prerequisites
 
 This sample is part of the FPGA code samples.
-It is categorized as a Tier 3 sample that demonstatres the usage of a tool.
+It is categorized as a Tier 3 sample that demonstrates the usage of a tool.
 
 ```mermaid
 flowchart LR

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Tools/use_library/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Tools/use_library/README.md
@@ -24,7 +24,7 @@ This FPGA tutorial demonstrates how to build SYCL device libraries from RTL sour
 ## Prerequisites
 
 This sample is part of the FPGA code samples.
-It is categorized as a Tier 3 sample that demonstatres the usage of a tool.
+It is categorized as a Tier 3 sample that demonstrates the usage of a tool.
 
 ```mermaid
 flowchart LR


### PR DESCRIPTION
This PR fixes a small typo that appears in many REAME files