### PR TITLE
FPGA: Remove resolved known issues for printf

### DIFF
--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/printf/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/printf/README.md
@@ -235,8 +235,6 @@ Result11: ABCD
 
 There are some known issues with the `experimental::printf()` and that's why the function is in the experimental namespace. The following limitations exist when using `experimental::printf()` on FPGA simulation and hardware:
 
-* Printing string literals %s is not supported yet. You can put the string directly in the format as a workaround. For example: `PRINTF("Hello, World!\n")`.
-* Printing pointer address %p is not supported yet.
 * If you have multiple PRINTF statements in the kernel, the order of printed data in the stdout might not obey the sequential order of those statements in the code.
 * Buffer is only flushed to stdout after the kernel finishes in hardware.
 * Printing `long` integers in Windows results is not supported yet. Printing `long` integers in Linux works as intended.


### PR DESCRIPTION
# Existing Sample Changes
## Description
The known issues with %s and %p for printf are no longer relevant.

Fixes Issue# 

## External Dependencies.

## Type of change
Documentation change

## How Has This Been Tested?

