### PR TITLE
update dpc_common.hpp

### DIFF
--- a/DirectProgramming/C++/ParallelPatterns/openmp_reduction/src/dpc_common.hpp
+++ b/DirectProgramming/C++/ParallelPatterns/openmp_reduction/src/dpc_common.hpp
@@ -1,0 +1,47 @@
+// Copyright (C) 2020 Intel Corporation
+// SPDX-License-Identifier: MIT
+
+#ifndef _DP_HPP
+#define _DP_HPP
+
+#include <stdlib.h>
+#include <exception>
+
+#include <CL/sycl.hpp>
+
+namespace dpc_common {
+// This exception handler will catch async exceptions
+static auto exception_handler = [](cl::sycl::exception_list eList) {
+  for (std::exception_ptr const &e : eList) {
+    try {
+      std::rethrow_exception(e);
+    } catch (std::exception const &e) {
+#if _DEBUG
+      std::cout << "Failure" << std::endl;
+#endif
+      std::terminate();
+    }
+  }
+};
+
+// The TimeInterval is a simple RAII class.
+// Construct the timer at the point you want to start timing.
+// Use the Elapsed() method to return time since construction.
+
+class TimeInterval {
+ public:
+  TimeInterval() : start_(std::chrono::steady_clock::now()) {}
+
+  double Elapsed() {
+    auto now = std::chrono::steady_clock::now();
+    return std::chrono::duration_cast<Duration>(now - start_).count();
+  }
+
+ private:
+  using Duration = std::chrono::duration<double>;
+  std::chrono::steady_clock::time_point start_;
+};
+
+};  // namespace dpc_common
+
+#endif


### PR DESCRIPTION
# Existing Sample Changes
## 

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes Issue# 
With the current dpc_common.hpp, running make shows the following error:
`/opt/intel/oneapi/dev-utilities/2021.8.0/include/dpc_common.hpp:14:36: error: use of undeclared identifier 'cl'
static auto exception_handler = [](cl::sycl::exception_list eList) {
                                   ^
1 error generated.
make[2]: *** [src/CMakeFiles/openmp_reduction.dir/build.make:63: src/CMakeFiles/openmp_reduction.dir/main.cpp.o] Error 1
make[1]: *** [CMakeFiles/Makefile2:122: src/CMakeFiles/openmp_reduction.dir/all] Error 2
make: *** [Makefile:84: all] Error 2`

Changing the header from sycl/sycl.hpp to CL/sycl.hpp in dpc_common.hpp resolves the issue. 
## External Dependencies

List any external dependencies created as a result of this change.

## Type of change

Please delete options that are not relevant. Add a 'X' to the one that is applicable. 

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Implement fixes for ONSAM Jiras

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [X] Command Line
- [ ] oneapi-cli
- [ ] Visual Studio
- [ ] Eclipse IDE
- [ ] VSCode
- [ ] When compiling the compliler flag "-Wall -Wformat-security -Werror=format-security" was used

