### PR TITLE
add report target to part1 of fpga_compile(case14019123195)

### DIFF
--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/GettingStarted/fpga_compile/part1_cpp/src/CMakeLists.txt
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/GettingStarted/fpga_compile/part1_cpp/src/CMakeLists.txt
@@ -12,12 +12,17 @@ set(EMULATOR_TARGET ${TARGET_NAME}.fpga_emu)
 add_executable(${EMULATOR_TARGET} ${SOURCE_FILE})
 add_custom_target(fpga_emu DEPENDS ${EMULATOR_TARGET})
 
-# This code sample do not support simulator and fpga. 
-# following targets are added to be compatiable with reg-tests
+# This code sample do not support simulator, report and fpga. 
+# following dummy targets are added to be compatiable with reg-tests
 set(SIMULATOR_TARGET ${TARGET_NAME}.fpga_sim)
 
 add_executable(${SIMULATOR_TARGET} ${SOURCE_FILE})
 add_custom_target(fpga_sim DEPENDS ${SIMULATOR_TARGET})
+
+set(FPGA_EARLY_IMAGE ${TARGET_NAME}_report.a)
+
+add_executable(${FPGA_EARLY_IMAGE} ${SOURCE_FILE})
+add_custom_target(report DEPENDS ${FPGA_EARLY_IMAGE})
 
 set(FPGA_TARGET ${TARGET_NAME}.fpga)
 


### PR DESCRIPTION
# Existing Sample Changes
## Description

in part 1 of fpga_compile, report target is added (don't do anything since its a c++ example). This is done to address [this case](https://hsdes.intel.com/appstore/article/#/14019123195) 

## External Dependencies

No change.

## Type of change

-  Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
### Linux regtests target emulation and report
https://spetc.intel.com/testanalysis?trview=0&testRunIds=7868167&tapgsize=20 

