### PR TITLE
Updated Makefile in Fourier corrleation sample to remove sycl.lib

### DIFF
--- a/Libraries/oneMKL/fourier_correlation/makefile
+++ b/Libraries/oneMKL/fourier_correlation/makefile
@@ -9,7 +9,7 @@ run_all: fcorr_1d_buff.exe fcorr_1d_usm.exe
 	.\fcorr_1d_usm 1024
 	.\fcorr_2d_usm
 
-DPCPP_OPTS=-DMKL_ILP64 -I"%MKLROOT%\include" /Qmkl sycl.lib OpenCL.lib /EHsc
+DPCPP_OPTS=-DMKL_ILP64 -I"%MKLROOT%\include" /Qmkl OpenCL.lib /EHsc
 
 fcorr_1d_buff.exe: fcorr_1d_buffers.cpp
 	icx-cl -fsycl fcorr_1d_buffers.cpp /Fefcorr_1d_buff.exe $(DPCPP_OPTS)


### PR DESCRIPTION
# Existing Sample Changes
## Description

Updated Makefile in Fourier corrleation sample to remove sycl.lib so that the code sample can compile on Windows.

Fixes Issue #ONSAM-1576

## Type of change

Please delete options that are not relevant. Add a 'X' to the one that is applicable. 

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Implement fixes for ONSAM Jiras

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [X] Command Line
- [ ] oneapi-cli
- [ ] Visual Studio
- [ ] Eclipse IDE
- [ ] VSCode
- [ ] When compiling the compliler flag "-Wall -Wformat-security -Werror=format-security" was used