### PR TITLE
Fixed building of monte_carlo_european_opt on Windows

### DIFF
--- a/Libraries/oneMKL/monte_carlo_european_opt/makefile
+++ b/Libraries/oneMKL/monte_carlo_european_opt/makefile
@@ -8,7 +8,7 @@ all: montecarlo
 	GENERATOR=/DUSE_PHILOX
 !endif
 
-DPCPP_OPTS=/I$(MKLROOT)\include /DMKL_ILP64 $(GENERATOR) -fsycl -fsycl-device-code-split=per_kernel -qmkl
+DPCPP_OPTS=/I"$(MKLROOT)\include" /DMKL_ILP64 $(GENERATOR) -fsycl -fsycl-device-code-split=per_kernel -qmkl
 
 montecarlo: src/montecarlo_main.cpp
 	icpx src/montecarlo_main.cpp /omontecarlo.exe $(DPCPP_OPTS)

--- a/Libraries/oneMKL/monte_carlo_european_opt/makefile
+++ b/Libraries/oneMKL/monte_carlo_european_opt/makefile
@@ -1,18 +1,12 @@
 all: montecarlo
 
-generator ?= mcg59
+!if "$(generator)" == "mrg"
+	GENERATOR=/DUSE_MRG
+!endif
 
-ifeq ($(generator), mrg)
-	GENERATOR = /DUSE_MRG
-endif
-
-ifeq ($(generator), philox)
-	GENERATOR = /DUSE_PHILOX
-endif
-
-ifneq ($(generator), $(filter $(generator),mrg philox mcg59))
- 	$(error "You use unknown generator. Please, use mrg philox or mcg59 (default)")
-endif
+!if "$(generator)" == "philox"
+	GENERATOR=/DUSE_PHILOX
+!endif
 
 DPCPP_OPTS=/I$(MKLROOT)\include /DMKL_ILP64 $(GENERATOR) -fsycl -fsycl-device-code-split=per_kernel -qmkl
 


### PR DESCRIPTION
# Existing Sample Changes
## Description

Fixed building of the `monte_carlo_european_opt` sample on Windows: refactored the makefile for Windows according to NMAKE rules.

## Type of change

Please delete options that are not relevant. Add a 'X' to the one that is applicable. 

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Implement fixes for ONSAM Jiras

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Command Line
- [ ] oneapi-cli
- [ ] Visual Studio
- [ ] Eclipse IDE
- [ ] VSCode
- [ ] When compiling the compliler flag "-Wall -Wformat-security -Werror=format-security" was used
