### PR TITLE
Relax correctness test for Ch04 matrix multiply

### DIFF
--- a/Publications/DPC++/Ch04_expressing_parallelism/fig_4_13_nd_range_matrix_multiply.cpp
+++ b/Publications/DPC++/Ch04_expressing_parallelism/fig_4_13_nd_range_matrix_multiply.cpp
@@ -59,7 +59,7 @@ int main() {
       for (int k = 0; k < N; ++k) {
         gold += a[j * N + k] * b[k * N + i];
       }
-      if (std::abs(gold - c[j * N + i]) / gold > 1.0E-06) {
+      if (std::abs(gold - c[j * N + i]) / gold > 1.0E-05) {
         passed = false;
       }
     }

--- a/Publications/DPC++/Ch04_expressing_parallelism/fig_4_20_hierarchical_matrix_multiply.cpp
+++ b/Publications/DPC++/Ch04_expressing_parallelism/fig_4_20_hierarchical_matrix_multiply.cpp
@@ -62,7 +62,7 @@ int main() {
       for (int k = 0; k < N; ++k) {
         gold += a[j * N + k] * b[k * N + i];
       }
-      if (std::abs(gold - c[j * N + i]) / gold > 1.0E-06) {
+      if (std::abs(gold - c[j * N + i]) / gold > 1.0E-05) {
         passed = false;
       }
     }

--- a/Publications/DPC++/Ch04_expressing_parallelism/fig_4_22_hierarchical_logical_matrix_multiply.cpp
+++ b/Publications/DPC++/Ch04_expressing_parallelism/fig_4_22_hierarchical_logical_matrix_multiply.cpp
@@ -62,7 +62,7 @@ int main() {
       for (int k = 0; k < N; ++k) {
         gold += a[j * N + k] * b[k * N + i];
       }
-      if (std::abs(gold - c[j * N + i]) / gold > 1.0E-06) {
+      if (std::abs(gold - c[j * N + i]) / gold > 1.0E-05) {
         passed = false;
       }
     }

--- a/Publications/DPC++/Ch04_expressing_parallelism/fig_4_7_basic_matrix_multiply.cpp
+++ b/Publications/DPC++/Ch04_expressing_parallelism/fig_4_7_basic_matrix_multiply.cpp
@@ -55,7 +55,7 @@ int main() {
       for (int k = 0; k < N; ++k) {
         gold += a[j * N + k] * b[k * N + i];
       }
-      if (std::abs(gold - c[j * N + i]) / gold > 1.0E-06) {
+      if (std::abs(gold - c[j * N + i]) / gold > 1.0E-05) {
         passed = false;
       }
     }


### PR DESCRIPTION
# Existing Sample Changes
## Description

Relaxes correctness test for Ch04 matrix multiply. Same commit as [here](https://github.com/Apress/data-parallel-CPP/commit/4ddd4858800800da29625dfc615aca1f71d26000).

## External Dependencies

List any external dependencies created as a result of this change.

## Type of change

Please delete options that are not relevant. Add a 'X' to the one that is applicable. 

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Implement fixes for ONSAM Jiras

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [X] Command Line
- [ ] oneapi-cli
- [ ] Visual Studio
- [ ] Eclipse IDE
- [ ] VSCode
- [ ] When compiling the compliler flag "-Wall -Wformat-security -Werror=format-security" was used