### PR TITLE
FPGA: Reduce test size from 64 to 2 for memory_attributes simulator target

### DIFF
--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/memory_attributes/src/memory_attributes.cpp
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/memory_attributes/src/memory_attributes.cpp
@@ -14,7 +14,11 @@ using namespace sycl;
 constexpr size_t kRows = 8;
 constexpr size_t kVec = 4;
 constexpr size_t kMaxVal = 512;
+#if defined (FPGA_SIMULATOR)
 constexpr size_t kNumTests = 2;
+#else
+constexpr size_t kNumTests = 64;
+#endif
 constexpr size_t kMaxIter = 8;
 
 // Forward declare the kernel name in the global scope.

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/memory_attributes/src/memory_attributes.cpp
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/memory_attributes/src/memory_attributes.cpp
@@ -14,7 +14,7 @@ using namespace sycl;
 constexpr size_t kRows = 8;
 constexpr size_t kVec = 4;
 constexpr size_t kMaxVal = 512;
-constexpr size_t kNumTests = 64;
+constexpr size_t kNumTests = 2;
 constexpr size_t kMaxIter = 8;
 
 // Forward declare the kernel name in the global scope.


### PR DESCRIPTION
# Existing Sample Changes
## Description
Currently this test takes unreasonably long (hours) for Windows simulator target. Reducing the test size helps to reduce the time taken to under 10 minutes.

## External Dependencies

## Type of change
Reduce test size

## How Has This Been Tested?
Reducing the test size should be a safe change.
I have also test the simulator target on both Windows and Linux for my change.