### PR TITLE
ApplicationDebugger: update make targets with ONEAPI_DEVICE_SELECTOR

### DIFF
--- a/Tools/ApplicationDebugger/array-transform/CMakeLists.txt
+++ b/Tools/ApplicationDebugger/array-transform/CMakeLists.txt
@@ -49,14 +49,14 @@ add_custom_target (debug-session
   DEPENDS ${PROJECT_NAME})
 
 # Add custom target for running
-add_custom_target(run ./${PROJECT_NAME} cpu
+add_custom_target(run ONEAPI_DEVICE_SELECTOR=*:cpu ./${PROJECT_NAME}
   DEPENDS ${PROJECT_NAME})
 
-add_custom_target(run-cpu ./${PROJECT_NAME} cpu
+add_custom_target(run-cpu ONEAPI_DEVICE_SELECTOR=*:cpu ./${PROJECT_NAME}
   DEPENDS ${PROJECT_NAME})
 
-add_custom_target(run-gpu ./${PROJECT_NAME} gpu
+add_custom_target(run-gpu ONEAPI_DEVICE_SELECTOR=level_zero:gpu ./${PROJECT_NAME}
   DEPENDS ${PROJECT_NAME})
 
-add_custom_target(run-fpga ./${PROJECT_NAME} accelerator
+add_custom_target(run-fpga ONEAPI_DEVICE_SELECTOR=*:fpga ./${PROJECT_NAME}
   DEPENDS ${PROJECT_NAME})

--- a/Tools/ApplicationDebugger/jacobi/CMakeLists.txt
+++ b/Tools/ApplicationDebugger/jacobi/CMakeLists.txt
@@ -40,20 +40,20 @@ add_custom_target (debug-session
   DEPENDS ${PROJECT_NAME_BUGGED})
 
 # Add custom target for running
-add_custom_target(run ./${PROJECT_NAME_BUGGED} cpu
+add_custom_target(run ONEAPI_DEVICE_SELECTOR=*:cpu ./${PROJECT_NAME_BUGGED}
   DEPENDS ${PROJECT_NAME_BUGGED})
 
-add_custom_target(run-cpu-fixed ./${PROJECT_NAME_FIXED} cpu
+add_custom_target(run-cpu-fixed ONEAPI_DEVICE_SELECTOR=*:cpu ./${PROJECT_NAME_FIXED}
   DEPENDS ${PROJECT_NAME_FIXED})
-add_custom_target(run-cpu ./${PROJECT_NAME_BUGGED} cpu
+add_custom_target(run-cpu ONEAPI_DEVICE_SELECTOR=*:cpu ./${PROJECT_NAME_BUGGED}
   DEPENDS ${PROJECT_NAME_BUGGED})
 
-add_custom_target(run-gpu-fixed ./${PROJECT_NAME_FIXED} gpu
+add_custom_target(run-gpu-fixed ONEAPI_DEVICE_SELECTOR=level_zero:gpu ./${PROJECT_NAME_FIXED}
   DEPENDS ${PROJECT_NAME_FIXED})
-add_custom_target(run-gpu ./${PROJECT_NAME_BUGGED} gpu
+add_custom_target(run-gpu ONEAPI_DEVICE_SELECTOR=level_zero:gpu ./${PROJECT_NAME_BUGGED}
   DEPENDS ${PROJECT_NAME_BUGGED})
 
-add_custom_target(run-fpga-fixed ./${PROJECT_NAME_FIXED} accelerator
+add_custom_target(run-fpga-fixed ONEAPI_DEVICE_SELECTOR=*:fpga ./${PROJECT_NAME_FIXED}
   DEPENDS ${PROJECT_NAME_FIXED})
-add_custom_target(run-fpga ./${PROJECT_NAME_BUGGED} accelerator
+add_custom_target(run-fpga ONEAPI_DEVICE_SELECTOR=*:fpga ./${PROJECT_NAME_BUGGED}
   DEPENDS ${PROJECT_NAME_BUGGED})


### PR DESCRIPTION
# Existing Sample Changes
## Description

I have missed this part in the previous PR: https://github.com/oneapi-src/oneAPI-samples/pull/1387
These targets are for convenience. AFAIK they are not mentioned in the documentation.
If it still can be included into 2023.1, that would be great, but it is not a stopper in my opinion.

## How Has This Been Tested?

- [x] Command Line

FYI @barisaktemur 