### PR TITLE
fix case 15012892040

### DIFF
--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/GettingStarted/fpga_template/src/fpga_template.cpp
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/GettingStarted/fpga_template/src/fpga_template.cpp
@@ -58,6 +58,14 @@ int main() {
                   sycl::property::queue::enable_profiling{});
 
     auto device = q.get_device();
+
+    if (!device.has(sycl::aspect::usm_host_allocations)) {
+      std::cerr << "This design must either target a board that supports USM "
+                   "Host/Shared allocations, or IP Component Authoring. "
+                << std::endl;
+      std::terminate();
+    }
+
     std::cout << "Running on device: "
               << device.get_info<sycl::info::device::name>().c_str()
               << std::endl;


### PR DESCRIPTION
# Existing Sample Changes
## Description

Fix bug https://hsdes.intel.com/appstore/article/#/15012892040. this only partially fixes the bug; there is a [compiler issue](https://hsdes.intel.com/appstore/article/#/18027925234) that causes this check to fail for simulator devices:

```c++
    if (!device.has(sycl::aspect::usm_host_allocations)) {
      std::terminate();
    }
```

Fixes Issue# 
https://hsdes.intel.com/appstore/article/#/15012892040

## External Dependencies

List any external dependencies created as a result of this change.

## Type of change

Please delete options that are not relevant. Add a 'X' to the one that is applicable. 

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Implement fixes for ONSAM Jiras

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [X] Command Line
The fix in this PR will not work until https://hsdes.intel.com/appstore/article/#/18027925234 is resolved.
- [ ] oneapi-cli
- [ ] Visual Studio
- [ ] Eclipse IDE
- [ ] VSCode
- [ ] When compiling the compliler flag "-Wall -Wformat-security -Werror=format-security" was used