### PR TITLE
Change array size to 16 for simulation

### DIFF
--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/loop_unroll/src/loop_unroll.cpp
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/loop_unroll/src/loop_unroll.cpp
@@ -92,7 +92,7 @@ void VecAdd(const std::vector<float> &summands1,
 
 int main(int argc, char *argv[]) {
 #if defined(FPGA_SIMULATOR)
-  size_t array_size = 1 << 10;
+  size_t array_size = 1 << 4;
 #else
   size_t array_size = 1 << 26;
 #endif


### PR DESCRIPTION
# Existing Sample Changes
## Description

The loop unroll code sample's array size was 1024 for simulation which caused simulating with Questa FSE on Windows to be very slow (>24 hours).

This changes the array size to 16 which lets the simulation to complete in ~1 hour using Questa FSE on Windows.

## External Dependencies

None

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Compiled and ran the loop unroll code sample for simulation on Windows.
