### PR TITLE
Removed compiler warnings for computed_tomography sample.

### DIFF
--- a/Libraries/oneMKL/computed_tomography/computed_tomography.cpp
+++ b/Libraries/oneMKL/computed_tomography/computed_tomography.cpp
@@ -140,7 +140,7 @@ int main(int argc, char **argv)
     };
 
     // create execution queue with asynchronous error handling
-    sycl::queue main_queue(sycl::device{sycl::default_selector{}}, exception_handler);
+    sycl::queue main_queue(sycl::device{sycl::default_selector_v}, exception_handler);
 
     std::cout << "Reading original image from " << original_bmpname << std::endl;
     matrix_r original_image(main_queue);


### PR DESCRIPTION
# Existing Sample Changes
## Description

Removed compiler warnings for computed_tomography sample.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [X] Command Line