### PR TITLE
FPGA: Reduce the design size of the memory_attributes design in simulation

### DIFF
--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/memory_attributes/src/memory_attributes.cpp
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/memory_attributes/src/memory_attributes.cpp
@@ -12,7 +12,12 @@ using namespace sycl;
 
 // constants for this tutorial
 constexpr size_t kRows = 8;
+#if defined(FPGA_SIMULATOR)
+// Use a smaller unroll factor when running simulation
+constexpr size_t kVec = 1;
+#else
 constexpr size_t kVec = 4;
+#endif
 constexpr size_t kMaxVal = 512;
 constexpr size_t kNumTests = 64;
 constexpr size_t kMaxIter = 8;


### PR DESCRIPTION
This will make the simulation runtime faster.