### PR TITLE
Fix Invalid Kmeans parameters on oneAPI 2023

### DIFF
--- a/AI-and-Analytics/Features-and-Functionality/IntelPython_daal4py_DistributedKMeans/IntelPython_daal4py_Distributed_Kmeans.py
+++ b/AI-and-Analytics/Features-and-Functionality/IntelPython_daal4py_DistributedKMeans/IntelPython_daal4py_Distributed_Kmeans.py
@@ -97,7 +97,8 @@ print("Here is our centroids loaded from file:\n\n",loaded_centroids)
 
 
 # compute the clusters/centroids
-kmeans_result = d4p.kmeans(nClusters = 3, maxIterations = 5, assignFlag = True).compute(X, init_result.centroids)
+kmeans_result = d4p.kmeans(nClusters = 3, maxIterations = 5, assignFlag = True,
+                           accuracyThreshold = 5.0e-6, gamma = 1.0).compute(X, init_result.centroids)
 
 
 # To **get Kmeans result objects** (assignments, centroids, goalFunction [deprecated], nIterations, and objectiveFunction):


### PR DESCRIPTION
# Existing Sample Changes
## Description

Fix K-means example invalid parameters issue on 2023.
Fixes Issue# https://jira.devtools.intel.com/browse/ONSAM-1560

## External Dependencies
No.

## Type of change

Please delete options that are not relevant. Add a 'X' to the one that is applicable. 
- [X ] Bug fix (non-breaking change which fixes an issue)
- [X ] Implement fixes for ONSAM Jiras

## How Has This Been Tested?
Run the example on oneAPI 2023 before and after merge the patch.
Without this fix, it reports invalid paramters.  https://jira.devtools.intel.com/browse/ONSAM-1560
With fix, it works, output result (no errors).

It works on oneAPI 2022, with/without the fix.
```
#cd oneAPI-samples/AI-and-Analytics/Features-and-Functionality/IntelPython_daal4py_DistributedKMeans
#python IntelPython_daal4py_Distributed_Kmeans.py
```

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ X] Command Line

**_Delete this line and everything below if this is not a PR for a new code sample_**