### PR TITLE
FPGA: Set fp model to "precise" for ac_fixed sample

### DIFF
--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/ac_fixed/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/ac_fixed/README.md
@@ -132,6 +132,8 @@ When you use the `ac_fixed` library, keep the following points in mind:
 
      The host program for this tutorial shows the accuracy differences between the result provided by floating point math library and the result provided by the `ac_fixed` math library functions, where the `float` version generates a more accurate result than the smaller-sized `ac_fixed` version.
 
+     Note: the program is compiled with fp-model set to "precise", so the accuracy of the floating-point math functions conform to the IEEE standard.
+
   - Emulation vs FPGA Hardware for fixed point math operations
 
      Due to the differences in the internal math implementations, the results from `ac_fixed` math functions in emulation and FPGA hardware might not always be bit-accurate. This tutorial shows how to build and run the sample for emulation and FPGA hardware so you can observe the difference.

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/ac_fixed/src/CMakeLists.txt
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/ac_fixed/src/CMakeLists.txt
@@ -20,16 +20,18 @@ endif()
 if(WIN32)
     set(WIN_FLAG "/EHsc")
     set(AC_TYPES_FLAG "/Qactypes")
+    set(EMULATOR_PLATFORM_FLAGS "/fp:precise")
 else()
     set(AC_TYPES_FLAG "-qactypes")
+    set(EMULATOR_PLATFORM_FLAGS "-fp-model=precise")
 endif()
 
 # A SYCL ahead-of-time (AoT) compile processes the device code in two stages.
 # 1. The "compile" stage compiles the device code to an intermediate representation (SPIR-V).
 # 2. The "link" stage invokes the compiler's FPGA backend before linking.
 #    For this reason, FPGA backend flags must be passed as link flags in CMake.
-set(EMULATOR_COMPILE_FLAGS "-fsycl -fintelfpga ${AC_TYPES_FLAG} -DFPGA_EMULATOR -Wall ${WIN_FLAG}")
-set(EMULATOR_LINK_FLAGS "-fsycl -fintelfpga ${AC_TYPES_FLAG}")
+set(EMULATOR_COMPILE_FLAGS "-fsycl -fintelfpga ${EMULATOR_PLATFORM_FLAGS} ${AC_TYPES_FLAG} -DFPGA_EMULATOR -Wall ${WIN_FLAG}")
+set(EMULATOR_LINK_FLAGS "-fsycl -fintelfpga ${EMULATOR_PLATFORM_FLAGS} ${AC_TYPES_FLAG}")
 set(SIMULATOR_COMPILE_FLAGS "-fsycl -fintelfpga ${AC_TYPES_FLAG} -DFPGA_SIMULATOR -Wall ${WIN_FLAG}")
 set(SIMULATOR_LINK_FLAGS "-fsycl -fintelfpga ${AC_TYPES_FLAG} -Xssimulation -Xsghdl -Xstarget=${FPGA_DEVICE} ${USER_HARDWARE_FLAGS}")
 set(REPORT_COMPILE_FLAGS "-fsycl -fintelfpga ${AC_TYPES_FLAG} -Wall ${WIN_FLAG} -DFPGA_REPORT")

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/ac_fixed/src/CMakeLists.txt
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/ac_fixed/src/CMakeLists.txt
@@ -19,19 +19,17 @@ endif()
 # 2. /Qactypes Include ac_types headers and link against ac_types emulation libraries
 if(WIN32)
     set(WIN_FLAG "/EHsc")
-    set(AC_TYPES_FLAG "/Qactypes")
-    set(EMULATOR_PLATFORM_FLAGS "/fp:precise")
+    set(AC_TYPES_FLAG "/Qactypes /fp:precise")
 else()
-    set(AC_TYPES_FLAG "-qactypes")
-    set(EMULATOR_PLATFORM_FLAGS "-fp-model=precise")
+    set(AC_TYPES_FLAG "-qactypes -fp-model=precise")
 endif()
 
 # A SYCL ahead-of-time (AoT) compile processes the device code in two stages.
 # 1. The "compile" stage compiles the device code to an intermediate representation (SPIR-V).
 # 2. The "link" stage invokes the compiler's FPGA backend before linking.
 #    For this reason, FPGA backend flags must be passed as link flags in CMake.
-set(EMULATOR_COMPILE_FLAGS "-fsycl -fintelfpga ${EMULATOR_PLATFORM_FLAGS} ${AC_TYPES_FLAG} -DFPGA_EMULATOR -Wall ${WIN_FLAG}")
-set(EMULATOR_LINK_FLAGS "-fsycl -fintelfpga ${EMULATOR_PLATFORM_FLAGS} ${AC_TYPES_FLAG}")
+set(EMULATOR_COMPILE_FLAGS "-fsycl -fintelfpga ${AC_TYPES_FLAG} -DFPGA_EMULATOR -Wall ${WIN_FLAG}")
+set(EMULATOR_LINK_FLAGS "-fsycl -fintelfpga ${AC_TYPES_FLAG}")
 set(SIMULATOR_COMPILE_FLAGS "-fsycl -fintelfpga ${AC_TYPES_FLAG} -DFPGA_SIMULATOR -Wall ${WIN_FLAG}")
 set(SIMULATOR_LINK_FLAGS "-fsycl -fintelfpga ${AC_TYPES_FLAG} -Xssimulation -Xsghdl -Xstarget=${FPGA_DEVICE} ${USER_HARDWARE_FLAGS}")
 set(REPORT_COMPILE_FLAGS "-fsycl -fintelfpga ${AC_TYPES_FLAG} -Wall ${WIN_FLAG} -DFPGA_REPORT")


### PR DESCRIPTION
# Existing Sample Changes
## Description

The `ac_fixed` sample breaks on emulator because the emulator default for fp model is changed to "fast-math" recently.
There's a larger gap regarding the precision between FP precise and FP fast-math (default) mode on FPGA emulator, compared with other platforms. As a result, the emulator precision cannot meet the error threshold set in the design, while the simulator precision can. 

This PR sets `-fp-model=precise`(linux) or `/fp:precise`(windows) to pass the tests on all platforms.

## Type of change

Please delete options that are not relevant. Add a 'X' to the one that is applicable. 

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Implement fixes for ONSAM Jiras

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Command Line
- [ ] oneapi-cli
- [ ] Visual Studio
- [ ] Eclipse IDE
- [ ] VSCode
- [ ] When compiling the compliler flag "-Wall -Wformat-security -Werror=format-security" was used
