### PR TITLE
FPGA: fix incorrect paths in Windows CI steps 

### DIFF
--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/experimental/hostpipes/sample.json
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/experimental/hostpipes/sample.json
@@ -46,7 +46,7 @@
         "id": "fpga_emu",
         "steps": [
           "icpx --version",
-          "cd ../../..",
+          "cd ../../../..",
           "mkdir build",
           "cd build",
           "cmake -G \"NMake Makefiles\" ../Tutorials/Features/experimental/hostpipes",
@@ -58,7 +58,7 @@
         "id": "report",
         "steps": [
           "icpx --version",
-          "cd ../../..",
+          "cd ../../../..",
           "mkdir build",
           "cd build",
           "cmake -G \"NMake Makefiles\" ../Tutorials/Features/experimental/hostpipes",

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/experimental/latency_control/sample.json
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/experimental/latency_control/sample.json
@@ -46,7 +46,7 @@
         "id": "fpga_emu",
         "steps": [
           "icpx --version",
-          "cd ../../..",
+          "cd ../../../..",
           "mkdir build",
           "cd build",
           "cmake -G \"NMake Makefiles\" ../Tutorials/Features/experimental/latency_control",
@@ -58,7 +58,7 @@
         "id": "report",
         "steps": [
           "icpx --version",
-          "cd ../../..",
+          "cd ../../../..",
           "mkdir build",
           "cd build",
           "cmake -G \"NMake Makefiles\" ../Tutorials/Features/experimental/latency_control",

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/optimization_levels/minimum_latency/sample.json
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/optimization_levels/minimum_latency/sample.json
@@ -46,7 +46,7 @@
         "id": "fpga_emu",
         "steps": [
           "icpx --version",
-          "cd ../../..",
+          "cd ../../../..",
           "mkdir build",
           "cd build",
           "cmake -G \"NMake Makefiles\" ../Tutorials/Features/optimization_levels/minimum_latency",
@@ -58,7 +58,7 @@
         "id": "report",
         "steps": [
           "icpx --version",
-          "cd ../../..",
+          "cd ../../../..",
           "mkdir build",
           "cd build",
           "cmake -G \"NMake Makefiles\" ../Tutorials/Features/optimization_levels/minimum_latency",


### PR DESCRIPTION
Some FPGA samples had incorrect path in their CI steps in the `sample.json` file.