### PR TITLE
FPGA: Reduce input size for `Shannonization`

### DIFF
--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/shannonization/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/shannonization/README.md
@@ -351,8 +351,8 @@ The following table explains the command-line arguments that can be passed to th
 
 | Argument name | Description               | Default
 |:---           |:---                       |:---
-|`--A`          | Set the size of array A   | 128 for emulation, 131072 for FPGA
-|`--B`          | Set the size of array B   | 256 for emulation, 262144 for FPGA
+|`--A`          | Set the size of array A   | 128 for emulation, 16384 for FPGA
+|`--B`          | Set the size of array B   | 256 for emulation, 32768 for FPGA
 |`--help`       | Print the help message    | N/A
 
 ### On Linux

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/shannonization/src/shannonization.cpp
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/shannonization/src/shannonization.cpp
@@ -191,8 +191,8 @@ int main(int argc, char** argv) {
   unsigned int a_size = 128;
   unsigned int b_size = 256;
 #else
-  unsigned int a_size = 131072;
-  unsigned int b_size = 262144;
+  unsigned int a_size = 16384;
+  unsigned int b_size = 32768;
 #endif
   bool need_help = false;
 


### PR DESCRIPTION
# Existing Sample Changes

Reduce the input size for `Shannonization` so Windows run would finish in a reasonable time.
There was not even one passed Windows run with the original input size at a time limit of 30 minutes in our full regtest history.
With this change, Windows run finishes in 3m on A10 and 5m on S10.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [ ] Command Line
- [ ] Regtest
  - Linux: https://spetc.intel.com/testanalysis?trview=0&testRunIds=7793483&tapgsize=1500&tasort=testCasePath&tasortdir=asc
  - Windows: https://spetc.intel.com/testanalysis?trview=0&testRunIds=7793461&tapgsize=1500&tasort=testCasePath&tasortdir=asc