### PR TITLE
Update oneTBB samples to SYCL2020

### DIFF
--- a/Libraries/oneTBB/tbb-async-sycl/src/tbb-async-sycl.cpp
+++ b/Libraries/oneTBB/tbb-async-sycl/src/tbb-async-sycl.cpp
@@ -66,7 +66,7 @@ class AsyncActivity {
         sycl::buffer b_buffer(b_array);
         sycl::buffer c_buffer(c_array);
 
-        sycl::queue q(sycl::default_selector{}, dpc_common::exception_handler);
+        sycl::queue q(sycl::default_selector_v, dpc_common::exception_handler);
         q.submit([&](sycl::handler& h) {     
               sycl::accessor a_accessor(a_buffer, h, sycl::read_only);
               sycl::accessor b_accessor(b_buffer, h, sycl::read_only);

--- a/Libraries/oneTBB/tbb-task-sycl/src/tbb-task-sycl.cpp
+++ b/Libraries/oneTBB/tbb-task-sycl/src/tbb-task-sycl.cpp
@@ -46,7 +46,7 @@ class ExecuteOnGpu {
       sycl::buffer b_buffer(b_array);
       sycl::buffer c_buffer(c_array);
 
-      sycl::queue q(sycl::default_selector{}, dpc_common::exception_handler);
+      sycl::queue q(sycl::default_selector_v, dpc_common::exception_handler);
       q.submit([&](sycl::handler& h) {            
             sycl::accessor a_accessor(a_buffer, h, sycl::read_only);
             sycl::accessor b_accessor(b_buffer, h, sycl::read_only);


### PR DESCRIPTION
# Existing Sample Changes
## Description

Updated oneTBB code samples to use default_selector_v to get the samples compiling and running with the latest compiler.

## External Dependencies

List any external dependencies created as a result of this change.

## Type of change

Please delete options that are not relevant. Add a 'X' to the one that is applicable. 

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Implement fixes for ONSAM Jiras

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [X] Command Line
- [ ] oneapi-cli
- [ ] Visual Studio
- [ ] Eclipse IDE
- [ ] VSCode
- [ ] When compiling the compliler flag "-Wall -Wformat-security -Werror=format-security" was used