### PR TITLE
FPGA: fix CI steps for printf and fpga_compile

### DIFF
--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/printf/sample.json
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/printf/sample.json
@@ -29,16 +29,6 @@
           "make fpga_emu",
           "./printf.fpga_emu"
         ]
-      },
-      {
-        "id": "report",
-        "steps": [
-          "icpx --version",
-          "mkdir build",
-          "cd build",
-          "cmake ..",
-          "make report"
-        ]
       }
     ],
     "windows": [
@@ -52,17 +42,6 @@
           "cmake -G \"NMake Makefiles\" ../Tutorials/Features/printf",
           "nmake fpga_emu",
           "printf.fpga_emu.exe"
-        ]
-      },
-      {
-        "id": "report",
-        "steps": [
-          "icpx --version",
-          "cd ../../..",
-          "mkdir build",
-          "cd build",
-          "cmake -G \"NMake Makefiles\" ../Tutorials/Features/printf",
-          "nmake report"
         ]
       }
     ]

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/GettingStarted/fpga_compile/sample.json
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/GettingStarted/fpga_compile/sample.json
@@ -20,48 +20,159 @@
   "ciTests": {
     "linux": [
       {
-        "id": "fpga_emu",
+        "id": "fpga_emu_1",
         "steps": [
           "icpx --version",
           "mkdir build",
           "cd build",
-          "cmake ..",
+          "cmake ../part1_cpp",
           "make fpga_emu",
-          "./fpga_compile.fpga_emu"
+          "./vector_add.fpga_emu"
         ]
       },
       {
-        "id": "report",
+        "id": "fpga_emu_2",
         "steps": [
           "icpx --version",
           "mkdir build",
           "cd build",
-          "cmake ..",
+          "cmake ../part2_dpcpp_functor_usm",
+          "make fpga_emu",
+          "./vector_add.fpga_emu"
+        ]
+      },
+      {
+        "id": "report_2",
+        "steps": [
+          "icpx --version",
+          "mkdir build",
+          "cd build",
+          "cmake ../part2_dpcpp_functor_usm",
+          "make report"
+        ]
+      },
+      {
+        "id": "fpga_emu_3",
+        "steps": [
+          "icpx --version",
+          "mkdir build",
+          "cd build",
+          "cmake ../part3_dpcpp_lambda_usm",
+          "make fpga_emu",
+          "./vector_add.fpga_emu"
+        ]
+      },
+      {
+        "id": "report_3",
+        "steps": [
+          "icpx --version",
+          "mkdir build",
+          "cd build",
+          "cmake ../part3_dpcpp_lambda_usm",
+          "make report"
+        ]
+      },
+      {
+        "id": "fpga_emu_4",
+        "steps": [
+          "icpx --version",
+          "mkdir build",
+          "cd build",
+          "cmake ../part4_dpcpp_lambda_buffers",
+          "make fpga_emu",
+          "./vector_add.fpga_emu"
+        ]
+      },
+      {
+        "id": "report_4",
+        "steps": [
+          "icpx --version",
+          "mkdir build",
+          "cd build",
+          "cmake ../part4_dpcpp_lambda_buffers",
           "make report"
         ]
       }
     ],
     "windows": [
       {
-        "id": "fpga_emu",
+        "id": "fpga_emu_1",
         "steps": [
           "icpx --version",
           "cd ../../..",
           "mkdir build",
           "cd build",
-          "cmake -G \"NMake Makefiles\" ../Tutorials/GettingStarted/fpga_compile",
+          "cmake -G \"NMake Makefiles\" ../Tutorials/GettingStarted/fpga_compile/part1_cpp",
           "nmake fpga_emu",
-          "fpga_compile.fpga_emu.exe"
+          "vector_add.fpga_emu.exe"
         ]
       },
       {
-        "id": "report",
+        "id": "fpga_emu_2",
         "steps": [
           "icpx --version",
           "cd ../../..",
           "mkdir build",
           "cd build",
-          "cmake -G \"NMake Makefiles\" ../Tutorials/GettingStarted/fpga_compile",
+          "cmake -G \"NMake Makefiles\" ../Tutorials/GettingStarted/fpga_compile/part2_dpcpp_functor_usm",
+          "nmake fpga_emu",
+          "vector_add.fpga_emu.exe"
+        ]
+      },
+      {
+        "id": "report_2",
+        "steps": [
+          "icpx --version",
+          "cd ../../..",
+          "mkdir build",
+          "cd build",
+          "cmake -G \"NMake Makefiles\" ../Tutorials/GettingStarted/fpga_compile/part2_dpcpp_functor_usm",
+          "nmake report"
+        ]
+      },
+      {
+        "id": "fpga_emu_3",
+        "steps": [
+          "icpx --version",
+          "cd ../../..",
+          "mkdir build",
+          "cd build",
+          "cmake -G \"NMake Makefiles\" ../Tutorials/GettingStarted/fpga_compile/part3_dpcpp_lambda_usm",
+          "nmake fpga_emu",
+          "vector_add.fpga_emu.exe"
+        ]
+      },
+      {
+        "id": "report_3",
+        "steps": [
+          "icpx --version",
+          "cd ../../..",
+          "mkdir build",
+          "cd build",
+          "cmake -G \"NMake Makefiles\" ../Tutorials/GettingStarted/fpga_compile/part3_dpcpp_lambda_usm",
+          "nmake report"
+        ]
+      },
+      {
+        "id": "fpga_emu_4",
+        "steps": [
+          "icpx --version",
+          "cd ../../..",
+          "mkdir build",
+          "cd build",
+          "cmake -G \"NMake Makefiles\" ../Tutorials/GettingStarted/fpga_compile/part4_dpcpp_lambda_buffers",
+          "nmake fpga_emu",
+          "vector_add.fpga_emu.exe"
+        ]
+      },
+      {
+        "id": "report_4",
+        "steps": [
+          "icpx --version",
+          "cd ../../..",
+          "mkdir build",
+          "cd build",
+          "cmake -G \"NMake Makefiles\" ../Tutorials/GettingStarted/fpga_compile/part4_dpcpp_lambda_buffers",
           "nmake report"
         ]
       }


### PR DESCRIPTION
This PR addresses some issues in the CI steps of the following designs:
- `printf`: this sample does not support the `report` target in IP Authoring mode
- `fpga_compile`: this sample was recently significantly reworked and broke into four different part. Its `sample.json` file has not been updated in this process.