### PR TITLE
Rtk development branch fix for validation 20230320

### DIFF
--- a/RenderingToolkit/Tutorial/IntroToRayTracingWithEmbree/sample.json
+++ b/RenderingToolkit/Tutorial/IntroToRayTracingWithEmbree/sample.json
@@ -67,7 +67,7 @@
 			"cd cpu",
                     "mkdir build",
                     "cd build",
-                    "cmake -DCMAKE_BUILD_TYPE=Release ..",
+                    "cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_PREFIX_PATH=/opt/intel/oneapi/rkcommon/latest/lib/cmake/rkcommon ..",
                     "cmake --build .",
 		    "cmake --install .",
 		    "cd ../bin",

--- a/RenderingToolkit/Tutorial/PathTracingWithEmbree/sample.json
+++ b/RenderingToolkit/Tutorial/PathTracingWithEmbree/sample.json
@@ -45,7 +45,7 @@
                     "cd cpu",
                     "mkdir build",
                     "cd build",
-                    "cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_PREFIX_PATH=/opt/intel/oneapi ..",
+                    "cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_PREFIX_PATH=/opt/intel/oneapi/rkcommon/latest/lib/cmake/rkcommon ..",
                     "cmake --build . ",
                     "export DYLD_LIBRARY_PATH=${LIBRARY_PATH} && ./rkPathTracer"
                  ]


### PR DESCRIPTION
# Existing Sample Changes
## Description

2023.2 Development branch: Validation team needed extra references in sample.json for the rkcommon utility support library to resolve on macOS. IntroToRayTracing and PathTracingWithEmbree samples.

Fixes Issue#

workaround for reference jira: ONSAM-1563

## External Dependencies

none

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Implement fixes for ONSAM Jiras

## How Has This Been Tested?

Run steps in samples.json 

- [x] Command Line
- [ ] oneapi-cli
- [ ] Visual Studio
- [ ] Eclipse IDE
- [ ] VSCode
- [ ] When compiling the compliler flag "-Wall -Wformat-security -Werror=format-security" was used

