### PR TITLE
Remove the FPGA targets from the default make command in the simple-add and vector-add samples

### DIFF
--- a/DirectProgramming/C++SYCL/DenseLinearAlgebra/simple-add/src/CMakeLists.txt
+++ b/DirectProgramming/C++SYCL/DenseLinearAlgebra/simple-add/src/CMakeLists.txt
@@ -80,7 +80,7 @@ set(HARDWARE_LINK_FLAGS "-fsycl -fintelfpga -Xshardware -Xstarget=${FPGA_DEVICE}
 # CMake executes:
 #    [compile] icpx -fsycl -fintelfpga -DFPGA_EMULATOR -o <file>.cpp.o -c <file>.cpp
 #    [link]    icpx -fsycl -fintelfpga <file>.cpp.o -o <file>.fpga_emu
-add_executable(${EMULATOR_TARGET} ${SOURCE_FILE})
+add_executable(${EMULATOR_TARGET} EXCLUDE_FROM_ALL ${SOURCE_FILE})
 set_target_properties(${EMULATOR_TARGET} PROPERTIES COMPILE_FLAGS "${EMULATOR_COMPILE_FLAGS}")
 set_target_properties(${EMULATOR_TARGET} PROPERTIES LINK_FLAGS "${EMULATOR_LINK_FLAGS}")
 add_custom_target(fpga_emu DEPENDS ${EMULATOR_TARGET})
@@ -93,7 +93,7 @@ add_custom_target(fpga_emu DEPENDS ${EMULATOR_TARGET})
 # CMake executes:
 #    [compile] icpx -fsycl -fintelfpga -Xssimulation -DFPGA_SIMULATOR -o <file>.cpp.o -c <file>.cpp
 #    [link]    icpx -fsycl -fintelfpga -Xssimulation -Xsghdl -Xstarget=<FPGA_DEVICE> <file>.cpp.o -o <file>.fpga_sim
-add_executable(${SIMULATOR_TARGET} ${SOURCE_FILE})
+add_executable(${SIMULATOR_TARGET} EXCLUDE_FROM_ALL ${SOURCE_FILE})
 set_target_properties(${SIMULATOR_TARGET} PROPERTIES COMPILE_FLAGS "${SIMULATOR_COMPILE_FLAGS}")
 set_target_properties(${SIMULATOR_TARGET} PROPERTIES LINK_FLAGS "${SIMULATOR_LINK_FLAGS}")
 add_custom_target(fpga_sim DEPENDS ${SIMULATOR_TARGET})
@@ -105,7 +105,7 @@ add_custom_target(fpga_sim DEPENDS ${SIMULATOR_TARGET})
 #   icpx -fsycl -fintelfpga -Xshardware -Xstarget=<FPGA_DEVICE> -fsycl-link=early <file>.cpp -o <file>_report.a
 set(FPGA_EARLY_IMAGE ${TARGET_NAME}_report.a)
 # The compile output is not an executable, but an intermediate compilation result unique to DPC++.
-add_executable(${FPGA_EARLY_IMAGE} ${SOURCE_FILE})
+add_executable(${FPGA_EARLY_IMAGE} EXCLUDE_FROM_ALL ${SOURCE_FILE})
 add_custom_target(report DEPENDS ${FPGA_EARLY_IMAGE})
 set_target_properties(${FPGA_EARLY_IMAGE} PROPERTIES COMPILE_FLAGS "${HARDWARE_COMPILE_FLAGS}")
 set_target_properties(${FPGA_EARLY_IMAGE} PROPERTIES LINK_FLAGS "${HARDWARE_LINK_FLAGS} -fsycl-link=early")

--- a/DirectProgramming/C++SYCL/DenseLinearAlgebra/vector-add/src/CMakeLists.txt
+++ b/DirectProgramming/C++SYCL/DenseLinearAlgebra/vector-add/src/CMakeLists.txt
@@ -81,7 +81,7 @@ set(HARDWARE_LINK_FLAGS "-fsycl -fintelfpga -Xshardware -Xstarget=${FPGA_DEVICE}
 # CMake executes:
 #    [compile] icpx -fsycl -fintelfpga -DFPGA_EMULATOR -o <file>.cpp.o -c <file>.cpp
 #    [link]    icpx -fsycl -fintelfpga <file>.cpp.o -o <file>.fpga_emu
-add_executable(${EMULATOR_TARGET} ${SOURCE_FILE})
+add_executable(${EMULATOR_TARGET} EXCLUDE_FROM_ALL ${SOURCE_FILE})
 set_target_properties(${EMULATOR_TARGET} PROPERTIES COMPILE_FLAGS "${EMULATOR_COMPILE_FLAGS}")
 set_target_properties(${EMULATOR_TARGET} PROPERTIES LINK_FLAGS "${EMULATOR_LINK_FLAGS}")
 add_custom_target(fpga_emu DEPENDS ${EMULATOR_TARGET})
@@ -94,7 +94,7 @@ add_custom_target(fpga_emu DEPENDS ${EMULATOR_TARGET})
 # CMake executes:
 #    [compile] icpx -fsycl -fintelfpga -Xssimulation -DFPGA_SIMULATOR -o <file>.cpp.o -c <file>.cpp
 #    [link]    icpx -fsycl -fintelfpga -Xssimulation -Xsghdl -Xstarget=<FPGA_DEVICE> <file>.cpp.o -o <file>.fpga_sim
-add_executable(${SIMULATOR_TARGET} ${SOURCE_FILE})
+add_executable(${SIMULATOR_TARGET} EXCLUDE_FROM_ALL ${SOURCE_FILE})
 set_target_properties(${SIMULATOR_TARGET} PROPERTIES COMPILE_FLAGS "${SIMULATOR_COMPILE_FLAGS}")
 set_target_properties(${SIMULATOR_TARGET} PROPERTIES LINK_FLAGS "${SIMULATOR_LINK_FLAGS}")
 add_custom_target(fpga_sim DEPENDS ${SIMULATOR_TARGET})
@@ -106,7 +106,7 @@ add_custom_target(fpga_sim DEPENDS ${SIMULATOR_TARGET})
 #   icpx -fsycl -fintelfpga -Xshardware -Xstarget=<FPGA_DEVICE> -fsycl-link=early <file>.cpp -o <file>_report.a
 set(FPGA_EARLY_IMAGE ${TARGET_NAME}_report.a)
 # The compile output is not an executable, but an intermediate compilation result unique to DPC++.
-add_executable(${FPGA_EARLY_IMAGE} ${SOURCE_FILE})
+add_executable(${FPGA_EARLY_IMAGE} EXCLUDE_FROM_ALL ${SOURCE_FILE})
 add_custom_target(report DEPENDS ${FPGA_EARLY_IMAGE})
 set_target_properties(${FPGA_EARLY_IMAGE} PROPERTIES COMPILE_FLAGS "${HARDWARE_COMPILE_FLAGS}")
 set_target_properties(${FPGA_EARLY_IMAGE} PROPERTIES LINK_FLAGS "${HARDWARE_LINK_FLAGS} -fsycl-link=early")


### PR DESCRIPTION
The default behavior when running `make` in these two samples was to build all available targets.
This PR disables all the FPGA targets from the default `make` command, only leaving the `cpu-gpu` one. 