### PR TITLE
Fix CI steps in vector-add and simple-add 

### DIFF
--- a/DirectProgramming/C++SYCL/DenseLinearAlgebra/simple-add/sample.json
+++ b/DirectProgramming/C++SYCL/DenseLinearAlgebra/simple-add/sample.json
@@ -114,7 +114,7 @@
         "steps": [
           "mkdir build",
           "cd build",
-          "cmake -G \"NMake Makefiles\" ..",
+          "cmake -G \"NMake Makefiles\" -DUSM=1 ..",
           "nmake fpga_emu",
           "simple-add-usm.fpga_emu.exe",
           "nmake clean"

--- a/DirectProgramming/C++SYCL/DenseLinearAlgebra/vector-add/sample.json
+++ b/DirectProgramming/C++SYCL/DenseLinearAlgebra/vector-add/sample.json
@@ -282,7 +282,7 @@
         "steps": [
           "mkdir build",
           "cd build",
-          "cmake -G \"NMake Makefiles\" ..",
+          "cmake -G \"NMake Makefiles\" -DUSM=1 ..",
           "nmake fpga_emu",
           "vector-add-usm.fpga_emu.exe",
           "nmake clean"


### PR DESCRIPTION
The Windows USM `fpga_emu` targets of these two samples where missing the `cmake` option to trigger the USM compile, resulting in a CI failure.