### PR TITLE
Allow Ch18 DPC++ book code samples to compile

### DIFF
--- a/Publications/DPC++/Ch18_using_libs/CMakeLists.txt
+++ b/Publications/DPC++/Ch18_using_libs/CMakeLists.txt
@@ -2,7 +2,7 @@
 
 # SPDX-License-Identifier: MIT
 cmake_minimum_required(VERSION 3.4 )
-project(Chap18)
+project(Chap18 CXX)
 add_book_sample(
     TEST
     TARGET fig_18_1_builtin

--- a/Publications/DPC++/Ch18_using_libs/CMakeLists.txt
+++ b/Publications/DPC++/Ch18_using_libs/CMakeLists.txt
@@ -1,35 +1,35 @@
 # Copyright (C) 2020 Intel Corporation
 
 # SPDX-License-Identifier: MIT
-# cmake_minimum_required(VERSION 3.4 )
-# project(Chap18 CXX)
-# add_book_sample(
-#     TEST
-#     TARGET fig_18_1_builtin
-#     SOURCES fig_18_1_builtin.cpp)
+cmake_minimum_required(VERSION 3.4 )
+project(Chap18)
+add_book_sample(
+    TEST
+    TARGET fig_18_1_builtin
+    SOURCES fig_18_1_builtin.cpp)
 
-# add_book_sample(
-#     TEST
-#     TARGET fig_18_7_swap
-#     SOURCES fig_18_7_swap.cpp)
+add_book_sample(
+    TEST
+    TARGET fig_18_7_swap
+    SOURCES fig_18_7_swap.cpp)
 
-# if(NOT NODPL)
-# add_book_sample(
-#     TEST
-#     TARGET fig_18_11_std_fill
-#     SOURCES fig_18_11_std_fill.cpp)
-# endif()
+if(NOT NODPL)
+add_book_sample(
+    TEST
+    TARGET fig_18_11_std_fill
+    SOURCES fig_18_11_std_fill.cpp)
+endif()
 
-# if(NOT NODPL)
-# add_book_sample(
-#     TEST
-#     TARGET fig_18_13_binary_search
-#     SOURCES fig_18_13_binary_search.cpp)
-# endif()
+if(NOT NODPL)
+add_book_sample(
+    TEST
+    TARGET fig_18_13_binary_search
+    SOURCES fig_18_13_binary_search.cpp)
+endif()
 
-# if(NOT NODPL)
-# add_book_sample(
-#     TEST
-#     TARGET fig_18_15_pstl_usm
-#     SOURCES fig_18_15_pstl_usm.cpp)
-# endif()
+if(NOT NODPL)
+add_book_sample(
+    TEST
+    TARGET fig_18_15_pstl_usm
+    SOURCES fig_18_15_pstl_usm.cpp)
+endif()


### PR DESCRIPTION
# Existing Sample Changes
## Description

Uncommented CMakeLists.txt in DPC++ book for Ch18 code samples.

Fixes Issue# 
ONSAM-1572

## External Dependencies

List any external dependencies created as a result of this change.

## Type of change

Please delete options that are not relevant. Add a 'X' to the one that is applicable. 

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] Implement fixes for ONSAM Jiras

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [X] Command Line
- [ ] oneapi-cli
- [ ] Visual Studio
- [ ] Eclipse IDE
- [ ] VSCode
- [ ] When compiling the compliler flag "-Wall -Wformat-security -Werror=format-security" was used