### PR TITLE
Revert "FPGA: Remove Windows simulator command for memory_attributes"

### DIFF
--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/memory_attributes/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/memory_attributes/README.md
@@ -249,6 +249,10 @@ The choice of attributes will be further discussed in the [Examining the Reports
      ```
      nmake fpga_emu
      ```
+   * Compile for simulation (fast compile time, targets simulated FPGA device, reduced data size):
+     ```
+     nmake fpga_sim
+     ```
    * Generate the optimization report:
      ```
      nmake report
@@ -316,6 +320,12 @@ There are often many ways to generate a stall-free memory system. As a programme
   * On Linux
     ```bash
     CL_CONTEXT_MPSIM_DEVICE_INTELFPGA=1 ./memory_attributes.fpga_sim
+    ```
+  * On Windows
+    ```bash
+    set CL_CONTEXT_MPSIM_DEVICE_INTELFPGA=1
+    memory_attributes.fpga_sim.exe
+    set CL_CONTEXT_MPSIM_DEVICE_INTELFPGA=
     ```
 3. Run the sample on the FPGA device (only if you ran `cmake` with `-DFPGA_DEVICE=<board-support-package>:<board-variant>`):
   ```

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/memory_attributes/src/CMakeLists.txt
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/memory_attributes/src/CMakeLists.txt
@@ -1,11 +1,8 @@
 set(SOURCE_FILE memory_attributes.cpp)
 set(TARGET_NAME memory_attributes)
 set(EMULATOR_TARGET ${TARGET_NAME}.fpga_emu)
+set(SIMULATOR_TARGET ${TARGET_NAME}.fpga_sim)
 set(FPGA_TARGET ${TARGET_NAME}.fpga)
-
-if(UNIX)
-    set(SIMULATOR_TARGET ${TARGET_NAME}.fpga_sim)
-endif()
 
 # FPGA board selection
 if(NOT DEFINED FPGA_DEVICE)
@@ -49,20 +46,18 @@ set_target_properties(${EMULATOR_TARGET} PROPERTIES LINK_FLAGS "${EMULATOR_LINK_
 add_custom_target(fpga_emu DEPENDS ${EMULATOR_TARGET})
 
 ###############################################################################
-### FPGA Simulator (for UNIX)
+### FPGA Simulator
 ###############################################################################
 # To compile in a single command:
 #    icpx -fsycl -fintelfpga -Xssimulation -DFPGA_SIMULATOR mem_channel.cpp -o mem_channel.fpga_sim
 # CMake executes:
 #    [compile] icpx -fsycl -fintelfpga -Xssimulation -DFPGA_SIMULATOR -o mem_channel.cpp.o -c mem_channel.cpp
 #    [link]    icpx -fsycl -fintelfpga -Xssimulation  mem_channel.cpp.o -o mem_channel.fpga_sim
-if(UNIX)
-    add_executable(${SIMULATOR_TARGET} ${SOURCE_FILE})
-    target_include_directories(${SIMULATOR_TARGET} PRIVATE ../../../../include)
-    set_target_properties(${SIMULATOR_TARGET} PROPERTIES COMPILE_FLAGS "${SIMULATOR_COMPILE_FLAGS}")
-    set_target_properties(${SIMULATOR_TARGET} PROPERTIES LINK_FLAGS "${SIMULATOR_LINK_FLAGS}")
-    add_custom_target(fpga_sim DEPENDS ${SIMULATOR_TARGET})
-endif()
+add_executable(${SIMULATOR_TARGET} ${SOURCE_FILE})
+target_include_directories(${SIMULATOR_TARGET} PRIVATE ../../../../include)
+set_target_properties(${SIMULATOR_TARGET} PROPERTIES COMPILE_FLAGS "${SIMULATOR_COMPILE_FLAGS}")
+set_target_properties(${SIMULATOR_TARGET} PROPERTIES LINK_FLAGS "${SIMULATOR_LINK_FLAGS}")
+add_custom_target(fpga_sim DEPENDS ${SIMULATOR_TARGET})
 
 ###############################################################################
 ### Generate Report


### PR DESCRIPTION
Reverts oneapi-src/oneAPI-samples#1374
We no longer need this above commit since we believe reducing the test size is a better solution here.