### PR TITLE
Updated Makefile.win in matrix_mul to resolve Windows compilation errors

### DIFF
--- a/DirectProgramming/C++SYCL/DenseLinearAlgebra/matrix_mul/Makefile.win
+++ b/DirectProgramming/C++SYCL/DenseLinearAlgebra/matrix_mul/Makefile.win
@@ -1,6 +1,6 @@
 SYCL_CXX = icx-cl
-SYCL_CXXFLAGS = /Zi /EHsc
-SYCL_LDFLAGS = 
+SYCL_CXXFLAGS = -fsycl /Zi /EHsc
+SYCL_LDFLAGS =
 SYCL_EXE_NAME = matrix_mul_sycl.exe
 SYCL_SOURCES = src/matrix_mul_sycl.cpp
 
@@ -17,5 +17,5 @@ run:
 run_sycl:
 	$(SYCL_EXE_NAME)
 
-clean: 
+clean:
 	del -rf $(SYCL_EXE_NAME) *.pdb


### PR DESCRIPTION
# Existing Sample Changes
## Description

This PR updates the Makefile.win file so that the matrix_mul code sample can compile without errors on Windows.

Fixes Issue# 

ONSAM-1578

## Type of change

Please delete options that are not relevant. Add a 'X' to the one that is applicable. 

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Implement fixes for ONSAM Jiras

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [X] Command Line
- [ ] oneapi-cli
- [ ] Visual Studio
- [ ] Eclipse IDE
- [ ] VSCode
- [ ] When compiling the compliler flag "-Wall -Wformat-security -Werror=format-security" was used