### PR TITLE
Hardcode missing headers to build in 2023.0

### DIFF
--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Tools/experimental/platform_designer/add-oneapi/CMakeLists.txt
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Tools/experimental/platform_designer/add-oneapi/CMakeLists.txt
@@ -82,6 +82,8 @@ message(STATUS "Additional USER_LIB_PATHS=${USER_LIB_PATHS}")
 link_libraries(${USER_LIBS})
 message(STATUS "Additional USER_LIBS=${USER_LIBS}")
 
+include_directories("/opt/intel/oneapi/compiler/2023.0.0/linux/lib/oclfpga/include")
+
 if(WIN32)
     # add qactypes for Windows
     set(QACTYPES "-Qactypes")


### PR DESCRIPTION
As is:

```bash
/victor@accelerationrobotics:/media/victor/intel/oneAPI-samples/DirectProgramming/C++SYCL_FPGA/Tutorials/Tools/experimental/platform_designer/add-oneapi/build$ cmake .. -DFPGA_DEVICE=agilex
-- The CXX compiler identification is IntelLLVM 2023.0.0
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: /opt/intel/oneapi/compiler/2023.0.0/linux/bin/icpx - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Configuring the design to run on FPGA board agilex
-- Additional USER_FPGA_FLAGS=
-- Additional USER_FLAGS=
-- Additional USER_INCLUDE_PATHS=../../../../../include
-- Additional USER_LIB_PATHS=
-- Additional USER_LIBS=
-- Configuring done
-- Generating done
-- Build files have been written to: /media/victor/intel/oneAPI-samples/DirectProgramming/C++SYCL_FPGA/Tutorials/Tools/experimental/platform_designer/add-oneapi/build
victor@accelerationrobotics:/media/victor/intel/oneAPI-samples/DirectProgramming/C++SYCL_FPGA/Tutorials/Tools/experimental/platform_designer/add-oneapi/build$ make fpga_ip_export
[ 33%] To compile manually:
/opt/intel/oneapi/compiler/2023.0.0/linux/bin/icpx -I../../../../../../include -fsycl -fintelfpga -Wall -qactypes -DFPGA_HARDWARE -c ../src/add.cpp -o CMakeFiles/fpga_ip_export.dir/src/add.cpp.o

To link manually:
/opt/intel/oneapi/compiler/2023.0.0/linux/bin/icpx -fsycl -fintelfpga -Xshardware -Xstarget=agilex -fsycl-link=early -fsycl-device-code-split=per_kernel -o add.fpga_ip_export CMakeFiles/fpga_ip_export.dir/src/add.cpp.o
[ 33%] Built target displayExportCompileCommands
[ 66%] Building CXX object CMakeFiles/fpga_ip_export.dir/src/add.cpp.o
/media/victor/intel/oneAPI-samples/DirectProgramming/C++SYCL_FPGA/Tutorials/Tools/experimental/platform_designer/add-oneapi/src/add.cpp:10:10: fatal error: 'sycl/ext/intel/prototype/host_pipes.hpp' file not found
#include <sycl/ext/intel/prototype/host_pipes.hpp>
         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
1 error generated.
make[3]: *** [CMakeFiles/fpga_ip_export.dir/build.make:76: CMakeFiles/fpga_ip_export.dir/src/add.cpp.o] Error 1
make[2]: *** [CMakeFiles/Makefile2:204: CMakeFiles/fpga_ip_export.dir/all] Error 2
make[1]: *** [CMakeFiles/Makefile2:211: CMakeFiles/fpga_ip_export.dir/rule] Error 2
```

After the fix:

```bash
victor@accelerationrobotics:/media/victor/intel/oneAPI-samples/DirectProgramming/C++SYCL_FPGA/Tutorials/Tools/experimental/platform_designer/add-oneapi/build$ cmake .. -DFPGA_DEVICE=agilex
-- Configuring the design to run on FPGA board agilex
-- Additional USER_FPGA_FLAGS=
-- Additional USER_FLAGS=
-- Additional USER_INCLUDE_PATHS=../../../../../include
-- Additional USER_LIB_PATHS=
-- Additional USER_LIBS=
-- Configuring done
-- Generating done
-- Build files have been written to: /media/victor/intel/oneAPI-samples/DirectProgramming/C++SYCL_FPGA/Tutorials/Tools/experimental/platform_designer/add-oneapi/build
victor@accelerationrobotics:/media/victor/intel/oneAPI-samples/DirectProgramming/C++SYCL_FPGA/Tutorials/Tools/experimental/platform_designer/add-oneapi/build$ make fpga_ip_export
[ 33%] To compile manually:
/opt/intel/oneapi/compiler/2023.0.0/linux/bin/icpx -I../../../../../../include -fsycl -fintelfpga -Wall -qactypes -DFPGA_HARDWARE -c ../src/add.cpp -o CMakeFiles/fpga_ip_export.dir/src/add.cpp.o

To link manually:
/opt/intel/oneapi/compiler/2023.0.0/linux/bin/icpx -fsycl -fintelfpga -Xshardware -Xstarget=agilex -fsycl-link=early -fsycl-device-code-split=per_kernel -o add.fpga_ip_export CMakeFiles/fpga_ip_export.dir/src/add.cpp.o
[ 33%] Built target displayExportCompileCommands
[ 66%] Building CXX object CMakeFiles/fpga_ip_export.dir/src/add.cpp.o
[100%] Linking CXX executable add.fpga_ip_export
[100%] Built target fpga_ip_export
```