### PR TITLE
update Makefile to compile with icpx

### DIFF
--- a/DirectProgramming/C++/GraphTraversal/MergesortOMP/Makefile
+++ b/DirectProgramming/C++/GraphTraversal/MergesortOMP/Makefile
@@ -1,9 +1,9 @@
-CXX := icpc
+CXX := icpx
 SRCDIR := src
 BUILDDIR := release
-CFLAGS := -O3 -ipo -qopenmp -std=c++11
+CFLAGS := -O3 -flto -qopenmp -std=c++11
 EXTRA_CFLAGS :=
-LIBFLAGS := -qopenmp
+LIBFLAGS := -flto -qopenmp
 
 ifdef perf_num
 	EXTRA_CFLAGS += -D PERF_NUM


### PR DESCRIPTION
# Existing Sample Changes
Changing the compiler from icpc to icpx as the icc compiler has been deprecated from 2023.

Fixes Issue# 
Removes deprecation warning messages

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Implement fixes for ONSAM Jiras

## How Has This Been Tested?

- [X] Command Line
- [ ] oneapi-cli
- [ ] Visual Studio
- [ ] Eclipse IDE
- [ ] VSCode
- [ ] When compiling the compliler flag "-Wall -Wformat-security -Werror=format-security" was used

