### PR TITLE
FPGA: Move the simple-add and vector-add samples to the IP Authoring flow

### DIFF
--- a/DirectProgramming/C++SYCL/DenseLinearAlgebra/simple-add/README.md
+++ b/DirectProgramming/C++SYCL/DenseLinearAlgebra/simple-add/README.md
@@ -22,8 +22,9 @@ USM, buffer, accessor, kernel, and command groups.
 | Optimized for      | Description
 |:---                |:---
 | OS                 | Ubuntu* 18.04 <br> Windows* 10
-| Hardware           | GEN9 or newer <br> Intel® Programmable Acceleration Card with Intel® Arria® 10 GX FPGA (Intel® PAC with Intel® Arria® 10 GX FPGA)
+| Hardware           | GEN9 or newer <br> Intel® Agilex®, Arria® 10, and Stratix® 10 FPGAs
 | Software           | Intel® oneAPI DPC++/C++ Compiler
+
 
 > **Note**: Even though the Intel DPC++/C++ OneAPI compiler is enough to compile for CPU, GPU, FPGA emulation, generating FPGA reports and generating RTL for FPGAs, there are extra software requirements for the FPGA simulation flow and FPGA compiles.
 >
@@ -33,6 +34,7 @@ USM, buffer, accessor, kernel, and command groups.
 > - ModelSim® SE
 >
 > When using the hardware compile flow, Intel® Quartus® Prime Pro Edition must be installed and accessible through your PATH.
+> **Warning** Make sure you add the device files associated with the FPGA that you are targeting to your Intel® Quartus® Prime installation.
 
 ## Key Implementation Details
 
@@ -103,6 +105,19 @@ To learn more about the extensions and how to configure the oneAPI environment, 
    cmake .. -DUSM=1
    ```
 
+   > **Note**: When building for FPGAs, the default FPGA family will be used (Intel® Agilex®).
+   > You can change the default target by using the command:
+   >  ```
+   >  cmake .. -DFPGA_DEVICE=<FPGA device family or FPGA part number>
+   >  ``` 
+   >
+   > Alternatively, you can target an explicit FPGA board variant and BSP by using the following command: 
+   >  ```
+   >  cmake .. -DFPGA_DEVICE=<board-support-package>:<board-variant>
+   >  ``` 
+   >
+   > You will only be able to run an executable on the FPGA if you specified a BSP.
+
 #### Build for CPU and GPU
     
 1. Build the program.
@@ -161,6 +176,19 @@ time.)
    cd build
    cmake -G "NMake Makefiles" .. -DUSM=1
    ```
+
+   > **Note**: When building for FPGAs, the default FPGA family will be used (Intel® Agilex®).
+   > You can change the default target by using the command:
+   >  ```
+   >  cmake -G "NMake Makefiles" .. -DFPGA_DEVICE=<FPGA device family or FPGA part number>
+   >  ``` 
+   >
+   > Alternatively, you can target an explicit FPGA board variant and BSP by using the following command: 
+   >  ```
+   >  cmake -G "NMake Makefiles" .. -DFPGA_DEVICE=<board-support-package>:<board-variant>
+   >  ``` 
+   >
+   > You will only be able to run an executable on the FPGA if you specified a BSP.
 
 #### Build for CPU and GPU
 
@@ -238,7 +266,7 @@ If you receive an error message, troubleshoot the problem using the **Diagnostic
    CL_CONTEXT_MPSIM_DEVICE_INTELFPGA=1 ./simple-add-buffers.fpga_sim
    CL_CONTEXT_MPSIM_DEVICE_INTELFPGA=1 ./simple-add-usm.fpga_sim
    ```
-4. Run on FPGA hardware.
+4. Run on FPGA hardware (only if you ran `cmake` with `-DFPGA_DEVICE=<board-support-package>:<board-variant>`).
    ```
    ./simple-add-buffers.fpga
    ./simple-add-usm.fpga
@@ -272,7 +300,7 @@ If you receive an error message, troubleshoot the problem using the **Diagnostic
    simple-add-usm.fpga_sim.exe
    set CL_CONTEXT_MPSIM_DEVICE_INTELFPGA=
    ```
-4. Run on FPGA hardware.
+4. Run on FPGA hardware (only if you ran `cmake` with `-DFPGA_DEVICE=<board-support-package>:<board-variant>`).
    ```
    simple-add-buffers.fpga.exe
    simple-add-usm.fpga.exe
@@ -298,8 +326,8 @@ qsub  -I  -l nodes=1:gpu:ppn=2 -d .
 
   |Available Nodes           |Command Options
   |:---                      |:---
-  |GPU	                    |`qsub -l nodes=1:gpu:ppn=2 -d .`
-  |CPU	                    |`qsub -l nodes=1:xeon:ppn=2 -d .`
+  |GPU	                     |`qsub -l nodes=1:gpu:ppn=2 -d .`
+  |CPU	                     |`qsub -l nodes=1:xeon:ppn=2 -d .`
   |FPGA Compile Time         |`qsub -l nodes=1:fpga_compile:ppn=2 -d .`
   |FPGA Runtime (Arria 10)   |`qsub -l nodes=1:fpga_runtime:arria10:ppn=2 -d .`
 

--- a/DirectProgramming/C++SYCL/DenseLinearAlgebra/simple-add/src/CMakeLists.txt
+++ b/DirectProgramming/C++SYCL/DenseLinearAlgebra/simple-add/src/CMakeLists.txt
@@ -48,15 +48,9 @@ add_custom_target(cpu-gpu DEPENDS ${TARGET_NAME})
 
 # FPGA device selection
 if(NOT DEFINED FPGA_DEVICE)
-    if(DEFINED USM AND (NOT(USM EQUAL 0)))
-        set(FPGA_DEVICE "intel_s10sx_pac:pac_s10_usm")
-        set(DEFAULT_BOARD_STR "Intel Stratix(R) 10 SX with USM support")
-    else()
-        set(FPGA_DEVICE "intel_a10gx_pac:pac_a10")
-        set(DEFAULT_BOARD_STR "Intel Arria(R) 10 GX")
-    endif()
+    set(FPGA_DEVICE "Agilex")
     message(STATUS "FPGA_DEVICE was not specified.\
-                \nConfiguring the design to run on the default FPGA board ${FPGA_DEVICE} (Intel(R) PAC with ${DEFAULT_BOARD_STR} FPGA). \
+                \nConfiguring the design to target the default FPGA family (Intel Agilex®). \
                 \nPlease refer to the README for information on board selection.")
 else()
     message(STATUS "Configuring the design to run on FPGA device ${FPGA_DEVICE}")

--- a/DirectProgramming/C++SYCL/DenseLinearAlgebra/vector-add/README.md
+++ b/DirectProgramming/C++SYCL/DenseLinearAlgebra/vector-add/README.md
@@ -25,7 +25,7 @@ This sample provides example implementations of both Unified Shared Memory (USM)
 | Optimized for                     | Description
 |:---                               |:---
 | OS                                | Ubuntu* 18.04 <br> Windows* 10
-| Hardware                          | GEN9 or newer <br> Intel® Programmable Acceleration Card with Intel® Arria® 10 GX FPGA (Intel® PAC with Intel® Arria® 10 GX FPGA)
+| Hardware                          | GEN9 or newer <br> Intel® Agilex®, Arria® 10, and Stratix® 10 FPGAs
 | Software                          | Intel® oneAPI DPC++/C++ Compiler
 
 > **Note**: Even though the Intel DPC++/C++ OneAPI compiler is enough to compile for CPU, GPU, FPGA emulation, generating FPGA reports and generating RTL for FPGAs, there are extra software requirements for the FPGA simulation flow and FPGA compiles.
@@ -36,6 +36,7 @@ This sample provides example implementations of both Unified Shared Memory (USM)
 > - ModelSim® SE
 >
 > When using the hardware compile flow, Intel® Quartus® Prime Pro Edition must be installed and accessible through your PATH.
+> **Warning** Make sure you add the device files associated with the FPGA that you are targeting to your Intel® Quartus® Prime installation.
 
 ## Key Implementation Details
 
@@ -103,6 +104,19 @@ To learn more about the extensions and how to configure the oneAPI environment, 
    cmake .. -DUSM=1
    ```
 
+   > **Note**: When building for FPGAs, the default FPGA family will be used (Intel® Agilex®).
+   > You can change the default target by using the command:
+   >  ```
+   >  cmake .. -DFPGA_DEVICE=<FPGA device family or FPGA part number>
+   >  ``` 
+   >
+   > Alternatively, you can target an explicit FPGA board variant and BSP by using the following command: 
+   >  ```
+   >  cmake .. -DFPGA_DEVICE=<board-support-package>:<board-variant>
+   >  ``` 
+   >
+   > You will only be able to run an executable on the FPGA if you specified a BSP.
+
 #### Build for CPU and GPU
     
 1. Build the program.
@@ -161,6 +175,19 @@ time.)
    cd build
    cmake -G "NMake Makefiles" .. -DUSM=1
    ```
+
+   > **Note**: When building for FPGAs, the default FPGA family will be used (Intel® Agilex®).
+   > You can change the default target by using the command:
+   >  ```
+   >  cmake -G "NMake Makefiles" .. -DFPGA_DEVICE=<FPGA device family or FPGA part number>
+   >  ``` 
+   >
+   > Alternatively, you can target an explicit FPGA board variant and BSP by using the following command: 
+   >  ```
+   >  cmake -G "NMake Makefiles" .. -DFPGA_DEVICE=<board-support-package>:<board-variant>
+   >  ``` 
+   >
+   > You will only be able to run an executable on the FPGA if you specified a BSP.
 
 #### Build for CPU and GPU
 
@@ -243,7 +270,7 @@ The source files (`vector-add-buffers.cpp` and `vector-add-usm.cpp`) specify the
    CL_CONTEXT_MPSIM_DEVICE_INTELFPGA=1 ./vector-add-buffers.fpga_sim
    CL_CONTEXT_MPSIM_DEVICE_INTELFPGA=1 ./vector-add-usm.fpga_sim
    ```
-4. Run on FPGA hardware.
+4. Run on FPGA hardware (only if you ran `cmake` with `-DFPGA_DEVICE=<board-support-package>:<board-variant>`).
     ```
     ./vector-add-buffers.fpga
     ./vector-add-usm.fpga
@@ -277,7 +304,7 @@ The source files (`vector-add-buffers.cpp` and `vector-add-usm.cpp`) specify the
    vector-add-usm.fpga_sim.exe
    set CL_CONTEXT_MPSIM_DEVICE_INTELFPGA=
    ```
-4. Run on FPGA hardware.
+4. Run on FPGA hardware (only if you ran `cmake` with `-DFPGA_DEVICE=<board-support-package>:<board-variant>`).
     ```
     vector-add-buffers.fpga.exe
     vector-add-usm.fpga.exe

--- a/DirectProgramming/C++SYCL/DenseLinearAlgebra/vector-add/src/CMakeLists.txt
+++ b/DirectProgramming/C++SYCL/DenseLinearAlgebra/vector-add/src/CMakeLists.txt
@@ -48,15 +48,9 @@ add_custom_target(cpu-gpu DEPENDS ${TARGET_NAME})
 
 # FPGA device selection
 if(NOT DEFINED FPGA_DEVICE)
-    if(DEFINED USM AND (NOT(USM EQUAL 0)))
-        set(FPGA_DEVICE "intel_s10sx_pac:pac_s10_usm")
-        set(DEFAULT_BOARD_STR "Intel Stratix(R) 10 SX with USM support")
-    else()
-        set(FPGA_DEVICE "intel_a10gx_pac:pac_a10")
-        set(DEFAULT_BOARD_STR "Intel Arria(R) 10 GX")
-    endif()
+    set(FPGA_DEVICE "Agilex")
     message(STATUS "FPGA_DEVICE was not specified.\
-                \nConfiguring the design to run on the default FPGA board ${FPGA_DEVICE} (Intel(R) PAC with ${DEFAULT_BOARD_STR} FPGA). \
+                \nConfiguring the design to target the default FPGA family (Intel Agilex®). \
                 \nPlease refer to the README for information on board selection.")
 else()
     message(STATUS "Configuring the design to run on FPGA device ${FPGA_DEVICE}")


### PR DESCRIPTION
This PR changes the default FPGA target of the `simple-add` and `vector-add` samples to Agilex.
It also changes the default flow from "full board" to "IP Authoring".
This change follows a similar change applied to all the FPGA code samples (https://github.com/oneapi-src/oneAPI-samples/pull/1307)