### PR TITLE
Upgrade Agilex branding to Agilex 7

### DIFF
--- a/DirectProgramming/C++SYCL/DenseLinearAlgebra/simple-add/README.md
+++ b/DirectProgramming/C++SYCL/DenseLinearAlgebra/simple-add/README.md
@@ -2,7 +2,7 @@
 
 The `Simple Add` sample demonstrates the simplest programming methods for using SYCL*-compliant buffers and Unified Shared Memory (USM). Additionally, building and running this sample verifies that your development environment is configured correctly for [Intel® oneAPI Toolkits](https://www.intel.com/content/www/us/en/developer/tools/oneapi/toolkits.html).
 
-| Property            | Description 
+| Property            | Description
 |:---                 |:---
 | What you will learn | How to use SYCL*-compliant extensions to offload computations using both buffers and USM.
 | Time to complete    | 15 minutes
@@ -22,7 +22,7 @@ USM, buffer, accessor, kernel, and command groups.
 | Optimized for      | Description
 |:---                |:---
 | OS                 | Ubuntu* 18.04 <br> Windows* 10
-| Hardware           | GEN9 or newer <br> Intel® Agilex®, Arria® 10, and Stratix® 10 FPGAs
+| Hardware           | GEN9 or newer <br> Intel® Agilex® 7, Arria® 10, and Stratix® 10 FPGAs
 | Software           | Intel® oneAPI DPC++/C++ Compiler
 
 
@@ -81,7 +81,7 @@ The basic steps to build and run a sample using VS Code include:
 3. Open a terminal in VS Code (**Terminal > New Terminal**).
 4. Run the sample in the VS Code terminal using the instructions below.
 
-To learn more about the extensions and how to configure the oneAPI environment, see the 
+To learn more about the extensions and how to configure the oneAPI environment, see the
 *[Using Visual Studio Code with Intel® oneAPI Toolkits User Guide](https://www.intel.com/content/www/us/en/develop/documentation/using-vs-code-with-intel-oneapi/top.html)*.
 
 ### On Linux*
@@ -89,7 +89,7 @@ To learn more about the extensions and how to configure the oneAPI environment, 
 #### Configure the build system
 
 1. Change to the sample directory.
-2. 
+2.
    Configure the project to use the buffer-based implementation.
    ```
    mkdir build
@@ -105,25 +105,25 @@ To learn more about the extensions and how to configure the oneAPI environment, 
    cmake .. -DUSM=1
    ```
 
-   > **Note**: When building for FPGAs, the default FPGA family will be used (Intel® Agilex®).
+   > **Note**: When building for FPGAs, the default FPGA family will be used (Intel® Agilex® 7).
    > You can change the default target by using the command:
    >  ```
    >  cmake .. -DFPGA_DEVICE=<FPGA device family or FPGA part number>
-   >  ``` 
+   >  ```
    >
-   > Alternatively, you can target an explicit FPGA board variant and BSP by using the following command: 
+   > Alternatively, you can target an explicit FPGA board variant and BSP by using the following command:
    >  ```
    >  cmake .. -DFPGA_DEVICE=<board-support-package>:<board-variant>
-   >  ``` 
+   >  ```
    >
    > You will only be able to run an executable on the FPGA if you specified a BSP.
 
 #### Build for CPU and GPU
-    
+
 1. Build the program.
    ```
    make cpu-gpu
-   ```   
+   ```
 2. Clean the program. (Optional)
    ```
    make clean
@@ -161,7 +161,7 @@ time.)
 #### Configure the build system
 
 1. Change to the sample directory.
-2. 
+2.
    Configure the project to use the buffer-based implementation.
    ```
    mkdir build
@@ -177,16 +177,16 @@ time.)
    cmake -G "NMake Makefiles" .. -DUSM=1
    ```
 
-   > **Note**: When building for FPGAs, the default FPGA family will be used (Intel® Agilex®).
+   > **Note**: When building for FPGAs, the default FPGA family will be used (Intel® Agilex® 7).
    > You can change the default target by using the command:
    >  ```
    >  cmake -G "NMake Makefiles" .. -DFPGA_DEVICE=<FPGA device family or FPGA part number>
-   >  ``` 
+   >  ```
    >
-   > Alternatively, you can target an explicit FPGA board variant and BSP by using the following command: 
+   > Alternatively, you can target an explicit FPGA board variant and BSP by using the following command:
    >  ```
    >  cmake -G "NMake Makefiles" .. -DFPGA_DEVICE=<board-support-package>:<board-variant>
-   >  ``` 
+   >  ```
    >
    > You will only be able to run an executable on the FPGA if you specified a BSP.
 
@@ -321,7 +321,7 @@ qsub  -I  -l nodes=1:gpu:ppn=2 -d .
 ```
 
 - `-I` (upper case I) requests an interactive session.
-- `-l nodes=1:gpu:ppn=2` (lower case L) assigns one full GPU node. 
+- `-l nodes=1:gpu:ppn=2` (lower case L) assigns one full GPU node.
 - `-d .` makes the current folder as the working directory for the task.
 
   |Available Nodes           |Command Options

--- a/DirectProgramming/C++SYCL/DenseLinearAlgebra/simple-add/src/CMakeLists.txt
+++ b/DirectProgramming/C++SYCL/DenseLinearAlgebra/simple-add/src/CMakeLists.txt
@@ -1,5 +1,5 @@
 # Select between the USM and buffer variant of the
-# code to compile, depending on the value of USM 
+# code to compile, depending on the value of USM
 # given to cmake
 # e.g. if cmake is called with -DUSM=1, the USM
 # source code will be compiled
@@ -7,7 +7,7 @@ if(DEFINED USM AND (NOT(USM EQUAL 0)))
     message(STATUS "Using the USM variant.")
     set(SOURCE_FILE simple-add-usm.cpp)
     set(TARGET_NAME simple-add-usm)
-else()    
+else()
     set(SOURCE_FILE simple-add-buffers.cpp)
     set(TARGET_NAME simple-add-buffers)
 endif()
@@ -17,7 +17,7 @@ if(WIN32)
     set(WIN_FLAG "/EHsc")
 endif()
 
-# 
+#
 # SECTION 1
 # This section defines rules to create a cpu-gpu make target
 # This can safely be removed if your project is only targetting FPGAs
@@ -36,21 +36,21 @@ set_target_properties(${TARGET_NAME} PROPERTIES COMPILE_FLAGS "${COMPILE_FLAGS}"
 set_target_properties(${TARGET_NAME} PROPERTIES LINK_FLAGS "${LINK_FLAGS}")
 add_custom_target(cpu-gpu DEPENDS ${TARGET_NAME})
 
-# 
+#
 # End of SECTION 1
 #
 
 #
-# SECTION 2 
+# SECTION 2
 # This section defines rules to create the fpga_emu, report and fpga make targets
 # This can safely be removed if your project is only targetting CPUs/GPUs
 #
 
 # FPGA device selection
 if(NOT DEFINED FPGA_DEVICE)
-    set(FPGA_DEVICE "Agilex")
+    set(FPGA_DEVICE "Agilex7")
     message(STATUS "FPGA_DEVICE was not specified.\
-                \nConfiguring the design to target the default FPGA family (Intel Agilex®). \
+                \nConfiguring the design to target the default FPGA family (Intel Agilex® 7). \
                 \nPlease refer to the README for information on board selection.")
 else()
     message(STATUS "Configuring the design to run on FPGA device ${FPGA_DEVICE}")
@@ -124,7 +124,7 @@ add_custom_target(fpga DEPENDS ${FPGA_TARGET})
 set_target_properties(${FPGA_TARGET} PROPERTIES COMPILE_FLAGS "${HARDWARE_COMPILE_FLAGS}")
 set_target_properties(${FPGA_TARGET} PROPERTIES LINK_FLAGS "${HARDWARE_LINK_FLAGS}")
 
-# 
+#
 # End of SECTION 2
 #
 

--- a/DirectProgramming/C++SYCL/DenseLinearAlgebra/vector-add/README.md
+++ b/DirectProgramming/C++SYCL/DenseLinearAlgebra/vector-add/README.md
@@ -25,7 +25,7 @@ This sample provides example implementations of both Unified Shared Memory (USM)
 | Optimized for                     | Description
 |:---                               |:---
 | OS                                | Ubuntu* 18.04 <br> Windows* 10
-| Hardware                          | GEN9 or newer <br> Intel® Agilex®, Arria® 10, and Stratix® 10 FPGAs
+| Hardware                          | GEN9 or newer <br> Intel® Agilex® 7, Arria® 10, and Stratix® 10 FPGAs
 | Software                          | Intel® oneAPI DPC++/C++ Compiler
 
 > **Note**: Even though the Intel DPC++/C++ OneAPI compiler is enough to compile for CPU, GPU, FPGA emulation, generating FPGA reports and generating RTL for FPGAs, there are extra software requirements for the FPGA simulation flow and FPGA compiles.
@@ -80,7 +80,7 @@ The basic steps to build and run a sample using VS Code include:
 3. Open a terminal in VS Code (**Terminal > New Terminal**).
 4. Run the sample in the VS Code terminal using the instructions below.
 
-To learn more about the extensions and how to configure the oneAPI environment, see the 
+To learn more about the extensions and how to configure the oneAPI environment, see the
 [Using Visual Studio Code with Intel® oneAPI Toolkits User Guide](https://www.intel.com/content/www/us/en/develop/documentation/using-vs-code-with-intel-oneapi/top.html).
 
 ### On Linux*
@@ -88,7 +88,7 @@ To learn more about the extensions and how to configure the oneAPI environment, 
 #### Configure the build system
 
 1. Change to the sample directory.
-2. 
+2.
    Configure the project to use the buffer-based implementation.
    ```
    mkdir build
@@ -104,25 +104,25 @@ To learn more about the extensions and how to configure the oneAPI environment, 
    cmake .. -DUSM=1
    ```
 
-   > **Note**: When building for FPGAs, the default FPGA family will be used (Intel® Agilex®).
+   > **Note**: When building for FPGAs, the default FPGA family will be used (Intel® Agilex® 7).
    > You can change the default target by using the command:
    >  ```
    >  cmake .. -DFPGA_DEVICE=<FPGA device family or FPGA part number>
-   >  ``` 
+   >  ```
    >
-   > Alternatively, you can target an explicit FPGA board variant and BSP by using the following command: 
+   > Alternatively, you can target an explicit FPGA board variant and BSP by using the following command:
    >  ```
    >  cmake .. -DFPGA_DEVICE=<board-support-package>:<board-variant>
-   >  ``` 
+   >  ```
    >
    > You will only be able to run an executable on the FPGA if you specified a BSP.
 
 #### Build for CPU and GPU
-    
+
 1. Build the program.
    ```
    make cpu-gpu
-   ```   
+   ```
 2. Clean the program. (Optional)
    ```
    make clean
@@ -160,7 +160,7 @@ time.)
 #### Configure the build system
 
 1. Change to the sample directory.
-2. 
+2.
    Configure the project to use the buffer-based implementation.
    ```
    mkdir build
@@ -176,16 +176,16 @@ time.)
    cmake -G "NMake Makefiles" .. -DUSM=1
    ```
 
-   > **Note**: When building for FPGAs, the default FPGA family will be used (Intel® Agilex®).
+   > **Note**: When building for FPGAs, the default FPGA family will be used (Intel® Agilex® 7).
    > You can change the default target by using the command:
    >  ```
    >  cmake -G "NMake Makefiles" .. -DFPGA_DEVICE=<FPGA device family or FPGA part number>
-   >  ``` 
+   >  ```
    >
-   > Alternatively, you can target an explicit FPGA board variant and BSP by using the following command: 
+   > Alternatively, you can target an explicit FPGA board variant and BSP by using the following command:
    >  ```
    >  cmake -G "NMake Makefiles" .. -DFPGA_DEVICE=<board-support-package>:<board-variant>
-   >  ``` 
+   >  ```
    >
    > You will only be able to run an executable on the FPGA if you specified a BSP.
 
@@ -325,7 +325,7 @@ qsub  -I  -l nodes=1:gpu:ppn=2 -d .
 ```
 
 - `-I` (upper case I) requests an interactive session.
-- `-l nodes=1:gpu:ppn=2` (lower case L) assigns one full GPU node. 
+- `-l nodes=1:gpu:ppn=2` (lower case L) assigns one full GPU node.
 - `-d .` makes the current folder as the working directory for the task.
 
   |Available Nodes           |Command Options

--- a/DirectProgramming/C++SYCL/DenseLinearAlgebra/vector-add/src/CMakeLists.txt
+++ b/DirectProgramming/C++SYCL/DenseLinearAlgebra/vector-add/src/CMakeLists.txt
@@ -1,5 +1,5 @@
 # Select between the USM and buffer variant of the
-# code to compile, depending on the value of USM 
+# code to compile, depending on the value of USM
 # given to cmake
 # e.g. if cmake is called with -DUSM=1, the USM
 # source code will be compiled
@@ -7,7 +7,7 @@ if(DEFINED USM AND (NOT(USM EQUAL 0)))
     message(STATUS "Using the USM variant.")
     set(SOURCE_FILE vector-add-usm.cpp)
     set(TARGET_NAME vector-add-usm)
-else()    
+else()
     set(SOURCE_FILE vector-add-buffers.cpp)
     set(TARGET_NAME vector-add-buffers)
 endif()
@@ -17,7 +17,7 @@ if(WIN32)
     set(WIN_FLAG "/EHsc")
 endif()
 
-# 
+#
 # SECTION 1
 # This section defines rules to create a cpu-gpu make target
 # This can safely be removed if your project is only targetting FPGAs
@@ -36,21 +36,21 @@ set_target_properties(${TARGET_NAME} PROPERTIES COMPILE_FLAGS "${COMPILE_FLAGS}"
 set_target_properties(${TARGET_NAME} PROPERTIES LINK_FLAGS "${LINK_FLAGS}")
 add_custom_target(cpu-gpu DEPENDS ${TARGET_NAME})
 
-# 
+#
 # End of SECTION 1
 #
 
 #
-# SECTION 2 
+# SECTION 2
 # This section defines rules to create the fpga_emu, report and fpga make targets
 # This can safely be removed if your project is only targetting CPUs/GPUs
 #
 
 # FPGA device selection
 if(NOT DEFINED FPGA_DEVICE)
-    set(FPGA_DEVICE "Agilex")
+    set(FPGA_DEVICE "Agilex7")
     message(STATUS "FPGA_DEVICE was not specified.\
-                \nConfiguring the design to target the default FPGA family (Intel Agilex®). \
+                \nConfiguring the design to target the default FPGA family (Intel Agilex® 7). \
                 \nPlease refer to the README for information on board selection.")
 else()
     message(STATUS "Configuring the design to run on FPGA device ${FPGA_DEVICE}")
@@ -125,7 +125,7 @@ add_custom_target(fpga DEPENDS ${FPGA_TARGET})
 set_target_properties(${FPGA_TARGET} PROPERTIES COMPILE_FLAGS "${HARDWARE_COMPILE_FLAGS}")
 set_target_properties(${FPGA_TARGET} PROPERTIES LINK_FLAGS "${HARDWARE_LINK_FLAGS}")
 
-# 
+#
 # End of SECTION 2
 #
 

--- a/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/anr/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/anr/README.md
@@ -22,9 +22,9 @@ flowchart LR
    tier2("Tier 2: Explore the Fundamentals")
    tier3("Tier 3: Explore the Advanced Techniques")
    tier4("Tier 4: Explore the Reference Designs")
-   
+
    tier1 --> tier2 --> tier3 --> tier4
-   
+
    style tier1 fill:#0071c1,stroke:#0071c1,stroke-width:1px,color:#fff
    style tier2 fill:#0071c1,stroke:#0071c1,stroke-width:1px,color:#fff
    style tier3 fill:#0071c1,stroke:#0071c1,stroke-width:1px,color:#fff
@@ -37,7 +37,7 @@ You can also find more information about [troubleshooting build errors](/DirectP
 | Optimized for                     | Description
 |:---                               |:---
 | OS                                | Ubuntu* 18.04/20.04 <br> RHEL*/CentOS* 8 <br> SUSE* 15 <br> Windows* 10
-| Hardware                          | Intel® Agilex®, Arria® 10, and Stratix® 10 FPGAs
+| Hardware                          | Intel® Agilex 7®, Arria® 10, and Stratix® 10 FPGAs
 | Software                          | Intel® oneAPI DPC++/C++ Compiler
 
 > **Note**: Even though the Intel DPC++/C++ OneAPI compiler is enough to compile for emulation, generating reports and generating RTL, there are extra software requirements for the simulation flow and FPGA compiles.
@@ -133,8 +133,8 @@ The design uses the following generic header files.
 
 ## Build the `Adaptive Noise Reduction` Reference Design
 
-> **Note**: When working with the command-line interface (CLI), you should configure the oneAPI toolkits using environment variables. 
-> Set up your CLI environment by sourcing the `setvars` script located in the root of your oneAPI installation every time you open a new terminal window. 
+> **Note**: When working with the command-line interface (CLI), you should configure the oneAPI toolkits using environment variables.
+> Set up your CLI environment by sourcing the `setvars` script located in the root of your oneAPI installation every time you open a new terminal window.
 > This practice ensures that your compiler, libraries, and tools are ready for development.
 >
 > Linux*:
@@ -151,7 +151,7 @@ The design uses the following generic header files.
 ### On Linux*
 
 1. Change to the sample directory.
-2. Configure the build system for the Agilex® device family, which is the default.
+2. Configure the build system for the Agilex 7® device family, which is the default.
 
    ```
    mkdir build
@@ -162,12 +162,12 @@ The design uses the following generic header files.
    > **Note**: You can change the default target by using the command:
    >  ```
    >  cmake .. -DFPGA_DEVICE=<FPGA device family or FPGA part number>
-   >  ``` 
+   >  ```
    >
-   > Alternatively, you can target an explicit FPGA board variant and BSP by using the following command: 
+   > Alternatively, you can target an explicit FPGA board variant and BSP by using the following command:
    >  ```
    >  cmake .. -DFPGA_DEVICE=<board-support-package>:<board-variant> -DIS_BSP=1
-   >  ``` 
+   >  ```
    >
    > You will only be able to run an executable on the FPGA if you specified a BSP.
 
@@ -195,7 +195,7 @@ The design uses the following generic header files.
 ### On Windows*
 
 1. Change to the sample directory.
-2. Configure the build system for the Agilex® device family, which is the default.
+2. Configure the build system for the Agilex 7® device family, which is the default.
    ```
    mkdir build
    cd build
@@ -205,12 +205,12 @@ The design uses the following generic header files.
    > **Note**: You can change the default target by using the command:
    >  ```
    >  cmake -G "NMake Makefiles" .. -DFPGA_DEVICE=<FPGA device family or FPGA part number>
-   >  ``` 
+   >  ```
    >
-   > Alternatively, you can target an explicit FPGA board variant and BSP by using the following command: 
+   > Alternatively, you can target an explicit FPGA board variant and BSP by using the following command:
    >  ```
    >  cmake -G "NMake Makefiles" .. -DFPGA_DEVICE=<board-support-package>:<board-variant> -DIS_BSP=1
-   >  ``` 
+   >  ```
    >
    > You will only be able to run an executable on the FPGA if you specified a BSP.
 

--- a/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/anr/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/anr/README.md
@@ -37,7 +37,7 @@ You can also find more information about [troubleshooting build errors](/DirectP
 | Optimized for                     | Description
 |:---                               |:---
 | OS                                | Ubuntu* 18.04/20.04 <br> RHEL*/CentOS* 8 <br> SUSE* 15 <br> Windows* 10
-| Hardware                          | Intel® Agilex 7®, Arria® 10, and Stratix® 10 FPGAs
+| Hardware                          | Intel® Agilex® 7, Arria® 10, and Stratix® 10 FPGAs
 | Software                          | Intel® oneAPI DPC++/C++ Compiler
 
 > **Note**: Even though the Intel DPC++/C++ OneAPI compiler is enough to compile for emulation, generating reports and generating RTL, there are extra software requirements for the simulation flow and FPGA compiles.
@@ -151,7 +151,7 @@ The design uses the following generic header files.
 ### On Linux*
 
 1. Change to the sample directory.
-2. Configure the build system for the Agilex 7® device family, which is the default.
+2. Configure the build system for the Agilex® 7 device family, which is the default.
 
    ```
    mkdir build
@@ -195,7 +195,7 @@ The design uses the following generic header files.
 ### On Windows*
 
 1. Change to the sample directory.
-2. Configure the build system for the Agilex 7® device family, which is the default.
+2. Configure the build system for the Agilex® 7 device family, which is the default.
    ```
    mkdir build
    cd build

--- a/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/anr/src/CMakeLists.txt
+++ b/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/anr/src/CMakeLists.txt
@@ -6,8 +6,8 @@ set(FPGA_TARGET ${TARGET_NAME}.fpga)
 
 # FPGA board selection
 if(NOT DEFINED FPGA_DEVICE)
-    set(FPGA_DEVICE "Agilex")
-    set(DEVICE_FLAG "Agilex")
+    set(FPGA_DEVICE "Agilex 7")
+    set(DEVICE_FLAG "Agilex 7")
     message(STATUS "FPGA_DEVICE was not specified.\
                     \nConfiguring the design to the default FPGA family: ${FPGA_DEVICE}\
                     \nPlease refer to the README for information on target selection.")
@@ -20,7 +20,7 @@ else()
     elseif(FPGA_DEVICE_NAME MATCHES ".*s10.*" OR FPGA_DEVICE_NAME MATCHES ".*stratix10.*")
       set(DEVICE_FLAG "S10")
     elseif(FPGA_DEVICE_NAME MATCHES ".*agilex.*")
-      set(DEVICE_FLAG "Agilex")
+      set(DEVICE_FLAG "Agilex 7")
     endif()
     message(STATUS "Configuring the design with the following target: ${FPGA_DEVICE}")
 
@@ -37,7 +37,7 @@ endif()
 if(NOT DEFINED DEVICE_FLAG)
     message(FATAL_ERROR "An unrecognized or custom board was passed, but DEVICE_FLAG was not specified. \
                          Please make sure you have set -DDEVICE_FLAG=A10, -DDEVICE_FLAG=S10 or \
-                         -DDEVICE_FLAG=Agilex.")
+                         -DDEVICE_FLAG=Agilex 7.")
 endif()
 
 # These are Windows-specific flags:
@@ -76,7 +76,7 @@ if(NOT DEFINED SEED)
     set(SEED 1)
   elseif(DEVICE_FLAG MATCHES "S10")
     set(SEED 2)
-  elseif(DEVICE_FLAG MATCHES "Agilex")
+  elseif(DEVICE_FLAG MATCHES "Agilex 7")
     set(SEED 3)
   else()
     set(SEED 4)
@@ -109,7 +109,7 @@ else()
     set(PIXELS_PER_CYCLE 2)
   elseif(DEVICE_FLAG MATCHES "S10")
     set(PIXELS_PER_CYCLE 2)
-  elseif(DEVICE_FLAG MATCHES "Agilex")
+  elseif(DEVICE_FLAG MATCHES "Agilex 7")
     set(PIXELS_PER_CYCLE 1)
   else()
     message(WARNING "Unknown board: setting PIXELS_PER_CYCLE to 1")

--- a/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/anr/src/CMakeLists.txt
+++ b/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/anr/src/CMakeLists.txt
@@ -6,8 +6,8 @@ set(FPGA_TARGET ${TARGET_NAME}.fpga)
 
 # FPGA board selection
 if(NOT DEFINED FPGA_DEVICE)
-    set(FPGA_DEVICE "Agilex 7")
-    set(DEVICE_FLAG "Agilex 7")
+    set(FPGA_DEVICE "Agilex7")
+    set(DEVICE_FLAG "Agilex7")
     message(STATUS "FPGA_DEVICE was not specified.\
                     \nConfiguring the design to the default FPGA family: ${FPGA_DEVICE}\
                     \nPlease refer to the README for information on target selection.")
@@ -20,7 +20,7 @@ else()
     elseif(FPGA_DEVICE_NAME MATCHES ".*s10.*" OR FPGA_DEVICE_NAME MATCHES ".*stratix10.*")
       set(DEVICE_FLAG "S10")
     elseif(FPGA_DEVICE_NAME MATCHES ".*agilex.*")
-      set(DEVICE_FLAG "Agilex 7")
+      set(DEVICE_FLAG "Agilex7")
     endif()
     message(STATUS "Configuring the design with the following target: ${FPGA_DEVICE}")
 
@@ -37,7 +37,7 @@ endif()
 if(NOT DEFINED DEVICE_FLAG)
     message(FATAL_ERROR "An unrecognized or custom board was passed, but DEVICE_FLAG was not specified. \
                          Please make sure you have set -DDEVICE_FLAG=A10, -DDEVICE_FLAG=S10 or \
-                         -DDEVICE_FLAG=Agilex 7.")
+                         -DDEVICE_FLAG=Agilex7.")
 endif()
 
 # These are Windows-specific flags:
@@ -76,7 +76,7 @@ if(NOT DEFINED SEED)
     set(SEED 1)
   elseif(DEVICE_FLAG MATCHES "S10")
     set(SEED 2)
-  elseif(DEVICE_FLAG MATCHES "Agilex 7")
+  elseif(DEVICE_FLAG MATCHES "Agilex7")
     set(SEED 3)
   else()
     set(SEED 4)
@@ -109,7 +109,7 @@ else()
     set(PIXELS_PER_CYCLE 2)
   elseif(DEVICE_FLAG MATCHES "S10")
     set(PIXELS_PER_CYCLE 2)
-  elseif(DEVICE_FLAG MATCHES "Agilex 7")
+  elseif(DEVICE_FLAG MATCHES "Agilex7")
     set(PIXELS_PER_CYCLE 1)
   else()
     message(WARNING "Unknown board: setting PIXELS_PER_CYCLE to 1")

--- a/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/board_test/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/board_test/README.md
@@ -40,7 +40,7 @@ You can also find more information about [troubleshooting build errors](/DirectP
 | Optimized for           | Description
 |:---                     |:---
 | OS                      | Ubuntu* 18.04/20.04 <br> RHEL*/CentOS* 8 <br> SUSE* 15 <br> Windows* 10
-| Hardware                | Intel® Agilex®, Arria® 10, and Stratix® 10 FPGAs
+| Hardware                | Intel® Agilex 7®, Arria® 10, and Stratix® 10 FPGAs
 | Software                | Intel® oneAPI DPC++/C++ Compiler
 
 > **Note**: Even though the Intel DPC++/C++ OneAPI compiler is enough to compile for emulation, generating reports and generating RTL, there are extra software requirements for the simulation flow and FPGA compiles.
@@ -122,7 +122,7 @@ Performance results are based on testing as of Jan 31, 2022.
 ### On Linux*
 
 1. Change to the sample directory.
-2. Configure the build system for the Agilex® device family, which is the default.
+2. Configure the build system for the Agilex 7® device family, which is the default.
 
    ```
    mkdir build
@@ -162,7 +162,7 @@ Performance results are based on testing as of Jan 31, 2022.
 ### On Windows*
 
 1. Change to the sample directory.
-2. Configure the build system for the Agilex® device family, which is the default.
+2. Configure the build system for the Agilex 7® device family, which is the default.
    ```
    mkdir build
    cd build

--- a/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/board_test/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/board_test/README.md
@@ -40,7 +40,7 @@ You can also find more information about [troubleshooting build errors](/DirectP
 | Optimized for           | Description
 |:---                     |:---
 | OS                      | Ubuntu* 18.04/20.04 <br> RHEL*/CentOS* 8 <br> SUSE* 15 <br> Windows* 10
-| Hardware                | Intel® Agilex 7®, Arria® 10, and Stratix® 10 FPGAs
+| Hardware                | Intel® Agilex® 7, Arria® 10, and Stratix® 10 FPGAs
 | Software                | Intel® oneAPI DPC++/C++ Compiler
 
 > **Note**: Even though the Intel DPC++/C++ OneAPI compiler is enough to compile for emulation, generating reports and generating RTL, there are extra software requirements for the simulation flow and FPGA compiles.
@@ -122,7 +122,7 @@ Performance results are based on testing as of Jan 31, 2022.
 ### On Linux*
 
 1. Change to the sample directory.
-2. Configure the build system for the Agilex 7® device family, which is the default.
+2. Configure the build system for the Agilex® 7 device family, which is the default.
 
    ```
    mkdir build
@@ -162,7 +162,7 @@ Performance results are based on testing as of Jan 31, 2022.
 ### On Windows*
 
 1. Change to the sample directory.
-2. Configure the build system for the Agilex 7® device family, which is the default.
+2. Configure the build system for the Agilex® 7 device family, which is the default.
    ```
    mkdir build
    cd build

--- a/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/board_test/src/CMakeLists.txt
+++ b/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/board_test/src/CMakeLists.txt
@@ -9,7 +9,7 @@ set(FPGA_EARLY_IMAGE ${TARGET_NAME}_report.a)
 
 # FPGA board selection
 if(NOT DEFINED FPGA_DEVICE)
-    set(FPGA_DEVICE "Agilex 7")
+    set(FPGA_DEVICE "Agilex7")
     message(STATUS "FPGA_DEVICE was not specified.\
                     \nConfiguring the design to the default FPGA family: ${FPGA_DEVICE}\
                     \nPlease refer to the README for information on target selection.")

--- a/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/board_test/src/CMakeLists.txt
+++ b/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/board_test/src/CMakeLists.txt
@@ -9,7 +9,7 @@ set(FPGA_EARLY_IMAGE ${TARGET_NAME}_report.a)
 
 # FPGA board selection
 if(NOT DEFINED FPGA_DEVICE)
-    set(FPGA_DEVICE "Agilex")
+    set(FPGA_DEVICE "Agilex 7")
     message(STATUS "FPGA_DEVICE was not specified.\
                     \nConfiguring the design to the default FPGA family: ${FPGA_DEVICE}\
                     \nPlease refer to the README for information on target selection.")
@@ -38,7 +38,7 @@ endif()
 set(EMULATOR_COMPILE_FLAGS "-fsycl -fintelfpga ${PLATFORM_SPECIFIC_COMPILE_FLAGS} -DFPGA_EMULATOR -Wformat-security -Werror=format-security -Wall")
 set(EMULATOR_LINK_FLAGS "-fsycl -fintelfpga ${PLATFORM_SPECIFIC_LINK_FLAGS}")
 set(HARDWARE_COMPILE_FLAGS "-fsycl -fintelfpga ${PLATFORM_SPECIFIC_COMPILE_FLAGS} -DFPGA_HARDWARE")
-# By default oneAPI compiler burst interleaves across same memory type, 
+# By default oneAPI compiler burst interleaves across same memory type,
 # -Xsno-interleaving is used to disable burst interleaving and test each memory bank independently
 # Refer to https://www.intel.com/content/www/us/en/develop/documentation/oneapi-fpga-optimization-guide/top/flags-attr-prag-ext/optimization-flags/disabl-burst-int.html for more information
 set(HARDWARE_LINK_FLAGS "-fsycl -fintelfpga ${PLATFORM_SPECIFIC_LINK_FLAGS} -Xshardware -Xsno-interleaving=default -Xstarget=${FPGA_DEVICE} ${USER_HARDWARE_FLAGS}")

--- a/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/cholesky/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/cholesky/README.md
@@ -44,7 +44,7 @@ You can also find more information about [troubleshooting build errors](/DirectP
 | Optimized for      | Description
 |:---                |:---
 | OS                 | Ubuntu* 18.04/20.04 <br> RHEL*/CentOS* 8 <br> SUSE* 15 <br> Windows* 10
-| Hardware           | Intel® Agilex 7®, Arria® 10, and Stratix® 10 FPGAs
+| Hardware           | Intel® Agilex® 7, Arria® 10, and Stratix® 10 FPGAs
 | Software           | Intel® oneAPI DPC++/C++ Compiler
 
 > **Note**: Even though the Intel DPC++/C++ OneAPI compiler is enough to compile for emulation, generating reports and generating RTL, there are extra software requirements for the simulation flow and FPGA compiles.
@@ -143,7 +143,7 @@ For `constexpr_math.hpp`, `memory_utils.hpp`, `metaprogramming_utils.hpp`, and `
 ### On Linux*
 
 1. Change to the sample directory.
-2. Configure the build system for the Agilex 7® device family, which is the default.
+2. Configure the build system for the Agilex® 7 device family, which is the default.
 
    ```
    mkdir build
@@ -187,7 +187,7 @@ For `constexpr_math.hpp`, `memory_utils.hpp`, `metaprogramming_utils.hpp`, and `
 ### On Windows*
 
 1. Change to the sample directory.
-2. Configure the build system for the Agilex 7® device family, which is the default.
+2. Configure the build system for the Agilex® 7 device family, which is the default.
    ```
    mkdir build
    cd build

--- a/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/cholesky/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/cholesky/README.md
@@ -29,9 +29,9 @@ flowchart LR
    tier2("Tier 2: Explore the Fundamentals")
    tier3("Tier 3: Explore the Advanced Techniques")
    tier4("Tier 4: Explore the Reference Designs")
-   
+
    tier1 --> tier2 --> tier3 --> tier4
-   
+
    style tier1 fill:#0071c1,stroke:#0071c1,stroke-width:1px,color:#fff
    style tier2 fill:#0071c1,stroke:#0071c1,stroke-width:1px,color:#fff
    style tier3 fill:#0071c1,stroke:#0071c1,stroke-width:1px,color:#fff
@@ -44,7 +44,7 @@ You can also find more information about [troubleshooting build errors](/DirectP
 | Optimized for      | Description
 |:---                |:---
 | OS                 | Ubuntu* 18.04/20.04 <br> RHEL*/CentOS* 8 <br> SUSE* 15 <br> Windows* 10
-| Hardware           | Intel® Agilex®, Arria® 10, and Stratix® 10 FPGAs
+| Hardware           | Intel® Agilex 7®, Arria® 10, and Stratix® 10 FPGAs
 | Software           | Intel® oneAPI DPC++/C++ Compiler
 
 > **Note**: Even though the Intel DPC++/C++ OneAPI compiler is enough to compile for emulation, generating reports and generating RTL, there are extra software requirements for the simulation flow and FPGA compiles.
@@ -125,8 +125,8 @@ For `constexpr_math.hpp`, `memory_utils.hpp`, `metaprogramming_utils.hpp`, and `
 
 ## Build the `Cholesky Decomposition` Reference Design
 
-> **Note**: When working with the command-line interface (CLI), you should configure the oneAPI toolkits using environment variables. 
-> Set up your CLI environment by sourcing the `setvars` script located in the root of your oneAPI installation every time you open a new terminal window. 
+> **Note**: When working with the command-line interface (CLI), you should configure the oneAPI toolkits using environment variables.
+> Set up your CLI environment by sourcing the `setvars` script located in the root of your oneAPI installation every time you open a new terminal window.
 > This practice ensures that your compiler, libraries, and tools are ready for development.
 >
 > Linux*:
@@ -143,7 +143,7 @@ For `constexpr_math.hpp`, `memory_utils.hpp`, `metaprogramming_utils.hpp`, and `
 ### On Linux*
 
 1. Change to the sample directory.
-2. Configure the build system for the Agilex® device family, which is the default.
+2. Configure the build system for the Agilex 7® device family, which is the default.
 
    ```
    mkdir build
@@ -154,12 +154,12 @@ For `constexpr_math.hpp`, `memory_utils.hpp`, `metaprogramming_utils.hpp`, and `
    > **Note**: You can change the default target by using the command:
    >  ```
    >  cmake .. -DFPGA_DEVICE=<FPGA device family or FPGA part number>
-   >  ``` 
+   >  ```
    >
-   > Alternatively, you can target an explicit FPGA board variant and BSP by using the following command: 
+   > Alternatively, you can target an explicit FPGA board variant and BSP by using the following command:
    >  ```
    >  cmake .. -DFPGA_DEVICE=<board-support-package>:<board-variant> -DIS_BSP=1
-   >  ``` 
+   >  ```
    >
    > You will only be able to run an executable on the FPGA if you specified a BSP.
 
@@ -187,7 +187,7 @@ For `constexpr_math.hpp`, `memory_utils.hpp`, `metaprogramming_utils.hpp`, and `
 ### On Windows*
 
 1. Change to the sample directory.
-2. Configure the build system for the Agilex® device family, which is the default.
+2. Configure the build system for the Agilex 7® device family, which is the default.
    ```
    mkdir build
    cd build
@@ -197,12 +197,12 @@ For `constexpr_math.hpp`, `memory_utils.hpp`, `metaprogramming_utils.hpp`, and `
    > **Note**: You can change the default target by using the command:
    >  ```
    >  cmake -G "NMake Makefiles" .. -DFPGA_DEVICE=<FPGA device family or FPGA part number>
-   >  ``` 
+   >  ```
    >
-   > Alternatively, you can target an explicit FPGA board variant and BSP by using the following command: 
+   > Alternatively, you can target an explicit FPGA board variant and BSP by using the following command:
    >  ```
    >  cmake -G "NMake Makefiles" .. -DFPGA_DEVICE=<board-support-package>:<board-variant> -DIS_BSP=1
-   >  ``` 
+   >  ```
    >
    > You will only be able to run an executable on the FPGA if you specified a BSP.
 
@@ -279,7 +279,7 @@ These examples show output when running decomposition of 8 matrices 819,200 time
 
 ```
 Device name: pac_a10 : Intel PAC Platform (pac_f100000)
-Generating 8 random real matrices of size 32x32 
+Generating 8 random real matrices of size 32x32
 Computing the Cholesky decomposition of 8 matrices 819200 times
    Total duration:   29.6193 s
 Throughput: 221.261k matrices/s
@@ -292,7 +292,7 @@ PASSED
 
 ```
 Device name: pac_s10 : Intel PAC Platform (pac_f100000)
-Generating 8 random real matrices of size 32x32 
+Generating 8 random real matrices of size 32x32
 Computing the Cholesky decomposition of 8 matrices 819200 times
    Total duration:   30.58 s
 Throughput: 214.31k matrices/s

--- a/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/cholesky/src/CMakeLists.txt
+++ b/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/cholesky/src/CMakeLists.txt
@@ -54,7 +54,7 @@ elseif(DEVICE_FLAG MATCHES "S10")
     set(CLOCK_TARGET 450MHz)
     set(SEED "-Xsseed=5")
 elseif(DEVICE_FLAG MATCHES "Agilex7")
-    # Agilex7™ parameters
+    # Agilex 7 parameters
     set(MATRIX_DIMENSION 32)
     set(FIXED_ITERATIONS 45)
     set(COMPLEX 0)

--- a/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/cholesky/src/CMakeLists.txt
+++ b/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/cholesky/src/CMakeLists.txt
@@ -7,8 +7,8 @@ set(FPGA_EARLY_IMAGE ${TARGET_NAME}_report.a)
 
 # FPGA board selection
 if(NOT DEFINED FPGA_DEVICE)
-    set(FPGA_DEVICE "Agilex")
-    set(DEVICE_FLAG "Agilex")
+    set(FPGA_DEVICE "Agilex 7")
+    set(DEVICE_FLAG "Agilex 7")
     message(STATUS "FPGA_DEVICE was not specified.\
                     \nConfiguring the design to the default FPGA family: ${FPGA_DEVICE}\
                     \nPlease refer to the README for information on target selection.")
@@ -20,7 +20,7 @@ else()
     elseif(FPGA_DEVICE_NAME MATCHES ".*s10.*" OR FPGA_DEVICE_NAME MATCHES ".*stratix10.*")
       set(DEVICE_FLAG "S10")
     elseif(FPGA_DEVICE_NAME MATCHES ".*agilex.*")
-      set(DEVICE_FLAG "Agilex")
+      set(DEVICE_FLAG "Agilex 7")
     endif()
     message(STATUS "Configuring the design with the following target: ${FPGA_DEVICE}")
 
@@ -36,7 +36,7 @@ endif()
 
 if(NOT DEFINED DEVICE_FLAG)
     message(FATAL_ERROR "An unrecognized or custom board was passed, but DEVICE_FLAG was not specified. \
-                         Make sure you have set -DDEVICE_FLAG=A10, -DDEVICE_FLAG=S10 or -DDEVICE_FLAG=Agilex.")
+                         Make sure you have set -DDEVICE_FLAG=A10, -DDEVICE_FLAG=S10 or -DDEVICE_FLAG=Agilex 7.")
 endif()
 
 if(DEVICE_FLAG MATCHES "A10")
@@ -53,15 +53,15 @@ elseif(DEVICE_FLAG MATCHES "S10")
     set(FIXED_ITERATIONS 44)
     set(CLOCK_TARGET 450MHz)
     set(SEED "-Xsseed=5")
-elseif(DEVICE_FLAG MATCHES "Agilex")
-    # Agilex™ parameters
+elseif(DEVICE_FLAG MATCHES "Agilex 7")
+    # Agilex 7™ parameters
     set(MATRIX_DIMENSION 32)
     set(FIXED_ITERATIONS 45)
     set(COMPLEX 0)
     set(CLOCK_TARGET 520MHz)
     set(SEED "-Xsseed=5")
 else()
-    message(FATAL_ERROR "An incorrect DEVICE_FLAG was given. Make sure you have set -DDEVICE_FLAG=A10, -DDEVICE_FLAG=S10 or -DDEVICE_FLAG=Agilex.")
+    message(FATAL_ERROR "An incorrect DEVICE_FLAG was given. Make sure you have set -DDEVICE_FLAG=A10, -DDEVICE_FLAG=S10 or -DDEVICE_FLAG=Agilex 7.")
 endif()
 
 # This is a Windows-specific flag that enables error handling in host code

--- a/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/cholesky/src/CMakeLists.txt
+++ b/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/cholesky/src/CMakeLists.txt
@@ -7,8 +7,8 @@ set(FPGA_EARLY_IMAGE ${TARGET_NAME}_report.a)
 
 # FPGA board selection
 if(NOT DEFINED FPGA_DEVICE)
-    set(FPGA_DEVICE "Agilex 7")
-    set(DEVICE_FLAG "Agilex 7")
+    set(FPGA_DEVICE "Agilex7")
+    set(DEVICE_FLAG "Agilex7")
     message(STATUS "FPGA_DEVICE was not specified.\
                     \nConfiguring the design to the default FPGA family: ${FPGA_DEVICE}\
                     \nPlease refer to the README for information on target selection.")
@@ -20,7 +20,7 @@ else()
     elseif(FPGA_DEVICE_NAME MATCHES ".*s10.*" OR FPGA_DEVICE_NAME MATCHES ".*stratix10.*")
       set(DEVICE_FLAG "S10")
     elseif(FPGA_DEVICE_NAME MATCHES ".*agilex.*")
-      set(DEVICE_FLAG "Agilex 7")
+      set(DEVICE_FLAG "Agilex7")
     endif()
     message(STATUS "Configuring the design with the following target: ${FPGA_DEVICE}")
 
@@ -36,7 +36,7 @@ endif()
 
 if(NOT DEFINED DEVICE_FLAG)
     message(FATAL_ERROR "An unrecognized or custom board was passed, but DEVICE_FLAG was not specified. \
-                         Make sure you have set -DDEVICE_FLAG=A10, -DDEVICE_FLAG=S10 or -DDEVICE_FLAG=Agilex 7.")
+                         Make sure you have set -DDEVICE_FLAG=A10, -DDEVICE_FLAG=S10 or -DDEVICE_FLAG=Agilex7.")
 endif()
 
 if(DEVICE_FLAG MATCHES "A10")
@@ -53,15 +53,15 @@ elseif(DEVICE_FLAG MATCHES "S10")
     set(FIXED_ITERATIONS 44)
     set(CLOCK_TARGET 450MHz)
     set(SEED "-Xsseed=5")
-elseif(DEVICE_FLAG MATCHES "Agilex 7")
-    # Agilex 7™ parameters
+elseif(DEVICE_FLAG MATCHES "Agilex7")
+    # Agilex7™ parameters
     set(MATRIX_DIMENSION 32)
     set(FIXED_ITERATIONS 45)
     set(COMPLEX 0)
     set(CLOCK_TARGET 520MHz)
     set(SEED "-Xsseed=5")
 else()
-    message(FATAL_ERROR "An incorrect DEVICE_FLAG was given. Make sure you have set -DDEVICE_FLAG=A10, -DDEVICE_FLAG=S10 or -DDEVICE_FLAG=Agilex 7.")
+    message(FATAL_ERROR "An incorrect DEVICE_FLAG was given. Make sure you have set -DDEVICE_FLAG=A10, -DDEVICE_FLAG=S10 or -DDEVICE_FLAG=Agilex7.")
 endif()
 
 # This is a Windows-specific flag that enables error handling in host code

--- a/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/cholesky_inversion/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/cholesky_inversion/README.md
@@ -57,7 +57,7 @@ You can also find more information about [troubleshooting build errors](/DirectP
 | Optimized for        | Description
 |:---                  |:---
 | OS                   | Ubuntu* 18.04/20.04 <br> RHEL*/CentOS* 8 <br> SUSE* 15 <br> Windows* 10
-| Hardware             | Intel® Agilex 7®, Arria® 10, and Stratix® 10 FPGAs
+| Hardware             | Intel® Agilex® 7, Arria® 10, and Stratix® 10 FPGAs
 | Software             | Intel® oneAPI DPC++/C++ Compiler
 
 > **Note**: Even though the Intel DPC++/C++ OneAPI compiler is enough to compile for emulation, generating reports and generating RTL, there are extra software requirements for the simulation flow and FPGA compiles.
@@ -165,7 +165,7 @@ Additionaly, the cmake build system can be configured using the following parame
 ### On Linux*
 
 1. Change to the sample directory.
-2. Configure the build system for the Agilex 7® device family, which is the default.
+2. Configure the build system for the Agilex® 7 device family, which is the default.
 
    ```
    mkdir build
@@ -209,7 +209,7 @@ Additionaly, the cmake build system can be configured using the following parame
 ### On Windows*
 
 1. Change to the sample directory.
-2. Configure the build system for the Agilex 7® device family, which is the default.
+2. Configure the build system for the Agilex® 7 device family, which is the default.
    ```
    mkdir build
    cd build

--- a/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/cholesky_inversion/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/cholesky_inversion/README.md
@@ -3,7 +3,7 @@
 This `Cholesky-based Matrix Inversion` sample is a reference design that demonstrates the use of Cholesky decomposition and inversion header libraries on 32x32 real matrices:
 
 - `streaming_cholesky.hpp` - linear algebra header library implements the Cholesky decomposition of matrices with pipe interfaces.
-- `streaming_cholesky_inversion.hpp` - linear algebra header library implements the inversion of matrices with pipe interfaces, based on the outputs of the cholesky decomposition implemented in `streaming_cholesky.hpp`. 
+- `streaming_cholesky_inversion.hpp` - linear algebra header library implements the inversion of matrices with pipe interfaces, based on the outputs of the cholesky decomposition implemented in `streaming_cholesky.hpp`.
 
 Both the decomposition and the inversion have template parameters that can be set to decompose/invert custom sized real or complex square matrices.
 
@@ -42,9 +42,9 @@ flowchart LR
    tier2("Tier 2: Explore the Fundamentals")
    tier3("Tier 3: Explore the Advanced Techniques")
    tier4("Tier 4: Explore the Reference Designs")
-   
+
    tier1 --> tier2 --> tier3 --> tier4
-   
+
    style tier1 fill:#0071c1,stroke:#0071c1,stroke-width:1px,color:#fff
    style tier2 fill:#0071c1,stroke:#0071c1,stroke-width:1px,color:#fff
    style tier3 fill:#0071c1,stroke:#0071c1,stroke-width:1px,color:#fff
@@ -57,7 +57,7 @@ You can also find more information about [troubleshooting build errors](/DirectP
 | Optimized for        | Description
 |:---                  |:---
 | OS                   | Ubuntu* 18.04/20.04 <br> RHEL*/CentOS* 8 <br> SUSE* 15 <br> Windows* 10
-| Hardware             | Intel® Agilex®, Arria® 10, and Stratix® 10 FPGAs
+| Hardware             | Intel® Agilex 7®, Arria® 10, and Stratix® 10 FPGAs
 | Software             | Intel® oneAPI DPC++/C++ Compiler
 
 > **Note**: Even though the Intel DPC++/C++ OneAPI compiler is enough to compile for emulation, generating reports and generating RTL, there are extra software requirements for the simulation flow and FPGA compiles.
@@ -115,7 +115,7 @@ The design uses the following key optimization techniques:
 
 ### Source Code Breakdown
 
-The following source files can be found in the `src/` sub-directory. 
+The following source files can be found in the `src/` sub-directory.
 
 | File                                | Description
 |:---                                 |:---
@@ -147,8 +147,8 @@ Additionaly, the cmake build system can be configured using the following parame
 
 ## Build the `Cholesky-based Matrix Inversion` Program
 
-> **Note**: When working with the command-line interface (CLI), you should configure the oneAPI toolkits using environment variables. 
-> Set up your CLI environment by sourcing the `setvars` script located in the root of your oneAPI installation every time you open a new terminal window. 
+> **Note**: When working with the command-line interface (CLI), you should configure the oneAPI toolkits using environment variables.
+> Set up your CLI environment by sourcing the `setvars` script located in the root of your oneAPI installation every time you open a new terminal window.
 > This practice ensures that your compiler, libraries, and tools are ready for development.
 >
 > Linux*:
@@ -165,7 +165,7 @@ Additionaly, the cmake build system can be configured using the following parame
 ### On Linux*
 
 1. Change to the sample directory.
-2. Configure the build system for the Agilex® device family, which is the default.
+2. Configure the build system for the Agilex 7® device family, which is the default.
 
    ```
    mkdir build
@@ -176,12 +176,12 @@ Additionaly, the cmake build system can be configured using the following parame
    > **Note**: You can change the default target by using the command:
    >  ```
    >  cmake .. -DFPGA_DEVICE=<FPGA device family or FPGA part number>
-   >  ``` 
+   >  ```
    >
-   > Alternatively, you can target an explicit FPGA board variant and BSP by using the following command: 
+   > Alternatively, you can target an explicit FPGA board variant and BSP by using the following command:
    >  ```
    >  cmake .. -DFPGA_DEVICE=<board-support-package>:<board-variant> -DIS_BSP=1
-   >  ``` 
+   >  ```
    >
    > You will only be able to run an executable on the FPGA if you specified a BSP.
 
@@ -209,7 +209,7 @@ Additionaly, the cmake build system can be configured using the following parame
 ### On Windows*
 
 1. Change to the sample directory.
-2. Configure the build system for the Agilex® device family, which is the default.
+2. Configure the build system for the Agilex 7® device family, which is the default.
    ```
    mkdir build
    cd build
@@ -219,12 +219,12 @@ Additionaly, the cmake build system can be configured using the following parame
    > **Note**: You can change the default target by using the command:
    >  ```
    >  cmake -G "NMake Makefiles" .. -DFPGA_DEVICE=<FPGA device family or FPGA part number>
-   >  ``` 
+   >  ```
    >
-   > Alternatively, you can target an explicit FPGA board variant and BSP by using the following command: 
+   > Alternatively, you can target an explicit FPGA board variant and BSP by using the following command:
    >  ```
    >  cmake -G "NMake Makefiles" .. -DFPGA_DEVICE=<board-support-package>:<board-variant> -DIS_BSP=1
-   >  ``` 
+   >  ```
    >
    > You will only be able to run an executable on the FPGA if you specified a BSP.
 
@@ -315,7 +315,7 @@ PASSED
 ### Intel® FPGA PAC D5005 (with Intel Stratix® 10 SX)
 ```
 Device name: pac_s10 : Intel PAC Platform (pac_f100000)
-Generating 8 random real matrices of size 32x32 
+Generating 8 random real matrices of size 32x32
 Computing the Cholesky-based inversion of 8 matrices 819200 times
  Total duration:   25.694 s
 Throughput: 255.063k matrices/s

--- a/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/cholesky_inversion/src/CMakeLists.txt
+++ b/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/cholesky_inversion/src/CMakeLists.txt
@@ -67,7 +67,7 @@ elseif(DEVICE_FLAG MATCHES "S10")
     set(CLOCK_TARGET 450MHz)
     set(SEED "-Xsseed=5")
 elseif(DEVICE_FLAG MATCHES "Agilex7")
-    # Agilex7™ parameters
+    # Agilex 7 parameters
     set(MATRIX_DIMENSION 32)
     set(FIXED_ITERATIONS_DECOMPOSITION 45)
     set(FIXED_ITERATIONS_INVERSION 45)

--- a/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/cholesky_inversion/src/CMakeLists.txt
+++ b/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/cholesky_inversion/src/CMakeLists.txt
@@ -7,8 +7,8 @@ set(FPGA_EARLY_IMAGE ${TARGET_NAME}_report.a)
 
 # FPGA board selection
 if(NOT DEFINED FPGA_DEVICE)
-    set(FPGA_DEVICE "Agilex")
-    set(DEVICE_FLAG "Agilex")
+    set(FPGA_DEVICE "Agilex 7")
+    set(DEVICE_FLAG "Agilex 7")
     message(STATUS "FPGA_DEVICE was not specified.\
                     \nConfiguring the design to the default FPGA family: ${FPGA_DEVICE}\
                     \nPlease refer to the README for information on target selection.")
@@ -20,7 +20,7 @@ else()
     elseif(FPGA_DEVICE_NAME MATCHES ".*s10.*" OR FPGA_DEVICE_NAME MATCHES ".*stratix10.*")
       set(DEVICE_FLAG "S10")
     elseif(FPGA_DEVICE_NAME MATCHES ".*agilex.*")
-      set(DEVICE_FLAG "Agilex")
+      set(DEVICE_FLAG "Agilex 7")
     endif()
     message(STATUS "Configuring the design with the following target: ${FPGA_DEVICE}")
 
@@ -36,7 +36,7 @@ endif()
 
 if(NOT DEFINED DEVICE_FLAG)
     message(FATAL_ERROR "An unrecognized or custom board was passed, but DEVICE_FLAG was not specified. \
-                         Make sure you have set -DDEVICE_FLAG=A10, -DDEVICE_FLAG=S10 or -DDEVICE_FLAG=Agilex.")
+                         Make sure you have set -DDEVICE_FLAG=A10, -DDEVICE_FLAG=S10 or -DDEVICE_FLAG=Agilex 7.")
 endif()
 
 # This is a Windows-specific flag that enables error handling in host code
@@ -66,8 +66,8 @@ elseif(DEVICE_FLAG MATCHES "S10")
     set(FIXED_ITERATIONS_INVERSION 44)
     set(CLOCK_TARGET 450MHz)
     set(SEED "-Xsseed=5")
-elseif(DEVICE_FLAG MATCHES "Agilex")
-    # Agilex™ parameters
+elseif(DEVICE_FLAG MATCHES "Agilex 7")
+    # Agilex 7™ parameters
     set(MATRIX_DIMENSION 32)
     set(FIXED_ITERATIONS_DECOMPOSITION 45)
     set(FIXED_ITERATIONS_INVERSION 45)
@@ -75,7 +75,7 @@ elseif(DEVICE_FLAG MATCHES "Agilex")
     set(CLOCK_TARGET 520MHz)
     set(SEED "-Xsseed=5")
 else()
-    message(FATAL_ERROR "An incorrect DEVICE_FLAG was given. Make sure you have set -DDEVICE_FLAG=A10, -DDEVICE_FLAG=S10 or -DDEVICE_FLAG=Agilex.")
+    message(FATAL_ERROR "An incorrect DEVICE_FLAG was given. Make sure you have set -DDEVICE_FLAG=A10, -DDEVICE_FLAG=S10 or -DDEVICE_FLAG=Agilex 7.")
 endif()
 
 if(IGNORE_DEFAULT_SEED)

--- a/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/cholesky_inversion/src/CMakeLists.txt
+++ b/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/cholesky_inversion/src/CMakeLists.txt
@@ -7,8 +7,8 @@ set(FPGA_EARLY_IMAGE ${TARGET_NAME}_report.a)
 
 # FPGA board selection
 if(NOT DEFINED FPGA_DEVICE)
-    set(FPGA_DEVICE "Agilex 7")
-    set(DEVICE_FLAG "Agilex 7")
+    set(FPGA_DEVICE "Agilex7")
+    set(DEVICE_FLAG "Agilex7")
     message(STATUS "FPGA_DEVICE was not specified.\
                     \nConfiguring the design to the default FPGA family: ${FPGA_DEVICE}\
                     \nPlease refer to the README for information on target selection.")
@@ -20,7 +20,7 @@ else()
     elseif(FPGA_DEVICE_NAME MATCHES ".*s10.*" OR FPGA_DEVICE_NAME MATCHES ".*stratix10.*")
       set(DEVICE_FLAG "S10")
     elseif(FPGA_DEVICE_NAME MATCHES ".*agilex.*")
-      set(DEVICE_FLAG "Agilex 7")
+      set(DEVICE_FLAG "Agilex7")
     endif()
     message(STATUS "Configuring the design with the following target: ${FPGA_DEVICE}")
 
@@ -36,7 +36,7 @@ endif()
 
 if(NOT DEFINED DEVICE_FLAG)
     message(FATAL_ERROR "An unrecognized or custom board was passed, but DEVICE_FLAG was not specified. \
-                         Make sure you have set -DDEVICE_FLAG=A10, -DDEVICE_FLAG=S10 or -DDEVICE_FLAG=Agilex 7.")
+                         Make sure you have set -DDEVICE_FLAG=A10, -DDEVICE_FLAG=S10 or -DDEVICE_FLAG=Agilex7.")
 endif()
 
 # This is a Windows-specific flag that enables error handling in host code
@@ -66,8 +66,8 @@ elseif(DEVICE_FLAG MATCHES "S10")
     set(FIXED_ITERATIONS_INVERSION 44)
     set(CLOCK_TARGET 450MHz)
     set(SEED "-Xsseed=5")
-elseif(DEVICE_FLAG MATCHES "Agilex 7")
-    # Agilex 7™ parameters
+elseif(DEVICE_FLAG MATCHES "Agilex7")
+    # Agilex7™ parameters
     set(MATRIX_DIMENSION 32)
     set(FIXED_ITERATIONS_DECOMPOSITION 45)
     set(FIXED_ITERATIONS_INVERSION 45)
@@ -75,7 +75,7 @@ elseif(DEVICE_FLAG MATCHES "Agilex 7")
     set(CLOCK_TARGET 520MHz)
     set(SEED "-Xsseed=5")
 else()
-    message(FATAL_ERROR "An incorrect DEVICE_FLAG was given. Make sure you have set -DDEVICE_FLAG=A10, -DDEVICE_FLAG=S10 or -DDEVICE_FLAG=Agilex 7.")
+    message(FATAL_ERROR "An incorrect DEVICE_FLAG was given. Make sure you have set -DDEVICE_FLAG=A10, -DDEVICE_FLAG=S10 or -DDEVICE_FLAG=Agilex7.")
 endif()
 
 if(IGNORE_DEFAULT_SEED)

--- a/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/crr/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/crr/README.md
@@ -39,7 +39,7 @@ You can also find more information about [troubleshooting build errors](/DirectP
 | Optimized for        | Description
 |:---                  |:---
 | OS                   | Ubuntu* 18.04/20.04 <br> RHEL*/CentOS* 8 <br> SUSE* 15 <br> Windows* 10
-| Hardware             | Intel® Agilex®, Arria® 10, and Stratix® 10 FPGAs
+| Hardware             | Intel® Agilex® 7, Arria® 10, and Stratix® 10 FPGAs
 | Software             | Intel® oneAPI DPC++/C++ Compiler
 
 > **Note**: Even though the Intel DPC++/C++ OneAPI compiler is enough to compile for emulation, generating reports and generating RTL, there are extra software requirements for the simulation flow and FPGA compiles.
@@ -155,7 +155,7 @@ This design measures the FPGA performance to determine how many assets can be pr
 ### On Linux*
 
 1. Change to the sample directory.
-2. Configure the build system for the Agilex® device family, which is the default.
+2. Configure the build system for the Agilex® 7 device family, which is the default.
 
    ```
    mkdir build
@@ -195,7 +195,7 @@ This design measures the FPGA performance to determine how many assets can be pr
 ### On Windows*
 
 1. Change to the sample directory.
-2. Configure the build system for the Agilex® device family, which is the default.
+2. Configure the build system for the Agilex® 7 device family, which is the default.
    ```
    mkdir build
    cd build

--- a/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/crr/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/crr/README.md
@@ -24,9 +24,9 @@ flowchart LR
    tier2("Tier 2: Explore the Fundamentals")
    tier3("Tier 3: Explore the Advanced Techniques")
    tier4("Tier 4: Explore the Reference Designs")
-   
+
    tier1 --> tier2 --> tier3 --> tier4
-   
+
    style tier1 fill:#0071c1,stroke:#0071c1,stroke-width:1px,color:#fff
    style tier2 fill:#0071c1,stroke:#0071c1,stroke-width:1px,color:#fff
    style tier3 fill:#0071c1,stroke:#0071c1,stroke-width:1px,color:#fff
@@ -53,7 +53,7 @@ You can also find more information about [troubleshooting build errors](/DirectP
 >
 > :warning: Make sure you add the device files associated with the FPGA that you are targeting to your Intel® Quartus® Prime installation.
 
-> **Note**: You'll need a large FPGA part to be able to fit this design 
+> **Note**: You'll need a large FPGA part to be able to fit this design
 
 ### Performance
 
@@ -137,8 +137,8 @@ This design measures the FPGA performance to determine how many assets can be pr
 
 ## Build the `CRR Binomial Tree` Sample
 
-> **Note**: When working with the command-line interface (CLI), you should configure the oneAPI toolkits using environment variables. 
-> Set up your CLI environment by sourcing the `setvars` script located in the root of your oneAPI installation every time you open a new terminal window. 
+> **Note**: When working with the command-line interface (CLI), you should configure the oneAPI toolkits using environment variables.
+> Set up your CLI environment by sourcing the `setvars` script located in the root of your oneAPI installation every time you open a new terminal window.
 > This practice ensures that your compiler, libraries, and tools are ready for development.
 >
 > Linux*:
@@ -166,12 +166,12 @@ This design measures the FPGA performance to determine how many assets can be pr
    > **Note**: You can change the default target by using the command:
    >  ```
    >  cmake .. -DFPGA_DEVICE=<FPGA device family or FPGA part number>
-   >  ``` 
+   >  ```
    >
-   > Alternatively, you can target an explicit FPGA board variant and BSP by using the following command: 
+   > Alternatively, you can target an explicit FPGA board variant and BSP by using the following command:
    >  ```
    >  cmake .. -DFPGA_DEVICE=<board-support-package>:<board-variant>
-   >  ``` 
+   >  ```
    >
    > You will only be able to run an executable on the FPGA if you specified a BSP.
 
@@ -205,12 +205,12 @@ This design measures the FPGA performance to determine how many assets can be pr
    > **Note**: You can change the default target by using the command:
    >  ```
    >  cmake -G "NMake Makefiles" .. -DFPGA_DEVICE=<FPGA device family or FPGA part number>
-   >  ``` 
+   >  ```
    >
-   > Alternatively, you can target an explicit FPGA board variant and BSP by using the following command: 
+   > Alternatively, you can target an explicit FPGA board variant and BSP by using the following command:
    >  ```
    >  cmake -G "NMake Makefiles" .. -DFPGA_DEVICE=<board-support-package>:<board-variant>
-   >  ``` 
+   >  ```
    >
    > You will only be able to run an executable on the FPGA if you specified a BSP.
 

--- a/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/crr/src/CMakeLists.txt
+++ b/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/crr/src/CMakeLists.txt
@@ -6,8 +6,8 @@ set(FPGA_TARGET ${TARGET_NAME}.fpga)
 
 # FPGA board selection
 if(NOT DEFINED FPGA_DEVICE)
-    set(FPGA_DEVICE "Agilex")
-    set(DEVICE_FLAG "Agilex")
+    set(FPGA_DEVICE "Agilex 7")
+    set(DEVICE_FLAG "Agilex 7")
     message(STATUS "FPGA_DEVICE was not specified.\
                     \nConfiguring the design to the default FPGA family: ${FPGA_DEVICE}\
                     \nPlease refer to the README for information on target selection.")
@@ -18,7 +18,7 @@ else()
     elseif(FPGA_DEVICE_NAME MATCHES ".*s10.*" OR FPGA_DEVICE_NAME MATCHES ".*stratix10.*")
       set(DEVICE_FLAG "S10")
     elseif(FPGA_DEVICE_NAME MATCHES ".*agilex.*")
-      set(DEVICE_FLAG "Agilex")
+      set(DEVICE_FLAG "Agilex 7")
     endif()
     message(STATUS "Configuring the design with the following target: ${FPGA_DEVICE}")
 endif()
@@ -26,7 +26,7 @@ endif()
 if(NOT DEFINED DEVICE_FLAG)
     message(FATAL_ERROR "An unrecognized or custom board was passed, but DEVICE_FLAG was not specified. \
                          Please make sure you have set -DDEVICE_FLAG=A10, -DDEVICE_FLAG=S10 or \
-                         -DDEVICE_FLAG=Agilex.")
+                         -DDEVICE_FLAG=Agilex 7.")
 endif()
 
 # This is a Windows-specific flag that enables error handling in host code
@@ -47,8 +47,8 @@ elseif(DEVICE_FLAG MATCHES "S10")
     set(INNER_UNROLL 64)
     set(OUTER_UNROLL_POW2 2)
     set(SEED "-Xsseed=2")
-elseif(DEVICE_FLAG MATCHES "Agilex")
-    # Agilex™
+elseif(DEVICE_FLAG MATCHES "Agilex 7")
+    # Agilex 7™
     set(OUTER_UNROLL 2)
     set(INNER_UNROLL 64)
     set(OUTER_UNROLL_POW2 2)

--- a/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/crr/src/CMakeLists.txt
+++ b/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/crr/src/CMakeLists.txt
@@ -6,8 +6,8 @@ set(FPGA_TARGET ${TARGET_NAME}.fpga)
 
 # FPGA board selection
 if(NOT DEFINED FPGA_DEVICE)
-    set(FPGA_DEVICE "Agilex 7")
-    set(DEVICE_FLAG "Agilex 7")
+    set(FPGA_DEVICE "Agilex7")
+    set(DEVICE_FLAG "Agilex7")
     message(STATUS "FPGA_DEVICE was not specified.\
                     \nConfiguring the design to the default FPGA family: ${FPGA_DEVICE}\
                     \nPlease refer to the README for information on target selection.")
@@ -18,7 +18,7 @@ else()
     elseif(FPGA_DEVICE_NAME MATCHES ".*s10.*" OR FPGA_DEVICE_NAME MATCHES ".*stratix10.*")
       set(DEVICE_FLAG "S10")
     elseif(FPGA_DEVICE_NAME MATCHES ".*agilex.*")
-      set(DEVICE_FLAG "Agilex 7")
+      set(DEVICE_FLAG "Agilex7")
     endif()
     message(STATUS "Configuring the design with the following target: ${FPGA_DEVICE}")
 endif()
@@ -26,7 +26,7 @@ endif()
 if(NOT DEFINED DEVICE_FLAG)
     message(FATAL_ERROR "An unrecognized or custom board was passed, but DEVICE_FLAG was not specified. \
                          Please make sure you have set -DDEVICE_FLAG=A10, -DDEVICE_FLAG=S10 or \
-                         -DDEVICE_FLAG=Agilex 7.")
+                         -DDEVICE_FLAG=Agilex7.")
 endif()
 
 # This is a Windows-specific flag that enables error handling in host code
@@ -47,8 +47,8 @@ elseif(DEVICE_FLAG MATCHES "S10")
     set(INNER_UNROLL 64)
     set(OUTER_UNROLL_POW2 2)
     set(SEED "-Xsseed=2")
-elseif(DEVICE_FLAG MATCHES "Agilex 7")
-    # Agilex 7™
+elseif(DEVICE_FLAG MATCHES "Agilex7")
+    # Agilex7™
     set(OUTER_UNROLL 2)
     set(INNER_UNROLL 64)
     set(OUTER_UNROLL_POW2 2)

--- a/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/crr/src/CMakeLists.txt
+++ b/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/crr/src/CMakeLists.txt
@@ -48,7 +48,7 @@ elseif(DEVICE_FLAG MATCHES "S10")
     set(OUTER_UNROLL_POW2 2)
     set(SEED "-Xsseed=2")
 elseif(DEVICE_FLAG MATCHES "Agilex7")
-    # Agilex7™
+    # Agilex 7
     set(OUTER_UNROLL 2)
     set(INNER_UNROLL 64)
     set(OUTER_UNROLL_POW2 2)

--- a/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/db/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/db/README.md
@@ -25,9 +25,9 @@ flowchart LR
    tier2("Tier 2: Explore the Fundamentals")
    tier3("Tier 3: Explore the Advanced Techniques")
    tier4("Tier 4: Explore the Reference Designs")
-   
+
    tier1 --> tier2 --> tier3 --> tier4
-   
+
    style tier1 fill:#0071c1,stroke:#0071c1,stroke-width:1px,color:#fff
    style tier2 fill:#0071c1,stroke:#0071c1,stroke-width:1px,color:#fff
    style tier3 fill:#0071c1,stroke:#0071c1,stroke-width:1px,color:#fff
@@ -40,7 +40,7 @@ You can also find more information about [troubleshooting build errors](/DirectP
 | Optimized for                     | Description
 ---                                 |---
 | OS                                | Ubuntu* 18.04/20.04 <br> RHEL*/CentOS* 8 <br> SUSE* 15 <br> Windows* 10
-| Hardware                          | Intel® Agilex®, Arria® 10, and Stratix® 10 FPGAs
+| Hardware                          | Intel® Agilex 7®, Arria® 10, and Stratix® 10 FPGAs
 | Software                          | Intel® oneAPI DPC++/C++ Compiler
 
 > **Note**: Even though the Intel DPC++/C++ OneAPI compiler is enough to compile for emulation, generating reports and generating RTL, there are extra software requirements for the simulation flow and FPGA compiles.
@@ -54,7 +54,7 @@ You can also find more information about [troubleshooting build errors](/DirectP
 >
 > :warning: Make sure you add the device files associated with the FPGA that you are targeting to your Intel® Quartus® Prime installation.
 
-> **Note**: You'll need a large FPGA part to be able to fit the query 9 variant of this design 
+> **Note**: You'll need a large FPGA part to be able to fit the query 9 variant of this design
 
 ### Performance
 
@@ -131,8 +131,8 @@ Query 12 showcases the `MergeJoin` database operator. The block diagram of the d
 
 ## Build the `DB` Reference Design
 
-> **Note**: When working with the command-line interface (CLI), you should configure the oneAPI toolkits using environment variables. 
-> Set up your CLI environment by sourcing the `setvars` script located in the root of your oneAPI installation every time you open a new terminal window. 
+> **Note**: When working with the command-line interface (CLI), you should configure the oneAPI toolkits using environment variables.
+> Set up your CLI environment by sourcing the `setvars` script located in the root of your oneAPI installation every time you open a new terminal window.
 > This practice ensures that your compiler, libraries, and tools are ready for development.
 >
 > Linux*:
@@ -148,7 +148,7 @@ Query 12 showcases the `MergeJoin` database operator. The block diagram of the d
 
 ### On Linux*
 1. Change to the sample directory.
-2. Configure the build system for the default target (the Agilex® device family).
+2. Configure the build system for the default target (the Agilex 7® device family).
    ```
    mkdir build
    cd build
@@ -159,12 +159,12 @@ Query 12 showcases the `MergeJoin` database operator. The block diagram of the d
    > **Note**: You can change the default target by using the command:
    >  ```
    >  cmake .. -DQUERY=<QUERY_NUMBER> -DFPGA_DEVICE=<FPGA device family or FPGA part number>
-   >  ``` 
+   >  ```
    >
-   > Alternatively, you can target an explicit FPGA board variant and BSP by using the following command: 
+   > Alternatively, you can target an explicit FPGA board variant and BSP by using the following command:
    >  ```
    >  cmake .. -DQUERY=<QUERY_NUMBER> -DFPGA_DEVICE=<board-support-package>:<board-variant>
-   >  ``` 
+   >  ```
    >
    > You will only be able to run an executable on the FPGA if you specified a BSP.
 
@@ -197,7 +197,7 @@ Query 12 showcases the `MergeJoin` database operator. The block diagram of the d
 ### On Windows*
 
 1. Change to the sample directory.
-2. Configure the build system for the default target (the Agilex® device family).
+2. Configure the build system for the default target (the Agilex 7® device family).
    ```
    mkdir build
    cd build
@@ -208,12 +208,12 @@ Query 12 showcases the `MergeJoin` database operator. The block diagram of the d
    > **Note**: You can change the default target by using the command:
    >  ```
    >  cmake -G "NMake Makefiles" .. -DQUERY=<QUERY_NUMBER> -DFPGA_DEVICE=<FPGA device family or FPGA part number>
-   >  ``` 
+   >  ```
    >
-   > Alternatively, you can target an explicit FPGA board variant and BSP by using the following command: 
+   > Alternatively, you can target an explicit FPGA board variant and BSP by using the following command:
    >  ```
    >  cmake -G "NMake Makefiles" .. -DQUERY=<QUERY_NUMBER> -DFPGA_DEVICE=<board-support-package>:<board-variant>
-   >  ``` 
+   >  ```
    >
    > You will only be able to run an executable on the FPGA if you specified a BSP.
 

--- a/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/db/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/db/README.md
@@ -40,7 +40,7 @@ You can also find more information about [troubleshooting build errors](/DirectP
 | Optimized for                     | Description
 ---                                 |---
 | OS                                | Ubuntu* 18.04/20.04 <br> RHEL*/CentOS* 8 <br> SUSE* 15 <br> Windows* 10
-| Hardware                          | Intel® Agilex 7®, Arria® 10, and Stratix® 10 FPGAs
+| Hardware                          | Intel® Agilex® 7, Arria® 10, and Stratix® 10 FPGAs
 | Software                          | Intel® oneAPI DPC++/C++ Compiler
 
 > **Note**: Even though the Intel DPC++/C++ OneAPI compiler is enough to compile for emulation, generating reports and generating RTL, there are extra software requirements for the simulation flow and FPGA compiles.
@@ -148,7 +148,7 @@ Query 12 showcases the `MergeJoin` database operator. The block diagram of the d
 
 ### On Linux*
 1. Change to the sample directory.
-2. Configure the build system for the default target (the Agilex 7® device family).
+2. Configure the build system for the default target (the Agilex® 7 device family).
    ```
    mkdir build
    cd build
@@ -197,7 +197,7 @@ Query 12 showcases the `MergeJoin` database operator. The block diagram of the d
 ### On Windows*
 
 1. Change to the sample directory.
-2. Configure the build system for the default target (the Agilex 7® device family).
+2. Configure the build system for the default target (the Agilex® 7 device family).
    ```
    mkdir build
    cd build

--- a/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/db/src/CMakeLists.txt
+++ b/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/db/src/CMakeLists.txt
@@ -14,8 +14,8 @@ endif()
 
 # FPGA board selection
 if(NOT DEFINED FPGA_DEVICE)
-    set(FPGA_DEVICE "Agilex 7")
-    set(DEVICE_FLAG "Agilex 7")
+    set(FPGA_DEVICE "Agilex7")
+    set(DEVICE_FLAG "Agilex7")
     message(STATUS "FPGA_DEVICE was not specified.\
                     \nConfiguring the design to the default FPGA family: ${FPGA_DEVICE}\
                     \nPlease refer to the README for information on target selection.")
@@ -26,7 +26,7 @@ else()
     elseif(FPGA_DEVICE_NAME MATCHES ".*s10.*" OR FPGA_DEVICE_NAME MATCHES ".*stratix10.*")
       set(DEVICE_FLAG "S10")
     elseif(FPGA_DEVICE_NAME MATCHES ".*agilex.*")
-      set(DEVICE_FLAG "Agilex 7")
+      set(DEVICE_FLAG "Agilex7")
     endif()
     message(STATUS "Configuring the design with the following target: ${FPGA_DEVICE}")
 endif()
@@ -34,7 +34,7 @@ endif()
 if(NOT DEFINED DEVICE_FLAG)
     message(FATAL_ERROR "An unrecognized or custom board was passed, but DEVICE_FLAG was not specified. \
                          Please make sure you have set -DDEVICE_FLAG=A10, -DDEVICE_FLAG=S10 or \
-                         -DDEVICE_FLAG=Agilex 7.")
+                         -DDEVICE_FLAG=Agilex7.")
 endif()
 
 # This is a Windows-specific flag that enables error handling in host code
@@ -73,7 +73,7 @@ if(NOT DEFINED SEED)
         elseif(${QUERY} EQUAL 12)
             set(SEED "-Xsseed=2")
         endif()
-    elseif(DEVICE_FLAG MATCHES "Agilex 7")
+    elseif(DEVICE_FLAG MATCHES "Agilex7")
         if(${QUERY} EQUAL 1)
             set(SEED "-Xsseed=2")
         elseif(${QUERY} EQUAL 9)

--- a/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/db/src/CMakeLists.txt
+++ b/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/db/src/CMakeLists.txt
@@ -14,8 +14,8 @@ endif()
 
 # FPGA board selection
 if(NOT DEFINED FPGA_DEVICE)
-    set(FPGA_DEVICE "Agilex")
-    set(DEVICE_FLAG "Agilex")
+    set(FPGA_DEVICE "Agilex 7")
+    set(DEVICE_FLAG "Agilex 7")
     message(STATUS "FPGA_DEVICE was not specified.\
                     \nConfiguring the design to the default FPGA family: ${FPGA_DEVICE}\
                     \nPlease refer to the README for information on target selection.")
@@ -26,7 +26,7 @@ else()
     elseif(FPGA_DEVICE_NAME MATCHES ".*s10.*" OR FPGA_DEVICE_NAME MATCHES ".*stratix10.*")
       set(DEVICE_FLAG "S10")
     elseif(FPGA_DEVICE_NAME MATCHES ".*agilex.*")
-      set(DEVICE_FLAG "Agilex")
+      set(DEVICE_FLAG "Agilex 7")
     endif()
     message(STATUS "Configuring the design with the following target: ${FPGA_DEVICE}")
 endif()
@@ -34,7 +34,7 @@ endif()
 if(NOT DEFINED DEVICE_FLAG)
     message(FATAL_ERROR "An unrecognized or custom board was passed, but DEVICE_FLAG was not specified. \
                          Please make sure you have set -DDEVICE_FLAG=A10, -DDEVICE_FLAG=S10 or \
-                         -DDEVICE_FLAG=Agilex.")
+                         -DDEVICE_FLAG=Agilex 7.")
 endif()
 
 # This is a Windows-specific flag that enables error handling in host code
@@ -73,7 +73,7 @@ if(NOT DEFINED SEED)
         elseif(${QUERY} EQUAL 12)
             set(SEED "-Xsseed=2")
         endif()
-    elseif(DEVICE_FLAG MATCHES "Agilex")
+    elseif(DEVICE_FLAG MATCHES "Agilex 7")
         if(${QUERY} EQUAL 1)
             set(SEED "-Xsseed=2")
         elseif(${QUERY} EQUAL 9)

--- a/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/decompress/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/decompress/README.md
@@ -21,9 +21,9 @@ flowchart LR
    tier2("Tier 2: Explore the Fundamentals")
    tier3("Tier 3: Explore the Advanced Techniques")
    tier4("Tier 4: Explore the Reference Designs")
-   
+
    tier1 --> tier2 --> tier3 --> tier4
-   
+
    style tier1 fill:#0071c1,stroke:#0071c1,stroke-width:1px,color:#fff
    style tier2 fill:#0071c1,stroke:#0071c1,stroke-width:1px,color:#fff
    style tier3 fill:#0071c1,stroke:#0071c1,stroke-width:1px,color:#fff
@@ -36,7 +36,7 @@ You can also find more information about [troubleshooting build errors](/DirectP
 | Optimized for        | Description
 |:---                  |:---
 | OS                   | Ubuntu* 18.04/20.04 <br> RHEL*/CentOS* 8 <br> SUSE* 15 <br> Windows* 10
-| Hardware             | Intel® Agilex®, Arria® 10, and Stratix® 10 FPGAs
+| Hardware             | Intel® Agilex 7®, Arria® 10, and Stratix® 10 FPGAs
 | Software             | Intel® oneAPI DPC++/C++ Compiler
 
 > **Note**: Even though the Intel DPC++/C++ OneAPI compiler is enough to compile for emulation, generating reports and generating RTL, there are extra software requirements for the simulation flow and FPGA compiles.
@@ -120,13 +120,13 @@ Once the shortest match length is found, the bit stream is shifted by that many 
 
 ![](assets/huffman_decoder.png)
 
-The Huffman decoder uses two Huffman tables: a 289-element table for literals and lengths, and a 32-element table for distances. The decoder knows that if it decodes a length from the first table that the next symbol must be a distance. 
+The Huffman decoder uses two Huffman tables: a 289-element table for literals and lengths, and a 32-element table for distances. The decoder knows that if it decodes a length from the first table that the next symbol must be a distance.
 
 The Huffman decoder in this design uses an intelligent method for storing the Huffman tables to significantly reduces area and improves performance. The decoder takes advantage of the fact that codes of the same bit lengths are sequential. For the literal and length table, it stores 4 tables:
    * A 289-element table that holds the symbols in increasing order of code length (`lit_map`), with no gaps. That is, it stores all symbols of length 1, followed directly by all symbols of length 2, and so on.
    * A 15-element table to store the first code for each code length (`first_code`).
    * A 15-element table to store the last code for each code length (`last_code`).
-   * A 15-element table to store the base index of the first element in the `lit_map` table for each code length (`base_idx`). 
+   * A 15-element table to store the base index of the first element in the `lit_map` table for each code length (`base_idx`).
 
 For a code length `L` and the code value `C`, the pseudocode snippet below describes how these tables are used to check for a match and decode the symbol. As described earlier, this pseudocode is done in parallel 15 times for code lengths (`L`) of 1-15 bits.
 
@@ -136,13 +136,13 @@ offset = C - first_code[L];
 symbol = lit_map[base_idx[L] + offset]
 ```
 
-The Huffman decoder decodes a literal in 1 iteration of the main loop, and a {length, distance} pair in 2 iterations. When decoding a {length, distance} pair, the length code can be 1-15 bits and, based on the decoded length, 0-5 extra bits. Similarly, the distance code can be 1-15 bits and 0-15 extra bits. 
+The Huffman decoder decodes a literal in 1 iteration of the main loop, and a {length, distance} pair in 2 iterations. When decoding a {length, distance} pair, the length code can be 1-15 bits and, based on the decoded length, 0-5 extra bits. Similarly, the distance code can be 1-15 bits and 0-15 extra bits.
 
 To decode a {length, distance} in 2 iterations, the Huffman decoder looks at 30 bits in parallel. The first 15 are examined as described earlier. The decoder also examines the 15x5 and 15x15 different possibilities for the extra length and distance bits. For the extra length bits, the shortest matching code can be 1-15 bits, giving 15 possibilities for where the extra bits could start. There can be 1-5 extra bits, giving 5 possibilities, which yields 15x5 possibilities for the extra length bits. Decoding the extra distance bits uses the same approach but with 0-15 extra bits, yielding 15x15 possibilities.
 
 #### LZ77 Decoder Kernel
 
-The input to the LZ77 decoder kernel is a stream of symbols that are either an 8-bit literal or a {length, distance} pair. The output is a stream of literals (8-bit characters). The LZ77 decoder keeps a 32KB *history buffer* which stores the last 32K literals it has streamed to the output. 
+The input to the LZ77 decoder kernel is a stream of symbols that are either an 8-bit literal or a {length, distance} pair. The output is a stream of literals (8-bit characters). The LZ77 decoder keeps a 32KB *history buffer* which stores the last 32K literals it has streamed to the output.
 
 If the incoming command is an 8-bit literal, the LZ77 decoder simply forwards the literal to the output stream and tracks it in the history buffer. For a {length, distance} pair, the decoder goes back `distance` literals in the history buffer and streams `length` of them to the output and back into the history buffer.
 
@@ -163,7 +163,7 @@ Characters:    E T H O M E P H O N E
 Buffer index:  0 1 2 3 0 1 2 3 0 1 2 3
 ```
 
-The `Current History Buffer Index` is 3. That is, the next history buffer to write into is 3. Now, the LZ77 decoder receives a {length, distance} pair of `{4, 9}`, which means copy `H O M E`. To read the `N=4` elements, the LZ77 decoder unconditionally reads from each history buffer in parallel and computes a shuffle vector to reorder the output. 
+The `Current History Buffer Index` is 3. That is, the next history buffer to write into is 3. Now, the LZ77 decoder receives a {length, distance} pair of `{4, 9}`, which means copy `H O M E`. To read the `N=4` elements, the LZ77 decoder unconditionally reads from each history buffer in parallel and computes a shuffle vector to reorder the output.
 
 To compute the shuffle vector, the LZ77 decoder determines which buffer should be read from first: `first_buf_idx = ('Current History Buffer Index' - distance) % N`. In this case `first_buf_idx = (3 - 9) % 4 = 2`. Then, the shuffle vector is computed as: `shuffle_vector = {first_buf_idx, (first_buf_idx + 1) % N, ..., (first_buf_idx + N - 1) % N} = {2, 3, 0, 1}`. The output from the `N=4` history buffers in this case would be `M E H O`, since `M` is in buffer `0`, `E` is in buffer `1`, and so on. Finally, the shuffling happens as follows:
 ```
@@ -286,8 +286,8 @@ For `constexpr_math.hpp`, `memory_utils.hpp`, `metaprogramming_utils.hpp`, `tupl
 
 ## Build the `Decompression` Design
 
-> **Note**: When working with the command-line interface (CLI), you should configure the oneAPI toolkits using environment variables. 
-> Set up your CLI environment by sourcing the `setvars` script located in the root of your oneAPI installation every time you open a new terminal window. 
+> **Note**: When working with the command-line interface (CLI), you should configure the oneAPI toolkits using environment variables.
+> Set up your CLI environment by sourcing the `setvars` script located in the root of your oneAPI installation every time you open a new terminal window.
 > This practice ensures that your compiler, libraries, and tools are ready for development.
 >
 > Linux*:
@@ -304,7 +304,7 @@ For `constexpr_math.hpp`, `memory_utils.hpp`, `metaprogramming_utils.hpp`, `tupl
 ### On Linux*
 
 1. Change to the sample directory.
-2. Configure the build system for the Agilex® device family, which is the default.
+2. Configure the build system for the Agilex 7® device family, which is the default.
 
    ```
    mkdir build
@@ -321,12 +321,12 @@ For `constexpr_math.hpp`, `memory_utils.hpp`, `metaprogramming_utils.hpp`, `tupl
    > **Note**: You can change the default target by using the command:
    >  ```
    >  cmake .. -DFPGA_DEVICE=<FPGA device family or FPGA part number>
-   >  ``` 
+   >  ```
    >
-   > Alternatively, you can target an explicit FPGA board variant and BSP by using the following command: 
+   > Alternatively, you can target an explicit FPGA board variant and BSP by using the following command:
    >  ```
    >  cmake .. -DFPGA_DEVICE=<board-support-package>:<board-variant> -DIS_BSP=1
-   >  ``` 
+   >  ```
    >
    > You will only be able to run an executable on the FPGA if you specified a BSP.
 
@@ -354,7 +354,7 @@ For `constexpr_math.hpp`, `memory_utils.hpp`, `metaprogramming_utils.hpp`, `tupl
 ### On Windows*
 
 1. Change to the sample directory.
-2. Configure the build system for the Agilex® device family, which is the default.
+2. Configure the build system for the Agilex 7® device family, which is the default.
    ```
    mkdir build
    cd build
@@ -369,12 +369,12 @@ For `constexpr_math.hpp`, `memory_utils.hpp`, `metaprogramming_utils.hpp`, `tupl
   > **Note**: You can change the default target by using the command:
   >  ```
   >  cmake -G "NMake Makefiles" .. -DFPGA_DEVICE=<FPGA device family or FPGA part number>
-  >  ``` 
+  >  ```
   >
-  > Alternatively, you can target an explicit FPGA board variant and BSP by using the following command: 
+  > Alternatively, you can target an explicit FPGA board variant and BSP by using the following command:
   >  ```
   >  cmake -G "NMake Makefiles" .. -DFPGA_DEVICE=<board-support-package>:<board-variant> -DIS_BSP=1
-  >  ``` 
+  >  ```
   >
   > You will only be able to run an executable on the FPGA if you specified a BSP.
 

--- a/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/decompress/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/decompress/README.md
@@ -36,7 +36,7 @@ You can also find more information about [troubleshooting build errors](/DirectP
 | Optimized for        | Description
 |:---                  |:---
 | OS                   | Ubuntu* 18.04/20.04 <br> RHEL*/CentOS* 8 <br> SUSE* 15 <br> Windows* 10
-| Hardware             | Intel® Agilex 7®, Arria® 10, and Stratix® 10 FPGAs
+| Hardware             | Intel® Agilex® 7, Arria® 10, and Stratix® 10 FPGAs
 | Software             | Intel® oneAPI DPC++/C++ Compiler
 
 > **Note**: Even though the Intel DPC++/C++ OneAPI compiler is enough to compile for emulation, generating reports and generating RTL, there are extra software requirements for the simulation flow and FPGA compiles.
@@ -304,7 +304,7 @@ For `constexpr_math.hpp`, `memory_utils.hpp`, `metaprogramming_utils.hpp`, `tupl
 ### On Linux*
 
 1. Change to the sample directory.
-2. Configure the build system for the Agilex 7® device family, which is the default.
+2. Configure the build system for the Agilex® 7 device family, which is the default.
 
    ```
    mkdir build
@@ -354,7 +354,7 @@ For `constexpr_math.hpp`, `memory_utils.hpp`, `metaprogramming_utils.hpp`, `tupl
 ### On Windows*
 
 1. Change to the sample directory.
-2. Configure the build system for the Agilex 7® device family, which is the default.
+2. Configure the build system for the Agilex® 7 device family, which is the default.
    ```
    mkdir build
    cd build

--- a/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/decompress/src/CMakeLists.txt
+++ b/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/decompress/src/CMakeLists.txt
@@ -6,8 +6,8 @@ set(FPGA_TARGET ${TARGET_NAME}.fpga)
 
 # FPGA board selection
 if(NOT DEFINED FPGA_DEVICE)
-    set(FPGA_DEVICE "Agilex 7")
-    set(DEVICE_FLAG "Agilex 7")
+    set(FPGA_DEVICE "Agilex7")
+    set(DEVICE_FLAG "Agilex7")
     message(STATUS "FPGA_DEVICE was not specified.\
                     \nConfiguring the design to the default FPGA family: ${FPGA_DEVICE}\
                     \nPlease refer to the README for information on target selection.")
@@ -19,7 +19,7 @@ else()
     elseif(FPGA_DEVICE_NAME MATCHES ".*s10.*" OR FPGA_DEVICE_NAME MATCHES ".*stratix10.*")
       set(DEVICE_FLAG "S10")
     elseif(FPGA_DEVICE_NAME MATCHES ".*agilex.*")
-      set(DEVICE_FLAG "Agilex 7")
+      set(DEVICE_FLAG "Agilex7")
     endif()
     message(STATUS "Configuring the design with the following target: ${FPGA_DEVICE}")
 
@@ -35,7 +35,7 @@ endif()
 
 if(NOT DEFINED DEVICE_FLAG)
     message(FATAL_ERROR "An unrecognized or custom board was passed, but DEVICE_FLAG was not specified. \
-                         Make sure you have set -DDEVICE_FLAG=A10, -DDEVICE_FLAG=S10 or -DDEVICE_FLAG=Agilex 7.")
+                         Make sure you have set -DDEVICE_FLAG=A10, -DDEVICE_FLAG=S10 or -DDEVICE_FLAG=Agilex7.")
 endif()
 
 # Select between SNAPPY and GZIP decompression
@@ -96,7 +96,7 @@ else()
       set(SEED 1)
     elseif(DEVICE_FLAG MATCHES "S10")
       set(SEED 2)
-    elseif(DEVICE_FLAG MATCHES "Agilex 7")
+    elseif(DEVICE_FLAG MATCHES "Agilex7")
       set(SEED 3)
     else()
       message(STATUS "SEED not defined and no known seed for this board -- defaulting to SEED = 1")

--- a/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/decompress/src/CMakeLists.txt
+++ b/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/decompress/src/CMakeLists.txt
@@ -6,8 +6,8 @@ set(FPGA_TARGET ${TARGET_NAME}.fpga)
 
 # FPGA board selection
 if(NOT DEFINED FPGA_DEVICE)
-    set(FPGA_DEVICE "Agilex")
-    set(DEVICE_FLAG "Agilex")
+    set(FPGA_DEVICE "Agilex 7")
+    set(DEVICE_FLAG "Agilex 7")
     message(STATUS "FPGA_DEVICE was not specified.\
                     \nConfiguring the design to the default FPGA family: ${FPGA_DEVICE}\
                     \nPlease refer to the README for information on target selection.")
@@ -19,7 +19,7 @@ else()
     elseif(FPGA_DEVICE_NAME MATCHES ".*s10.*" OR FPGA_DEVICE_NAME MATCHES ".*stratix10.*")
       set(DEVICE_FLAG "S10")
     elseif(FPGA_DEVICE_NAME MATCHES ".*agilex.*")
-      set(DEVICE_FLAG "Agilex")
+      set(DEVICE_FLAG "Agilex 7")
     endif()
     message(STATUS "Configuring the design with the following target: ${FPGA_DEVICE}")
 
@@ -35,7 +35,7 @@ endif()
 
 if(NOT DEFINED DEVICE_FLAG)
     message(FATAL_ERROR "An unrecognized or custom board was passed, but DEVICE_FLAG was not specified. \
-                         Make sure you have set -DDEVICE_FLAG=A10, -DDEVICE_FLAG=S10 or -DDEVICE_FLAG=Agilex.")
+                         Make sure you have set -DDEVICE_FLAG=A10, -DDEVICE_FLAG=S10 or -DDEVICE_FLAG=Agilex 7.")
 endif()
 
 # Select between SNAPPY and GZIP decompression
@@ -96,7 +96,7 @@ else()
       set(SEED 1)
     elseif(DEVICE_FLAG MATCHES "S10")
       set(SEED 2)
-    elseif(DEVICE_FLAG MATCHES "Agilex")
+    elseif(DEVICE_FLAG MATCHES "Agilex 7")
       set(SEED 3)
     else()
       message(STATUS "SEED not defined and no known seed for this board -- defaulting to SEED = 1")

--- a/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/gzip/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/gzip/README.md
@@ -39,7 +39,7 @@ You can also find more information about [troubleshooting build errors](/DirectP
 | Optimized for        | Description
 |:---                  |:---
 | OS                   | Ubuntu* 18.04/20.04 <br> RHEL*/CentOS* 8 <br> SUSE* 15 <br> Windows* 10
-| Hardware             | Intel® Agilex 7®, Arria® 10, and Stratix® 10 FPGAs
+| Hardware             | Intel® Agilex® 7, Arria® 10, and Stratix® 10 FPGAs
 | Software             | Intel® oneAPI DPC++/C++ Compiler
 
 > **Note**: Even though the Intel DPC++/C++ OneAPI compiler is enough to compile for emulation, generating reports and generating RTL, there are extra software requirements for the simulation flow and FPGA compiles.
@@ -57,7 +57,7 @@ You can also find more information about [troubleshooting build errors](/DirectP
 
 The GZIP DEFLATE algorithm uses a GZIP-compatible Limpel-Ziv 77 (LZ77) algorithm for data de-duplication and a GZIP-compatible Static Huffman algorithm for bit reduction. The implementation includes three FPGA accelerated tasks (LZ77, Static Huffman, and CRC).
 
-The FPGA implementation of the algorithm enables either one or two independent GZIP compute engines to operate in parallel on the FPGA. The available FPGA resources constrain the number of engines. By default, the design is parameterized to create a single engine when the design is compiled to target an Intel® Arria® 10 FPGA. Two engines are created when compiling for Intel® Stratix® 10 or Agilex 7® FPGAs, which are a larger device.
+The FPGA implementation of the algorithm enables either one or two independent GZIP compute engines to operate in parallel on the FPGA. The available FPGA resources constrain the number of engines. By default, the design is parameterized to create a single engine when the design is compiled to target an Intel® Arria® 10 FPGA. Two engines are created when compiling for Intel® Stratix® 10 or Agilex® 7 FPGAs, which are a larger device.
 
 This reference design contains two variants: "High Bandwidth" and "Low-Latency."
 
@@ -142,7 +142,7 @@ Performance results are based on testing as of October 27, 2020.
 ### On Linux*
 
 1. Change to the sample directory.
-2. Configure the build system for the Agilex 7® device family, which is the default.
+2. Configure the build system for the Agilex® 7 device family, which is the default.
 
    ```
    mkdir build
@@ -189,7 +189,7 @@ Performance results are based on testing as of October 27, 2020.
 ### On Windows*
 
 1. Change to the sample directory.
-2. Configure the build system for the Agilex 7® device family, which is the default.
+2. Configure the build system for the Agilex® 7 device family, which is the default.
    ```
    mkdir build
    cd build

--- a/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/gzip/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/gzip/README.md
@@ -24,9 +24,9 @@ flowchart LR
    tier2("Tier 2: Explore the Fundamentals")
    tier3("Tier 3: Explore the Advanced Techniques")
    tier4("Tier 4: Explore the Reference Designs")
-   
+
    tier1 --> tier2 --> tier3 --> tier4
-   
+
    style tier1 fill:#0071c1,stroke:#0071c1,stroke-width:1px,color:#fff
    style tier2 fill:#0071c1,stroke:#0071c1,stroke-width:1px,color:#fff
    style tier3 fill:#0071c1,stroke:#0071c1,stroke-width:1px,color:#fff
@@ -39,7 +39,7 @@ You can also find more information about [troubleshooting build errors](/DirectP
 | Optimized for        | Description
 |:---                  |:---
 | OS                   | Ubuntu* 18.04/20.04 <br> RHEL*/CentOS* 8 <br> SUSE* 15 <br> Windows* 10
-| Hardware             | Intel® Agilex®, Arria® 10, and Stratix® 10 FPGAs
+| Hardware             | Intel® Agilex 7®, Arria® 10, and Stratix® 10 FPGAs
 | Software             | Intel® oneAPI DPC++/C++ Compiler
 
 > **Note**: Even though the Intel DPC++/C++ OneAPI compiler is enough to compile for emulation, generating reports and generating RTL, there are extra software requirements for the simulation flow and FPGA compiles.
@@ -57,7 +57,7 @@ You can also find more information about [troubleshooting build errors](/DirectP
 
 The GZIP DEFLATE algorithm uses a GZIP-compatible Limpel-Ziv 77 (LZ77) algorithm for data de-duplication and a GZIP-compatible Static Huffman algorithm for bit reduction. The implementation includes three FPGA accelerated tasks (LZ77, Static Huffman, and CRC).
 
-The FPGA implementation of the algorithm enables either one or two independent GZIP compute engines to operate in parallel on the FPGA. The available FPGA resources constrain the number of engines. By default, the design is parameterized to create a single engine when the design is compiled to target an Intel® Arria® 10 FPGA. Two engines are created when compiling for Intel® Stratix® 10 or Agilex® FPGAs, which are a larger device.
+The FPGA implementation of the algorithm enables either one or two independent GZIP compute engines to operate in parallel on the FPGA. The available FPGA resources constrain the number of engines. By default, the design is parameterized to create a single engine when the design is compiled to target an Intel® Arria® 10 FPGA. Two engines are created when compiling for Intel® Stratix® 10 or Agilex 7® FPGAs, which are a larger device.
 
 This reference design contains two variants: "High Bandwidth" and "Low-Latency."
 
@@ -123,8 +123,8 @@ Performance results are based on testing as of October 27, 2020.
 
 ## Build the `GZIP` Design
 
-> **Note**: When working with the command-line interface (CLI), you should configure the oneAPI toolkits using environment variables. 
-> Set up your CLI environment by sourcing the `setvars` script located in the root of your oneAPI installation every time you open a new terminal window. 
+> **Note**: When working with the command-line interface (CLI), you should configure the oneAPI toolkits using environment variables.
+> Set up your CLI environment by sourcing the `setvars` script located in the root of your oneAPI installation every time you open a new terminal window.
 > This practice ensures that your compiler, libraries, and tools are ready for development.
 >
 > Linux*:
@@ -142,7 +142,7 @@ Performance results are based on testing as of October 27, 2020.
 ### On Linux*
 
 1. Change to the sample directory.
-2. Configure the build system for the Agilex® device family, which is the default.
+2. Configure the build system for the Agilex 7® device family, which is the default.
 
    ```
    mkdir build
@@ -155,12 +155,12 @@ Performance results are based on testing as of October 27, 2020.
    > **Note**: You can change the default target by using the command:
    >  ```
    >  cmake .. -DFPGA_DEVICE=<FPGA device family or FPGA part number>
-   >  ``` 
+   >  ```
    >
-   > Alternatively, you can target an explicit FPGA board variant and BSP by using the following command: 
+   > Alternatively, you can target an explicit FPGA board variant and BSP by using the following command:
    >  ```
    >  cmake .. -DFPGA_DEVICE=<board-support-package>:<board-variant> -DIS_BSP=1
-   >  ``` 
+   >  ```
    >
    > You will only be able to run an executable on the FPGA if you specified a BSP.
 
@@ -189,7 +189,7 @@ Performance results are based on testing as of October 27, 2020.
 ### On Windows*
 
 1. Change to the sample directory.
-2. Configure the build system for the Agilex® device family, which is the default.
+2. Configure the build system for the Agilex 7® device family, which is the default.
    ```
    mkdir build
    cd build
@@ -201,12 +201,12 @@ Performance results are based on testing as of October 27, 2020.
   > **Note**: You can change the default target by using the command:
   >  ```
   >  cmake -G "NMake Makefiles" .. -DFPGA_DEVICE=<FPGA device family or FPGA part number>
-  >  ``` 
+  >  ```
   >
-  > Alternatively, you can target an explicit FPGA board variant and BSP by using the following command: 
+  > Alternatively, you can target an explicit FPGA board variant and BSP by using the following command:
   >  ```
   >  cmake -G "NMake Makefiles" .. -DFPGA_DEVICE=<board-support-package>:<board-variant> -DIS_BSP=1
-  >  ``` 
+  >  ```
   >
   > You will only be able to run an executable on the FPGA if you specified a BSP.
 
@@ -239,7 +239,7 @@ Performance results are based on testing as of October 27, 2020.
 
 | Argument             | Description
 |:---                  |:---
-| `<input_file>`       | Specifies the file to be compressed. <br> Use an 120+ MB file to achieve peak performance. <br> Use an 80 KB file for Low Latency variant. <br> Use a smaller file such as an 100 B file if the simulator flow is taking too long. 
+| `<input_file>`       | Specifies the file to be compressed. <br> Use an 120+ MB file to achieve peak performance. <br> Use an 80 KB file for Low Latency variant. <br> Use a smaller file such as an 100 B file if the simulator flow is taking too long.
 | `-o=<output_file>`   | Specifies the name of the output file. The default name of the output file is `<input_file>.gz`. <br> When using two engines, the single `<input_file>` is fed to both engines, yielding two identical output files, using `<output_file>` as the basis for the filenames.
 
 ### On Linux
@@ -248,7 +248,7 @@ Performance results are based on testing as of October 27, 2020.
     ```
     ./gzip.fpga_emu <input_file> -o=<output_file>
     ```
-    
+
  2. Run the sample on the FPGA simulator.
     ```
     CL_CONTEXT_MPSIM_DEVICE_INTELFPGA=1 ./gzip.fpga_sim <input_file> -o=<output_file>

--- a/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/gzip/src/CMakeLists.txt
+++ b/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/gzip/src/CMakeLists.txt
@@ -21,8 +21,8 @@ set(FPGA_TARGET ${TARGET_NAME}.fpga)
 
 # FPGA board selection
 if(NOT DEFINED FPGA_DEVICE)
-    set(FPGA_DEVICE "Agilex 7")
-    set(DEVICE_FLAG "Agilex 7")
+    set(FPGA_DEVICE "Agilex7")
+    set(DEVICE_FLAG "Agilex7")
     message(STATUS "FPGA_DEVICE was not specified.\
                     \nConfiguring the design to the default FPGA family: ${FPGA_DEVICE}\
                     \nPlease refer to the README for information on target selection.")
@@ -35,7 +35,7 @@ else()
     elseif(FPGA_DEVICE_NAME MATCHES ".*s10.*" OR FPGA_DEVICE_NAME MATCHES ".*stratix10.*")
       set(DEVICE_FLAG "S10")
     elseif(FPGA_DEVICE_NAME MATCHES ".*agilex.*")
-      set(DEVICE_FLAG "Agilex 7")
+      set(DEVICE_FLAG "Agilex7")
     endif()
     message(STATUS "Configuring the design with the following target: ${FPGA_DEVICE}")
 
@@ -51,7 +51,7 @@ endif()
 
 if(NOT DEFINED DEVICE_FLAG)
     message(FATAL_ERROR "An unrecognized or custom board was passed, but DEVICE_FLAG was not specified. \
-                         Make sure you have set -DDEVICE_FLAG=A10, -DDEVICE_FLAG=S10 or -DDEVICE_FLAG=Agilex 7.")
+                         Make sure you have set -DDEVICE_FLAG=A10, -DDEVICE_FLAG=S10 or -DDEVICE_FLAG=Agilex7.")
 endif()
 
 # This is a Windows-specific flag that enables error handling in host code
@@ -82,8 +82,8 @@ elseif(DEVICE_FLAG MATCHES "S10")
         # For Low Latency variant this is not necessary since only one channel of global memory is used (host memory).
         set(NUM_REORDER "-Xsnum-reorder=6")
     endif()
-elseif(DEVICE_FLAG MATCHES "Agilex 7")
-    # Agilex 7™
+elseif(DEVICE_FLAG MATCHES "Agilex7")
+    # Agilex7™
     set(NUM_ENGINES 2)
     if(DEFINED LOW_LATENCY)
         set(SEED "-Xsseed=1")

--- a/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/gzip/src/CMakeLists.txt
+++ b/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/gzip/src/CMakeLists.txt
@@ -21,8 +21,8 @@ set(FPGA_TARGET ${TARGET_NAME}.fpga)
 
 # FPGA board selection
 if(NOT DEFINED FPGA_DEVICE)
-    set(FPGA_DEVICE "Agilex")
-    set(DEVICE_FLAG "Agilex")
+    set(FPGA_DEVICE "Agilex 7")
+    set(DEVICE_FLAG "Agilex 7")
     message(STATUS "FPGA_DEVICE was not specified.\
                     \nConfiguring the design to the default FPGA family: ${FPGA_DEVICE}\
                     \nPlease refer to the README for information on target selection.")
@@ -35,7 +35,7 @@ else()
     elseif(FPGA_DEVICE_NAME MATCHES ".*s10.*" OR FPGA_DEVICE_NAME MATCHES ".*stratix10.*")
       set(DEVICE_FLAG "S10")
     elseif(FPGA_DEVICE_NAME MATCHES ".*agilex.*")
-      set(DEVICE_FLAG "Agilex")
+      set(DEVICE_FLAG "Agilex 7")
     endif()
     message(STATUS "Configuring the design with the following target: ${FPGA_DEVICE}")
 
@@ -51,7 +51,7 @@ endif()
 
 if(NOT DEFINED DEVICE_FLAG)
     message(FATAL_ERROR "An unrecognized or custom board was passed, but DEVICE_FLAG was not specified. \
-                         Make sure you have set -DDEVICE_FLAG=A10, -DDEVICE_FLAG=S10 or -DDEVICE_FLAG=Agilex.")
+                         Make sure you have set -DDEVICE_FLAG=A10, -DDEVICE_FLAG=S10 or -DDEVICE_FLAG=Agilex 7.")
 endif()
 
 # This is a Windows-specific flag that enables error handling in host code
@@ -82,8 +82,8 @@ elseif(DEVICE_FLAG MATCHES "S10")
         # For Low Latency variant this is not necessary since only one channel of global memory is used (host memory).
         set(NUM_REORDER "-Xsnum-reorder=6")
     endif()
-elseif(DEVICE_FLAG MATCHES "Agilex")
-    # Agilex™
+elseif(DEVICE_FLAG MATCHES "Agilex 7")
+    # Agilex 7™
     set(NUM_ENGINES 2)
     if(DEFINED LOW_LATENCY)
         set(SEED "-Xsseed=1")
@@ -145,7 +145,7 @@ add_custom_target(fpga_emu DEPENDS ${EMULATOR_TARGET})
 ### FPGA Simulator
 ###############################################################################
 add_executable(${SIMULATOR_TARGET} ${SOURCE_FILE} ${DEVICE_SOURCE_FILE})
-target_include_directories(${SIMULATOR_TARGET} PRIVATE ../../../include) 
+target_include_directories(${SIMULATOR_TARGET} PRIVATE ../../../include)
 set_target_properties(${SIMULATOR_TARGET} PROPERTIES COMPILE_FLAGS "${SIMULATOR_COMPILE_FLAGS}")
 set_target_properties(${SIMULATOR_TARGET} PROPERTIES LINK_FLAGS "${SIMULATOR_LINK_FLAGS}")
 add_custom_target(fpga_sim DEPENDS ${SIMULATOR_TARGET})

--- a/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/gzip/src/CMakeLists.txt
+++ b/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/gzip/src/CMakeLists.txt
@@ -83,7 +83,7 @@ elseif(DEVICE_FLAG MATCHES "S10")
         set(NUM_REORDER "-Xsnum-reorder=6")
     endif()
 elseif(DEVICE_FLAG MATCHES "Agilex7")
-    # Agilex7™
+    # Agilex 7
     set(NUM_ENGINES 2)
     if(DEFINED LOW_LATENCY)
         set(SEED "-Xsseed=1")

--- a/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/merge_sort/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/merge_sort/README.md
@@ -41,7 +41,7 @@ You can also find more information about [troubleshooting build errors](/DirectP
 | Optimized for        | Description
 |:---                  |:---
 | OS                   | Ubuntu* 18.04/20.04 <br> RHEL*/CentOS* 8 <br> SUSE* 15
-| Hardware             | Intel® Agilex 7®, Arria® 10, and Stratix® 10 FPGAs
+| Hardware             | Intel® Agilex® 7, Arria® 10, and Stratix® 10 FPGAs
 | Software             | Intel® oneAPI DPC++/C++ Compiler
 
 > **Note**: Even though the Intel DPC++/C++ OneAPI compiler is enough to compile for emulation, generating reports and generating RTL, there are extra software requirements for the simulation flow and FPGA compiles.
@@ -118,7 +118,7 @@ For `constexpr_math.hpp`, `pipe_utils.hpp`, and `unrolled_loop.hpp` see the READ
 ### On Linux*
 
 1. Change to the sample directory.
-2. Configure the build system for the Agilex 7® device family, which is the default.
+2. Configure the build system for the Agilex® 7 device family, which is the default.
 
    ```
    mkdir build

--- a/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/merge_sort/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/merge_sort/README.md
@@ -26,9 +26,9 @@ flowchart LR
    tier2("Tier 2: Explore the Fundamentals")
    tier3("Tier 3: Explore the Advanced Techniques")
    tier4("Tier 4: Explore the Reference Designs")
-   
+
    tier1 --> tier2 --> tier3 --> tier4
-   
+
    style tier1 fill:#0071c1,stroke:#0071c1,stroke-width:1px,color:#fff
    style tier2 fill:#0071c1,stroke:#0071c1,stroke-width:1px,color:#fff
    style tier3 fill:#0071c1,stroke:#0071c1,stroke-width:1px,color:#fff
@@ -41,7 +41,7 @@ You can also find more information about [troubleshooting build errors](/DirectP
 | Optimized for        | Description
 |:---                  |:---
 | OS                   | Ubuntu* 18.04/20.04 <br> RHEL*/CentOS* 8 <br> SUSE* 15
-| Hardware             | Intel® Agilex®, Arria® 10, and Stratix® 10 FPGAs
+| Hardware             | Intel® Agilex 7®, Arria® 10, and Stratix® 10 FPGAs
 | Software             | Intel® oneAPI DPC++/C++ Compiler
 
 > **Note**: Even though the Intel DPC++/C++ OneAPI compiler is enough to compile for emulation, generating reports and generating RTL, there are extra software requirements for the simulation flow and FPGA compiles.
@@ -75,7 +75,7 @@ A single merge unit requires `lg(N)` iterations to sort `N` elements. This requi
 
 To achieve SIMD-level (**S**ingle **I**nstruction **M**ultiple **D**ata) parallelism, we enhance the merge unit to merge `k` elements per cycle. The figure below illustrates how this is done. In the following discussion, we will assume that we are sorting from smallest-to-largest, but the logic is very similar for sorting largest-to-smallest and is easily configurable at compile time in this design.
 
-The merge unit looks at the two inputs of size `k` coming from the `ProduceA` and `ProduceB` kernels (in the figure below, `k=4`) and compares the first elements of each set; remember, the set of `k` elements are already sorted, so we are comparing the smallest elements of the set. Whichever set of elements has the *smaller of the smallest elements* is chosen and combined with `k` other elements from the `feedback` path. These `2*k` elements go through a merge sort network that sorts them in a single cycle. After the `2*k` elements are sorted, the smallest `k` elements are sent to the output (to the `Consume` kernel) and the largest `k` elements are fed back into the sorting network (the `feedback` path in the figure below), and the process repeats. This allows the merge unit to process `k` elements per cycle in the steady state. Note that `k` must be a power of 2. 
+The merge unit looks at the two inputs of size `k` coming from the `ProduceA` and `ProduceB` kernels (in the figure below, `k=4`) and compares the first elements of each set; remember, the set of `k` elements are already sorted, so we are comparing the smallest elements of the set. Whichever set of elements has the *smaller of the smallest elements* is chosen and combined with `k` other elements from the `feedback` path. These `2*k` elements go through a merge sort network that sorts them in a single cycle. After the `2*k` elements are sorted, the smallest `k` elements are sent to the output (to the `Consume` kernel) and the largest `k` elements are fed back into the sorting network (the `feedback` path in the figure below), and the process repeats. This allows the merge unit to process `k` elements per cycle in the steady state. Note that `k` must be a power of 2.
 
 >**Note**: You can find more information about this design in the paper *[A High Performance FPGA-Based Sorting Accelerator with a Data Compression Mechanism](https://www.researchgate.net/publication/316604001_A_High_Performance_FPGA-Based_Sorting_Accelerator_with_a_Data_Compression_Mechanism)* by Ryohei Kobayashi and Kenji Kise.
 
@@ -104,8 +104,8 @@ For `constexpr_math.hpp`, `pipe_utils.hpp`, and `unrolled_loop.hpp` see the READ
 
 ## Build the `Merge Sort` Design
 
-> **Note**: When working with the command-line interface (CLI), you should configure the oneAPI toolkits using environment variables. 
-> Set up your CLI environment by sourcing the `setvars` script located in the root of your oneAPI installation every time you open a new terminal window. 
+> **Note**: When working with the command-line interface (CLI), you should configure the oneAPI toolkits using environment variables.
+> Set up your CLI environment by sourcing the `setvars` script located in the root of your oneAPI installation every time you open a new terminal window.
 > This practice ensures that your compiler, libraries, and tools are ready for development.
 >
 > Linux*:
@@ -118,7 +118,7 @@ For `constexpr_math.hpp`, `pipe_utils.hpp`, and `unrolled_loop.hpp` see the READ
 ### On Linux*
 
 1. Change to the sample directory.
-2. Configure the build system for the Agilex® device family, which is the default.
+2. Configure the build system for the Agilex 7® device family, which is the default.
 
    ```
    mkdir build
@@ -129,12 +129,12 @@ For `constexpr_math.hpp`, `pipe_utils.hpp`, and `unrolled_loop.hpp` see the READ
    > **Note**: You can change the default target by using the command:
    >  ```
    >  cmake .. -DFPGA_DEVICE=<FPGA device family or FPGA part number>
-   >  ``` 
+   >  ```
    >
-   > Alternatively, you can target an explicit FPGA board variant and BSP by using the following command: 
+   > Alternatively, you can target an explicit FPGA board variant and BSP by using the following command:
    >  ```
    >  cmake .. -DFPGA_DEVICE=<board-support-package>:<board-variant> -DIS_BSP=1
-   >  ``` 
+   >  ```
    >
    > You will only be able to run an executable on the FPGA if you specified a BSP.
 

--- a/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/merge_sort/src/CMakeLists.txt
+++ b/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/merge_sort/src/CMakeLists.txt
@@ -6,7 +6,7 @@ set(FPGA_TARGET ${TARGET_NAME}.fpga)
 
 # FPGA board selection
 if(NOT DEFINED FPGA_DEVICE)
-    set(FPGA_DEVICE "Agilex")
+    set(FPGA_DEVICE "Agilex 7")
     message(STATUS "FPGA_DEVICE was not specified.\
                     \nConfiguring the design to the default FPGA family: ${FPGA_DEVICE}\
                     \nPlease refer to the README for information on target selection.")

--- a/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/merge_sort/src/CMakeLists.txt
+++ b/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/merge_sort/src/CMakeLists.txt
@@ -6,7 +6,7 @@ set(FPGA_TARGET ${TARGET_NAME}.fpga)
 
 # FPGA board selection
 if(NOT DEFINED FPGA_DEVICE)
-    set(FPGA_DEVICE "Agilex 7")
+    set(FPGA_DEVICE "Agilex7")
     message(STATUS "FPGA_DEVICE was not specified.\
                     \nConfiguring the design to the default FPGA family: ${FPGA_DEVICE}\
                     \nPlease refer to the README for information on target selection.")

--- a/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/mvdr_beamforming/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/mvdr_beamforming/README.md
@@ -49,7 +49,7 @@ You can also find more information about [troubleshooting build errors](/DirectP
 | Optimized for        | Description
 |:---                  |:---
 | OS                   | Ubuntu* 18.04/20.04 <br> RHEL*/CentOS* 8 <br> SUSE* 15 <br> Windows* 10
-| Hardware             | Intel® Agilex 7®, Arria® 10, and Stratix® 10 FPGAs
+| Hardware             | Intel® Agilex® 7, Arria® 10, and Stratix® 10 FPGAs
 | Software             | Intel® oneAPI DPC++/C++ Compiler
 
 > **Note**: Even though the Intel DPC++/C++ OneAPI compiler is enough to compile for emulation, generating reports and generating RTL, there are extra software requirements for the simulation flow and FPGA compiles.
@@ -121,7 +121,7 @@ The `DataProducer` kernel replaces the input IO pipe in the first image. The spl
 ### On Linux*
 
 1. Change to the sample directory.
-2. Configure the build system for the Agilex 7® device family, which is the default.
+2. Configure the build system for the Agilex® 7 device family, which is the default.
 
    ```
    mkdir build
@@ -165,7 +165,7 @@ The `DataProducer` kernel replaces the input IO pipe in the first image. The spl
 ### On Windows*
 
 1. Change to the sample directory.
-2. Configure the build system for the Agilex 7® device family, which is the default.
+2. Configure the build system for the Agilex® 7 device family, which is the default.
    ```
    mkdir build
    cd build

--- a/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/mvdr_beamforming/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/mvdr_beamforming/README.md
@@ -34,9 +34,9 @@ flowchart LR
    tier2("Tier 2: Explore the Fundamentals")
    tier3("Tier 3: Explore the Advanced Techniques")
    tier4("Tier 4: Explore the Reference Designs")
-   
+
    tier1 --> tier2 --> tier3 --> tier4
-   
+
    style tier1 fill:#0071c1,stroke:#0071c1,stroke-width:1px,color:#fff
    style tier2 fill:#0071c1,stroke:#0071c1,stroke-width:1px,color:#fff
    style tier3 fill:#0071c1,stroke:#0071c1,stroke-width:1px,color:#fff
@@ -49,7 +49,7 @@ You can also find more information about [troubleshooting build errors](/DirectP
 | Optimized for        | Description
 |:---                  |:---
 | OS                   | Ubuntu* 18.04/20.04 <br> RHEL*/CentOS* 8 <br> SUSE* 15 <br> Windows* 10
-| Hardware             | Intel® Agilex®, Arria® 10, and Stratix® 10 FPGAs
+| Hardware             | Intel® Agilex 7®, Arria® 10, and Stratix® 10 FPGAs
 | Software             | Intel® oneAPI DPC++/C++ Compiler
 
 > **Note**: Even though the Intel DPC++/C++ OneAPI compiler is enough to compile for emulation, generating reports and generating RTL, there are extra software requirements for the simulation flow and FPGA compiles.
@@ -103,8 +103,8 @@ The `DataProducer` kernel replaces the input IO pipe in the first image. The spl
 
 ## Build the `MVDR Beamforming` Design
 
-> **Note**: When working with the command-line interface (CLI), you should configure the oneAPI toolkits using environment variables. 
-> Set up your CLI environment by sourcing the `setvars` script located in the root of your oneAPI installation every time you open a new terminal window. 
+> **Note**: When working with the command-line interface (CLI), you should configure the oneAPI toolkits using environment variables.
+> Set up your CLI environment by sourcing the `setvars` script located in the root of your oneAPI installation every time you open a new terminal window.
 > This practice ensures that your compiler, libraries, and tools are ready for development.
 >
 > Linux*:
@@ -121,7 +121,7 @@ The `DataProducer` kernel replaces the input IO pipe in the first image. The spl
 ### On Linux*
 
 1. Change to the sample directory.
-2. Configure the build system for the Agilex® device family, which is the default.
+2. Configure the build system for the Agilex 7® device family, which is the default.
 
    ```
    mkdir build
@@ -132,12 +132,12 @@ The `DataProducer` kernel replaces the input IO pipe in the first image. The spl
    > **Note**: You can change the default target by using the command:
    >  ```
    >  cmake .. -DFPGA_DEVICE=<FPGA device family or FPGA part number>
-   >  ``` 
+   >  ```
    >
-   > Alternatively, you can target an explicit FPGA board variant and BSP by using the following command: 
+   > Alternatively, you can target an explicit FPGA board variant and BSP by using the following command:
    >  ```
    >  cmake .. -DFPGA_DEVICE=<board-support-package>:<board-variant> -DIS_BSP=1
-   >  ``` 
+   >  ```
    >
    > You will only be able to run an executable on the FPGA if you specified a BSP.
 
@@ -165,7 +165,7 @@ The `DataProducer` kernel replaces the input IO pipe in the first image. The spl
 ### On Windows*
 
 1. Change to the sample directory.
-2. Configure the build system for the Agilex® device family, which is the default.
+2. Configure the build system for the Agilex 7® device family, which is the default.
    ```
    mkdir build
    cd build
@@ -175,12 +175,12 @@ The `DataProducer` kernel replaces the input IO pipe in the first image. The spl
   > **Note**: You can change the default target by using the command:
   >  ```
   >  cmake -G "NMake Makefiles" .. -DFPGA_DEVICE=<FPGA device family or FPGA part number>
-  >  ``` 
+  >  ```
   >
-  > Alternatively, you can target an explicit FPGA board variant and BSP by using the following command: 
+  > Alternatively, you can target an explicit FPGA board variant and BSP by using the following command:
   >  ```
   >  cmake -G "NMake Makefiles" .. -DFPGA_DEVICE=<board-support-package>:<board-variant> -DIS_BSP=1
-  >  ``` 
+  >  ```
   >
   > You will only be able to run an executable on the FPGA if you specified a BSP.
 

--- a/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/mvdr_beamforming/src/CMakeLists.txt
+++ b/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/mvdr_beamforming/src/CMakeLists.txt
@@ -6,7 +6,7 @@ set(FPGA_TARGET ${TARGET_NAME}.fpga)
 
 # FPGA board selection
 if(NOT DEFINED FPGA_DEVICE)
-    set(FPGA_DEVICE "Agilex")
+    set(FPGA_DEVICE "Agilex 7")
     message(STATUS "FPGA_DEVICE was not specified.\
                     \nConfiguring the design to the default FPGA family: ${FPGA_DEVICE}\
                     \nPlease refer to the README for information on target selection.")

--- a/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/mvdr_beamforming/src/CMakeLists.txt
+++ b/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/mvdr_beamforming/src/CMakeLists.txt
@@ -6,7 +6,7 @@ set(FPGA_TARGET ${TARGET_NAME}.fpga)
 
 # FPGA board selection
 if(NOT DEFINED FPGA_DEVICE)
-    set(FPGA_DEVICE "Agilex 7")
+    set(FPGA_DEVICE "Agilex7")
     message(STATUS "FPGA_DEVICE was not specified.\
                     \nConfiguring the design to the default FPGA family: ${FPGA_DEVICE}\
                     \nPlease refer to the README for information on target selection.")

--- a/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/qrd/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/qrd/README.md
@@ -44,7 +44,7 @@ You can also find more information about [troubleshooting build errors](/DirectP
 | Optimized for        | Description
 |:---                  |:---
 | OS                   | Ubuntu* 18.04/20.04 <br> RHEL*/CentOS* 8 <br> SUSE* 15 <br> Windows* 10
-| Hardware             | Intel® Agilex 7®, Arria® 10, and Stratix® 10 FPGAs
+| Hardware             | Intel® Agilex® 7, Arria® 10, and Stratix® 10 FPGAs
 | Software             | Intel® oneAPI DPC++/C++ Compiler
 
 > **Note**: Even though the Intel DPC++/C++ OneAPI compiler is enough to compile for emulation, generating reports and generating RTL, there are extra software requirements for the simulation flow and FPGA compiles.
@@ -76,7 +76,7 @@ The QR decomposition algorithm factors a complex _m_ × _n_ matrix, where _m_ �
 
 With this optimization, our FPGA implementation requires 4*m* DSPs to compute the complex floating point dot product or 2*m* DSPs for the real case. The matrix size is constrained by the total FPGA DSP resources available.
 
-By default, the design is parameterized to process 128 × 128 matrices when compiled targeting an Intel® Arria® 10 FPGA. It is parameterized to process 256 × 256 matrices when compiled targeting a Intel® Stratix® 10 or Intel® Agilex 7® FPGA; however, the design can process matrices from 4 x 4 to 512 x 512.
+By default, the design is parameterized to process 128 × 128 matrices when compiled targeting an Intel® Arria® 10 FPGA. It is parameterized to process 256 × 256 matrices when compiled targeting a Intel® Stratix® 10 or Intel® Agilex® 7 FPGA; however, the design can process matrices from 4 x 4 to 512 x 512.
 
 To optimize the performance-critical loop in its algorithm, the design leverages concepts discussed in the following FPGA tutorials:
 
@@ -133,7 +133,7 @@ Additionaly, the cmake build system can be configured using the following parame
 ### On Linux*
 
 1. Change to the sample directory.
-2. Configure the build system for the Agilex 7® device family, which is the default.
+2. Configure the build system for the Agilex® 7 device family, which is the default.
 
    ```
    mkdir build
@@ -177,7 +177,7 @@ Additionaly, the cmake build system can be configured using the following parame
 ### On Windows*
 
 1. Change to the sample directory.
-2. Configure the build system for the Agilex 7® device family, which is the default.
+2. Configure the build system for the Agilex® 7 device family, which is the default.
    ```
    mkdir build
    cd build

--- a/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/qrd/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/qrd/README.md
@@ -29,9 +29,9 @@ flowchart LR
    tier2("Tier 2: Explore the Fundamentals")
    tier3("Tier 3: Explore the Advanced Techniques")
    tier4("Tier 4: Explore the Reference Designs")
-   
+
    tier1 --> tier2 --> tier3 --> tier4
-   
+
    style tier1 fill:#0071c1,stroke:#0071c1,stroke-width:1px,color:#fff
    style tier2 fill:#0071c1,stroke:#0071c1,stroke-width:1px,color:#fff
    style tier3 fill:#0071c1,stroke:#0071c1,stroke-width:1px,color:#fff
@@ -44,7 +44,7 @@ You can also find more information about [troubleshooting build errors](/DirectP
 | Optimized for        | Description
 |:---                  |:---
 | OS                   | Ubuntu* 18.04/20.04 <br> RHEL*/CentOS* 8 <br> SUSE* 15 <br> Windows* 10
-| Hardware             | Intel® Agilex®, Arria® 10, and Stratix® 10 FPGAs
+| Hardware             | Intel® Agilex 7®, Arria® 10, and Stratix® 10 FPGAs
 | Software             | Intel® oneAPI DPC++/C++ Compiler
 
 > **Note**: Even though the Intel DPC++/C++ OneAPI compiler is enough to compile for emulation, generating reports and generating RTL, there are extra software requirements for the simulation flow and FPGA compiles.
@@ -76,7 +76,7 @@ The QR decomposition algorithm factors a complex _m_ × _n_ matrix, where _m_ �
 
 With this optimization, our FPGA implementation requires 4*m* DSPs to compute the complex floating point dot product or 2*m* DSPs for the real case. The matrix size is constrained by the total FPGA DSP resources available.
 
-By default, the design is parameterized to process 128 × 128 matrices when compiled targeting an Intel® Arria® 10 FPGA. It is parameterized to process 256 × 256 matrices when compiled targeting a Intel® Stratix® 10 or Intel® Agilex® FPGA; however, the design can process matrices from 4 x 4 to 512 x 512.
+By default, the design is parameterized to process 128 × 128 matrices when compiled targeting an Intel® Arria® 10 FPGA. It is parameterized to process 256 × 256 matrices when compiled targeting a Intel® Stratix® 10 or Intel® Agilex 7® FPGA; however, the design can process matrices from 4 x 4 to 512 x 512.
 
 To optimize the performance-critical loop in its algorithm, the design leverages concepts discussed in the following FPGA tutorials:
 
@@ -115,8 +115,8 @@ Additionaly, the cmake build system can be configured using the following parame
 
 ## Build the `QRD` Design
 
-> **Note**: When working with the command-line interface (CLI), you should configure the oneAPI toolkits using environment variables. 
-> Set up your CLI environment by sourcing the `setvars` script located in the root of your oneAPI installation every time you open a new terminal window. 
+> **Note**: When working with the command-line interface (CLI), you should configure the oneAPI toolkits using environment variables.
+> Set up your CLI environment by sourcing the `setvars` script located in the root of your oneAPI installation every time you open a new terminal window.
 > This practice ensures that your compiler, libraries, and tools are ready for development.
 >
 > Linux*:
@@ -133,7 +133,7 @@ Additionaly, the cmake build system can be configured using the following parame
 ### On Linux*
 
 1. Change to the sample directory.
-2. Configure the build system for the Agilex® device family, which is the default.
+2. Configure the build system for the Agilex 7® device family, which is the default.
 
    ```
    mkdir build
@@ -144,12 +144,12 @@ Additionaly, the cmake build system can be configured using the following parame
    > **Note**: You can change the default target by using the command:
    >  ```
    >  cmake .. -DFPGA_DEVICE=<FPGA device family or FPGA part number>
-   >  ``` 
+   >  ```
    >
-   > Alternatively, you can target an explicit FPGA board variant and BSP by using the following command: 
+   > Alternatively, you can target an explicit FPGA board variant and BSP by using the following command:
    >  ```
    >  cmake .. -DFPGA_DEVICE=<board-support-package>:<board-variant> -DIS_BSP=1
-   >  ``` 
+   >  ```
    >
    > You will only be able to run an executable on the FPGA if you specified a BSP.
 
@@ -177,7 +177,7 @@ Additionaly, the cmake build system can be configured using the following parame
 ### On Windows*
 
 1. Change to the sample directory.
-2. Configure the build system for the Agilex® device family, which is the default.
+2. Configure the build system for the Agilex 7® device family, which is the default.
    ```
    mkdir build
    cd build
@@ -187,12 +187,12 @@ Additionaly, the cmake build system can be configured using the following parame
   > **Note**: You can change the default target by using the command:
   >  ```
   >  cmake -G "NMake Makefiles" .. -DFPGA_DEVICE=<FPGA device family or FPGA part number>
-  >  ``` 
+  >  ```
   >
-  > Alternatively, you can target an explicit FPGA board variant and BSP by using the following command: 
+  > Alternatively, you can target an explicit FPGA board variant and BSP by using the following command:
   >  ```
   >  cmake -G "NMake Makefiles" .. -DFPGA_DEVICE=<board-support-package>:<board-variant> -DIS_BSP=1
-  >  ``` 
+  >  ```
   >
   > You will only be able to run an executable on the FPGA if you specified a BSP.
 
@@ -266,7 +266,7 @@ You can perform the QR decomposition of the set of matrices repeatedly. This ste
    set CL_CONFIG_CPU_FORCE_PRIVATE_MEM_SIZE=32MB
    qrd.fpga_emu.exe
    ```
-   
+
 #### Run on FPGA Simulator
 
 1. Run the sample on the FPGA simulator.
@@ -289,7 +289,7 @@ Example Output when running on **Intel® PAC with Intel® Arria® 10 GX FPGA** f
 
 ```
 Device name: pac_a10 : Intel PAC Platform (pac_f000000)
-Generating 8 random complex matrices of size 128x128 
+Generating 8 random complex matrices of size 128x128
 Running QR decomposition of 8 matrices 819200 times
  Total duration:   268.733 s
 Throughput: 24.387k matrices/s
@@ -301,7 +301,7 @@ Example output when running on **Intel® FPGA PAC D5005 (with Intel Stratix® 10
 
 ```
 Device name: pac_s10 : Intel PAC Platform (pac_f100000)
-Generating 8 random complex matrices of size 256x256 
+Generating 8 random complex matrices of size 256x256
 Running QR decomposition of 8 matrices 819200 times
  Total duration:   888.077 s
 Throughput: 7.37954k matrices/s

--- a/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/qrd/src/CMakeLists.txt
+++ b/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/qrd/src/CMakeLists.txt
@@ -74,7 +74,7 @@ elseif(DEVICE_FLAG MATCHES "S10")
     set(CLOCK_TARGET "-Xsclock=480MHz")
     set(SEED "-Xsseed=3")
 elseif(DEVICE_FLAG MATCHES "Agilex7")
-    # Agilex7™ parameters
+    # Agilex 7 parameters
     set(ROWS_COMPONENT 256)
     set(COLS_COMPONENT 256)
     set(FIXED_ITERATIONS 110)

--- a/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/qrd/src/CMakeLists.txt
+++ b/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/qrd/src/CMakeLists.txt
@@ -7,8 +7,8 @@ set(FPGA_EARLY_IMAGE ${TARGET_NAME}_report.a)
 
 # FPGA board selection
 if(NOT DEFINED FPGA_DEVICE)
-    set(FPGA_DEVICE "Agilex")
-    set(DEVICE_FLAG "Agilex")
+    set(FPGA_DEVICE "Agilex 7")
+    set(DEVICE_FLAG "Agilex 7")
     message(STATUS "FPGA_DEVICE was not specified.\
                     \nConfiguring the design to the default FPGA family: ${FPGA_DEVICE}\
                     \nPlease refer to the README for information on target selection.")
@@ -20,7 +20,7 @@ else()
     elseif(FPGA_DEVICE_NAME MATCHES ".*s10.*" OR FPGA_DEVICE_NAME MATCHES ".*stratix10.*")
       set(DEVICE_FLAG "S10")
     elseif(FPGA_DEVICE_NAME MATCHES ".*agilex.*")
-      set(DEVICE_FLAG "Agilex")
+      set(DEVICE_FLAG "Agilex 7")
     endif()
     message(STATUS "Configuring the design with the following target: ${FPGA_DEVICE}")
 
@@ -31,12 +31,12 @@ else()
         set(BSP_FLAG "")
         message(STATUS "The selected target ${FPGA_DEVICE} is assumed to be an FPGA part number, so the IS_BSP macro will not be passed to your C++ code.")
         message(STATUS "If the target is actually a BSP, run cmake with -DIS_BSP=1 to pass the IS_BSP macro to your C++ code.")
-    endif()    
+    endif()
 endif()
 
 if(NOT DEFINED DEVICE_FLAG)
     message(FATAL_ERROR "An unrecognized or custom board was passed, but DEVICE_FLAG was not specified. \
-                         Make sure you have set -DDEVICE_FLAG=A10, -DDEVICE_FLAG=S10 or -DDEVICE_FLAG=Agilex")
+                         Make sure you have set -DDEVICE_FLAG=A10, -DDEVICE_FLAG=S10 or -DDEVICE_FLAG=Agilex 7")
 endif()
 
 # This is a Windows-specific flag that enables error handling in host code
@@ -73,8 +73,8 @@ elseif(DEVICE_FLAG MATCHES "S10")
     set(FIXED_ITERATIONS 110)
     set(CLOCK_TARGET "-Xsclock=480MHz")
     set(SEED "-Xsseed=3")
-elseif(DEVICE_FLAG MATCHES "Agilex")
-    # Agilex™ parameters
+elseif(DEVICE_FLAG MATCHES "Agilex 7")
+    # Agilex 7™ parameters
     set(ROWS_COMPONENT 256)
     set(COLS_COMPONENT 256)
     set(FIXED_ITERATIONS 110)

--- a/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/qrd/src/CMakeLists.txt
+++ b/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/qrd/src/CMakeLists.txt
@@ -7,8 +7,8 @@ set(FPGA_EARLY_IMAGE ${TARGET_NAME}_report.a)
 
 # FPGA board selection
 if(NOT DEFINED FPGA_DEVICE)
-    set(FPGA_DEVICE "Agilex 7")
-    set(DEVICE_FLAG "Agilex 7")
+    set(FPGA_DEVICE "Agilex7")
+    set(DEVICE_FLAG "Agilex7")
     message(STATUS "FPGA_DEVICE was not specified.\
                     \nConfiguring the design to the default FPGA family: ${FPGA_DEVICE}\
                     \nPlease refer to the README for information on target selection.")
@@ -20,7 +20,7 @@ else()
     elseif(FPGA_DEVICE_NAME MATCHES ".*s10.*" OR FPGA_DEVICE_NAME MATCHES ".*stratix10.*")
       set(DEVICE_FLAG "S10")
     elseif(FPGA_DEVICE_NAME MATCHES ".*agilex.*")
-      set(DEVICE_FLAG "Agilex 7")
+      set(DEVICE_FLAG "Agilex7")
     endif()
     message(STATUS "Configuring the design with the following target: ${FPGA_DEVICE}")
 
@@ -36,7 +36,7 @@ endif()
 
 if(NOT DEFINED DEVICE_FLAG)
     message(FATAL_ERROR "An unrecognized or custom board was passed, but DEVICE_FLAG was not specified. \
-                         Make sure you have set -DDEVICE_FLAG=A10, -DDEVICE_FLAG=S10 or -DDEVICE_FLAG=Agilex 7")
+                         Make sure you have set -DDEVICE_FLAG=A10, -DDEVICE_FLAG=S10 or -DDEVICE_FLAG=Agilex7")
 endif()
 
 # This is a Windows-specific flag that enables error handling in host code
@@ -73,8 +73,8 @@ elseif(DEVICE_FLAG MATCHES "S10")
     set(FIXED_ITERATIONS 110)
     set(CLOCK_TARGET "-Xsclock=480MHz")
     set(SEED "-Xsseed=3")
-elseif(DEVICE_FLAG MATCHES "Agilex 7")
-    # Agilex 7™ parameters
+elseif(DEVICE_FLAG MATCHES "Agilex7")
+    # Agilex7™ parameters
     set(ROWS_COMPONENT 256)
     set(COLS_COMPONENT 256)
     set(FIXED_ITERATIONS 110)

--- a/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/qri/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/qri/README.md
@@ -44,7 +44,7 @@ You can also find more information about [troubleshooting build errors](/DirectP
 | Optimized for        | Description
 |:---                  |:---
 | OS                   | Ubuntu* 18.04/20.04 <br> RHEL*/CentOS* 8 <br> SUSE* 15 <br> Windows* 10
-| Hardware             | Intel® Agilex 7®, Arria® 10, and Stratix® 10 FPGAs
+| Hardware             | Intel® Agilex® 7, Arria® 10, and Stratix® 10 FPGAs
 | Software             | Intel® oneAPI DPC++/C++ Compiler
 
 > **Note**: Even though the Intel DPC++/C++ OneAPI compiler is enough to compile for emulation, generating reports and generating RTL, there are extra software requirements for the simulation flow and FPGA compiles.
@@ -123,7 +123,7 @@ Additionaly, the cmake build system can be configured using the following parame
 ### On Linux*
 
 1. Change to the sample directory.
-2. Configure the build system for the Agilex 7® device family, which is the default.
+2. Configure the build system for the Agilex® 7 device family, which is the default.
 
    ```
    mkdir build
@@ -166,7 +166,7 @@ Additionaly, the cmake build system can be configured using the following parame
 ### On Windows*
 
 1. Change to the sample directory.
-2. Configure the build system for the Agilex 7® device family, which is the default.
+2. Configure the build system for the Agilex® 7 device family, which is the default.
    ```
    mkdir build
    cd build

--- a/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/qri/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/qri/README.md
@@ -29,9 +29,9 @@ flowchart LR
    tier2("Tier 2: Explore the Fundamentals")
    tier3("Tier 3: Explore the Advanced Techniques")
    tier4("Tier 4: Explore the Reference Designs")
-   
+
    tier1 --> tier2 --> tier3 --> tier4
-   
+
    style tier1 fill:#0071c1,stroke:#0071c1,stroke-width:1px,color:#fff
    style tier2 fill:#0071c1,stroke:#0071c1,stroke-width:1px,color:#fff
    style tier3 fill:#0071c1,stroke:#0071c1,stroke-width:1px,color:#fff
@@ -44,7 +44,7 @@ You can also find more information about [troubleshooting build errors](/DirectP
 | Optimized for        | Description
 |:---                  |:---
 | OS                   | Ubuntu* 18.04/20.04 <br> RHEL*/CentOS* 8 <br> SUSE* 15 <br> Windows* 10
-| Hardware             | Intel® Agilex®, Arria® 10, and Stratix® 10 FPGAs
+| Hardware             | Intel® Agilex 7®, Arria® 10, and Stratix® 10 FPGAs
 | Software             | Intel® oneAPI DPC++/C++ Compiler
 
 > **Note**: Even though the Intel DPC++/C++ OneAPI compiler is enough to compile for emulation, generating reports and generating RTL, there are extra software requirements for the simulation flow and FPGA compiles.
@@ -105,8 +105,8 @@ Additionaly, the cmake build system can be configured using the following parame
 
 ## Build the `QRI` Sample
 
-> **Note**: When working with the command-line interface (CLI), you should configure the oneAPI toolkits using environment variables. 
-> Set up your CLI environment by sourcing the `setvars` script located in the root of your oneAPI installation every time you open a new terminal window. 
+> **Note**: When working with the command-line interface (CLI), you should configure the oneAPI toolkits using environment variables.
+> Set up your CLI environment by sourcing the `setvars` script located in the root of your oneAPI installation every time you open a new terminal window.
 > This practice ensures that your compiler, libraries, and tools are ready for development.
 >
 > Linux*:
@@ -123,7 +123,7 @@ Additionaly, the cmake build system can be configured using the following parame
 ### On Linux*
 
 1. Change to the sample directory.
-2. Configure the build system for the Agilex® device family, which is the default.
+2. Configure the build system for the Agilex 7® device family, which is the default.
 
    ```
    mkdir build
@@ -133,12 +133,12 @@ Additionaly, the cmake build system can be configured using the following parame
    > **Note**: You can change the default target by using the command:
    >  ```
    >  cmake .. -DFPGA_DEVICE=<FPGA device family or FPGA part number>
-   >  ``` 
+   >  ```
    >
-   > Alternatively, you can target an explicit FPGA board variant and BSP by using the following command: 
+   > Alternatively, you can target an explicit FPGA board variant and BSP by using the following command:
    >  ```
    >  cmake .. -DFPGA_DEVICE=<board-support-package>:<board-variant> -DIS_BSP=1
-   >  ``` 
+   >  ```
    >
    > You will only be able to run an executable on the FPGA if you specified a BSP.
 
@@ -166,7 +166,7 @@ Additionaly, the cmake build system can be configured using the following parame
 ### On Windows*
 
 1. Change to the sample directory.
-2. Configure the build system for the Agilex® device family, which is the default.
+2. Configure the build system for the Agilex 7® device family, which is the default.
    ```
    mkdir build
    cd build
@@ -176,12 +176,12 @@ Additionaly, the cmake build system can be configured using the following parame
   > **Note**: You can change the default target by using the command:
   >  ```
   >  cmake -G "NMake Makefiles" .. -DFPGA_DEVICE=<FPGA device family or FPGA part number>
-  >  ``` 
+  >  ```
   >
-  > Alternatively, you can target an explicit FPGA board variant and BSP by using the following command: 
+  > Alternatively, you can target an explicit FPGA board variant and BSP by using the following command:
   >  ```
   >  cmake -G "NMake Makefiles" .. -DFPGA_DEVICE=<board-support-package>:<board-variant> -DIS_BSP=1
-  >  ``` 
+  >  ```
   >
   > You will only be able to run an executable on the FPGA if you specified a BSP.
 

--- a/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/qri/src/CMakeLists.txt
+++ b/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/qri/src/CMakeLists.txt
@@ -65,7 +65,7 @@ elseif(DEVICE_FLAG MATCHES "S10")
     set(CLOCK_TARGET 450MHz)
     set(SEED "-Xsseed=5")
 elseif(DEVICE_FLAG MATCHES "Agilex7")
-    # Agilex7™ parameters
+    # Agilex 7 parameters
     set(ROWS_COMPONENT 32)
     set(COLS_COMPONENT 32)
     set(FIXED_ITERATIONS_QRD 58)

--- a/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/qri/src/CMakeLists.txt
+++ b/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/qri/src/CMakeLists.txt
@@ -7,13 +7,13 @@ set(FPGA_EARLY_IMAGE ${TARGET_NAME}_report.a)
 
 # FPGA board selection
 if(NOT DEFINED FPGA_DEVICE)
-    set(FPGA_DEVICE "Agilex")
-    set(DEVICE_FLAG "Agilex")
+    set(FPGA_DEVICE "Agilex 7")
+    set(DEVICE_FLAG "Agilex 7")
     message(STATUS "FPGA_DEVICE was not specified.\
                     \nConfiguring the design to the default FPGA family: ${FPGA_DEVICE}\
                     \nPlease refer to the README for information on target selection.")
 
-    set(BSP_FLAG "")    
+    set(BSP_FLAG "")
 else()
     string(TOLOWER ${FPGA_DEVICE} FPGA_DEVICE_NAME)
     if(FPGA_DEVICE_NAME MATCHES ".*a10.*" OR FPGA_DEVICE_NAME MATCHES ".*arria10.*")
@@ -21,7 +21,7 @@ else()
     elseif(FPGA_DEVICE_NAME MATCHES ".*s10.*" OR FPGA_DEVICE_NAME MATCHES ".*stratix10.*")
       set(DEVICE_FLAG "S10")
     elseif(FPGA_DEVICE_NAME MATCHES ".*agilex.*")
-      set(DEVICE_FLAG "Agilex")
+      set(DEVICE_FLAG "Agilex 7")
     endif()
     message(STATUS "Configuring the design with the following target: ${FPGA_DEVICE}")
 
@@ -32,7 +32,7 @@ else()
         set(BSP_FLAG "")
         message(STATUS "The selected target ${FPGA_DEVICE} is assumed to be an FPGA part number, so the IS_BSP macro will not be passed to your C++ code.")
         message(STATUS "If the target is actually a BSP, run cmake with -DIS_BSP=1 to pass the IS_BSP macro to your C++ code.")
-    endif()   
+    endif()
 endif()
 
 # This is a Windows-specific flag that enables error handling in host code
@@ -64,8 +64,8 @@ elseif(DEVICE_FLAG MATCHES "S10")
     set(FIXED_ITERATIONS_QRI 38)
     set(CLOCK_TARGET 450MHz)
     set(SEED "-Xsseed=5")
-elseif(DEVICE_FLAG MATCHES "Agilex")
-    # Agilex™ parameters
+elseif(DEVICE_FLAG MATCHES "Agilex 7")
+    # Agilex 7™ parameters
     set(ROWS_COMPONENT 32)
     set(COLS_COMPONENT 32)
     set(FIXED_ITERATIONS_QRD 58)
@@ -74,7 +74,7 @@ elseif(DEVICE_FLAG MATCHES "Agilex")
     set(CLOCK_TARGET 520MHz)
     set(SEED "-Xsseed=5")
 else()
-    message(FATAL_ERROR "An incorrect DEVICE_FLAG was given. Make sure you have set -DDEVICE_FLAG=A10, -DDEVICE_FLAG=S10 or -DDEVICE_FLAG=Agilex.")
+    message(FATAL_ERROR "An incorrect DEVICE_FLAG was given. Make sure you have set -DDEVICE_FLAG=A10, -DDEVICE_FLAG=S10 or -DDEVICE_FLAG=Agilex 7.")
 endif()
 
 if(IGNORE_DEFAULT_SEED)

--- a/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/qri/src/CMakeLists.txt
+++ b/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/qri/src/CMakeLists.txt
@@ -7,8 +7,8 @@ set(FPGA_EARLY_IMAGE ${TARGET_NAME}_report.a)
 
 # FPGA board selection
 if(NOT DEFINED FPGA_DEVICE)
-    set(FPGA_DEVICE "Agilex 7")
-    set(DEVICE_FLAG "Agilex 7")
+    set(FPGA_DEVICE "Agilex7")
+    set(DEVICE_FLAG "Agilex7")
     message(STATUS "FPGA_DEVICE was not specified.\
                     \nConfiguring the design to the default FPGA family: ${FPGA_DEVICE}\
                     \nPlease refer to the README for information on target selection.")
@@ -21,7 +21,7 @@ else()
     elseif(FPGA_DEVICE_NAME MATCHES ".*s10.*" OR FPGA_DEVICE_NAME MATCHES ".*stratix10.*")
       set(DEVICE_FLAG "S10")
     elseif(FPGA_DEVICE_NAME MATCHES ".*agilex.*")
-      set(DEVICE_FLAG "Agilex 7")
+      set(DEVICE_FLAG "Agilex7")
     endif()
     message(STATUS "Configuring the design with the following target: ${FPGA_DEVICE}")
 
@@ -64,8 +64,8 @@ elseif(DEVICE_FLAG MATCHES "S10")
     set(FIXED_ITERATIONS_QRI 38)
     set(CLOCK_TARGET 450MHz)
     set(SEED "-Xsseed=5")
-elseif(DEVICE_FLAG MATCHES "Agilex 7")
-    # Agilex 7™ parameters
+elseif(DEVICE_FLAG MATCHES "Agilex7")
+    # Agilex7™ parameters
     set(ROWS_COMPONENT 32)
     set(COLS_COMPONENT 32)
     set(FIXED_ITERATIONS_QRD 58)
@@ -74,7 +74,7 @@ elseif(DEVICE_FLAG MATCHES "Agilex 7")
     set(CLOCK_TARGET 520MHz)
     set(SEED "-Xsseed=5")
 else()
-    message(FATAL_ERROR "An incorrect DEVICE_FLAG was given. Make sure you have set -DDEVICE_FLAG=A10, -DDEVICE_FLAG=S10 or -DDEVICE_FLAG=Agilex 7.")
+    message(FATAL_ERROR "An incorrect DEVICE_FLAG was given. Make sure you have set -DDEVICE_FLAG=A10, -DDEVICE_FLAG=S10 or -DDEVICE_FLAG=Agilex7.")
 endif()
 
 if(IGNORE_DEFAULT_SEED)

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/autorun/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/autorun/README.md
@@ -38,7 +38,7 @@ You can also find more information about [troubleshooting build errors](/DirectP
 | Optimized for      | Description
 |:---                |:---
 | OS                 | Ubuntu* 18.04/20.04 <br> RHEL*/CentOS* 8 <br> SUSE* 15 <br> Windows* 10
-| Hardware           | Intel® Agilex 7®, Arria® 10, and Stratix® 10 FPGAs
+| Hardware           | Intel® Agilex® 7, Arria® 10, and Stratix® 10 FPGAs
 | Software           | Intel® oneAPI DPC++/C++ Compiler
 
 > **Note**: Even though the Intel DPC++/C++ OneAPI compiler is enough to compile for emulation, generating reports and generating RTL, there are extra software requirements for the simulation flow and FPGA compiles.
@@ -85,7 +85,7 @@ Typically, these kernels are meant to run forever, and data is streamed to and f
 ### On Linux*
 
 1. Change to the sample directory.
-2. Build the program for the Agilex 7® device family, which is the default.
+2. Build the program for the Agilex® 7 device family, which is the default.
 
    ```
    mkdir build
@@ -129,7 +129,7 @@ Typically, these kernels are meant to run forever, and data is streamed to and f
 ### On Windows*
 
 1. Change to the sample directory.
-2. Build the program for the Agilex 7® device family, which is the default.
+2. Build the program for the Agilex® 7 device family, which is the default.
    ```
    mkdir build
    cd build

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/autorun/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/autorun/README.md
@@ -23,9 +23,9 @@ flowchart LR
    tier2("Tier 2: Explore the Fundamentals")
    tier3("Tier 3: Explore the Advanced Techniques")
    tier4("Tier 4: Explore the Reference Designs")
-   
+
    tier1 --> tier2 --> tier3 --> tier4
-   
+
    style tier1 fill:#0071c1,stroke:#0071c1,stroke-width:1px,color:#fff
    style tier2 fill:#0071c1,stroke:#0071c1,stroke-width:1px,color:#fff
    style tier3 fill:#f96,stroke:#333,stroke-width:1px,color:#fff
@@ -38,7 +38,7 @@ You can also find more information about [troubleshooting build errors](/DirectP
 | Optimized for      | Description
 |:---                |:---
 | OS                 | Ubuntu* 18.04/20.04 <br> RHEL*/CentOS* 8 <br> SUSE* 15 <br> Windows* 10
-| Hardware           | Intel® Agilex®, Arria® 10, and Stratix® 10 FPGAs
+| Hardware           | Intel® Agilex 7®, Arria® 10, and Stratix® 10 FPGAs
 | Software           | Intel® oneAPI DPC++/C++ Compiler
 
 > **Note**: Even though the Intel DPC++/C++ OneAPI compiler is enough to compile for emulation, generating reports and generating RTL, there are extra software requirements for the simulation flow and FPGA compiles.
@@ -67,8 +67,8 @@ Typically, these kernels are meant to run forever, and data is streamed to and f
 
 ## Build the `Autorun Kernels` Sample
 
-> **Note**: When working with the command-line interface (CLI), you should configure the oneAPI toolkits using environment variables. 
-> Set up your CLI environment by sourcing the `setvars` script located in the root of your oneAPI installation every time you open a new terminal window. 
+> **Note**: When working with the command-line interface (CLI), you should configure the oneAPI toolkits using environment variables.
+> Set up your CLI environment by sourcing the `setvars` script located in the root of your oneAPI installation every time you open a new terminal window.
 > This practice ensures that your compiler, libraries, and tools are ready for development.
 >
 > Linux*:
@@ -85,7 +85,7 @@ Typically, these kernels are meant to run forever, and data is streamed to and f
 ### On Linux*
 
 1. Change to the sample directory.
-2. Build the program for the Agilex® device family, which is the default.
+2. Build the program for the Agilex 7® device family, which is the default.
 
    ```
    mkdir build
@@ -96,12 +96,12 @@ Typically, these kernels are meant to run forever, and data is streamed to and f
    > **Note**: You can change the default target by using the command:
    >  ```
    >  cmake .. -DFPGA_DEVICE=<FPGA device family or FPGA part number>
-   >  ``` 
+   >  ```
    >
-   > Alternatively, you can target an explicit FPGA board variant and BSP by using the following command: 
+   > Alternatively, you can target an explicit FPGA board variant and BSP by using the following command:
    >  ```
    >  cmake .. -DFPGA_DEVICE=<board-support-package>:<board-variant>
-   >  ``` 
+   >  ```
    >
    > You will only be able to run an executable on the FPGA if you specified a BSP.
 
@@ -129,7 +129,7 @@ Typically, these kernels are meant to run forever, and data is streamed to and f
 ### On Windows*
 
 1. Change to the sample directory.
-2. Build the program for the Agilex® device family, which is the default.
+2. Build the program for the Agilex 7® device family, which is the default.
    ```
    mkdir build
    cd build
@@ -139,12 +139,12 @@ Typically, these kernels are meant to run forever, and data is streamed to and f
   > **Note**: You can change the default target by using the command:
   >  ```
   >  cmake -G "NMake Makefiles" .. -DFPGA_DEVICE=<FPGA device family or FPGA part number>
-  >  ``` 
+  >  ```
   >
-  > Alternatively, you can target an explicit FPGA board variant and BSP by using the following command: 
+  > Alternatively, you can target an explicit FPGA board variant and BSP by using the following command:
   >  ```
   >  cmake -G "NMake Makefiles" .. -DFPGA_DEVICE=<board-support-package>:<board-variant>
-  >  ``` 
+  >  ```
   >
   > You will only be able to run an executable on the FPGA if you specified a BSP.
 

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/autorun/src/CMakeLists.txt
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/autorun/src/CMakeLists.txt
@@ -6,7 +6,7 @@ set(FPGA_TARGET ${TARGET_NAME}.fpga)
 
 # FPGA board selection
 if(NOT DEFINED FPGA_DEVICE)
-    set(FPGA_DEVICE "Agilex")
+    set(FPGA_DEVICE "Agilex 7")
     message(STATUS "FPGA_DEVICE was not specified.\
                     \nConfiguring the design to the default FPGA family: ${FPGA_DEVICE}\
                     \nPlease refer to the README for information on target selection.")

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/autorun/src/CMakeLists.txt
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/autorun/src/CMakeLists.txt
@@ -6,7 +6,7 @@ set(FPGA_TARGET ${TARGET_NAME}.fpga)
 
 # FPGA board selection
 if(NOT DEFINED FPGA_DEVICE)
-    set(FPGA_DEVICE "Agilex 7")
+    set(FPGA_DEVICE "Agilex7")
     message(STATUS "FPGA_DEVICE was not specified.\
                     \nConfiguring the design to the default FPGA family: ${FPGA_DEVICE}\
                     \nPlease refer to the README for information on target selection.")

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/buffered_host_streaming/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/buffered_host_streaming/README.md
@@ -47,7 +47,7 @@ You can also find more information about [troubleshooting build errors](/DirectP
 | Optimized for      | Description
 |:---                |:---
 | OS                 | Ubuntu* 18.04/20.04 <br> RHEL*/CentOS* 8 <br> SUSE* 15 <br> Windows* 10
-| Hardware           | Intel® Agilex 7®, Arria® 10, and Stratix® 10 FPGAs
+| Hardware           | Intel® Agilex® 7, Arria® 10, and Stratix® 10 FPGAs
 | Software           | Intel® oneAPI DPC++/C++ Compiler
 
 > **Note**: Even though the Intel DPC++/C++ OneAPI compiler is enough to compile for emulation, generating reports and generating RTL, there are extra software requirements for the simulation flow and FPGA compiles.
@@ -93,7 +93,7 @@ This sample demonstrates the following concepts:
 ### On Linux*
 
 1. Change to the sample directory.
-2. Build the program for the Agilex 7® device family, which is the default.
+2. Build the program for the Agilex® 7 device family, which is the default.
 
    ```
    mkdir build
@@ -137,7 +137,7 @@ This sample demonstrates the following concepts:
 ### On Windows*
 
 1. Change to the sample directory.
-2. Build the program for the Agilex 7® device family, which is the default.
+2. Build the program for the Agilex® 7 device family, which is the default.
    ```
    mkdir build
    cd build

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/buffered_host_streaming/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/buffered_host_streaming/README.md
@@ -32,9 +32,9 @@ flowchart LR
    tier2("Tier 2: Explore the Fundamentals")
    tier3("Tier 3: Explore the Advanced Techniques")
    tier4("Tier 4: Explore the Reference Designs")
-   
+
    tier1 --> tier2 --> tier3 --> tier4
-   
+
    style tier1 fill:#0071c1,stroke:#0071c1,stroke-width:1px,color:#fff
    style tier2 fill:#0071c1,stroke:#0071c1,stroke-width:1px,color:#fff
    style tier3 fill:#f96,stroke:#333,stroke-width:1px,color:#fff
@@ -47,7 +47,7 @@ You can also find more information about [troubleshooting build errors](/DirectP
 | Optimized for      | Description
 |:---                |:---
 | OS                 | Ubuntu* 18.04/20.04 <br> RHEL*/CentOS* 8 <br> SUSE* 15 <br> Windows* 10
-| Hardware           | Intel® Agilex®, Arria® 10, and Stratix® 10 FPGAs
+| Hardware           | Intel® Agilex 7®, Arria® 10, and Stratix® 10 FPGAs
 | Software           | Intel® oneAPI DPC++/C++ Compiler
 
 > **Note**: Even though the Intel DPC++/C++ OneAPI compiler is enough to compile for emulation, generating reports and generating RTL, there are extra software requirements for the simulation flow and FPGA compiles.
@@ -75,8 +75,8 @@ This sample demonstrates the following concepts:
 
 ## Build the `Buffered Host-Device Streaming` Sample
 
-> **Note**: When working with the command-line interface (CLI), you should configure the oneAPI toolkits using environment variables. 
-> Set up your CLI environment by sourcing the `setvars` script located in the root of your oneAPI installation every time you open a new terminal window. 
+> **Note**: When working with the command-line interface (CLI), you should configure the oneAPI toolkits using environment variables.
+> Set up your CLI environment by sourcing the `setvars` script located in the root of your oneAPI installation every time you open a new terminal window.
 > This practice ensures that your compiler, libraries, and tools are ready for development.
 >
 > Linux*:
@@ -93,7 +93,7 @@ This sample demonstrates the following concepts:
 ### On Linux*
 
 1. Change to the sample directory.
-2. Build the program for the Agilex® device family, which is the default.
+2. Build the program for the Agilex 7® device family, which is the default.
 
    ```
    mkdir build
@@ -104,12 +104,12 @@ This sample demonstrates the following concepts:
    > **Note**: You can change the default target by using the command:
    >  ```
    >  cmake .. -DFPGA_DEVICE=<FPGA device family or FPGA part number>
-   >  ``` 
+   >  ```
    >
-   > Alternatively, you can target an explicit FPGA board variant and BSP by using the following command: 
+   > Alternatively, you can target an explicit FPGA board variant and BSP by using the following command:
    >  ```
    >  cmake .. -DFPGA_DEVICE=<board-support-package>:<board-variant> -DIS_BSP=1
-   >  ``` 
+   >  ```
    >
    > You will only be able to run an executable on the FPGA if you specified a BSP.
 
@@ -137,7 +137,7 @@ This sample demonstrates the following concepts:
 ### On Windows*
 
 1. Change to the sample directory.
-2. Build the program for the Agilex® device family, which is the default.
+2. Build the program for the Agilex 7® device family, which is the default.
    ```
    mkdir build
    cd build
@@ -147,12 +147,12 @@ This sample demonstrates the following concepts:
   > **Note**: You can change the default target by using the command:
   >  ```
   >  cmake -G "NMake Makefiles" .. -DFPGA_DEVICE=<FPGA device family or FPGA part number>
-  >  ``` 
+  >  ```
   >
-  > Alternatively, you can target an explicit FPGA board variant and BSP by using the following command: 
+  > Alternatively, you can target an explicit FPGA board variant and BSP by using the following command:
   >  ```
   >  cmake -G "NMake Makefiles" .. -DFPGA_DEVICE=<board-support-package>:<board-variant> -DIS_BSP=1
-  >  ``` 
+  >  ```
   >
   > You will only be able to run an executable on the FPGA if you specified a BSP.
 

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/buffered_host_streaming/src/CMakeLists.txt
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/buffered_host_streaming/src/CMakeLists.txt
@@ -7,7 +7,7 @@ set(REPORTS_TARGET ${TARGET_NAME}_report)
 
 # FPGA board selection
 if(NOT DEFINED FPGA_DEVICE)
-    set(FPGA_DEVICE "Agilex")
+    set(FPGA_DEVICE "Agilex 7")
     message(STATUS "FPGA_DEVICE was not specified.\
                     \nConfiguring the design to the default FPGA family: ${FPGA_DEVICE}\
                     \nPlease refer to the README for information on target selection.")

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/buffered_host_streaming/src/CMakeLists.txt
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/buffered_host_streaming/src/CMakeLists.txt
@@ -7,7 +7,7 @@ set(REPORTS_TARGET ${TARGET_NAME}_report)
 
 # FPGA board selection
 if(NOT DEFINED FPGA_DEVICE)
-    set(FPGA_DEVICE "Agilex 7")
+    set(FPGA_DEVICE "Agilex7")
     message(STATUS "FPGA_DEVICE was not specified.\
                     \nConfiguring the design to the default FPGA family: ${FPGA_DEVICE}\
                     \nPlease refer to the README for information on target selection.")

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/compute_units/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/compute_units/README.md
@@ -41,7 +41,7 @@ You can also find more information about [troubleshooting build errors](/DirectP
 | Optimized for      | Description
 |:---                |:---
 | OS                 | Ubuntu* 18.04/20.04 <br> RHEL*/CentOS* 8 <br> SUSE* 15 <br> Windows* 10
-| Hardware           | Intel® Agilex 7®, Arria® 10, and Stratix® 10 FPGAs
+| Hardware           | Intel® Agilex® 7, Arria® 10, and Stratix® 10 FPGAs
 | Software           | Intel® oneAPI DPC++/C++ Compiler
 
 > **Note**: Even though the Intel DPC++/C++ OneAPI compiler is enough to compile for emulation, generating reports and generating RTL, there are extra software requirements for the simulation flow and FPGA compiles.
@@ -134,7 +134,7 @@ Each compute unit in the chain from `Source` to `Sink` must read from a unique p
 ### On Linux*
 
 1. Change to the sample directory.
-2. Build the program for the Agilex 7® device family, which is the default.
+2. Build the program for the Agilex® 7 device family, which is the default.
 
    ```
    mkdir build
@@ -178,7 +178,7 @@ Each compute unit in the chain from `Source` to `Sink` must read from a unique p
 ### On Windows*
 
 1. Change to the sample directory.
-2. Build the program for the Agilex 7® device family, which is the default.
+2. Build the program for the Agilex® 7 device family, which is the default.
    ```
    mkdir build
    cd build

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/compute_units/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/compute_units/README.md
@@ -26,9 +26,9 @@ flowchart LR
    tier2("Tier 2: Explore the Fundamentals")
    tier3("Tier 3: Explore the Advanced Techniques")
    tier4("Tier 4: Explore the Reference Designs")
-   
+
    tier1 --> tier2 --> tier3 --> tier4
-   
+
    style tier1 fill:#0071c1,stroke:#0071c1,stroke-width:1px,color:#fff
    style tier2 fill:#0071c1,stroke:#0071c1,stroke-width:1px,color:#fff
    style tier3 fill:#f96,stroke:#333,stroke-width:1px,color:#fff
@@ -41,7 +41,7 @@ You can also find more information about [troubleshooting build errors](/DirectP
 | Optimized for      | Description
 |:---                |:---
 | OS                 | Ubuntu* 18.04/20.04 <br> RHEL*/CentOS* 8 <br> SUSE* 15 <br> Windows* 10
-| Hardware           | Intel® Agilex®, Arria® 10, and Stratix® 10 FPGAs
+| Hardware           | Intel® Agilex 7®, Arria® 10, and Stratix® 10 FPGAs
 | Software           | Intel® oneAPI DPC++/C++ Compiler
 
 > **Note**: Even though the Intel DPC++/C++ OneAPI compiler is enough to compile for emulation, generating reports and generating RTL, there are extra software requirements for the simulation flow and FPGA compiles.
@@ -116,8 +116,8 @@ Each compute unit in the chain from `Source` to `Sink` must read from a unique p
 
 ## Build the `Compute Units` Sample
 
-> **Note**: When working with the command-line interface (CLI), you should configure the oneAPI toolkits using environment variables. 
-> Set up your CLI environment by sourcing the `setvars` script located in the root of your oneAPI installation every time you open a new terminal window. 
+> **Note**: When working with the command-line interface (CLI), you should configure the oneAPI toolkits using environment variables.
+> Set up your CLI environment by sourcing the `setvars` script located in the root of your oneAPI installation every time you open a new terminal window.
 > This practice ensures that your compiler, libraries, and tools are ready for development.
 >
 > Linux*:
@@ -134,7 +134,7 @@ Each compute unit in the chain from `Source` to `Sink` must read from a unique p
 ### On Linux*
 
 1. Change to the sample directory.
-2. Build the program for the Agilex® device family, which is the default.
+2. Build the program for the Agilex 7® device family, which is the default.
 
    ```
    mkdir build
@@ -145,12 +145,12 @@ Each compute unit in the chain from `Source` to `Sink` must read from a unique p
    > **Note**: You can change the default target by using the command:
    >  ```
    >  cmake .. -DFPGA_DEVICE=<FPGA device family or FPGA part number>
-   >  ``` 
+   >  ```
    >
-   > Alternatively, you can target an explicit FPGA board variant and BSP by using the following command: 
+   > Alternatively, you can target an explicit FPGA board variant and BSP by using the following command:
    >  ```
    >  cmake .. -DFPGA_DEVICE=<board-support-package>:<board-variant>
-   >  ``` 
+   >  ```
    >
    > You will only be able to run an executable on the FPGA if you specified a BSP.
 
@@ -178,7 +178,7 @@ Each compute unit in the chain from `Source` to `Sink` must read from a unique p
 ### On Windows*
 
 1. Change to the sample directory.
-2. Build the program for the Agilex® device family, which is the default.
+2. Build the program for the Agilex 7® device family, which is the default.
    ```
    mkdir build
    cd build
@@ -188,12 +188,12 @@ Each compute unit in the chain from `Source` to `Sink` must read from a unique p
   > **Note**: You can change the default target by using the command:
   >  ```
   >  cmake -G "NMake Makefiles" .. -DFPGA_DEVICE=<FPGA device family or FPGA part number>
-  >  ``` 
+  >  ```
   >
-  > Alternatively, you can target an explicit FPGA board variant and BSP by using the following command: 
+  > Alternatively, you can target an explicit FPGA board variant and BSP by using the following command:
   >  ```
   >  cmake -G "NMake Makefiles" .. -DFPGA_DEVICE=<board-support-package>:<board-variant>
-  >  ``` 
+  >  ```
   >
   > You will only be able to run an executable on the FPGA if you specified a BSP.
 

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/compute_units/src/CMakeLists.txt
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/compute_units/src/CMakeLists.txt
@@ -6,7 +6,7 @@ set(FPGA_TARGET ${TARGET_NAME}.fpga)
 
 # FPGA board selection
 if(NOT DEFINED FPGA_DEVICE)
-    set(FPGA_DEVICE "Agilex")
+    set(FPGA_DEVICE "Agilex 7")
     message(STATUS "FPGA_DEVICE was not specified.\
                     \nConfiguring the design to the default FPGA family: ${FPGA_DEVICE}\
                     \nPlease refer to the README for information on target selection.")

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/compute_units/src/CMakeLists.txt
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/compute_units/src/CMakeLists.txt
@@ -6,7 +6,7 @@ set(FPGA_TARGET ${TARGET_NAME}.fpga)
 
 # FPGA board selection
 if(NOT DEFINED FPGA_DEVICE)
-    set(FPGA_DEVICE "Agilex 7")
+    set(FPGA_DEVICE "Agilex7")
     message(STATUS "FPGA_DEVICE was not specified.\
                     \nConfiguring the design to the default FPGA family: ${FPGA_DEVICE}\
                     \nPlease refer to the README for information on target selection.")

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/double_buffering/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/double_buffering/README.md
@@ -27,9 +27,9 @@ flowchart LR
    tier2("Tier 2: Explore the Fundamentals")
    tier3("Tier 3: Explore the Advanced Techniques")
    tier4("Tier 4: Explore the Reference Designs")
-   
+
    tier1 --> tier2 --> tier3 --> tier4
-   
+
    style tier1 fill:#0071c1,stroke:#0071c1,stroke-width:1px,color:#fff
    style tier2 fill:#f96,stroke:#333,stroke-width:1px,color:#fff
    style tier3 fill:#0071c1,stroke:#0071c1,stroke-width:1px,color:#fff
@@ -42,7 +42,7 @@ You can also find more information about [troubleshooting build errors](/DirectP
 | Optimized for      | Description
 |:---                |:---
 | OS                 | Ubuntu* 18.04/20.04 <br> RHEL*/CentOS* 8 <br> SUSE* 15 <br> Windows* 10
-| Hardware           | Intel® Agilex®, Arria® 10, and Stratix® 10 FPGAs
+| Hardware           | Intel® Agilex 7®, Arria® 10, and Stratix® 10 FPGAs
 | Software           | Intel® oneAPI DPC++/C++ Compiler
 
 > **Note**: Even though the Intel DPC++/C++ OneAPI compiler is enough to compile for emulation, generating reports and generating RTL, there are extra software requirements for the simulation flow and FPGA compiles.
@@ -66,8 +66,8 @@ The key concepts discussed in this sample are as followed:
 
 ## Build the `Double Buffering` Sample
 
-> **Note**: When working with the command-line interface (CLI), you should configure the oneAPI toolkits using environment variables. 
-> Set up your CLI environment by sourcing the `setvars` script located in the root of your oneAPI installation every time you open a new terminal window. 
+> **Note**: When working with the command-line interface (CLI), you should configure the oneAPI toolkits using environment variables.
+> Set up your CLI environment by sourcing the `setvars` script located in the root of your oneAPI installation every time you open a new terminal window.
 > This practice ensures that your compiler, libraries, and tools are ready for development.
 >
 > Linux*:
@@ -84,7 +84,7 @@ The key concepts discussed in this sample are as followed:
 ### On Linux*
 
 1. Change to the sample directory.
-2. Build the program for the Agilex® device family, which is the default.
+2. Build the program for the Agilex 7® device family, which is the default.
 
    ```
    mkdir build
@@ -95,12 +95,12 @@ The key concepts discussed in this sample are as followed:
    > **Note**: You can change the default target by using the command:
    >  ```
    >  cmake .. -DFPGA_DEVICE=<FPGA device family or FPGA part number>
-   >  ``` 
+   >  ```
    >
-   > Alternatively, you can target an explicit FPGA board variant and BSP by using the following command: 
+   > Alternatively, you can target an explicit FPGA board variant and BSP by using the following command:
    >  ```
    >  cmake .. -DFPGA_DEVICE=<board-support-package>:<board-variant>
-   >  ``` 
+   >  ```
    >
    > You will only be able to run an executable on the FPGA if you specified a BSP.
 
@@ -128,7 +128,7 @@ The key concepts discussed in this sample are as followed:
 ### On Windows*
 
 1. Change to the sample directory.
-2. Build the program for the Agilex® device family, which is the default.
+2. Build the program for the Agilex 7® device family, which is the default.
    ```
    mkdir build
    cd build
@@ -138,12 +138,12 @@ The key concepts discussed in this sample are as followed:
   > **Note**: You can change the default target by using the command:
   >  ```
   >  cmake -G "NMake Makefiles" .. -DFPGA_DEVICE=<FPGA device family or FPGA part number>
-  >  ``` 
+  >  ```
   >
-  > Alternatively, you can target an explicit FPGA board variant and BSP by using the following command: 
+  > Alternatively, you can target an explicit FPGA board variant and BSP by using the following command:
   >  ```
   >  cmake -G "NMake Makefiles" .. -DFPGA_DEVICE=<board-support-package>:<board-variant>
-  >  ``` 
+  >  ```
   >
   > You will only be able to run an executable on the FPGA if you specified a BSP.
 

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/double_buffering/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/double_buffering/README.md
@@ -42,7 +42,7 @@ You can also find more information about [troubleshooting build errors](/DirectP
 | Optimized for      | Description
 |:---                |:---
 | OS                 | Ubuntu* 18.04/20.04 <br> RHEL*/CentOS* 8 <br> SUSE* 15 <br> Windows* 10
-| Hardware           | Intel® Agilex 7®, Arria® 10, and Stratix® 10 FPGAs
+| Hardware           | Intel® Agilex® 7, Arria® 10, and Stratix® 10 FPGAs
 | Software           | Intel® oneAPI DPC++/C++ Compiler
 
 > **Note**: Even though the Intel DPC++/C++ OneAPI compiler is enough to compile for emulation, generating reports and generating RTL, there are extra software requirements for the simulation flow and FPGA compiles.
@@ -84,7 +84,7 @@ The key concepts discussed in this sample are as followed:
 ### On Linux*
 
 1. Change to the sample directory.
-2. Build the program for the Agilex 7® device family, which is the default.
+2. Build the program for the Agilex® 7 device family, which is the default.
 
    ```
    mkdir build
@@ -128,7 +128,7 @@ The key concepts discussed in this sample are as followed:
 ### On Windows*
 
 1. Change to the sample directory.
-2. Build the program for the Agilex 7® device family, which is the default.
+2. Build the program for the Agilex® 7 device family, which is the default.
    ```
    mkdir build
    cd build

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/double_buffering/src/CMakeLists.txt
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/double_buffering/src/CMakeLists.txt
@@ -6,7 +6,7 @@ set(FPGA_TARGET ${TARGET_NAME}.fpga)
 
 # FPGA board selection
 if(NOT DEFINED FPGA_DEVICE)
-    set(FPGA_DEVICE "Agilex")
+    set(FPGA_DEVICE "Agilex 7")
     message(STATUS "FPGA_DEVICE was not specified.\
                     \nConfiguring the design to the default FPGA family: ${FPGA_DEVICE}\
                     \nPlease refer to the README for information on target selection.")

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/double_buffering/src/CMakeLists.txt
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/double_buffering/src/CMakeLists.txt
@@ -6,7 +6,7 @@ set(FPGA_TARGET ${TARGET_NAME}.fpga)
 
 # FPGA board selection
 if(NOT DEFINED FPGA_DEVICE)
-    set(FPGA_DEVICE "Agilex 7")
+    set(FPGA_DEVICE "Agilex7")
     message(STATUS "FPGA_DEVICE was not specified.\
                     \nConfiguring the design to the default FPGA family: ${FPGA_DEVICE}\
                     \nPlease refer to the README for information on target selection.")

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/explicit_data_movement/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/explicit_data_movement/README.md
@@ -38,7 +38,7 @@ You can also find more information about [troubleshooting build errors](/DirectP
 | Optimized for      | Description
 |:---                |:---
 | OS                 | Ubuntu* 18.04/20.04 <br> RHEL*/CentOS* 8 <br> SUSE* 15 <br> Windows* 10
-| Hardware           | Intel® Agilex 7®, Arria® 10, and Stratix® 10 FPGAs
+| Hardware           | Intel® Agilex® 7, Arria® 10, and Stratix® 10 FPGAs
 | Software           | Intel® oneAPI DPC++/C++ Compiler
 
 > **Note**: Even though the Intel DPC++/C++ OneAPI compiler is enough to compile for emulation, generating reports and generating RTL, there are extra software requirements for the simulation flow and FPGA compiles.
@@ -107,7 +107,7 @@ Alternatively, there is a hybrid approach that uses some implicit data movement 
 ### On Linux*
 
 1. Change to the sample directory.
-2. Build the program for the Agilex 7® device family, which is the default.
+2. Build the program for the Agilex® 7 device family, which is the default.
 
    ```
    mkdir build
@@ -150,7 +150,7 @@ Alternatively, there is a hybrid approach that uses some implicit data movement 
 ### On Windows*
 
 1. Change to the sample directory.
-2. Build the program for the Agilex 7® device family, which is the default.
+2. Build the program for the Agilex® 7 device family, which is the default.
    ```
    mkdir build
    cd build

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/explicit_data_movement/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/explicit_data_movement/README.md
@@ -23,9 +23,9 @@ flowchart LR
    tier2("Tier 2: Explore the Fundamentals")
    tier3("Tier 3: Explore the Advanced Techniques")
    tier4("Tier 4: Explore the Reference Designs")
-   
+
    tier1 --> tier2 --> tier3 --> tier4
-   
+
    style tier1 fill:#0071c1,stroke:#0071c1,stroke-width:1px,color:#fff
    style tier2 fill:#f96,stroke:#333,stroke-width:1px,color:#fff
    style tier3 fill:#0071c1,stroke:#0071c1,stroke-width:1px,color:#fff
@@ -38,7 +38,7 @@ You can also find more information about [troubleshooting build errors](/DirectP
 | Optimized for      | Description
 |:---                |:---
 | OS                 | Ubuntu* 18.04/20.04 <br> RHEL*/CentOS* 8 <br> SUSE* 15 <br> Windows* 10
-| Hardware           | Intel® Agilex®, Arria® 10, and Stratix® 10 FPGAs
+| Hardware           | Intel® Agilex 7®, Arria® 10, and Stratix® 10 FPGAs
 | Software           | Intel® oneAPI DPC++/C++ Compiler
 
 > **Note**: Even though the Intel DPC++/C++ OneAPI compiler is enough to compile for emulation, generating reports and generating RTL, there are extra software requirements for the simulation flow and FPGA compiles.
@@ -89,8 +89,8 @@ Alternatively, there is a hybrid approach that uses some implicit data movement 
 
 ## Build the `Explicit Data Movement` Sample
 
-> **Note**: When working with the command-line interface (CLI), you should configure the oneAPI toolkits using environment variables. 
-> Set up your CLI environment by sourcing the `setvars` script located in the root of your oneAPI installation every time you open a new terminal window. 
+> **Note**: When working with the command-line interface (CLI), you should configure the oneAPI toolkits using environment variables.
+> Set up your CLI environment by sourcing the `setvars` script located in the root of your oneAPI installation every time you open a new terminal window.
 > This practice ensures that your compiler, libraries, and tools are ready for development.
 >
 > Linux*:
@@ -107,7 +107,7 @@ Alternatively, there is a hybrid approach that uses some implicit data movement 
 ### On Linux*
 
 1. Change to the sample directory.
-2. Build the program for the Agilex® device family, which is the default.
+2. Build the program for the Agilex 7® device family, which is the default.
 
    ```
    mkdir build
@@ -118,12 +118,12 @@ Alternatively, there is a hybrid approach that uses some implicit data movement 
    > **Note**: You can change the default target by using the command:
    >  ```
    >  cmake .. -DFPGA_DEVICE=<FPGA device family or FPGA part number>
-   >  ``` 
+   >  ```
    >
-   > Alternatively, you can target an explicit FPGA board variant and BSP by using the following command: 
+   > Alternatively, you can target an explicit FPGA board variant and BSP by using the following command:
    >  ```
    >  cmake .. -DFPGA_DEVICE=<board-support-package>:<board-variant> -DIS_BSP=1
-   >  ``` 
+   >  ```
    >
    > You will only be able to run an executable on the FPGA if you specified a BSP.
 
@@ -150,7 +150,7 @@ Alternatively, there is a hybrid approach that uses some implicit data movement 
 ### On Windows*
 
 1. Change to the sample directory.
-2. Build the program for the Agilex® device family, which is the default.
+2. Build the program for the Agilex 7® device family, which is the default.
    ```
    mkdir build
    cd build
@@ -160,12 +160,12 @@ Alternatively, there is a hybrid approach that uses some implicit data movement 
   > **Note**: You can change the default target by using the command:
   >  ```
   >  cmake -G "NMake Makefiles" .. -DFPGA_DEVICE=<FPGA device family or FPGA part number>
-  >  ``` 
+  >  ```
   >
-  > Alternatively, you can target an explicit FPGA board variant and BSP by using the following command: 
+  > Alternatively, you can target an explicit FPGA board variant and BSP by using the following command:
   >  ```
   >  cmake -G "NMake Makefiles" .. -DFPGA_DEVICE=<board-support-package>:<board-variant> -DIS_BSP=1
-  >  ``` 
+  >  ```
   >
   > You will only be able to run an executable on the FPGA if you specified a BSP.
 

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/explicit_data_movement/src/CMakeLists.txt
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/explicit_data_movement/src/CMakeLists.txt
@@ -6,7 +6,7 @@ set(FPGA_TARGET ${TARGET_NAME}.fpga)
 
 # FPGA board selection
 if(NOT DEFINED FPGA_DEVICE)
-    set(FPGA_DEVICE "Agilex")
+    set(FPGA_DEVICE "Agilex 7")
     message(STATUS "FPGA_DEVICE was not specified.\
                     \nConfiguring the design to the default FPGA family: ${FPGA_DEVICE}\
                     \nPlease refer to the README for information on target selection.")

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/explicit_data_movement/src/CMakeLists.txt
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/explicit_data_movement/src/CMakeLists.txt
@@ -6,7 +6,7 @@ set(FPGA_TARGET ${TARGET_NAME}.fpga)
 
 # FPGA board selection
 if(NOT DEFINED FPGA_DEVICE)
-    set(FPGA_DEVICE "Agilex 7")
+    set(FPGA_DEVICE "Agilex7")
     message(STATUS "FPGA_DEVICE was not specified.\
                     \nConfiguring the design to the default FPGA family: ${FPGA_DEVICE}\
                     \nPlease refer to the README for information on target selection.")

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/io_streaming/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/io_streaming/README.md
@@ -38,7 +38,7 @@ You can also find more information about [troubleshooting build errors](/DirectP
 | Optimized for      | Description
 |:---                |:---
 | OS                 | Ubuntu* 18.04/20.04 <br> RHEL*/CentOS* 8 <br> SUSE* 15 <br> Windows* 10
-| Hardware           | Intel® Agilex 7®, Arria® 10, and Stratix® 10 FPGAs
+| Hardware           | Intel® Agilex® 7, Arria® 10, and Stratix® 10 FPGAs
 | Software           | Intel® oneAPI DPC++/C++ Compiler
 
 > **Note**: Even though the Intel DPC++/C++ OneAPI compiler is enough to compile for emulation, generating reports and generating RTL, there are extra software requirements for the simulation flow and FPGA compiles.
@@ -136,7 +136,7 @@ Notice that the main kernel in the `SubmitSideChannelKernels` function in *src/S
 ### On Linux*
 
 1. Change to the sample directory.
-2. Build the program for the Agilex 7® device family, which is the default.
+2. Build the program for the Agilex® 7 device family, which is the default.
 
    ```
    mkdir build
@@ -180,7 +180,7 @@ Notice that the main kernel in the `SubmitSideChannelKernels` function in *src/S
 ### On Windows*
 
 1. Change to the sample directory.
-2. Build the program for the Agilex 7® device family, which is the default.
+2. Build the program for the Agilex® 7 device family, which is the default.
    ```
    mkdir build
    cd build

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/io_streaming/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/io_streaming/README.md
@@ -23,9 +23,9 @@ flowchart LR
    tier2("Tier 2: Explore the Fundamentals")
    tier3("Tier 3: Explore the Advanced Techniques")
    tier4("Tier 4: Explore the Reference Designs")
-   
+
    tier1 --> tier2 --> tier3 --> tier4
-   
+
    style tier1 fill:#0071c1,stroke:#0071c1,stroke-width:1px,color:#fff
    style tier2 fill:#0071c1,stroke:#0071c1,stroke-width:1px,color:#fff
    style tier3 fill:#f96,stroke:#333,stroke-width:1px,color:#fff
@@ -38,7 +38,7 @@ You can also find more information about [troubleshooting build errors](/DirectP
 | Optimized for      | Description
 |:---                |:---
 | OS                 | Ubuntu* 18.04/20.04 <br> RHEL*/CentOS* 8 <br> SUSE* 15 <br> Windows* 10
-| Hardware           | Intel® Agilex®, Arria® 10, and Stratix® 10 FPGAs
+| Hardware           | Intel® Agilex 7®, Arria® 10, and Stratix® 10 FPGAs
 | Software           | Intel® oneAPI DPC++/C++ Compiler
 
 > **Note**: Even though the Intel DPC++/C++ OneAPI compiler is enough to compile for emulation, generating reports and generating RTL, there are extra software requirements for the simulation flow and FPGA compiles.
@@ -118,8 +118,8 @@ Notice that the main kernel in the `SubmitSideChannelKernels` function in *src/S
 
 ## Build the `IO Streaming with SYCL IO Pipes` Sample
 
-> **Note**: When working with the command-line interface (CLI), you should configure the oneAPI toolkits using environment variables. 
-> Set up your CLI environment by sourcing the `setvars` script located in the root of your oneAPI installation every time you open a new terminal window. 
+> **Note**: When working with the command-line interface (CLI), you should configure the oneAPI toolkits using environment variables.
+> Set up your CLI environment by sourcing the `setvars` script located in the root of your oneAPI installation every time you open a new terminal window.
 > This practice ensures that your compiler, libraries, and tools are ready for development.
 >
 > Linux*:
@@ -136,7 +136,7 @@ Notice that the main kernel in the `SubmitSideChannelKernels` function in *src/S
 ### On Linux*
 
 1. Change to the sample directory.
-2. Build the program for the Agilex® device family, which is the default.
+2. Build the program for the Agilex 7® device family, which is the default.
 
    ```
    mkdir build
@@ -147,12 +147,12 @@ Notice that the main kernel in the `SubmitSideChannelKernels` function in *src/S
    > **Note**: You can change the default target by using the command:
    >  ```
    >  cmake .. -DFPGA_DEVICE=<FPGA device family or FPGA part number>
-   >  ``` 
+   >  ```
    >
-   > Alternatively, you can target an explicit FPGA board variant and BSP by using the following command: 
+   > Alternatively, you can target an explicit FPGA board variant and BSP by using the following command:
    >  ```
    >  cmake .. -DFPGA_DEVICE=<board-support-package>:<board-variant> -DIS_BSP=1
-   >  ``` 
+   >  ```
    >
    > You will only be able to run an executable on the FPGA if you specified a BSP.
 
@@ -180,7 +180,7 @@ Notice that the main kernel in the `SubmitSideChannelKernels` function in *src/S
 ### On Windows*
 
 1. Change to the sample directory.
-2. Build the program for the Agilex® device family, which is the default.
+2. Build the program for the Agilex 7® device family, which is the default.
    ```
    mkdir build
    cd build
@@ -190,12 +190,12 @@ Notice that the main kernel in the `SubmitSideChannelKernels` function in *src/S
   > **Note**: You can change the default target by using the command:
   >  ```
   >  cmake -G "NMake Makefiles" .. -DFPGA_DEVICE=<FPGA device family or FPGA part number>
-  >  ``` 
+  >  ```
   >
-  > Alternatively, you can target an explicit FPGA board variant and BSP by using the following command: 
+  > Alternatively, you can target an explicit FPGA board variant and BSP by using the following command:
   >  ```
   >  cmake -G "NMake Makefiles" .. -DFPGA_DEVICE=<board-support-package>:<board-variant> -DIS_BSP=1
-  >  ``` 
+  >  ```
   >
   > You will only be able to run an executable on the FPGA if you specified a BSP.
 

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/io_streaming/src/CMakeLists.txt
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/io_streaming/src/CMakeLists.txt
@@ -6,7 +6,7 @@ set(FPGA_TARGET ${TARGET_NAME}.fpga)
 
 # FPGA board selection
 if(NOT DEFINED FPGA_DEVICE)
-    set(FPGA_DEVICE "Agilex 7")
+    set(FPGA_DEVICE "Agilex7")
     message(STATUS "FPGA_DEVICE was not specified.\
                     \nConfiguring the design to the default FPGA family: ${FPGA_DEVICE}\
                     \nPlease refer to the README for information on target selection.")

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/io_streaming/src/CMakeLists.txt
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/io_streaming/src/CMakeLists.txt
@@ -6,7 +6,7 @@ set(FPGA_TARGET ${TARGET_NAME}.fpga)
 
 # FPGA board selection
 if(NOT DEFINED FPGA_DEVICE)
-    set(FPGA_DEVICE "Agilex")
+    set(FPGA_DEVICE "Agilex 7")
     message(STATUS "FPGA_DEVICE was not specified.\
                     \nConfiguring the design to the default FPGA family: ${FPGA_DEVICE}\
                     \nPlease refer to the README for information on target selection.")
@@ -29,7 +29,7 @@ if(WIN32)
     set(WIN_FLAG "/EHsc")
 endif()
 
-# Use USM host allocations if the BSP supports them or if we target an FPGA part 
+# Use USM host allocations if the BSP supports them or if we target an FPGA part
 if((IS_BSP STREQUAL "0") OR FPGA_DEVICE MATCHES ".usm.*")
   set(USM_HOST_ALLOCATIONS "-DUSM_HOST_ALLOCATIONS")
   message(STATUS "USM host allocations are enabled")

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/loop_carried_dependency/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/loop_carried_dependency/README.md
@@ -41,7 +41,7 @@ You can also find more information about [troubleshooting build errors](/DirectP
 | Optimized for      | Description
 |:---                |:---
 | OS                 | Ubuntu* 18.04/20.04 <br> RHEL*/CentOS* 8 <br> SUSE* 15 <br> Windows* 10
-| Hardware           | Intel® Agilex 7®, Arria® 10, and Stratix® 10 FPGAs
+| Hardware           | Intel® Agilex® 7, Arria® 10, and Stratix® 10 FPGAs
 | Software           | Intel® oneAPI DPC++/C++ Compiler
 
 > **Note**: Even though the Intel DPC++/C++ OneAPI compiler is enough to compile for emulation, generating reports and generating RTL, there are extra software requirements for the simulation flow and FPGA compiles.
@@ -124,7 +124,7 @@ Look at the _Compiler Report > Throughput Analysis > Loop Analysis_ section in t
 > For more information on configuring environment variables, see [Use the setvars Script with Linux* or macOS*](https://www.intel.com/content/www/us/en/develop/documentation/oneapi-programming-guide/top/oneapi-development-environment-setup/use-the-setvars-script-with-linux-or-macos.html) or [Use the setvars Script with Windows*](https://www.intel.com/content/www/us/en/develop/documentation/oneapi-programming-guide/top/oneapi-development-environment-setup/use-the-setvars-script-with-windows.html).
 
 1. Change to the sample directory.
-2. Build the program for the Agilex 7® device family, which is the default.
+2. Build the program for the Agilex® 7 device family, which is the default.
 
    ```
    mkdir build
@@ -170,7 +170,7 @@ Look at the _Compiler Report > Throughput Analysis > Loop Analysis_ section in t
 ### On Windows*
 
 1. Change to the sample directory.
-2. Build the program for the Agilex 7® device family, which is the default.
+2. Build the program for the Agilex® 7 device family, which is the default.
    ```
    mkdir build
    cd build

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/loop_carried_dependency/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/loop_carried_dependency/README.md
@@ -26,9 +26,9 @@ flowchart LR
    tier2("Tier 2: Explore the Fundamentals")
    tier3("Tier 3: Explore the Advanced Techniques")
    tier4("Tier 4: Explore the Reference Designs")
-   
+
    tier1 --> tier2 --> tier3 --> tier4
-   
+
    style tier1 fill:#0071c1,stroke:#0071c1,stroke-width:1px,color:#fff
    style tier2 fill:#0071c1,stroke:#0071c1,stroke-width:1px,color:#fff
    style tier3 fill:#f96,stroke:#333,stroke-width:1px,color:#fff
@@ -41,7 +41,7 @@ You can also find more information about [troubleshooting build errors](/DirectP
 | Optimized for      | Description
 |:---                |:---
 | OS                 | Ubuntu* 18.04/20.04 <br> RHEL*/CentOS* 8 <br> SUSE* 15 <br> Windows* 10
-| Hardware           | Intel® Agilex®, Arria® 10, and Stratix® 10 FPGAs
+| Hardware           | Intel® Agilex 7®, Arria® 10, and Stratix® 10 FPGAs
 | Software           | Intel® oneAPI DPC++/C++ Compiler
 
 > **Note**: Even though the Intel DPC++/C++ OneAPI compiler is enough to compile for emulation, generating reports and generating RTL, there are extra software requirements for the simulation flow and FPGA compiles.
@@ -57,7 +57,7 @@ You can also find more information about [troubleshooting build errors](/DirectP
 
 ## Key Implementation Details
 
-This tutorial demonstrates how to remove a loop-carried dependency in FPGA device code. 
+This tutorial demonstrates how to remove a loop-carried dependency in FPGA device code.
 
 A snippet of the baseline unoptimized code (the `Unoptimized` function in `src/loop_carried_dependency.cpp`) is shown below.
 
@@ -108,8 +108,8 @@ Look at the _Compiler Report > Throughput Analysis > Loop Analysis_ section in t
 
 ## Build the `Remove Loop Carried Dependency` Sample
 
-> **Note**: When working with the command-line interface (CLI), you should configure the oneAPI toolkits using environment variables. 
-> Set up your CLI environment by sourcing the `setvars` script located in the root of your oneAPI installation every time you open a new terminal window. 
+> **Note**: When working with the command-line interface (CLI), you should configure the oneAPI toolkits using environment variables.
+> Set up your CLI environment by sourcing the `setvars` script located in the root of your oneAPI installation every time you open a new terminal window.
 > This practice ensures that your compiler, libraries, and tools are ready for development.
 >
 > Linux*:
@@ -124,7 +124,7 @@ Look at the _Compiler Report > Throughput Analysis > Loop Analysis_ section in t
 > For more information on configuring environment variables, see [Use the setvars Script with Linux* or macOS*](https://www.intel.com/content/www/us/en/develop/documentation/oneapi-programming-guide/top/oneapi-development-environment-setup/use-the-setvars-script-with-linux-or-macos.html) or [Use the setvars Script with Windows*](https://www.intel.com/content/www/us/en/develop/documentation/oneapi-programming-guide/top/oneapi-development-environment-setup/use-the-setvars-script-with-windows.html).
 
 1. Change to the sample directory.
-2. Build the program for the Agilex® device family, which is the default.
+2. Build the program for the Agilex 7® device family, which is the default.
 
    ```
    mkdir build
@@ -135,12 +135,12 @@ Look at the _Compiler Report > Throughput Analysis > Loop Analysis_ section in t
    > **Note**: You can change the default target by using the command:
    >  ```
    >  cmake .. -DFPGA_DEVICE=<FPGA device family or FPGA part number>
-   >  ``` 
+   >  ```
    >
-   > Alternatively, you can target an explicit FPGA board variant and BSP by using the following command: 
+   > Alternatively, you can target an explicit FPGA board variant and BSP by using the following command:
    >  ```
    >  cmake .. -DFPGA_DEVICE=<board-support-package>:<board-variant>
-   >  ``` 
+   >  ```
    >
    > You will only be able to run an executable on the FPGA if you specified a BSP.
 
@@ -170,7 +170,7 @@ Look at the _Compiler Report > Throughput Analysis > Loop Analysis_ section in t
 ### On Windows*
 
 1. Change to the sample directory.
-2. Build the program for the Agilex® device family, which is the default.
+2. Build the program for the Agilex 7® device family, which is the default.
    ```
    mkdir build
    cd build
@@ -180,12 +180,12 @@ Look at the _Compiler Report > Throughput Analysis > Loop Analysis_ section in t
   > **Note**: You can change the default target by using the command:
   >  ```
   >  cmake -G "NMake Makefiles" .. -DFPGA_DEVICE=<FPGA device family or FPGA part number>
-  >  ``` 
+  >  ```
   >
-  > Alternatively, you can target an explicit FPGA board variant and BSP by using the following command: 
+  > Alternatively, you can target an explicit FPGA board variant and BSP by using the following command:
   >  ```
   >  cmake -G "NMake Makefiles" .. -DFPGA_DEVICE=<board-support-package>:<board-variant>
-  >  ``` 
+  >  ```
   >
   > You will only be able to run an executable on the FPGA if you specified a BSP.
 

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/loop_carried_dependency/src/CMakeLists.txt
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/loop_carried_dependency/src/CMakeLists.txt
@@ -6,7 +6,7 @@ set(FPGA_TARGET ${TARGET_NAME}.fpga)
 
 # FPGA board selection
 if(NOT DEFINED FPGA_DEVICE)
-    set(FPGA_DEVICE "Agilex")
+    set(FPGA_DEVICE "Agilex 7")
     message(STATUS "FPGA_DEVICE was not specified.\
                     \nConfiguring the design to the default FPGA family: ${FPGA_DEVICE}\
                     \nPlease refer to the README for information on target selection.")

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/loop_carried_dependency/src/CMakeLists.txt
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/loop_carried_dependency/src/CMakeLists.txt
@@ -6,7 +6,7 @@ set(FPGA_TARGET ${TARGET_NAME}.fpga)
 
 # FPGA board selection
 if(NOT DEFINED FPGA_DEVICE)
-    set(FPGA_DEVICE "Agilex 7")
+    set(FPGA_DEVICE "Agilex7")
     message(STATUS "FPGA_DEVICE was not specified.\
                     \nConfiguring the design to the default FPGA family: ${FPGA_DEVICE}\
                     \nPlease refer to the README for information on target selection.")

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/n_way_buffering/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/n_way_buffering/README.md
@@ -39,7 +39,7 @@ You can also find more information about [troubleshooting build errors](/DirectP
 | Optimized for      | Description
 |:---                |:---
 | OS                 | Ubuntu* 18.04/20.04 <br> RHEL*/CentOS* 8 <br> SUSE* 15 <br> Windows* 10
-| Hardware           | Intel® Agilex 7®, Arria® 10, and Stratix® 10 FPGAs
+| Hardware           | Intel® Agilex® 7, Arria® 10, and Stratix® 10 FPGAs
 | Software           | Intel® oneAPI DPC++/C++ Compiler
 
 > **Note**: Even though the Intel DPC++/C++ OneAPI compiler is enough to compile for emulation, generating reports and generating RTL, there are extra software requirements for the simulation flow and FPGA compiles.
@@ -164,7 +164,7 @@ After each kernel is launched, the host-side operations (that occur *after* the 
 ### On Linux*
 
 1. Change to the sample directory.
-2. Build the program for the Agilex 7® device family, which is the default.
+2. Build the program for the Agilex® 7 device family, which is the default.
 
    ```
    mkdir build
@@ -210,7 +210,7 @@ After each kernel is launched, the host-side operations (that occur *after* the 
 ### On Windows*
 
 1. Change to the sample directory.
-2. Build the program for the Agilex 7® device family, which is the default.
+2. Build the program for the Agilex® 7 device family, which is the default.
    ```
    mkdir build
    cd build

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/n_way_buffering/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/n_way_buffering/README.md
@@ -24,9 +24,9 @@ flowchart LR
    tier2("Tier 2: Explore the Fundamentals")
    tier3("Tier 3: Explore the Advanced Techniques")
    tier4("Tier 4: Explore the Reference Designs")
-   
+
    tier1 --> tier2 --> tier3 --> tier4
-   
+
    style tier1 fill:#0071c1,stroke:#0071c1,stroke-width:1px,color:#fff
    style tier2 fill:#0071c1,stroke:#0071c1,stroke-width:1px,color:#fff
    style tier3 fill:#f96,stroke:#333,stroke-width:1px,color:#fff
@@ -39,7 +39,7 @@ You can also find more information about [troubleshooting build errors](/DirectP
 | Optimized for      | Description
 |:---                |:---
 | OS                 | Ubuntu* 18.04/20.04 <br> RHEL*/CentOS* 8 <br> SUSE* 15 <br> Windows* 10
-| Hardware           | Intel® Agilex®, Arria® 10, and Stratix® 10 FPGAs
+| Hardware           | Intel® Agilex 7®, Arria® 10, and Stratix® 10 FPGAs
 | Software           | Intel® oneAPI DPC++/C++ Compiler
 
 > **Note**: Even though the Intel DPC++/C++ OneAPI compiler is enough to compile for emulation, generating reports and generating RTL, there are extra software requirements for the simulation flow and FPGA compiles.
@@ -146,8 +146,8 @@ After each kernel is launched, the host-side operations (that occur *after* the 
 
 ## Build the `N-Way Buffering` Sample
 
-> **Note**: When working with the command-line interface (CLI), you should configure the oneAPI toolkits using environment variables. 
-> Set up your CLI environment by sourcing the `setvars` script located in the root of your oneAPI installation every time you open a new terminal window. 
+> **Note**: When working with the command-line interface (CLI), you should configure the oneAPI toolkits using environment variables.
+> Set up your CLI environment by sourcing the `setvars` script located in the root of your oneAPI installation every time you open a new terminal window.
 > This practice ensures that your compiler, libraries, and tools are ready for development.
 >
 > Linux*:
@@ -164,7 +164,7 @@ After each kernel is launched, the host-side operations (that occur *after* the 
 ### On Linux*
 
 1. Change to the sample directory.
-2. Build the program for the Agilex® device family, which is the default.
+2. Build the program for the Agilex 7® device family, which is the default.
 
    ```
    mkdir build
@@ -175,12 +175,12 @@ After each kernel is launched, the host-side operations (that occur *after* the 
    > **Note**: You can change the default target by using the command:
    >  ```
    >  cmake .. -DFPGA_DEVICE=<FPGA device family or FPGA part number>
-   >  ``` 
+   >  ```
    >
-   > Alternatively, you can target an explicit FPGA board variant and BSP by using the following command: 
+   > Alternatively, you can target an explicit FPGA board variant and BSP by using the following command:
    >  ```
    >  cmake .. -DFPGA_DEVICE=<board-support-package>:<board-variant>
-   >  ``` 
+   >  ```
    >
    > You will only be able to run an executable on the FPGA if you specified a BSP.
 
@@ -210,7 +210,7 @@ After each kernel is launched, the host-side operations (that occur *after* the 
 ### On Windows*
 
 1. Change to the sample directory.
-2. Build the program for the Agilex® device family, which is the default.
+2. Build the program for the Agilex 7® device family, which is the default.
    ```
    mkdir build
    cd build
@@ -220,12 +220,12 @@ After each kernel is launched, the host-side operations (that occur *after* the 
   > **Note**: You can change the default target by using the command:
   >  ```
   >  cmake -G "NMake Makefiles" .. -DFPGA_DEVICE=<FPGA device family or FPGA part number>
-  >  ``` 
+  >  ```
   >
-  > Alternatively, you can target an explicit FPGA board variant and BSP by using the following command: 
+  > Alternatively, you can target an explicit FPGA board variant and BSP by using the following command:
   >  ```
   >  cmake -G "NMake Makefiles" .. -DFPGA_DEVICE=<board-support-package>:<board-variant>
-  >  ``` 
+  >  ```
   >
   > You will only be able to run an executable on the FPGA if you specified a BSP.
 

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/n_way_buffering/src/CMakeLists.txt
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/n_way_buffering/src/CMakeLists.txt
@@ -6,7 +6,7 @@ set(FPGA_TARGET ${TARGET_NAME}.fpga)
 
 # FPGA board selection
 if(NOT DEFINED FPGA_DEVICE)
-    set(FPGA_DEVICE "Agilex")
+    set(FPGA_DEVICE "Agilex 7")
     message(STATUS "FPGA_DEVICE was not specified.\
                     \nConfiguring the design to the default FPGA family: ${FPGA_DEVICE}\
                     \nPlease refer to the README for information on target selection.")

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/n_way_buffering/src/CMakeLists.txt
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/n_way_buffering/src/CMakeLists.txt
@@ -6,7 +6,7 @@ set(FPGA_TARGET ${TARGET_NAME}.fpga)
 
 # FPGA board selection
 if(NOT DEFINED FPGA_DEVICE)
-    set(FPGA_DEVICE "Agilex 7")
+    set(FPGA_DEVICE "Agilex7")
     message(STATUS "FPGA_DEVICE was not specified.\
                     \nConfiguring the design to the default FPGA family: ${FPGA_DEVICE}\
                     \nPlease refer to the README for information on target selection.")

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/onchip_memory_cache/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/onchip_memory_cache/README.md
@@ -21,7 +21,7 @@ This sample demonstrates the following concepts:
 | Optimized for                     | Description
 ---                                 |---
 | OS                                | Ubuntu* 18.04/20.04 <br> RHEL*/CentOS* 8 <br> SUSE* 15 <br> Windows* 10
-| Hardware                          | Intel® Agilex®, Arria® 10, and Stratix® 10 FPGAs
+| Hardware                          | Intel® Agilex 7®, Arria® 10, and Stratix® 10 FPGAs
 | Software                          | Intel® oneAPI DPC++/C++ Compiler
 
 > **Note**: Even though the Intel DPC++/C++ OneAPI compiler is enough to compile for emulation, generating reports and generating RTL, there are extra software requirements for the simulation flow and FPGA compiles.
@@ -43,9 +43,9 @@ flowchart LR
    tier2("Tier 2: Explore the Fundamentals")
    tier3("Tier 3: Explore the Advanced Techniques")
    tier4("Tier 4: Explore the Reference Designs")
-   
+
    tier1 --> tier2 --> tier3 --> tier4
-   
+
    style tier1 fill:#0071c1,stroke:#0071c1,stroke-width:1px,color:#fff
    style tier2 fill:#0071c1,stroke:#0071c1,stroke-width:1px,color:#fff
    style tier3 fill:#f96,stroke:#333,stroke-width:1px,color:#fff
@@ -106,8 +106,8 @@ This tutorial creates multiple kernels sweeping across different cache depths wi
 
 ### On Linux*
 
-1. Change to the sample directory. 
-2. Build the program for Intel® Agilex® device family, which is the default.
+1. Change to the sample directory.
+2. Build the program for Intel® Agilex 7® device family, which is the default.
    ```
    mkdir build
    cd build
@@ -116,12 +116,12 @@ This tutorial creates multiple kernels sweeping across different cache depths wi
    > **Note**: You can change the default target by using the command:
    >  ```
    >  cmake .. -DFPGA_DEVICE=<FPGA device family or FPGA part number>
-   >  ``` 
+   >  ```
    >
-   > Alternatively, you can target an explicit FPGA board variant and BSP by using the following command: 
+   > Alternatively, you can target an explicit FPGA board variant and BSP by using the following command:
    >  ```
    >  cmake .. -DFPGA_DEVICE=<board-support-package>:<board-variant>
-   >  ``` 
+   >  ```
    >
    > You will only be able to run an executable on the FPGA if you specified a BSP.
 
@@ -136,7 +136,7 @@ This tutorial creates multiple kernels sweeping across different cache depths wi
         make report
         ```
        The report resides at `onchip_memory_cache_report.prj/reports/report.html`.
-       
+
        Compare the Loop Analysis reports for kernels with various cache depths, as described in the "When is the on-chip memory cache technique applicable?" section.  This will illustrate that any cache depth > 0 allows a loop II of 1.
 
        Open the Kernel Memory viewer and compare the Load Latency on the loads from kernels with various cache depths, as describe in the "When is the on-chip memory cache technique applicable?" section. This will illustrate that a cache depth of at least 7 is required to achieve a load latency of > 1.
@@ -152,8 +152,8 @@ This tutorial creates multiple kernels sweeping across different cache depths wi
 
 ### On Windows*
 
-1. Change to the sample directory. 
-2. Build the program for the Agilex™ device family, which is the default.
+1. Change to the sample directory.
+2. Build the program for the Agilex 7™ device family, which is the default.
    ```
    mkdir build
    cd build
@@ -162,12 +162,12 @@ This tutorial creates multiple kernels sweeping across different cache depths wi
    > **Note**: You can change the default target by using the command:
    >  ```
    >  cmake -G "NMake Makefiles" .. -DFPGA_DEVICE=<FPGA device family or FPGA part number>
-   >  ``` 
+   >  ```
    >
-   > Alternatively, you can target an explicit FPGA board variant and BSP by using the following command: 
+   > Alternatively, you can target an explicit FPGA board variant and BSP by using the following command:
    >  ```
    >  cmake -G "NMake Makefiles" .. -DFPGA_DEVICE=<board-support-package>:<board-variant>
-   >  ``` 
+   >  ```
    >
    > You will only be able to run an executable on the FPGA if you specified a BSP.
 
@@ -182,7 +182,7 @@ This tutorial creates multiple kernels sweeping across different cache depths wi
       nmake report
       ```
        The report resides at `onchip_memory_cache_report.prj.a/reports/report.html`.
-       
+
        Compare the Loop Analysis reports for kernels with various cache depths, as described in the "When is the on-chip memory cache technique applicable?" section.  This will illustrate that any cache depth > 0 allows a loop II of 1.
 
        Open the Kernel Memory viewer and compare the Load Latency on the loads from kernels with various cache depths, as describe in the "When is the on-chip memory cache technique applicable?" section. This will illustrate that a cache depth of at least 7 is required to achieve a load latency of > 1.

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/onchip_memory_cache/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/onchip_memory_cache/README.md
@@ -21,7 +21,7 @@ This sample demonstrates the following concepts:
 | Optimized for                     | Description
 ---                                 |---
 | OS                                | Ubuntu* 18.04/20.04 <br> RHEL*/CentOS* 8 <br> SUSE* 15 <br> Windows* 10
-| Hardware                          | Intel® Agilex 7®, Arria® 10, and Stratix® 10 FPGAs
+| Hardware                          | Intel® Agilex® 7, Arria® 10, and Stratix® 10 FPGAs
 | Software                          | Intel® oneAPI DPC++/C++ Compiler
 
 > **Note**: Even though the Intel DPC++/C++ OneAPI compiler is enough to compile for emulation, generating reports and generating RTL, there are extra software requirements for the simulation flow and FPGA compiles.
@@ -107,7 +107,7 @@ This tutorial creates multiple kernels sweeping across different cache depths wi
 ### On Linux*
 
 1. Change to the sample directory.
-2. Build the program for Intel® Agilex 7® device family, which is the default.
+2. Build the program for Intel® Agilex® 7 device family, which is the default.
    ```
    mkdir build
    cd build

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/onchip_memory_cache/src/CMakeLists.txt
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/onchip_memory_cache/src/CMakeLists.txt
@@ -6,7 +6,7 @@ set(FPGA_TARGET ${TARGET_NAME}.fpga)
 
 # FPGA board selection
 if(NOT DEFINED FPGA_DEVICE)
-    set(FPGA_DEVICE "Agilex 7")
+    set(FPGA_DEVICE "Agilex7")
     message(STATUS "FPGA_DEVICE was not specified.\
                     \nConfiguring the design to the default FPGA family: ${FPGA_DEVICE}\
                     \nPlease refer to the README for information on target selection.")

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/onchip_memory_cache/src/CMakeLists.txt
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/onchip_memory_cache/src/CMakeLists.txt
@@ -6,7 +6,7 @@ set(FPGA_TARGET ${TARGET_NAME}.fpga)
 
 # FPGA board selection
 if(NOT DEFINED FPGA_DEVICE)
-    set(FPGA_DEVICE "Agilex")
+    set(FPGA_DEVICE "Agilex 7")
     message(STATUS "FPGA_DEVICE was not specified.\
                     \nConfiguring the design to the default FPGA family: ${FPGA_DEVICE}\
                     \nPlease refer to the README for information on target selection.")
@@ -22,7 +22,7 @@ else()
     set(AC_TYPES_FLAG "-qactypes")
 endif()
 
-# Allow the user to specify the minimum and maximum cache depth, or select a 
+# Allow the user to specify the minimum and maximum cache depth, or select a
 # default value if unspecified
 # e.g. cmake .. -DMAX_CACHE_DEPTH=4
 if(NOT DEFINED MAX_CACHE_DEPTH)

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/optimize_inner_loop/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/optimize_inner_loop/README.md
@@ -19,7 +19,7 @@ This is an advanced sample (tutorial) that relies on understanding f<sub>MAX</su
 | Optimized for        | Description
 |:---                  |:---
 | OS                   | Ubuntu* 18.04/20.04 <br> RHEL*/CentOS* 8 <br> SUSE* 15 <br> Windows* 10
-| Hardware             | Intel® Agilex®, Arria® 10, and Stratix® 10 FPGAs
+| Hardware             | Intel® Agilex 7®, Arria® 10, and Stratix® 10 FPGAs
 | Software             | Intel® oneAPI DPC++/C++ Compiler
 
 > **Note**: Even though the Intel® oneAPI DPC++/C++ Compiler is enough to compile for emulation, generating reports, generating RTL, there are extra software requirements for the simulation flow and FPGA compiles.
@@ -41,9 +41,9 @@ flowchart LR
    tier2("Tier 2: Explore the Fundamentals")
    tier3("Tier 3: Explore the Advanced Techniques")
    tier4("Tier 4: Explore the Reference Designs")
-   
+
    tier1 --> tier2 --> tier3 --> tier4
-   
+
    style tier1 fill:#0071c1,stroke:#0071c1,stroke-width:1px,color:#fff
    style tier2 fill:#0071c1,stroke:#0071c1,stroke-width:1px,color:#fff
    style tier3 fill:#f96,stroke:#333,stroke-width:1px,color:#fff
@@ -145,7 +145,7 @@ while (Pipe::read()) {
 ### On Linux*
 
 1. Change to the sample directory.
-2. Build the program for Intel® Agilex® device family, which is the default.
+2. Build the program for Intel® Agilex 7® device family, which is the default.
    ```
    mkdir build
    cd build
@@ -186,7 +186,7 @@ while (Pipe::read()) {
 ### On Windows*
 
 1. Change to the sample directory.
-2. Build the program for the Intel® Agilex® device family, which is the default.
+2. Build the program for the Intel® Agilex 7® device family, which is the default.
    ```
    mkdir build
    cd build
@@ -229,7 +229,7 @@ while (Pipe::read()) {
 
 ### Reading the Reports
 
-Open the reports in a browser and look at the *Loop Analysis* pane. 
+Open the reports in a browser and look at the *Loop Analysis* pane.
 
 Examine the loop attributes for the three different versions of the `Producer` kernel (`Producer<0>`, `Producer<1>`, and `Producer<2>`). Note that each has an outer loop with an II of 1 and an inner loop with an II of 1. As discussed earlier in this tutorial, the II of the outer loop will be *dynamic* and depend on the inner loop's execution for each outer loop iteration. Also, note the *Speculated Iterations* column, which should show 2 speculated loop iterations on the inner loop for `Producer<0>` and 0 for `Producer<1>` and `Producer<2>`. There is no information in the reports indicating whether there will be a 1 cycle delay in starting the loop. We are working on improving our reports to help you better debug throughput bottlenecks.
 

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/optimize_inner_loop/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/optimize_inner_loop/README.md
@@ -19,7 +19,7 @@ This is an advanced sample (tutorial) that relies on understanding f<sub>MAX</su
 | Optimized for        | Description
 |:---                  |:---
 | OS                   | Ubuntu* 18.04/20.04 <br> RHEL*/CentOS* 8 <br> SUSE* 15 <br> Windows* 10
-| Hardware             | Intel® Agilex 7®, Arria® 10, and Stratix® 10 FPGAs
+| Hardware             | Intel® Agilex® 7, Arria® 10, and Stratix® 10 FPGAs
 | Software             | Intel® oneAPI DPC++/C++ Compiler
 
 > **Note**: Even though the Intel® oneAPI DPC++/C++ Compiler is enough to compile for emulation, generating reports, generating RTL, there are extra software requirements for the simulation flow and FPGA compiles.
@@ -145,7 +145,7 @@ while (Pipe::read()) {
 ### On Linux*
 
 1. Change to the sample directory.
-2. Build the program for Intel® Agilex 7® device family, which is the default.
+2. Build the program for Intel® Agilex® 7 device family, which is the default.
    ```
    mkdir build
    cd build
@@ -186,7 +186,7 @@ while (Pipe::read()) {
 ### On Windows*
 
 1. Change to the sample directory.
-2. Build the program for the Intel® Agilex 7® device family, which is the default.
+2. Build the program for the Intel® Agilex® 7 device family, which is the default.
    ```
    mkdir build
    cd build

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/optimize_inner_loop/src/CMakeLists.txt
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/optimize_inner_loop/src/CMakeLists.txt
@@ -6,7 +6,7 @@ set(FPGA_TARGET ${TARGET_NAME}.fpga)
 
 # FPGA board selection
 if(NOT DEFINED FPGA_DEVICE)
-    set(FPGA_DEVICE "Agilex")
+    set(FPGA_DEVICE "Agilex 7")
     message(STATUS "FPGA_DEVICE was not specified.\
                     \nConfiguring the design to the default FPGA family: ${FPGA_DEVICE}\
                     \nPlease refer to the README for information on target selection.")

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/optimize_inner_loop/src/CMakeLists.txt
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/optimize_inner_loop/src/CMakeLists.txt
@@ -6,7 +6,7 @@ set(FPGA_TARGET ${TARGET_NAME}.fpga)
 
 # FPGA board selection
 if(NOT DEFINED FPGA_DEVICE)
-    set(FPGA_DEVICE "Agilex 7")
+    set(FPGA_DEVICE "Agilex7")
     message(STATUS "FPGA_DEVICE was not specified.\
                     \nConfiguring the design to the default FPGA family: ${FPGA_DEVICE}\
                     \nPlease refer to the README for information on target selection.")

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/pipe_array/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/pipe_array/README.md
@@ -22,7 +22,7 @@ This tutorial provides a convenient pair of header files defining an abstraction
 | Optimized for        | Description
 |:---                  |:---
 | OS                   | Ubuntu* 18.04/20.04 <br> RHEL*/CentOS* 8 <br> SUSE* 15 <br> Windows* 10
-| Hardware             | Intel® Agilex®, Arria® 10, and Stratix® 10 FPGAs
+| Hardware             | Intel® Agilex 7®, Arria® 10, and Stratix® 10 FPGAs
 | Software             | Intel® oneAPI DPC++/C++ Compiler
 
 > **Note**: Even though the Intel® oneAPI DPC++/C++ Compiler is enough to compile for emulation, generating reports, generating RTL, there are extra software requirements for the simulation flow and FPGA compiles.
@@ -45,9 +45,9 @@ flowchart LR
    tier2("Tier 2: Explore the Fundamentals")
    tier3("Tier 3: Explore the Advanced Techniques")
    tier4("Tier 4: Explore the Reference Designs")
-   
+
    tier1 --> tier2 --> tier3 --> tier4
-   
+
    style tier1 fill:#0071c1,stroke:#0071c1,stroke-width:1px,color:#fff
    style tier2 fill:#0071c1,stroke:#0071c1,stroke-width:1px,color:#fff
    style tier3 fill:#f96,stroke:#333,stroke-width:1px,color:#fff
@@ -194,7 +194,7 @@ The host must thus enqueue the producer kernel and `kNumRows * kNumCols` separat
 ### On Linux*
 
 1. Change to the sample directory.
-2. Build the program for Intel® Agilex® device family, which is the default.
+2. Build the program for Intel® Agilex 7® device family, which is the default.
    ```
    mkdir build
    cd build
@@ -238,7 +238,7 @@ The host must thus enqueue the producer kernel and `kNumRows * kNumCols` separat
 ### On Windows*
 
 1. Change to the sample directory.
-2. Build the program for the Intel® Agilex® device family, which is the default.
+2. Build the program for the Intel® Agilex 7® device family, which is the default.
    ```
    mkdir build
    cd build

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/pipe_array/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/pipe_array/README.md
@@ -22,7 +22,7 @@ This tutorial provides a convenient pair of header files defining an abstraction
 | Optimized for        | Description
 |:---                  |:---
 | OS                   | Ubuntu* 18.04/20.04 <br> RHEL*/CentOS* 8 <br> SUSE* 15 <br> Windows* 10
-| Hardware             | Intel® Agilex 7®, Arria® 10, and Stratix® 10 FPGAs
+| Hardware             | Intel® Agilex® 7, Arria® 10, and Stratix® 10 FPGAs
 | Software             | Intel® oneAPI DPC++/C++ Compiler
 
 > **Note**: Even though the Intel® oneAPI DPC++/C++ Compiler is enough to compile for emulation, generating reports, generating RTL, there are extra software requirements for the simulation flow and FPGA compiles.
@@ -194,7 +194,7 @@ The host must thus enqueue the producer kernel and `kNumRows * kNumCols` separat
 ### On Linux*
 
 1. Change to the sample directory.
-2. Build the program for Intel® Agilex 7® device family, which is the default.
+2. Build the program for Intel® Agilex® 7 device family, which is the default.
    ```
    mkdir build
    cd build
@@ -238,7 +238,7 @@ The host must thus enqueue the producer kernel and `kNumRows * kNumCols` separat
 ### On Windows*
 
 1. Change to the sample directory.
-2. Build the program for the Intel® Agilex 7® device family, which is the default.
+2. Build the program for the Intel® Agilex® 7 device family, which is the default.
    ```
    mkdir build
    cd build

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/pipe_array/src/CMakeLists.txt
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/pipe_array/src/CMakeLists.txt
@@ -6,7 +6,7 @@ set(FPGA_TARGET ${TARGET_NAME}.fpga)
 
 # FPGA board selection
 if(NOT DEFINED FPGA_DEVICE)
-    set(FPGA_DEVICE "Agilex")
+    set(FPGA_DEVICE "Agilex 7")
     message(STATUS "FPGA_DEVICE was not specified.\
                     \nConfiguring the design to the default FPGA family: ${FPGA_DEVICE}\
                     \nPlease refer to the README for information on target selection.")

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/pipe_array/src/CMakeLists.txt
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/pipe_array/src/CMakeLists.txt
@@ -6,7 +6,7 @@ set(FPGA_TARGET ${TARGET_NAME}.fpga)
 
 # FPGA board selection
 if(NOT DEFINED FPGA_DEVICE)
-    set(FPGA_DEVICE "Agilex 7")
+    set(FPGA_DEVICE "Agilex7")
     message(STATUS "FPGA_DEVICE was not specified.\
                     \nConfiguring the design to the default FPGA family: ${FPGA_DEVICE}\
                     \nPlease refer to the README for information on target selection.")

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/shannonization/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/shannonization/README.md
@@ -17,7 +17,7 @@ Demonstrate a loop optimization to improve the f<sub>MAX</sub>/II of an FPGA des
 | Optimized for        | Description
 |:---                  |:---
 | OS                   | Ubuntu* 18.04/20.04 <br> RHEL*/CentOS* 8 <br> SUSE* 15 <br> Windows* 10
-| Hardware             | Intel® Agilex®, Arria® 10, and Stratix® 10 FPGAs
+| Hardware             | Intel® Agilex 7®, Arria® 10, and Stratix® 10 FPGAs
 | Software             | Intel® oneAPI DPC++/C++ Compiler
 
 > **Note**: Even though the Intel® oneAPI DPC++/C++ Compiler is enough to compile for emulation, generating reports, generating RTL, there are extra software requirements for the simulation flow and FPGA compiles.
@@ -39,9 +39,9 @@ flowchart LR
    tier2("Tier 2: Explore the Fundamentals")
    tier3("Tier 3: Explore the Advanced Techniques")
    tier4("Tier 4: Explore the Reference Designs")
-   
+
    tier1 --> tier2 --> tier3 --> tier4
-   
+
    style tier1 fill:#0071c1,stroke:#0071c1,stroke-width:1px,color:#fff
    style tier2 fill:#0071c1,stroke:#0071c1,stroke-width:1px,color:#fff
    style tier3 fill:#f96,stroke:#333,stroke-width:1px,color:#fff
@@ -174,7 +174,7 @@ To achieve an II of 1 for the main `while` loop in the FPGA code shown above, th
 ### On Linux*
 
 1. Change to the sample directory.
-2. Build the program for Intel® Agilex® device family, which is the default.
+2. Build the program for Intel® Agilex 7® device family, which is the default.
    ```
    mkdir build
    cd build
@@ -216,7 +216,7 @@ To achieve an II of 1 for the main `while` loop in the FPGA code shown above, th
 ### On Windows*
 
 1. Change to the sample directory.
-2. Build the program for the Intel® Agilex® device family, which is the default.
+2. Build the program for the Intel® Agilex 7® device family, which is the default.
    ```
    mkdir build
    cd build
@@ -341,7 +341,7 @@ In general, these shannonization optimizations create a shift-register that prec
 
 #### Version 3
 
-As a consequence of the fabric architecture of the Intel® Stratix® 10 SX FPGA, the hardware implementation of pipes for the Intel® Stratix® 10 SX FPGA has a longer latency for blocking pipe reads and writes. In version 3 of the kernel, `Intersection<3>`, we transform the code to use non-blocking pipe reads. For the Intel® Arria® 10 FPGA, this does not have a noticeable difference. However, this transformation allows the design to reach an II of 1 for the Intel® Stratix® 10 and Intel Agilex® FPGAs.
+As a consequence of the fabric architecture of the Intel® Stratix® 10 SX FPGA, the hardware implementation of pipes for the Intel® Stratix® 10 SX FPGA has a longer latency for blocking pipe reads and writes. In version 3 of the kernel, `Intersection<3>`, we transform the code to use non-blocking pipe reads. For the Intel® Arria® 10 FPGA, this does not have a noticeable difference. However, this transformation allows the design to reach an II of 1 for the Intel® Stratix® 10 and Intel Agilex 7® FPGAs.
 
 ## Run the `Shannonization` Sample
 

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/shannonization/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/shannonization/README.md
@@ -17,7 +17,7 @@ Demonstrate a loop optimization to improve the f<sub>MAX</sub>/II of an FPGA des
 | Optimized for        | Description
 |:---                  |:---
 | OS                   | Ubuntu* 18.04/20.04 <br> RHEL*/CentOS* 8 <br> SUSE* 15 <br> Windows* 10
-| Hardware             | Intel® Agilex 7®, Arria® 10, and Stratix® 10 FPGAs
+| Hardware             | Intel® Agilex® 7, Arria® 10, and Stratix® 10 FPGAs
 | Software             | Intel® oneAPI DPC++/C++ Compiler
 
 > **Note**: Even though the Intel® oneAPI DPC++/C++ Compiler is enough to compile for emulation, generating reports, generating RTL, there are extra software requirements for the simulation flow and FPGA compiles.
@@ -174,7 +174,7 @@ To achieve an II of 1 for the main `while` loop in the FPGA code shown above, th
 ### On Linux*
 
 1. Change to the sample directory.
-2. Build the program for Intel® Agilex 7® device family, which is the default.
+2. Build the program for Intel® Agilex® 7 device family, which is the default.
    ```
    mkdir build
    cd build
@@ -216,7 +216,7 @@ To achieve an II of 1 for the main `while` loop in the FPGA code shown above, th
 ### On Windows*
 
 1. Change to the sample directory.
-2. Build the program for the Intel® Agilex 7® device family, which is the default.
+2. Build the program for the Intel® Agilex® 7 device family, which is the default.
    ```
    mkdir build
    cd build
@@ -341,7 +341,7 @@ In general, these shannonization optimizations create a shift-register that prec
 
 #### Version 3
 
-As a consequence of the fabric architecture of the Intel® Stratix® 10 SX FPGA, the hardware implementation of pipes for the Intel® Stratix® 10 SX FPGA has a longer latency for blocking pipe reads and writes. In version 3 of the kernel, `Intersection<3>`, we transform the code to use non-blocking pipe reads. For the Intel® Arria® 10 FPGA, this does not have a noticeable difference. However, this transformation allows the design to reach an II of 1 for the Intel® Stratix® 10 and Intel Agilex 7® FPGAs.
+As a consequence of the fabric architecture of the Intel® Stratix® 10 SX FPGA, the hardware implementation of pipes for the Intel® Stratix® 10 SX FPGA has a longer latency for blocking pipe reads and writes. In version 3 of the kernel, `Intersection<3>`, we transform the code to use non-blocking pipe reads. For the Intel® Arria® 10 FPGA, this does not have a noticeable difference. However, this transformation allows the design to reach an II of 1 for the Intel® Stratix® 10 and Intel Agilex® 7 FPGAs.
 
 ## Run the `Shannonization` Sample
 

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/shannonization/src/CMakeLists.txt
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/shannonization/src/CMakeLists.txt
@@ -7,8 +7,8 @@ set(REPORTS_TARGET ${TARGET_NAME}_report)
 
 # FPGA board selection
 if(NOT DEFINED FPGA_DEVICE)
-    set(FPGA_DEVICE "Agilex")
-    set(DEVICE_FLAG "Agilex")
+    set(FPGA_DEVICE "Agilex 7")
+    set(DEVICE_FLAG "Agilex 7")
     message(STATUS "FPGA_DEVICE was not specified.\
                     \nConfiguring the design to the default FPGA family: ${FPGA_DEVICE}\
                     \nPlease refer to the README for information on target selection.")
@@ -19,7 +19,7 @@ else()
     elseif(FPGA_DEVICE_NAME MATCHES ".*s10.*" OR FPGA_DEVICE_NAME MATCHES ".*stratix10.*")
       set(DEVICE_FLAG "S10")
     elseif(FPGA_DEVICE_NAME MATCHES ".*agilex.*")
-      set(DEVICE_FLAG "Agilex")
+      set(DEVICE_FLAG "Agilex 7")
     endif()
     message(STATUS "Configuring the design with the following target: ${FPGA_DEVICE}")
 endif()
@@ -27,7 +27,7 @@ endif()
 if(NOT DEFINED DEVICE_FLAG)
     message(FATAL_ERROR "An unrecognized or custom board was passed, but DEVICE_FLAG was not specified. \
                          Please make sure you have set -DDEVICE_FLAG=-A10, -DDEVICE_FLAG=-S10 or \
-                         -DDEVICE_FLAG=-Agilex.")
+                         -DDEVICE_FLAG=-Agilex 7.")
 endif()
 
 # This is a Windows-specific flag that enables exception handling in host code
@@ -35,8 +35,8 @@ if(WIN32)
     set(WIN_FLAG "/EHsc")
 endif()
 
-# Allow disabling of hyper-optimization for S10 and Agilex
-if((DEVICE_FLAG MATCHES "S10") OR (DEVICE_FLAG MATCHES "Agilex") OR (DEFINED ${NO_HYPER_OPTIMIZATION}))
+# Allow disabling of hyper-optimization for S10 and Agilex 7
+if((DEVICE_FLAG MATCHES "S10") OR (DEVICE_FLAG MATCHES "Agilex 7") OR (DEFINED ${NO_HYPER_OPTIMIZATION}))
     set(HYPER_FLAG -Xshyper-optimized-handshaking=off)
 endif()
 

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/shannonization/src/CMakeLists.txt
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/shannonization/src/CMakeLists.txt
@@ -7,8 +7,8 @@ set(REPORTS_TARGET ${TARGET_NAME}_report)
 
 # FPGA board selection
 if(NOT DEFINED FPGA_DEVICE)
-    set(FPGA_DEVICE "Agilex 7")
-    set(DEVICE_FLAG "Agilex 7")
+    set(FPGA_DEVICE "Agilex7")
+    set(DEVICE_FLAG "Agilex7")
     message(STATUS "FPGA_DEVICE was not specified.\
                     \nConfiguring the design to the default FPGA family: ${FPGA_DEVICE}\
                     \nPlease refer to the README for information on target selection.")
@@ -19,7 +19,7 @@ else()
     elseif(FPGA_DEVICE_NAME MATCHES ".*s10.*" OR FPGA_DEVICE_NAME MATCHES ".*stratix10.*")
       set(DEVICE_FLAG "S10")
     elseif(FPGA_DEVICE_NAME MATCHES ".*agilex.*")
-      set(DEVICE_FLAG "Agilex 7")
+      set(DEVICE_FLAG "Agilex7")
     endif()
     message(STATUS "Configuring the design with the following target: ${FPGA_DEVICE}")
 endif()
@@ -27,7 +27,7 @@ endif()
 if(NOT DEFINED DEVICE_FLAG)
     message(FATAL_ERROR "An unrecognized or custom board was passed, but DEVICE_FLAG was not specified. \
                          Please make sure you have set -DDEVICE_FLAG=-A10, -DDEVICE_FLAG=-S10 or \
-                         -DDEVICE_FLAG=-Agilex 7.")
+                         -DDEVICE_FLAG=-Agilex7.")
 endif()
 
 # This is a Windows-specific flag that enables exception handling in host code
@@ -35,8 +35,8 @@ if(WIN32)
     set(WIN_FLAG "/EHsc")
 endif()
 
-# Allow disabling of hyper-optimization for S10 and Agilex 7
-if((DEVICE_FLAG MATCHES "S10") OR (DEVICE_FLAG MATCHES "Agilex 7") OR (DEFINED ${NO_HYPER_OPTIMIZATION}))
+# Allow disabling of hyper-optimization for S10 and Agilex7
+if((DEVICE_FLAG MATCHES "S10") OR (DEVICE_FLAG MATCHES "Agilex7") OR (DEFINED ${NO_HYPER_OPTIMIZATION}))
     set(HYPER_FLAG -Xshyper-optimized-handshaking=off)
 endif()
 

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/shannonization/src/CMakeLists.txt
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/shannonization/src/CMakeLists.txt
@@ -26,8 +26,8 @@ endif()
 
 if(NOT DEFINED DEVICE_FLAG)
     message(FATAL_ERROR "An unrecognized or custom board was passed, but DEVICE_FLAG was not specified. \
-                         Please make sure you have set -DDEVICE_FLAG=-A10, -DDEVICE_FLAG=-S10 or \
-                         -DDEVICE_FLAG=-Agilex7.")
+                         Please make sure you have set -DDEVICE_FLAG=A10, -DDEVICE_FLAG=S10 or \
+                         -DDEVICE_FLAG=Agilex7.")
 endif()
 
 # This is a Windows-specific flag that enables exception handling in host code

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/shannonization/src/shannonization.cpp
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/shannonization/src/shannonization.cpp
@@ -289,9 +289,9 @@ int main(int argc, char** argv) {
     // can be seen in the "Block Scheduled Fmax" columns in the
     // "Loop Analysis" tab of the HTML reports.
     //
-    // On Stratix® 10 and Agilex 7™, the same discussion applies, but version 0
+    // On Stratix® 10 and Agilex® 7, the same discussion applies, but version 0
     // can only achieve an II of 3 while versions 1 and 2 can only achieve
-    // an II of 2. On Stratix® 10 and Agilex 7™, we can achieve an II of 1 if we use
+    // an II of 2. On Stratix® 10 and Agilex® 7, we can achieve an II of 1 if we use
     // non-blocking pipe reads in the IntersectionKernel, which is shown in
     // version 3 of the kernel.
     //
@@ -305,7 +305,7 @@ int main(int argc, char** argv) {
     success &= Intersection<1,2>(q, a, b, golden_n);
     success &= Intersection<2,2>(q, a, b, golden_n);
     success &= Intersection<3,1>(q, a, b, golden_n);
-#elif defined(Agilex 7)
+#elif defined(Agilex7)
     success &= Intersection<0,3>(q, a, b, golden_n);
     success &= Intersection<1,2>(q, a, b, golden_n);
     success &= Intersection<2,2>(q, a, b, golden_n);

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/shannonization/src/shannonization.cpp
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/shannonization/src/shannonization.cpp
@@ -101,7 +101,7 @@ event SubmitKernels(queue& q, std::vector<unsigned int>& a,
     accessor n_accessor(n_buf, h, write_only, no_init);
 
     h.single_task<Worker<Version>>([=]() [[intel::kernel_args_restrict]] {
-      // The 'Version' template parameter will choose between the different 
+      // The 'Version' template parameter will choose between the different
       // versions of the kernel defined in IntersectionKernel.hpp.
       // The operator() of the IntersectionKernel object will return the
       // size of the intersection of A and B.
@@ -114,12 +114,12 @@ event SubmitKernels(queue& q, std::vector<unsigned int>& a,
 }
 
 //
-// This function performs the intersection by submitting the 
+// This function performs the intersection by submitting the
 // different kernels. This method also validates the output
 // of the kernels and prints performance information
 //
 template <int Version, int II>
-bool Intersection(queue& q, std::vector<unsigned int>& a, 
+bool Intersection(queue& q, std::vector<unsigned int>& a,
                   std::vector<unsigned int>& b, int golden_n) {
   // For emulation, just do a single iteration.
   // For hardware, perform multiple iterations for a more
@@ -130,12 +130,12 @@ bool Intersection(queue& q, std::vector<unsigned int>& a,
   int iterations = 5;
 #endif
 
-  std::cout << "Running " << iterations 
+  std::cout << "Running " << iterations
             << ((iterations == 1) ? " iteration" : " iterations")
             << " of kernel " << Version
-            << " with |A|=" << a.size() 
+            << " with |A|=" << a.size()
             << " and |B|=" << b.size() << "\n";
-  
+
   bool success = true;
   std::vector<double> kernel_latency(iterations);
 
@@ -171,12 +171,12 @@ bool Intersection(queue& q, std::vector<unsigned int>& a,
         std::accumulate(kernel_latency.begin() + 1, kernel_latency.end(), 0.0) /
         (double)(iterations - 1);
 
-    double input_size_megabytes = 
+    double input_size_megabytes =
         ((a.size() + b.size()) * sizeof(unsigned int)) / (1024.0 * 1024.0);
 
     const double avg_throughput = input_size_megabytes / avg_kernel_latency;
 
-    std::cout << "Kernel " << Version 
+    std::cout << "Kernel " << Version
               << " average throughput: " << avg_throughput << " MB/s\n";
 #endif
   }
@@ -280,18 +280,18 @@ int main(int argc, char** argv) {
     //
     // On Arria® 10, we are able to achieve an II of 1 for all versions of the
     // kernel.
-    // Version 2 of the kernel can achieve the highest Fmax with 
+    // Version 2 of the kernel can achieve the highest Fmax with
     // an II of 1 (and therefore has the highest throughput).
     // Since this tutorial compiles to a single FPGA image, this is not
     // reflected in the final design (that is, version 1 bottlenecks the Fmax
     // of the entire design, which contains versions 0, 1 and 2).
     // However, the difference between versions 1 and 2
-    // can be seen in the "Block Scheduled Fmax" columns in the 
+    // can be seen in the "Block Scheduled Fmax" columns in the
     // "Loop Analysis" tab of the HTML reports.
     //
-    // On Stratix® 10 and Agilex™, the same discussion applies, but version 0
+    // On Stratix® 10 and Agilex 7™, the same discussion applies, but version 0
     // can only achieve an II of 3 while versions 1 and 2 can only achieve
-    // an II of 2. On Stratix® 10 and Agilex™, we can achieve an II of 1 if we use
+    // an II of 2. On Stratix® 10 and Agilex 7™, we can achieve an II of 1 if we use
     // non-blocking pipe reads in the IntersectionKernel, which is shown in
     // version 3 of the kernel.
     //
@@ -305,7 +305,7 @@ int main(int argc, char** argv) {
     success &= Intersection<1,2>(q, a, b, golden_n);
     success &= Intersection<2,2>(q, a, b, golden_n);
     success &= Intersection<3,1>(q, a, b, golden_n);
-#elif defined(Agilex)
+#elif defined(Agilex 7)
     success &= Intersection<0,3>(q, a, b, golden_n);
     success &= Intersection<1,2>(q, a, b, golden_n);
     success &= Intersection<2,2>(q, a, b, golden_n);

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/simple_host_streaming/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/simple_host_streaming/README.md
@@ -25,7 +25,7 @@ This tutorial includes three designs:
 | Optimized for        | Description
 |:---                  |:---
 | OS                   | Ubuntu* 18.04/20.04 <br> RHEL*/CentOS* 8 <br> SUSE* 15 <br> Windows* 10
-| Hardware             | Intel® Agilex 7®, Arria® 10, and Stratix® 10 FPGAs
+| Hardware             | Intel® Agilex® 7, Arria® 10, and Stratix® 10 FPGAs
 | Software             | Intel® oneAPI DPC++/C++ Compiler
 
 
@@ -144,7 +144,7 @@ We are currently working on an API and tutorial to address both of these drawbac
 ### On Linux*
 
 1. Change to the sample directory.
-2. Build the program for Intel® Agilex 7® device family, which is the default.
+2. Build the program for Intel® Agilex® 7 device family, which is the default.
    ```
    mkdir build
    cd build
@@ -186,7 +186,7 @@ We are currently working on an API and tutorial to address both of these drawbac
 ### On Windows*
 
 1. Change to the sample directory.
-2. Build the program for the Intel® Agilex 7® device family, which is the default.
+2. Build the program for the Intel® Agilex® 7 device family, which is the default.
    ```
    mkdir build
    cd build

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/simple_host_streaming/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/simple_host_streaming/README.md
@@ -25,7 +25,7 @@ This tutorial includes three designs:
 | Optimized for        | Description
 |:---                  |:---
 | OS                   | Ubuntu* 18.04/20.04 <br> RHEL*/CentOS* 8 <br> SUSE* 15 <br> Windows* 10
-| Hardware             | Intel® Agilex®, Arria® 10, and Stratix® 10 FPGAs
+| Hardware             | Intel® Agilex 7®, Arria® 10, and Stratix® 10 FPGAs
 | Software             | Intel® oneAPI DPC++/C++ Compiler
 
 
@@ -50,9 +50,9 @@ flowchart LR
    tier2("Tier 2: Explore the Fundamentals")
    tier3("Tier 3: Explore the Advanced Techniques")
    tier4("Tier 4: Explore the Reference Designs")
-   
+
    tier1 --> tier2 --> tier3 --> tier4
-   
+
    style tier1 fill:#0071c1,stroke:#0071c1,stroke-width:1px,color:#fff
    style tier2 fill:#0071c1,stroke:#0071c1,stroke-width:1px,color:#fff
    style tier3 fill:#f96,stroke:#333,stroke-width:1px,color:#fff
@@ -144,7 +144,7 @@ We are currently working on an API and tutorial to address both of these drawbac
 ### On Linux*
 
 1. Change to the sample directory.
-2. Build the program for Intel® Agilex® device family, which is the default.
+2. Build the program for Intel® Agilex 7® device family, which is the default.
    ```
    mkdir build
    cd build
@@ -186,7 +186,7 @@ We are currently working on an API and tutorial to address both of these drawbac
 ### On Windows*
 
 1. Change to the sample directory.
-2. Build the program for the Intel® Agilex® device family, which is the default.
+2. Build the program for the Intel® Agilex 7® device family, which is the default.
    ```
    mkdir build
    cd build

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/simple_host_streaming/src/CMakeLists.txt
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/simple_host_streaming/src/CMakeLists.txt
@@ -7,7 +7,7 @@ set(REPORTS_TARGET ${TARGET_NAME}_report)
 
 # FPGA board selection
 if(NOT DEFINED FPGA_DEVICE)
-    set(FPGA_DEVICE "Agilex")
+    set(FPGA_DEVICE "Agilex 7")
     message(STATUS "FPGA_DEVICE was not specified.\
                     \nConfiguring the design to the default FPGA family: ${FPGA_DEVICE}\
                     \nPlease refer to the README for information on target selection.")

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/simple_host_streaming/src/CMakeLists.txt
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/simple_host_streaming/src/CMakeLists.txt
@@ -7,7 +7,7 @@ set(REPORTS_TARGET ${TARGET_NAME}_report)
 
 # FPGA board selection
 if(NOT DEFINED FPGA_DEVICE)
-    set(FPGA_DEVICE "Agilex 7")
+    set(FPGA_DEVICE "Agilex7")
     message(STATUS "FPGA_DEVICE was not specified.\
                     \nConfiguring the design to the default FPGA family: ${FPGA_DEVICE}\
                     \nPlease refer to the README for information on target selection.")

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/triangular_loop/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/triangular_loop/README.md
@@ -18,7 +18,7 @@ This FPGA sample introduces an advanced optimization technique to improve the pe
 | Optimized for        | Description
 |:---                  |:---
 | OS                   | Ubuntu* 18.04/20.04 <br> RHEL*/CentOS* 8 <br> SUSE* 15 <br> Windows* 10
-| Hardware             | Intel® Agilex 7®, Arria® 10, and Stratix® 10 FPGAs
+| Hardware             | Intel® Agilex® 7, Arria® 10, and Stratix® 10 FPGAs
 | Software             | Intel® oneAPI DPC++/C++ Compiler
 
 > **Note**: Even though the Intel® oneAPI DPC++/C++ Compiler is enough to compile for emulation, generating reports, generating RTL, there are extra software requirements for the simulation flow and FPGA compiles.
@@ -216,7 +216,7 @@ Summing the number of real and dummy iterations gives the total iterations of th
 ### On Linux*
 
 1. Change to the sample directory.
-2. Build the program for Intel® Agilex 7® device family, which is the default.
+2. Build the program for Intel® Agilex® 7 device family, which is the default.
    ```
    mkdir build
    cd build
@@ -261,7 +261,7 @@ Summing the number of real and dummy iterations gives the total iterations of th
 ### On Windows*
 
 1. Change to the sample directory.
-2. Build the program for the Intel® Agilex 7® device family, which is the default.
+2. Build the program for the Intel® Agilex® 7 device family, which is the default.
    ```
    mkdir build
    cd build

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/triangular_loop/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/triangular_loop/README.md
@@ -18,7 +18,7 @@ This FPGA sample introduces an advanced optimization technique to improve the pe
 | Optimized for        | Description
 |:---                  |:---
 | OS                   | Ubuntu* 18.04/20.04 <br> RHEL*/CentOS* 8 <br> SUSE* 15 <br> Windows* 10
-| Hardware             | Intel® Agilex®, Arria® 10, and Stratix® 10 FPGAs
+| Hardware             | Intel® Agilex 7®, Arria® 10, and Stratix® 10 FPGAs
 | Software             | Intel® oneAPI DPC++/C++ Compiler
 
 > **Note**: Even though the Intel® oneAPI DPC++/C++ Compiler is enough to compile for emulation, generating reports, generating RTL, there are extra software requirements for the simulation flow and FPGA compiles.
@@ -40,9 +40,9 @@ flowchart LR
    tier2("Tier 2: Explore the Fundamentals")
    tier3("Tier 3: Explore the Advanced Techniques")
    tier4("Tier 4: Explore the Reference Designs")
-   
+
    tier1 --> tier2 --> tier3 --> tier4
-   
+
    style tier1 fill:#0071c1,stroke:#0071c1,stroke-width:1px,color:#fff
    style tier2 fill:#0071c1,stroke:#0071c1,stroke-width:1px,color:#fff
    style tier3 fill:#f96,stroke:#333,stroke-width:1px,color:#fff
@@ -216,7 +216,7 @@ Summing the number of real and dummy iterations gives the total iterations of th
 ### On Linux*
 
 1. Change to the sample directory.
-2. Build the program for Intel® Agilex® device family, which is the default.
+2. Build the program for Intel® Agilex 7® device family, which is the default.
    ```
    mkdir build
    cd build
@@ -261,7 +261,7 @@ Summing the number of real and dummy iterations gives the total iterations of th
 ### On Windows*
 
 1. Change to the sample directory.
-2. Build the program for the Intel® Agilex® device family, which is the default.
+2. Build the program for the Intel® Agilex 7® device family, which is the default.
    ```
    mkdir build
    cd build

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/triangular_loop/src/CMakeLists.txt
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/triangular_loop/src/CMakeLists.txt
@@ -6,7 +6,7 @@ set(FPGA_TARGET ${TARGET_NAME}.fpga)
 
 # FPGA board selection
 if(NOT DEFINED FPGA_DEVICE)
-    set(FPGA_DEVICE "Agilex")
+    set(FPGA_DEVICE "Agilex 7")
     message(STATUS "FPGA_DEVICE was not specified.\
                     \nConfiguring the design to the default FPGA family: ${FPGA_DEVICE}\
                     \nPlease refer to the README for information on target selection.")

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/triangular_loop/src/CMakeLists.txt
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/triangular_loop/src/CMakeLists.txt
@@ -6,7 +6,7 @@ set(FPGA_TARGET ${TARGET_NAME}.fpga)
 
 # FPGA board selection
 if(NOT DEFINED FPGA_DEVICE)
-    set(FPGA_DEVICE "Agilex 7")
+    set(FPGA_DEVICE "Agilex7")
     message(STATUS "FPGA_DEVICE was not specified.\
                     \nConfiguring the design to the default FPGA family: ${FPGA_DEVICE}\
                     \nPlease refer to the README for information on target selection.")

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/zero_copy_data_transfer/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/zero_copy_data_transfer/README.md
@@ -22,7 +22,7 @@ This sample demonstrates how to take advantage of zero-copy host memory for the 
 | Optimized for        | Description
 |:---                  |:---
 | OS                   | Ubuntu* 18.04/20.04 <br> RHEL*/CentOS* 8 <br> SUSE* 15 <br> Windows* 10
-| Hardware             | Intel® Agilex 7®, Arria® 10, and Stratix® 10 FPGAs
+| Hardware             | Intel® Agilex® 7, Arria® 10, and Stratix® 10 FPGAs
 | Software             | Intel® oneAPI DPC++/C++ Compiler
 
 > **Note**: Even though the Intel® oneAPI DPC++/C++ Compiler is enough to compile for emulation, generating reports, generating RTL, there are extra software requirements for the simulation flow and FPGA compiles.
@@ -96,7 +96,7 @@ This approach is not considered host streaming since the CPU and FPGA cannot (re
 ### On Linux*
 
 1. Change to the sample directory.
-2. Build the program for Intel® Agilex 7® device family, which is the default.
+2. Build the program for Intel® Agilex® 7 device family, which is the default.
    ```
    mkdir build
    cd build
@@ -138,7 +138,7 @@ This approach is not considered host streaming since the CPU and FPGA cannot (re
 ### On Windows*
 
 1. Change to the sample directory.
-2. Build the program for the Intel® Agilex 7® device family, which is the default.
+2. Build the program for the Intel® Agilex® 7 device family, which is the default.
    ```
    mkdir build
    cd build

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/zero_copy_data_transfer/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/zero_copy_data_transfer/README.md
@@ -22,7 +22,7 @@ This sample demonstrates how to take advantage of zero-copy host memory for the 
 | Optimized for        | Description
 |:---                  |:---
 | OS                   | Ubuntu* 18.04/20.04 <br> RHEL*/CentOS* 8 <br> SUSE* 15 <br> Windows* 10
-| Hardware             | Intel® Agilex®, Arria® 10, and Stratix® 10 FPGAs
+| Hardware             | Intel® Agilex 7®, Arria® 10, and Stratix® 10 FPGAs
 | Software             | Intel® oneAPI DPC++/C++ Compiler
 
 > **Note**: Even though the Intel® oneAPI DPC++/C++ Compiler is enough to compile for emulation, generating reports, generating RTL, there are extra software requirements for the simulation flow and FPGA compiles.
@@ -46,9 +46,9 @@ flowchart LR
    tier2("Tier 2: Explore the Fundamentals")
    tier3("Tier 3: Explore the Advanced Techniques")
    tier4("Tier 4: Explore the Reference Designs")
-   
+
    tier1 --> tier2 --> tier3 --> tier4
-   
+
    style tier1 fill:#0071c1,stroke:#0071c1,stroke-width:1px,color:#fff
    style tier2 fill:#0071c1,stroke:#0071c1,stroke-width:1px,color:#fff
    style tier3 fill:#f96,stroke:#333,stroke-width:1px,color:#fff
@@ -96,7 +96,7 @@ This approach is not considered host streaming since the CPU and FPGA cannot (re
 ### On Linux*
 
 1. Change to the sample directory.
-2. Build the program for Intel® Agilex® device family, which is the default.
+2. Build the program for Intel® Agilex 7® device family, which is the default.
    ```
    mkdir build
    cd build
@@ -138,7 +138,7 @@ This approach is not considered host streaming since the CPU and FPGA cannot (re
 ### On Windows*
 
 1. Change to the sample directory.
-2. Build the program for the Intel® Agilex® device family, which is the default.
+2. Build the program for the Intel® Agilex 7® device family, which is the default.
    ```
    mkdir build
    cd build

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/zero_copy_data_transfer/src/CMakeLists.txt
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/zero_copy_data_transfer/src/CMakeLists.txt
@@ -7,7 +7,7 @@ set(REPORTS_TARGET ${TARGET_NAME}_report)
 
 # FPGA board selection
 if(NOT DEFINED FPGA_DEVICE)
-    set(FPGA_DEVICE "Agilex")
+    set(FPGA_DEVICE "Agilex 7")
     message(STATUS "FPGA_DEVICE was not specified.\
                     \nConfiguring the design to the default FPGA family: ${FPGA_DEVICE}\
                     \nPlease refer to the README for information on target selection.")

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/zero_copy_data_transfer/src/CMakeLists.txt
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/zero_copy_data_transfer/src/CMakeLists.txt
@@ -7,7 +7,7 @@ set(REPORTS_TARGET ${TARGET_NAME}_report)
 
 # FPGA board selection
 if(NOT DEFINED FPGA_DEVICE)
-    set(FPGA_DEVICE "Agilex 7")
+    set(FPGA_DEVICE "Agilex7")
     message(STATUS "FPGA_DEVICE was not specified.\
                     \nConfiguring the design to the default FPGA family: ${FPGA_DEVICE}\
                     \nPlease refer to the README for information on target selection.")

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/ac_fixed/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/ac_fixed/README.md
@@ -5,7 +5,7 @@ This FPGA tutorial demonstrates how to use the Algorithmic C (AC) data type `ac_
 | Optimized for                     | Description
 |:---                               |:---
 | OS                                | CentOS*Linux 8 <br> Red Hat* Enterprise Linux*8 <br> SUSE* Linux Enterprise Server 15 <br> Ubuntu*18.04 LTS <br> Ubuntu 20.04 <br>Windows* 10
-| Hardware                          | Intel® Agilex 7®, Arria® 10, and Stratix® 10 FPGAs
+| Hardware                          | Intel® Agilex® 7, Arria® 10, and Stratix® 10 FPGAs
 | Software                          | Intel® oneAPI DPC++/C++ Compiler
 | What you will learn               | How different methods of `ac_fixed` number construction affect hardware resource utilization <br>Recommended method for constructing `ac_fixed` numbers in your kernel <br>Accessing and using the `ac_fixed` math library functions <br>Trading off accuracy of results for reduced resource usage on the FPGA
 | Time to complete                  | 30 minutes
@@ -170,7 +170,7 @@ When you use the `ac_fixed` library, keep the following points in mind:
   mkdir build
   cd build
   ```
-  To compile for the default target (the Agilex 7® device family), run `cmake` using the command:
+  To compile for the default target (the Agilex® 7 device family), run `cmake` using the command:
   ```
   cmake ..
   ```
@@ -221,7 +221,7 @@ When you use the `ac_fixed` library, keep the following points in mind:
   mkdir build
   cd build
   ```
-  To compile for the default target (the Agilex 7® device family), run `cmake` using the command:
+  To compile for the default target (the Agilex® 7 device family), run `cmake` using the command:
   ```
   cmake -G "NMake Makefiles" ..
   ```

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/ac_fixed/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/ac_fixed/README.md
@@ -5,7 +5,7 @@ This FPGA tutorial demonstrates how to use the Algorithmic C (AC) data type `ac_
 | Optimized for                     | Description
 |:---                               |:---
 | OS                                | CentOS*Linux 8 <br> Red Hat* Enterprise Linux*8 <br> SUSE* Linux Enterprise Server 15 <br> Ubuntu*18.04 LTS <br> Ubuntu 20.04 <br>Windows* 10
-| Hardware                          | Intel® Agilex®, Arria® 10, and Stratix® 10 FPGAs
+| Hardware                          | Intel® Agilex 7®, Arria® 10, and Stratix® 10 FPGAs
 | Software                          | Intel® oneAPI DPC++/C++ Compiler
 | What you will learn               | How different methods of `ac_fixed` number construction affect hardware resource utilization <br>Recommended method for constructing `ac_fixed` numbers in your kernel <br>Accessing and using the `ac_fixed` math library functions <br>Trading off accuracy of results for reduced resource usage on the FPGA
 | Time to complete                  | 30 minutes
@@ -32,9 +32,9 @@ flowchart LR
    tier2("Tier 2: Explore the Fundamentals")
    tier3("Tier 3: Explore the Advanced Techniques")
    tier4("Tier 4: Explore the Reference Designs")
-   
+
    tier1 --> tier2 --> tier3 --> tier4
-   
+
    style tier1 fill:#0071c1,stroke:#0071c1,stroke-width:1px,color:#fff
    style tier2 fill:#f96,stroke:#333,stroke-width:1px,color:#fff
    style tier3 fill:#0071c1,stroke:#0071c1,stroke-width:1px,color:#fff
@@ -147,8 +147,8 @@ When you use the `ac_fixed` library, keep the following points in mind:
 
 ## Building the `ac_fixed` Tutorial
 
-> **Note**: When working with the command-line interface (CLI), you should configure the oneAPI toolkits using environment variables. 
-> Set up your CLI environment by sourcing the `setvars` script located in the root of your oneAPI installation every time you open a new terminal window. 
+> **Note**: When working with the command-line interface (CLI), you should configure the oneAPI toolkits using environment variables.
+> Set up your CLI environment by sourcing the `setvars` script located in the root of your oneAPI installation every time you open a new terminal window.
 > This practice ensures that your compiler, libraries, and tools are ready for development.
 >
 > Linux*:
@@ -170,7 +170,7 @@ When you use the `ac_fixed` library, keep the following points in mind:
   mkdir build
   cd build
   ```
-  To compile for the default target (the Agilex® device family), run `cmake` using the command:
+  To compile for the default target (the Agilex 7® device family), run `cmake` using the command:
   ```
   cmake ..
   ```
@@ -178,12 +178,12 @@ When you use the `ac_fixed` library, keep the following points in mind:
   > **Note**: You can change the default target by using the command:
   >  ```
   >  cmake .. -DFPGA_DEVICE=<FPGA device family or FPGA part number>
-  >  ``` 
+  >  ```
   >
-  > Alternatively, you can target an explicit FPGA board variant and BSP by using the following command: 
+  > Alternatively, you can target an explicit FPGA board variant and BSP by using the following command:
   >  ```
   >  cmake .. -DFPGA_DEVICE=<board-support-package>:<board-variant>
-  >  ``` 
+  >  ```
   >
   > You will only be able to run an executable on the FPGA if you specified a BSP.
 
@@ -221,19 +221,19 @@ When you use the `ac_fixed` library, keep the following points in mind:
   mkdir build
   cd build
   ```
-  To compile for the default target (the Agilex® device family), run `cmake` using the command:
+  To compile for the default target (the Agilex 7® device family), run `cmake` using the command:
   ```
   cmake -G "NMake Makefiles" ..
   ```
   > **Note**: You can change the default target by using the command:
   >  ```
   >  cmake -G "NMake Makefiles" .. -DFPGA_DEVICE=<FPGA device family or FPGA part number>
-  >  ``` 
+  >  ```
   >
-  > Alternatively, you can target an explicit FPGA board variant and BSP by using the following command: 
+  > Alternatively, you can target an explicit FPGA board variant and BSP by using the following command:
   >  ```
   >  cmake -G "NMake Makefiles" .. -DFPGA_DEVICE=<board-support-package>:<board-variant>
-  >  ``` 
+  >  ```
   >
   > You will only be able to run an executable on the FPGA if you specified a BSP.
 

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/ac_fixed/src/CMakeLists.txt
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/ac_fixed/src/CMakeLists.txt
@@ -6,7 +6,7 @@ set(FPGA_TARGET ${TARGET_NAME}.fpga)
 
 # FPGA board selection
 if(NOT DEFINED FPGA_DEVICE)
-    set(FPGA_DEVICE "Agilex")
+    set(FPGA_DEVICE "Agilex 7")
     message(STATUS "FPGA_DEVICE was not specified.\
                     \nConfiguring the design to the default FPGA family: ${FPGA_DEVICE}\
                     \nPlease refer to the README for information on target selection.")

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/ac_fixed/src/CMakeLists.txt
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/ac_fixed/src/CMakeLists.txt
@@ -6,7 +6,7 @@ set(FPGA_TARGET ${TARGET_NAME}.fpga)
 
 # FPGA board selection
 if(NOT DEFINED FPGA_DEVICE)
-    set(FPGA_DEVICE "Agilex 7")
+    set(FPGA_DEVICE "Agilex7")
     message(STATUS "FPGA_DEVICE was not specified.\
                     \nConfiguring the design to the default FPGA family: ${FPGA_DEVICE}\
                     \nPlease refer to the README for information on target selection.")

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/ac_int/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/ac_int/README.md
@@ -5,7 +5,7 @@ This FPGA tutorial demonstrates how to use the Algorithmic C (AC) data type `ac_
 | Optimized for                     | Description
 |:---                               |:---
 | OS                                | Linux* Ubuntu* 18.04/20.04 <br> RHEL*/CentOS* 8 <br> SUSE* 15 <br> Windows* 10
-| Hardware                          | Intel® Agilex 7®, Arria® 10, and Stratix® 10 FPGAs
+| Hardware                          | Intel® Agilex® 7, Arria® 10, and Stratix® 10 FPGAs
 | Software                          | Intel® oneAPI DPC++/C++ Compiler
 | What you will learn               | Using the `ac_int` data type for basic operations <br> Efficiently using the left shift operation <br> Setting and reading certain bits of an `ac_int` number
 | Time to complete                  | 20 minutes
@@ -148,7 +148,7 @@ Kernel `BitOps` demonstrates bit operations with bit select operator `[]` and bi
   mkdir build
   cd build
   ```
-  To compile for the default target (the Agilex 7® device family), run `cmake` using the command:
+  To compile for the default target (the Agilex® 7 device family), run `cmake` using the command:
   ```
   cmake ..
   ```
@@ -199,7 +199,7 @@ Kernel `BitOps` demonstrates bit operations with bit select operator `[]` and bi
   mkdir build
   cd build
   ```
-  To compile for the default target (the Agilex 7® device family), run `cmake` using the command:
+  To compile for the default target (the Agilex® 7 device family), run `cmake` using the command:
   ```
   cmake -G "NMake Makefiles" ..
   ```

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/ac_int/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/ac_int/README.md
@@ -5,7 +5,7 @@ This FPGA tutorial demonstrates how to use the Algorithmic C (AC) data type `ac_
 | Optimized for                     | Description
 |:---                               |:---
 | OS                                | Linux* Ubuntu* 18.04/20.04 <br> RHEL*/CentOS* 8 <br> SUSE* 15 <br> Windows* 10
-| Hardware                          | Intel® Agilex®, Arria® 10, and Stratix® 10 FPGAs
+| Hardware                          | Intel® Agilex 7®, Arria® 10, and Stratix® 10 FPGAs
 | Software                          | Intel® oneAPI DPC++/C++ Compiler
 | What you will learn               | Using the `ac_int` data type for basic operations <br> Efficiently using the left shift operation <br> Setting and reading certain bits of an `ac_int` number
 | Time to complete                  | 20 minutes
@@ -32,9 +32,9 @@ flowchart LR
    tier2("Tier 2: Explore the Fundamentals")
    tier3("Tier 3: Explore the Advanced Techniques")
    tier4("Tier 4: Explore the Reference Designs")
-   
+
    tier1 --> tier2 --> tier3 --> tier4
-   
+
    style tier1 fill:#0071c1,stroke:#0071c1,stroke-width:1px,color:#fff
    style tier2 fill:#f96,stroke:#333,stroke-width:1px,color:#fff
    style tier3 fill:#0071c1,stroke:#0071c1,stroke-width:1px,color:#fff
@@ -125,8 +125,8 @@ Kernel `BitOps` demonstrates bit operations with bit select operator `[]` and bi
 
 ## Building the `ac_int` Tutorial
 
-> **Note**: When working with the command-line interface (CLI), you should configure the oneAPI toolkits using environment variables. 
-> Set up your CLI environment by sourcing the `setvars` script located in the root of your oneAPI installation every time you open a new terminal window. 
+> **Note**: When working with the command-line interface (CLI), you should configure the oneAPI toolkits using environment variables.
+> Set up your CLI environment by sourcing the `setvars` script located in the root of your oneAPI installation every time you open a new terminal window.
 > This practice ensures that your compiler, libraries, and tools are ready for development.
 >
 > Linux*:
@@ -148,7 +148,7 @@ Kernel `BitOps` demonstrates bit operations with bit select operator `[]` and bi
   mkdir build
   cd build
   ```
-  To compile for the default target (the Agilex® device family), run `cmake` using the command:
+  To compile for the default target (the Agilex 7® device family), run `cmake` using the command:
   ```
   cmake ..
   ```
@@ -156,12 +156,12 @@ Kernel `BitOps` demonstrates bit operations with bit select operator `[]` and bi
   > **Note**: You can change the default target by using the command:
   >  ```
   >  cmake .. -DFPGA_DEVICE=<FPGA device family or FPGA part number>
-  >  ``` 
+  >  ```
   >
-  > Alternatively, you can target an explicit FPGA board variant and BSP by using the following command: 
+  > Alternatively, you can target an explicit FPGA board variant and BSP by using the following command:
   >  ```
   >  cmake .. -DFPGA_DEVICE=<board-support-package>:<board-variant>
-  >  ``` 
+  >  ```
   >
   > You will only be able to run an executable on the FPGA if you specified a BSP.
 
@@ -199,19 +199,19 @@ Kernel `BitOps` demonstrates bit operations with bit select operator `[]` and bi
   mkdir build
   cd build
   ```
-  To compile for the default target (the Agilex® device family), run `cmake` using the command:
+  To compile for the default target (the Agilex 7® device family), run `cmake` using the command:
   ```
   cmake -G "NMake Makefiles" ..
   ```
   > **Note**: You can change the default target by using the command:
   >  ```
   >  cmake -G "NMake Makefiles" .. -DFPGA_DEVICE=<FPGA device family or FPGA part number>
-  >  ``` 
+  >  ```
   >
-  > Alternatively, you can target an explicit FPGA board variant and BSP by using the following command: 
+  > Alternatively, you can target an explicit FPGA board variant and BSP by using the following command:
   >  ```
   >  cmake -G "NMake Makefiles" .. -DFPGA_DEVICE=<board-support-package>:<board-variant>
-  >  ``` 
+  >  ```
   >
   > You will only be able to run an executable on the FPGA if you specified a BSP.
 

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/ac_int/src/CMakeLists.txt
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/ac_int/src/CMakeLists.txt
@@ -6,7 +6,7 @@ set(FPGA_TARGET ${TARGET_NAME}.fpga)
 
 # FPGA board selection
 if(NOT DEFINED FPGA_DEVICE)
-    set(FPGA_DEVICE "Agilex")
+    set(FPGA_DEVICE "Agilex 7")
     message(STATUS "FPGA_DEVICE was not specified.\
                     \nConfiguring the design to the default FPGA family: ${FPGA_DEVICE}\
                     \nPlease refer to the README for information on target selection.")

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/ac_int/src/CMakeLists.txt
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/ac_int/src/CMakeLists.txt
@@ -6,7 +6,7 @@ set(FPGA_TARGET ${TARGET_NAME}.fpga)
 
 # FPGA board selection
 if(NOT DEFINED FPGA_DEVICE)
-    set(FPGA_DEVICE "Agilex 7")
+    set(FPGA_DEVICE "Agilex7")
     message(STATUS "FPGA_DEVICE was not specified.\
                     \nConfiguring the design to the default FPGA family: ${FPGA_DEVICE}\
                     \nPlease refer to the README for information on target selection.")

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/dsp_control/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/dsp_control/README.md
@@ -5,7 +5,7 @@ This FPGA tutorial demonstrates how to set the implementation preference for cer
 | Optimized for                     | Description
 |:---                               |:---
 | OS                                | Linux* Ubuntu* 18.04/20.04 <br> RHEL*/CentOS* 8 <br> SUSE* 15 <br> Windows* 10
-| Hardware                          | Intel® Agilex 7®, Arria® 10, and Stratix® 10 FPGAs
+| Hardware                          | Intel® Agilex® 7, Arria® 10, and Stratix® 10 FPGAs
 | Software                          | Intel® oneAPI DPC++/C++ Compiler
 | What you will learn               |  How to apply global DSP control in command-line interface. <br> How to apply local DSP control in source code. <br> Scope of datatypes and math operations that support DSP control.
 | Time to complete                  | 15 minutes
@@ -120,7 +120,7 @@ The second template argument `Propagate::<option>` is an enum that determines wh
   mkdir build
   cd build
   ```
-  To compile for the default target (the Agilex 7® device family), run `cmake` using the command:
+  To compile for the default target (the Agilex® 7 device family), run `cmake` using the command:
   ```
   cmake ..
   ```
@@ -171,7 +171,7 @@ The second template argument `Propagate::<option>` is an enum that determines wh
   mkdir build
   cd build
   ```
-  To compile for the default target (the Agilex 7® device family), run `cmake` using the command:
+  To compile for the default target (the Agilex® 7 device family), run `cmake` using the command:
   ```
   cmake -G "NMake Makefiles" ..
   ```

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/dsp_control/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/dsp_control/README.md
@@ -5,7 +5,7 @@ This FPGA tutorial demonstrates how to set the implementation preference for cer
 | Optimized for                     | Description
 |:---                               |:---
 | OS                                | Linux* Ubuntu* 18.04/20.04 <br> RHEL*/CentOS* 8 <br> SUSE* 15 <br> Windows* 10
-| Hardware                          | Intel® Agilex®, Arria® 10, and Stratix® 10 FPGAs
+| Hardware                          | Intel® Agilex 7®, Arria® 10, and Stratix® 10 FPGAs
 | Software                          | Intel® oneAPI DPC++/C++ Compiler
 | What you will learn               |  How to apply global DSP control in command-line interface. <br> How to apply local DSP control in source code. <br> Scope of datatypes and math operations that support DSP control.
 | Time to complete                  | 15 minutes
@@ -32,9 +32,9 @@ flowchart LR
    tier2("Tier 2: Explore the Fundamentals")
    tier3("Tier 3: Explore the Advanced Techniques")
    tier4("Tier 4: Explore the Reference Designs")
-   
+
    tier1 --> tier2 --> tier3 --> tier4
-   
+
    style tier1 fill:#0071c1,stroke:#0071c1,stroke-width:1px,color:#fff
    style tier2 fill:#0071c1,stroke:#0071c1,stroke-width:1px,color:#fff
    style tier3 fill:#f96,stroke:#333,stroke-width:1px,color:#fff
@@ -97,8 +97,8 @@ The second template argument `Propagate::<option>` is an enum that determines wh
 
 ## Building the `dsp_control` Tutorial
 
-> **Note**: When working with the command-line interface (CLI), you should configure the oneAPI toolkits using environment variables. 
-> Set up your CLI environment by sourcing the `setvars` script located in the root of your oneAPI installation every time you open a new terminal window. 
+> **Note**: When working with the command-line interface (CLI), you should configure the oneAPI toolkits using environment variables.
+> Set up your CLI environment by sourcing the `setvars` script located in the root of your oneAPI installation every time you open a new terminal window.
 > This practice ensures that your compiler, libraries, and tools are ready for development.
 >
 > Linux*:
@@ -120,7 +120,7 @@ The second template argument `Propagate::<option>` is an enum that determines wh
   mkdir build
   cd build
   ```
-  To compile for the default target (the Agilex® device family), run `cmake` using the command:
+  To compile for the default target (the Agilex 7® device family), run `cmake` using the command:
   ```
   cmake ..
   ```
@@ -128,12 +128,12 @@ The second template argument `Propagate::<option>` is an enum that determines wh
   > **Note**: You can change the default target by using the command:
   >  ```
   >  cmake .. -DFPGA_DEVICE=<FPGA device family or FPGA part number>
-  >  ``` 
+  >  ```
   >
-  > Alternatively, you can target an explicit FPGA board variant and BSP by using the following command: 
+  > Alternatively, you can target an explicit FPGA board variant and BSP by using the following command:
   >  ```
   >  cmake .. -DFPGA_DEVICE=<board-support-package>:<board-variant>
-  >  ``` 
+  >  ```
   >
   > You will only be able to run an executable on the FPGA if you specified a BSP.
 
@@ -171,19 +171,19 @@ The second template argument `Propagate::<option>` is an enum that determines wh
   mkdir build
   cd build
   ```
-  To compile for the default target (the Agilex® device family), run `cmake` using the command:
+  To compile for the default target (the Agilex 7® device family), run `cmake` using the command:
   ```
   cmake -G "NMake Makefiles" ..
   ```
   > **Note**: You can change the default target by using the command:
   >  ```
   >  cmake -G "NMake Makefiles" .. -DFPGA_DEVICE=<FPGA device family or FPGA part number>
-  >  ``` 
+  >  ```
   >
-  > Alternatively, you can target an explicit FPGA board variant and BSP by using the following command: 
+  > Alternatively, you can target an explicit FPGA board variant and BSP by using the following command:
   >  ```
   >  cmake -G "NMake Makefiles" .. -DFPGA_DEVICE=<board-support-package>:<board-variant>
-  >  ``` 
+  >  ```
   >
   > You will only be able to run an executable on the FPGA if you specified a BSP.
 

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/dsp_control/src/CMakeLists.txt
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/dsp_control/src/CMakeLists.txt
@@ -6,7 +6,7 @@ set(FPGA_TARGET ${TARGET_NAME}.fpga)
 
 # FPGA board selection
 if(NOT DEFINED FPGA_DEVICE)
-    set(FPGA_DEVICE "Agilex")
+    set(FPGA_DEVICE "Agilex 7")
     message(STATUS "FPGA_DEVICE was not specified.\
                     \nConfiguring the design to the default FPGA family: ${FPGA_DEVICE}\
                     \nPlease refer to the README for information on target selection.")

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/dsp_control/src/CMakeLists.txt
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/dsp_control/src/CMakeLists.txt
@@ -6,7 +6,7 @@ set(FPGA_TARGET ${TARGET_NAME}.fpga)
 
 # FPGA board selection
 if(NOT DEFINED FPGA_DEVICE)
-    set(FPGA_DEVICE "Agilex 7")
+    set(FPGA_DEVICE "Agilex7")
     message(STATUS "FPGA_DEVICE was not specified.\
                     \nConfiguring the design to the default FPGA family: ${FPGA_DEVICE}\
                     \nPlease refer to the README for information on target selection.")

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/experimental/device_global/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/experimental/device_global/README.md
@@ -17,9 +17,9 @@ flowchart LR
    tier2("Tier 2: Explore the Fundamentals")
    tier3("Tier 3: Explore the Advanced Techniques")
    tier4("Tier 4: Explore the Reference Designs")
-   
+
    tier1 --> tier2 --> tier3 --> tier4
-   
+
    style tier1 fill:#0071c1,stroke:#0071c1,stroke-width:1px,color:#fff
    style tier2 fill:#f96,stroke:#333,stroke-width:1px,color:#fff
    style tier3 fill:#0071c1,stroke:#0071c1,stroke-width:1px,color:#fff
@@ -32,7 +32,7 @@ You can also find more information about [troubleshooting build errors](/DirectP
 | Optimized for      | Description
 |:---                |:---
 | OS                 | Ubuntu* 18.04/20.04 <br> RHEL*/CentOS* 8 <br> SUSE* 15 <br> Windows* 10
-| Hardware           | Intel® Agilex®, Arria® 10, and Stratix® 10 FPGAs
+| Hardware           | Intel® Agilex 7®, Arria® 10, and Stratix® 10 FPGAs
 | Software           | Intel® oneAPI DPC++/C++ Compiler
 
 > **Note**: Even though the Intel DPC++/C++ OneAPI compiler is enough to compile for emulation, generating reports and generating RTL, there are extra software requirements for the simulation flow and FPGA compiles.
@@ -89,8 +89,8 @@ int main () {
 * How initialize a `device_global` to non-zero value
 
 ## Building the `device_global` Tutorial
-> **Note**: When working with the command-line interface (CLI), you should configure the oneAPI toolkits using environment variables. 
-> Set up your CLI environment by sourcing the `setvars` script located in the root of your oneAPI installation every time you open a new terminal window. 
+> **Note**: When working with the command-line interface (CLI), you should configure the oneAPI toolkits using environment variables.
+> Set up your CLI environment by sourcing the `setvars` script located in the root of your oneAPI installation every time you open a new terminal window.
 > This practice ensures that your compiler, libraries, and tools are ready for development.
 >
 > Linux*:
@@ -111,7 +111,7 @@ int main () {
   mkdir build
   cd build
   ```
-  To compile for the default target (the Agilex® device family), run `cmake` using the command:
+  To compile for the default target (the Agilex 7® device family), run `cmake` using the command:
   ```
   cmake ..
   ```
@@ -119,12 +119,12 @@ int main () {
   > **Note**: You can change the default target by using the command:
   >  ```
   >  cmake .. -DFPGA_DEVICE=<FPGA device family or FPGA part number>
-  >  ``` 
+  >  ```
   >
-  > Alternatively, you can target an explicit FPGA board variant and BSP by using the following command: 
+  > Alternatively, you can target an explicit FPGA board variant and BSP by using the following command:
   >  ```
   >  cmake .. -DFPGA_DEVICE=<board-support-package>:<board-variant>
-  >  ``` 
+  >  ```
   >
   > You will only be able to run an executable on the FPGA if you specified a BSP.
 
@@ -154,19 +154,19 @@ int main () {
   mkdir build
   cd build
   ```
-  To compile for the default target (the Agilex® device family), run `cmake` using the command:
+  To compile for the default target (the Agilex 7® device family), run `cmake` using the command:
   ```
   cmake -G "NMake Makefiles" ..
   ```
   > **Note**: You can change the default target by using the command:
   >  ```
   >  cmake -G "NMake Makefiles" .. -DFPGA_DEVICE=<FPGA device family or FPGA part number>
-  >  ``` 
+  >  ```
   >
-  > Alternatively, you can target an explicit FPGA board variant and BSP by using the following command: 
+  > Alternatively, you can target an explicit FPGA board variant and BSP by using the following command:
   >  ```
   >  cmake -G "NMake Makefiles" .. -DFPGA_DEVICE=<board-support-package>:<board-variant>
-  >  ``` 
+  >  ```
   >
   > You will only be able to run an executable on the FPGA if you specified a BSP.
 

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/experimental/device_global/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/experimental/device_global/README.md
@@ -32,7 +32,7 @@ You can also find more information about [troubleshooting build errors](/DirectP
 | Optimized for      | Description
 |:---                |:---
 | OS                 | Ubuntu* 18.04/20.04 <br> RHEL*/CentOS* 8 <br> SUSE* 15 <br> Windows* 10
-| Hardware           | Intel® Agilex 7®, Arria® 10, and Stratix® 10 FPGAs
+| Hardware           | Intel® Agilex® 7, Arria® 10, and Stratix® 10 FPGAs
 | Software           | Intel® oneAPI DPC++/C++ Compiler
 
 > **Note**: Even though the Intel DPC++/C++ OneAPI compiler is enough to compile for emulation, generating reports and generating RTL, there are extra software requirements for the simulation flow and FPGA compiles.
@@ -111,7 +111,7 @@ int main () {
   mkdir build
   cd build
   ```
-  To compile for the default target (the Agilex 7® device family), run `cmake` using the command:
+  To compile for the default target (the Agilex® 7 device family), run `cmake` using the command:
   ```
   cmake ..
   ```
@@ -154,7 +154,7 @@ int main () {
   mkdir build
   cd build
   ```
-  To compile for the default target (the Agilex 7® device family), run `cmake` using the command:
+  To compile for the default target (the Agilex® 7 device family), run `cmake` using the command:
   ```
   cmake -G "NMake Makefiles" ..
   ```

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/experimental/device_global/src/CMakeLists.txt
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/experimental/device_global/src/CMakeLists.txt
@@ -6,8 +6,8 @@ set(FPGA_TARGET ${TARGET_NAME}.fpga)
 
 # FPGA board selection
 if(NOT DEFINED FPGA_DEVICE)
-    set(FPGA_DEVICE "Agilex")
-    set(DEVICE_FLAG "Agilex")
+    set(FPGA_DEVICE "Agilex 7")
+    set(DEVICE_FLAG "Agilex 7")
     message(STATUS "FPGA_DEVICE was not specified.\
             \nConfiguring the design to the default FPGA family: ${FPGA_DEVICE}\
             \nPlease refer to the README for information on target selection.")
@@ -18,7 +18,7 @@ else()
     elseif(FPGA_DEVICE_NAME MATCHES ".*s10.*" OR FPGA_DEVICE_NAME MATCHES ".*stratix10.*")
       set(DEVICE_FLAG "S10")
     elseif(FPGA_DEVICE_NAME MATCHES ".*agilex.*")
-      set(DEVICE_FLAG "Agilex")
+      set(DEVICE_FLAG "Agilex 7")
     endif()
     message(STATUS "Configuring the design with the following target: ${FPGA_DEVICE}")
 
@@ -26,7 +26,7 @@ endif()
 
 if(NOT DEFINED DEVICE_FLAG)
     message(FATAL_ERROR "An unrecognized or custom board was passed, but DEVICE_FLAG was not specified. \
-                         Make sure you have set -DDEVICE_FLAG=A10, -DDEVICE_FLAG=S10 or -DDEVICE_FLAG=Agilex.")
+                         Make sure you have set -DDEVICE_FLAG=A10, -DDEVICE_FLAG=S10 or -DDEVICE_FLAG=Agilex 7.")
 endif()
 
 # This is a Windows-specific flag that enables exception handling in host code

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/experimental/device_global/src/CMakeLists.txt
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/experimental/device_global/src/CMakeLists.txt
@@ -6,8 +6,8 @@ set(FPGA_TARGET ${TARGET_NAME}.fpga)
 
 # FPGA board selection
 if(NOT DEFINED FPGA_DEVICE)
-    set(FPGA_DEVICE "Agilex 7")
-    set(DEVICE_FLAG "Agilex 7")
+    set(FPGA_DEVICE "Agilex7")
+    set(DEVICE_FLAG "Agilex7")
     message(STATUS "FPGA_DEVICE was not specified.\
             \nConfiguring the design to the default FPGA family: ${FPGA_DEVICE}\
             \nPlease refer to the README for information on target selection.")
@@ -18,7 +18,7 @@ else()
     elseif(FPGA_DEVICE_NAME MATCHES ".*s10.*" OR FPGA_DEVICE_NAME MATCHES ".*stratix10.*")
       set(DEVICE_FLAG "S10")
     elseif(FPGA_DEVICE_NAME MATCHES ".*agilex.*")
-      set(DEVICE_FLAG "Agilex 7")
+      set(DEVICE_FLAG "Agilex7")
     endif()
     message(STATUS "Configuring the design with the following target: ${FPGA_DEVICE}")
 
@@ -26,7 +26,7 @@ endif()
 
 if(NOT DEFINED DEVICE_FLAG)
     message(FATAL_ERROR "An unrecognized or custom board was passed, but DEVICE_FLAG was not specified. \
-                         Make sure you have set -DDEVICE_FLAG=A10, -DDEVICE_FLAG=S10 or -DDEVICE_FLAG=Agilex 7.")
+                         Make sure you have set -DDEVICE_FLAG=A10, -DDEVICE_FLAG=S10 or -DDEVICE_FLAG=Agilex7.")
 endif()
 
 # This is a Windows-specific flag that enables exception handling in host code

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/experimental/hostpipes/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/experimental/hostpipes/README.md
@@ -5,7 +5,7 @@ This FPGA tutorial demonstrates how to use pipes to send and receive data betwee
 | Optimized for                     | Description
 ---                                 |---
 | OS                                | Linux* Ubuntu* 18.04/20.04, RHEL*/CentOS* 8, SUSE* 15; Windows* 10
-| Hardware                          | Intel® Agilex 7®, Arria® 10, and Stratix® 10 FPGAs
+| Hardware                          | Intel® Agilex® 7, Arria® 10, and Stratix® 10 FPGAs
 | Software                          | Intel® oneAPI DPC++/C++ Compiler
 | What you will learn               | Basics of host pipe declaration and usage
 | Time to complete                  | 30 minutes
@@ -292,7 +292,7 @@ In the latter launch-collect test, the entire contents of the `in` vector are wr
   mkdir build
   cd build
   ```
-  To compile for the default target (the Agilex 7® device family), run `cmake` using the command:
+  To compile for the default target (the Agilex® 7 device family), run `cmake` using the command:
   ```
   cmake ..
   ```
@@ -335,7 +335,7 @@ In the latter launch-collect test, the entire contents of the `in` vector are wr
   mkdir build
   cd build
   ```
-  To compile for the default target (the Agilex 7® device family), run `cmake` using the command:
+  To compile for the default target (the Agilex® 7 device family), run `cmake` using the command:
   ```
   cmake -G "NMake Makefiles" ..
   ```

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/experimental/hostpipes/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/experimental/hostpipes/README.md
@@ -5,9 +5,9 @@ This FPGA tutorial demonstrates how to use pipes to send and receive data betwee
 | Optimized for                     | Description
 ---                                 |---
 | OS                                | Linux* Ubuntu* 18.04/20.04, RHEL*/CentOS* 8, SUSE* 15; Windows* 10
-| Hardware                          | Intel® Agilex®, Arria® 10, and Stratix® 10 FPGAs
+| Hardware                          | Intel® Agilex 7®, Arria® 10, and Stratix® 10 FPGAs
 | Software                          | Intel® oneAPI DPC++/C++ Compiler
-| What you will learn               | Basics of host pipe declaration and usage 
+| What you will learn               | Basics of host pipe declaration and usage
 | Time to complete                  | 30 minutes
 
 > **Note**: Even though the Intel DPC++/C++ OneAPI compiler is enough to compile for emulation, generating reports and generating RTL, there are extra software requirements for the simulation flow and FPGA compiles.
@@ -32,9 +32,9 @@ flowchart LR
    tier2("Tier 2: Explore the Fundamentals")
    tier3("Tier 3: Explore the Advanced Techniques")
    tier4("Tier 4: Explore the Reference Designs")
-   
+
    tier1 --> tier2 --> tier3 --> tier4
-   
+
    style tier1 fill:#0071c1,stroke:#0071c1,stroke-width:1px,color:#fff
    style tier2 fill:#f96,stroke:#333,stroke-width:1px,color:#fff
    style tier3 fill:#0071c1,stroke:#0071c1,stroke-width:1px,color:#fff
@@ -66,7 +66,7 @@ Each individual host pipe is a function scope class declaration of the templated
 class FirstPipeT;
 class SecondPipeT;
 
-// two host pipes 
+// two host pipes
 using FirstPipeInstance = cl::sycl::ext::intel::prototype::pipe<
     // Usual pipe parameters
     FirstPipeT, // An identifier for the pipe
@@ -106,7 +106,7 @@ Host pipes use additional template parameters beyond the three described earlier
 Host Pipes expose read and write interfaces that allow a single element to be read or written in FIFO order to the pipe. These read and write interfaces are static class methods on the templated classes described in the Declaring a Host Pipe section above, and are described below.
 
 Host pipes expose read and write interfaces that allow a single element to be read or written in FIFO order to the pipe. These read and write interfaces are static class methods on the templated classes that are described in the [Declaring a Host Pipe](#declaring-a-host-pipe) section. The API provides the following interfaces:
-  
+
   - [Blocking write interface](#blocking-write)
   - [Non-blocking write interface](#non-blocking-write)
   - [Blocking read interface](#blocking-read)
@@ -135,8 +135,8 @@ SecondPipeInstance::write(data_element);
 ```
 
 #### Non-blocking Write
- 
-Non-blocking writes add a `bool` argument in both host and device APIs that is passed by reference and returns true in this argument if the write was successful, and false if it was unsuccessful. 
+
+Non-blocking writes add a `bool` argument in both host and device APIs that is passed by reference and returns true in this argument if the write was successful, and false if it was unsuccessful.
 
 On the host:
 
@@ -165,8 +165,8 @@ while (!success) SecondPipeInstance::write(data_element, success);
 ```
 
 #### Blocking Read
- 
-The host pipe read interface reads a single element of given datatype from the host pipe. Similar to write, the read interface on the host takes a SYCL* device queue as a parameter. The device read interface consists of the class method read call with no arguments. 
+
+The host pipe read interface reads a single element of given datatype from the host pipe. Similar to write, the read interface on the host takes a SYCL* device queue as a parameter. The device read interface consists of the class method read call with no arguments.
 
 On the host:
 
@@ -184,7 +184,7 @@ int read_element = FirstPipeInstance::read();
 
 #### Non-blocking Read
 
-Similar to non-blocking writes, non-blocking reads add a `bool` argument in both host and device APIs that is passed by reference and returns true in this argument if the read was successful, and false if it was unsuccessful. 
+Similar to non-blocking writes, non-blocking reads add a `bool` argument in both host and device APIs that is passed by reference and returns true in this argument if the read was successful, and false if it was unsuccessful.
 
 On the host:
 
@@ -270,8 +270,8 @@ In the latter launch-collect test, the entire contents of the `in` vector are wr
 
 ## Building the `hostpipes` Tutorial
 
-> **Note**: When working with the command-line interface (CLI), you should configure the oneAPI toolkits using environment variables. 
-> Set up your CLI environment by sourcing the `setvars` script located in the root of your oneAPI installation every time you open a new terminal window. 
+> **Note**: When working with the command-line interface (CLI), you should configure the oneAPI toolkits using environment variables.
+> Set up your CLI environment by sourcing the `setvars` script located in the root of your oneAPI installation every time you open a new terminal window.
 > This practice ensures that your compiler, libraries, and tools are ready for development.
 >
 > Linux*:
@@ -292,7 +292,7 @@ In the latter launch-collect test, the entire contents of the `in` vector are wr
   mkdir build
   cd build
   ```
-  To compile for the default target (the Agilex® device family), run `cmake` using the command:
+  To compile for the default target (the Agilex 7® device family), run `cmake` using the command:
   ```
   cmake ..
   ```
@@ -300,12 +300,12 @@ In the latter launch-collect test, the entire contents of the `in` vector are wr
   > **Note**: You can change the default target by using the command:
   >  ```
   >  cmake .. -DFPGA_DEVICE=<FPGA device family or FPGA part number>
-  >  ``` 
+  >  ```
   >
-  > Alternatively, you can target an explicit FPGA board variant and BSP by using the following command: 
+  > Alternatively, you can target an explicit FPGA board variant and BSP by using the following command:
   >  ```
   >  cmake .. -DFPGA_DEVICE=<board-support-package>:<board-variant> -DIS_BSP=1
-  >  ``` 
+  >  ```
   >
   > You will only be able to run an executable on the FPGA if you specified a BSP.
 
@@ -335,19 +335,19 @@ In the latter launch-collect test, the entire contents of the `in` vector are wr
   mkdir build
   cd build
   ```
-  To compile for the default target (the Agilex® device family), run `cmake` using the command:
+  To compile for the default target (the Agilex 7® device family), run `cmake` using the command:
   ```
   cmake -G "NMake Makefiles" ..
   ```
   > **Note**: You can change the default target by using the command:
   >  ```
   >  cmake -G "NMake Makefiles" .. -DFPGA_DEVICE=<FPGA device family or FPGA part number>
-  >  ``` 
+  >  ```
   >
-  > Alternatively, you can target an explicit FPGA board variant and BSP by using the following command: 
+  > Alternatively, you can target an explicit FPGA board variant and BSP by using the following command:
   >  ```
   >  cmake -G "NMake Makefiles" .. -DFPGA_DEVICE=<board-support-package>:<board-variant> -DIS_BSP=1
-  >  ``` 
+  >  ```
   >
   > You will only be able to run an executable on the FPGA if you specified a BSP.
 
@@ -395,12 +395,12 @@ using H2DPipe = cl::sycl::ext::intel::prototype::pipe<
    H2DPipeID,         // An identified for the pipe
    ...
    >;
-   
+
 using D2HPipe = cl::sycl::ext::intel::prototype::pipe<
    // Usual pipe parameters
    D2HPipeID,         // An identified for the pipe
    ...
-   >;     
+   >;
 ```
 
 ## Running the Sample
@@ -422,7 +422,7 @@ using D2HPipe = cl::sycl::ext::intel::prototype::pipe<
     hostpipes.fpga_sim.exe <input_file> [-o=<output_file>]
     set CL_CONTEXT_MPSIM_DEVICE_INTELFPGA=
     ```
-    
+
 3. Run the sample on the FPGA device (only if you ran `cmake` with `-DFPGA_DEVICE=<board-support-package>:<board-variant>`):
   ```
   ./hostpipes.fpga         (Linux)

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/experimental/hostpipes/src/CMakeLists.txt
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/experimental/hostpipes/src/CMakeLists.txt
@@ -6,7 +6,7 @@ set(FPGA_TARGET ${TARGET_NAME}.fpga)
 
 # FPGA board selection
 if(NOT DEFINED FPGA_DEVICE)
-    set(FPGA_DEVICE "Agilex")
+    set(FPGA_DEVICE "Agilex 7")
     message(STATUS "FPGA_DEVICE was not specified.\
                     \nConfiguring the design to the default FPGA family: ${FPGA_DEVICE}\
                     \nPlease refer to the README for information on target selection.")

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/experimental/hostpipes/src/CMakeLists.txt
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/experimental/hostpipes/src/CMakeLists.txt
@@ -6,7 +6,7 @@ set(FPGA_TARGET ${TARGET_NAME}.fpga)
 
 # FPGA board selection
 if(NOT DEFINED FPGA_DEVICE)
-    set(FPGA_DEVICE "Agilex 7")
+    set(FPGA_DEVICE "Agilex7")
     message(STATUS "FPGA_DEVICE was not specified.\
                     \nConfiguring the design to the default FPGA family: ${FPGA_DEVICE}\
                     \nPlease refer to the README for information on target selection.")

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/experimental/invocation_interfaces/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/experimental/invocation_interfaces/README.md
@@ -6,7 +6,7 @@ This FPGA tutorial demonstrates how to specify the kernel invocation interfaces 
 | Optimized for                     | Description
 ---                                 |---
 | OS                                | Linux* Ubuntu* 18.04/20.04 <br> RHEL*/CentOS* 8 <br> SUSE* 15 <br> Windows* 10
-| Hardware                          | Intel® Agilex 7®, Arria® 10, and Stratix® 10 FPGAs
+| Hardware                          | Intel® Agilex® 7, Arria® 10, and Stratix® 10 FPGAs
 | Software                          | Intel® oneAPI DPC++/C++ Compiler
 | What you will learn               | Basics of specifying kernel invocation interfaces and kernel argument interfaces
 | Time to complete                  | 30 minutes
@@ -220,7 +220,7 @@ void TestLambdaStreamingKernel(sycl::queue &q, ValueT *in, ValueT *out, size_t c
    mkdir build
    cd build
    ```
-   To compile for the default target (the Agilex 7® device family), run `cmake` using the following command:
+   To compile for the default target (the Agilex® 7 device family), run `cmake` using the following command:
    ```
    cmake ..
    ```
@@ -256,7 +256,7 @@ void TestLambdaStreamingKernel(sycl::queue &q, ValueT *in, ValueT *out, size_t c
    mkdir build
    cd build
    ```
-   To compile for the default target (the Agilex 7® device family), run `cmake` using the command:
+   To compile for the default target (the Agilex® 7 device family), run `cmake` using the command:
    ```
    cmake -G "NMake Makefiles" ..
    ```

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/experimental/invocation_interfaces/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/experimental/invocation_interfaces/README.md
@@ -6,7 +6,7 @@ This FPGA tutorial demonstrates how to specify the kernel invocation interfaces 
 | Optimized for                     | Description
 ---                                 |---
 | OS                                | Linux* Ubuntu* 18.04/20.04 <br> RHEL*/CentOS* 8 <br> SUSE* 15 <br> Windows* 10
-| Hardware                          | Intel® Agilex®, Arria® 10, and Stratix® 10 FPGAs
+| Hardware                          | Intel® Agilex 7®, Arria® 10, and Stratix® 10 FPGAs
 | Software                          | Intel® oneAPI DPC++/C++ Compiler
 | What you will learn               | Basics of specifying kernel invocation interfaces and kernel argument interfaces
 | Time to complete                  | 30 minutes
@@ -33,9 +33,9 @@ flowchart LR
    tier2("Tier 2: Explore the Fundamentals")
    tier3("Tier 3: Explore the Advanced Techniques")
    tier4("Tier 4: Explore the Reference Designs")
-   
+
    tier1 --> tier2 --> tier3 --> tier4
-   
+
    style tier1 fill:#0071c1,stroke:#0071c1,stroke-width:1px,color:#fff
    style tier2 fill:#f96,stroke:#333,stroke-width:1px,color:#fff
    style tier3 fill:#0071c1,stroke:#0071c1,stroke-width:1px,color:#fff
@@ -198,7 +198,7 @@ void TestLambdaStreamingKernel(sycl::queue &q, ValueT *in, ValueT *out, size_t c
 
 ## Building the `invocation_interfaces` Tutorial
 
-> **Note**: When working with the command-line interface (CLI), you should configure the oneAPI toolkits using environment variables. 
+> **Note**: When working with the command-line interface (CLI), you should configure the oneAPI toolkits using environment variables.
 > Set up your CLI environment by sourcing the `setvars` script located in the root of your oneAPI installation every time you open a new terminal window.
 > This practice ensures that your compiler, libraries, and tools are ready for development.
 >
@@ -220,14 +220,14 @@ void TestLambdaStreamingKernel(sycl::queue &q, ValueT *in, ValueT *out, size_t c
    mkdir build
    cd build
    ```
-   To compile for the default target (the Agilex® device family), run `cmake` using the following command:
+   To compile for the default target (the Agilex 7® device family), run `cmake` using the following command:
    ```
    cmake ..
    ```
   > **Note**: You can change the default target by using the command:
   >  ```
   >  cmake .. -DFPGA_DEVICE=<FPGA device family or FPGA part number>
-  >  ``` 
+  >  ```
 
 2. Compile the design through the generated `Makefile`. The following build targets are provided, matching the recommended development flow:
 
@@ -243,7 +243,7 @@ void TestLambdaStreamingKernel(sycl::queue &q, ValueT *in, ValueT *out, size_t c
      ```
      make report
      ```
-   * Run the generated HDL through Intel® Quartus® Prime to generate accurate f<sub>MAX</sub> and area estimates  
+   * Run the generated HDL through Intel® Quartus® Prime to generate accurate f<sub>MAX</sub> and area estimates
    :warning: The FPGA executables generated in this tutorial is ***not*** supported to be run on FPGA devices directly.
      ```
      make fpga
@@ -256,14 +256,14 @@ void TestLambdaStreamingKernel(sycl::queue &q, ValueT *in, ValueT *out, size_t c
    mkdir build
    cd build
    ```
-   To compile for the default target (the Agilex® device family), run `cmake` using the command:
+   To compile for the default target (the Agilex 7® device family), run `cmake` using the command:
    ```
-   cmake -G "NMake Makefiles" .. 
+   cmake -G "NMake Makefiles" ..
    ```
   > **Note**: You can change the default target by using the command:
   >  ```
   >  cmake -G "NMake Makefiles" .. -DFPGA_DEVICE=<FPGA device family or FPGA part number>
-  >  ``` 
+  >  ```
 
 2. Compile the design through the generated `Makefile`. The following build targets are provided, matching the recommended development flow:
 
@@ -279,7 +279,7 @@ void TestLambdaStreamingKernel(sycl::queue &q, ValueT *in, ValueT *out, size_t c
      ```
      nmake report
      ```
-   * Run the generated HDL through Intel® Quartus® Prime to generate accurate f<sub>MAX</sub> and area estimates  
+   * Run the generated HDL through Intel® Quartus® Prime to generate accurate f<sub>MAX</sub> and area estimates
    :warning: The FPGA executables generated in this tutorial is ***not*** supported to be run on FPGA devices directly.
      ```
      nmake fpga

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/experimental/invocation_interfaces/src/CMakeLists.txt
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/experimental/invocation_interfaces/src/CMakeLists.txt
@@ -24,7 +24,7 @@ set(STREAMING_LAMBDA_FPGA_TARGET ${STREAMING_LAMBDA_TARGET_NAME}.fpga)
 
 # FPGA board selection
 if(NOT DEFINED FPGA_DEVICE)
-    set(FPGA_DEVICE "Agilex")
+    set(FPGA_DEVICE "Agilex 7")
     message(STATUS "FPGA_DEVICE was not specified.\
                     \nConfiguring the design to run on the default FPGA family: ${FPGA_DEVICE} \
                     \nPlease refer to the README for information on target selection.")

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/experimental/invocation_interfaces/src/CMakeLists.txt
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/experimental/invocation_interfaces/src/CMakeLists.txt
@@ -24,7 +24,7 @@ set(STREAMING_LAMBDA_FPGA_TARGET ${STREAMING_LAMBDA_TARGET_NAME}.fpga)
 
 # FPGA board selection
 if(NOT DEFINED FPGA_DEVICE)
-    set(FPGA_DEVICE "Agilex 7")
+    set(FPGA_DEVICE "Agilex7")
     message(STATUS "FPGA_DEVICE was not specified.\
                     \nConfiguring the design to run on the default FPGA family: ${FPGA_DEVICE} \
                     \nPlease refer to the README for information on target selection.")

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/experimental/latency_control/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/experimental/latency_control/README.md
@@ -5,7 +5,7 @@ This FPGA tutorial demonstrates how to set latency constraints to pipes and load
 | Optimized for                     | Description
 |:---                               |:---
 | OS                                | Linux* Ubuntu* 18.04/20.04 <br> RHEL*/CentOS* 8 <br> SUSE* 15 <br> Windows* 10
-| Hardware                          | Intel® Agilex®, Arria® 10, and Stratix® 10 FPGAs
+| Hardware                          | Intel® Agilex 7®, Arria® 10, and Stratix® 10 FPGAs
 | Software                          | Intel® oneAPI DPC++/C++ Compiler
 | What you will learn               | How to set latency constraints to pipes and LSUs accesses.<br>How to confirm that the compiler respected the latency control directive.
 | Time to complete                  | 15 minutes
@@ -32,9 +32,9 @@ flowchart LR
    tier2("Tier 2: Explore the Fundamentals")
    tier3("Tier 3: Explore the Advanced Techniques")
    tier4("Tier 4: Explore the Reference Designs")
-   
+
    tier1 --> tier2 --> tier3 --> tier4
-   
+
    style tier1 fill:#0071c1,stroke:#0071c1,stroke-width:1px,color:#fff
    style tier2 fill:#0071c1,stroke:#0071c1,stroke-width:1px,color:#fff
    style tier3 fill:#f96,stroke:#333,stroke-width:1px,color:#fff
@@ -143,8 +143,8 @@ The compiler tries to achieve the latency constraints, and it errors out if some
 
 ## Building the `latency_control` Tutorial
 
-> **Note**: When working with the command-line interface (CLI), you should configure the oneAPI toolkits using environment variables. 
-> Set up your CLI environment by sourcing the `setvars` script located in the root of your oneAPI installation every time you open a new terminal window. 
+> **Note**: When working with the command-line interface (CLI), you should configure the oneAPI toolkits using environment variables.
+> Set up your CLI environment by sourcing the `setvars` script located in the root of your oneAPI installation every time you open a new terminal window.
 > This practice ensures that your compiler, libraries, and tools are ready for development.
 >
 > Linux*:
@@ -166,7 +166,7 @@ The compiler tries to achieve the latency constraints, and it errors out if some
   mkdir build
   cd build
   ```
-  To compile for the default target (the Agilex® device family), run `cmake` using the command:
+  To compile for the default target (the Agilex 7® device family), run `cmake` using the command:
   ```
   cmake ..
   ```
@@ -174,12 +174,12 @@ The compiler tries to achieve the latency constraints, and it errors out if some
   > **Note**: You can change the default target by using the command:
   >  ```
   >  cmake .. -DFPGA_DEVICE=<FPGA device family or FPGA part number>
-  >  ``` 
+  >  ```
   >
-  > Alternatively, you can target an explicit FPGA board variant and BSP by using the following command: 
+  > Alternatively, you can target an explicit FPGA board variant and BSP by using the following command:
   >  ```
   >  cmake .. -DFPGA_DEVICE=<board-support-package>:<board-variant>
-  >  ``` 
+  >  ```
   >
   > You will only be able to run an executable on the FPGA if you specified a BSP.
 
@@ -217,19 +217,19 @@ The compiler tries to achieve the latency constraints, and it errors out if some
   mkdir build
   cd build
   ```
-  To compile for the default target (the Agilex® device family), run `cmake` using the command:
+  To compile for the default target (the Agilex 7® device family), run `cmake` using the command:
   ```
   cmake -G "NMake Makefiles" ..
   ```
   > **Note**: You can change the default target by using the command:
   >  ```
   >  cmake -G "NMake Makefiles" .. -DFPGA_DEVICE=<FPGA device family or FPGA part number>
-  >  ``` 
+  >  ```
   >
-  > Alternatively, you can target an explicit FPGA board variant and BSP by using the following command: 
+  > Alternatively, you can target an explicit FPGA board variant and BSP by using the following command:
   >  ```
   >  cmake -G "NMake Makefiles" .. -DFPGA_DEVICE=<board-support-package>:<board-variant>
-  >  ``` 
+  >  ```
   >
   > You will only be able to run an executable on the FPGA if you specified a BSP.
 

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/experimental/latency_control/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/experimental/latency_control/README.md
@@ -5,7 +5,7 @@ This FPGA tutorial demonstrates how to set latency constraints to pipes and load
 | Optimized for                     | Description
 |:---                               |:---
 | OS                                | Linux* Ubuntu* 18.04/20.04 <br> RHEL*/CentOS* 8 <br> SUSE* 15 <br> Windows* 10
-| Hardware                          | Intel® Agilex 7®, Arria® 10, and Stratix® 10 FPGAs
+| Hardware                          | Intel® Agilex® 7, Arria® 10, and Stratix® 10 FPGAs
 | Software                          | Intel® oneAPI DPC++/C++ Compiler
 | What you will learn               | How to set latency constraints to pipes and LSUs accesses.<br>How to confirm that the compiler respected the latency control directive.
 | Time to complete                  | 15 minutes
@@ -166,7 +166,7 @@ The compiler tries to achieve the latency constraints, and it errors out if some
   mkdir build
   cd build
   ```
-  To compile for the default target (the Agilex 7® device family), run `cmake` using the command:
+  To compile for the default target (the Agilex® 7 device family), run `cmake` using the command:
   ```
   cmake ..
   ```
@@ -217,7 +217,7 @@ The compiler tries to achieve the latency constraints, and it errors out if some
   mkdir build
   cd build
   ```
-  To compile for the default target (the Agilex 7® device family), run `cmake` using the command:
+  To compile for the default target (the Agilex® 7 device family), run `cmake` using the command:
   ```
   cmake -G "NMake Makefiles" ..
   ```

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/experimental/latency_control/src/CMakeLists.txt
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/experimental/latency_control/src/CMakeLists.txt
@@ -6,7 +6,7 @@ set(FPGA_TARGET ${TARGET_NAME}.fpga)
 
 # FPGA board selection
 if(NOT DEFINED FPGA_DEVICE)
-    set(FPGA_DEVICE "Agilex")
+    set(FPGA_DEVICE "Agilex 7")
     message(STATUS "FPGA_DEVICE was not specified.\
                     \nConfiguring the design to the default FPGA family: ${FPGA_DEVICE}\
                     \nPlease refer to the README for information on target selection.")

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/experimental/latency_control/src/CMakeLists.txt
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/experimental/latency_control/src/CMakeLists.txt
@@ -6,7 +6,7 @@ set(FPGA_TARGET ${TARGET_NAME}.fpga)
 
 # FPGA board selection
 if(NOT DEFINED FPGA_DEVICE)
-    set(FPGA_DEVICE "Agilex 7")
+    set(FPGA_DEVICE "Agilex7")
     message(STATUS "FPGA_DEVICE was not specified.\
                     \nConfiguring the design to the default FPGA family: ${FPGA_DEVICE}\
                     \nPlease refer to the README for information on target selection.")

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/fpga_reg/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/fpga_reg/README.md
@@ -7,7 +7,7 @@ This FPGA tutorial demonstrates how a power user can apply the SYCL*-compliant C
 | Optimized for                     | Description
 ---                                 |---
 | OS                                | Linux* Ubuntu* 18.04/20.04 <br> RHEL*/CentOS* 8 <br> SUSE* 15 <br> Windows* 10
-| Hardware                          | Intel® Agilex®, Arria® 10, and Stratix® 10 FPGAs
+| Hardware                          | Intel® Agilex 7®, Arria® 10, and Stratix® 10 FPGAs
 | Software                          | Intel® oneAPI DPC++/C++ Compiler
 | What you will learn               | How to use the `ext::intel::fpga_reg` extension <br> How `ext::intel::fpga_reg` can be used to re-structure the compiler-generated hardware <br> Situations in which applying  `ext::intel::fpga_reg` might be beneficial
 | Time to complete                  | 20 minutes
@@ -34,9 +34,9 @@ flowchart LR
    tier2("Tier 2: Explore the Fundamentals")
    tier3("Tier 3: Explore the Advanced Techniques")
    tier4("Tier 4: Explore the Reference Designs")
-   
+
    tier1 --> tier2 --> tier3 --> tier4
-   
+
    style tier1 fill:#0071c1,stroke:#0071c1,stroke-width:1px,color:#fff
    style tier2 fill:#0071c1,stroke:#0071c1,stroke-width:1px,color:#fff
    style tier3 fill:#f96,stroke:#333,stroke-width:1px,color:#fff
@@ -119,8 +119,8 @@ Since the outer loop is pipelined and has a high trip count, the inner loop's in
 
 ## Building the `fpga_reg` Design
 
-> **Note**: When working with the command-line interface (CLI), you should configure the oneAPI toolkits using environment variables. 
-> Set up your CLI environment by sourcing the `setvars` script located in the root of your oneAPI installation every time you open a new terminal window. 
+> **Note**: When working with the command-line interface (CLI), you should configure the oneAPI toolkits using environment variables.
+> Set up your CLI environment by sourcing the `setvars` script located in the root of your oneAPI installation every time you open a new terminal window.
 > This practice ensures that your compiler, libraries, and tools are ready for development.
 >
 > Linux*:
@@ -143,7 +143,7 @@ Since the outer loop is pipelined and has a high trip count, the inner loop's in
    cd build
    ```
 
-   To compile for the default target (the Agilex® device family), run `cmake` using the command:
+   To compile for the default target (the Agilex 7® device family), run `cmake` using the command:
    ```
    cmake ..
    ```
@@ -151,12 +151,12 @@ Since the outer loop is pipelined and has a high trip count, the inner loop's in
    > **Note**: You can change the default target by using the command:
    >  ```
    >  cmake .. -DFPGA_DEVICE=<FPGA device family or FPGA part number>
-   >  ``` 
+   >  ```
    >
-   > Alternatively, you can target an explicit FPGA board variant and BSP by using the following command: 
+   > Alternatively, you can target an explicit FPGA board variant and BSP by using the following command:
    >  ```
    >  cmake .. -DFPGA_DEVICE=<board-support-package>:<board-variant>
-   >  ``` 
+   >  ```
    >
    > You will only be able to run an executable on the FPGA if you specified a BSP.
 
@@ -195,19 +195,19 @@ Since the outer loop is pipelined and has a high trip count, the inner loop's in
    cd build
    ```
 
-   To compile for the default target (the Agilex® device family), run `cmake` using the command:
+   To compile for the default target (the Agilex 7® device family), run `cmake` using the command:
    ```
    cmake -G "NMake Makefiles" ..
    ```
    > **Note**: You can change the default target by using the command:
    >  ```
    >  cmake -G "NMake Makefiles" .. -DFPGA_DEVICE=<FPGA device family or FPGA part number>
-   >  ``` 
+   >  ```
    >
-   > Alternatively, you can target an explicit FPGA board variant and BSP by using the following command: 
+   > Alternatively, you can target an explicit FPGA board variant and BSP by using the following command:
    >  ```
    >  cmake -G "NMake Makefiles" .. -DFPGA_DEVICE=<board-support-package>:<board-variant>
-   >  ``` 
+   >  ```
    >
    > You will only be able to run an executable on the FPGA if you specified a BSP.
 

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/fpga_reg/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/fpga_reg/README.md
@@ -7,7 +7,7 @@ This FPGA tutorial demonstrates how a power user can apply the SYCL*-compliant C
 | Optimized for                     | Description
 ---                                 |---
 | OS                                | Linux* Ubuntu* 18.04/20.04 <br> RHEL*/CentOS* 8 <br> SUSE* 15 <br> Windows* 10
-| Hardware                          | Intel® Agilex 7®, Arria® 10, and Stratix® 10 FPGAs
+| Hardware                          | Intel® Agilex® 7, Arria® 10, and Stratix® 10 FPGAs
 | Software                          | Intel® oneAPI DPC++/C++ Compiler
 | What you will learn               | How to use the `ext::intel::fpga_reg` extension <br> How `ext::intel::fpga_reg` can be used to re-structure the compiler-generated hardware <br> Situations in which applying  `ext::intel::fpga_reg` might be beneficial
 | Time to complete                  | 20 minutes
@@ -143,7 +143,7 @@ Since the outer loop is pipelined and has a high trip count, the inner loop's in
    cd build
    ```
 
-   To compile for the default target (the Agilex 7® device family), run `cmake` using the command:
+   To compile for the default target (the Agilex® 7 device family), run `cmake` using the command:
    ```
    cmake ..
    ```
@@ -195,7 +195,7 @@ Since the outer loop is pipelined and has a high trip count, the inner loop's in
    cd build
    ```
 
-   To compile for the default target (the Agilex 7® device family), run `cmake` using the command:
+   To compile for the default target (the Agilex® 7 device family), run `cmake` using the command:
    ```
    cmake -G "NMake Makefiles" ..
    ```

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/fpga_reg/src/CMakeLists.txt
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/fpga_reg/src/CMakeLists.txt
@@ -9,7 +9,7 @@ set(FPGA_TARGET_REG ${TARGET_NAME_REG}.fpga)
 
 # FPGA board selection
 if(NOT DEFINED FPGA_DEVICE)
-    set(FPGA_DEVICE "Agilex")
+    set(FPGA_DEVICE "Agilex 7")
     message(STATUS "FPGA_DEVICE was not specified.\
                     \nConfiguring the design to the default FPGA family: ${FPGA_DEVICE}\
                     \nPlease refer to the README for information on target selection.")

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/fpga_reg/src/CMakeLists.txt
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/fpga_reg/src/CMakeLists.txt
@@ -9,7 +9,7 @@ set(FPGA_TARGET_REG ${TARGET_NAME_REG}.fpga)
 
 # FPGA board selection
 if(NOT DEFINED FPGA_DEVICE)
-    set(FPGA_DEVICE "Agilex 7")
+    set(FPGA_DEVICE "Agilex7")
     message(STATUS "FPGA_DEVICE was not specified.\
                     \nConfiguring the design to the default FPGA family: ${FPGA_DEVICE}\
                     \nPlease refer to the README for information on target selection.")

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/kernel_args_restrict/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/kernel_args_restrict/README.md
@@ -5,7 +5,7 @@ This tutorial explains the  `kernel_args_restrict` attribute and its effect on t
 | Optimized for                     | Description
 |:---                               |:---
 | OS                                | Linux* Ubuntu* 18.04/20.04 <br> RHEL*/CentOS* 8 <br> SUSE* 15 <br> Windows* 10
-| Hardware                          | Intel® Agilex®, Arria® 10, and Stratix® 10 FPGAs
+| Hardware                          | Intel® Agilex 7®, Arria® 10, and Stratix® 10 FPGAs
 | Software                          | Intel® oneAPI DPC++/C++ Compiler
 | What you will learn               |  The problem of *pointer aliasing* and its impact on compiler optimizations. <br> The behavior of the `kernel_args_restrict` attribute and when to use it on your kernel. <br> The effect this attribute can have on your kernel's performance on FPGA.
 | Time to complete                  | 20 minutes
@@ -32,9 +32,9 @@ flowchart LR
    tier2("Tier 2: Explore the Fundamentals")
    tier3("Tier 3: Explore the Advanced Techniques")
    tier4("Tier 4: Explore the Reference Designs")
-   
+
    tier1 --> tier2 --> tier3 --> tier4
-   
+
    style tier1 fill:#0071c1,stroke:#0071c1,stroke-width:1px,color:#fff
    style tier2 fill:#f96,stroke:#333,stroke-width:1px,color:#fff
    style tier3 fill:#0071c1,stroke:#0071c1,stroke-width:1px,color:#fff
@@ -92,8 +92,8 @@ In this tutorial, we will show how to use the `kernel_args_restrict` attribute f
 
 ## Building the `kernel_args_restrict` Tutorial
 
-> **Note**: When working with the command-line interface (CLI), you should configure the oneAPI toolkits using environment variables. 
-> Set up your CLI environment by sourcing the `setvars` script located in the root of your oneAPI installation every time you open a new terminal window. 
+> **Note**: When working with the command-line interface (CLI), you should configure the oneAPI toolkits using environment variables.
+> Set up your CLI environment by sourcing the `setvars` script located in the root of your oneAPI installation every time you open a new terminal window.
 > This practice ensures that your compiler, libraries, and tools are ready for development.
 >
 > Linux*:
@@ -114,7 +114,7 @@ In this tutorial, we will show how to use the `kernel_args_restrict` attribute f
   mkdir build
   cd build
   ```
-  To compile for the default target (the Agilex® device family), run `cmake` using the command:
+  To compile for the default target (the Agilex 7® device family), run `cmake` using the command:
   ```
   cmake ..
   ```
@@ -122,12 +122,12 @@ In this tutorial, we will show how to use the `kernel_args_restrict` attribute f
   > **Note**: You can change the default target by using the command:
   >  ```
   >  cmake .. -DFPGA_DEVICE=<FPGA device family or FPGA part number>
-  >  ``` 
+  >  ```
   >
-  > Alternatively, you can target an explicit FPGA board variant and BSP by using the following command: 
+  > Alternatively, you can target an explicit FPGA board variant and BSP by using the following command:
   >  ```
   >  cmake .. -DFPGA_DEVICE=<board-support-package>:<board-variant>
-  >  ``` 
+  >  ```
   >
   > You will only be able to run an executable on the FPGA if you specified a BSP.
 
@@ -165,19 +165,19 @@ In this tutorial, we will show how to use the `kernel_args_restrict` attribute f
   mkdir build
   cd build
   ```
-  To compile for the default target (the Agilex® device family), run `cmake` using the command:
+  To compile for the default target (the Agilex 7® device family), run `cmake` using the command:
   ```
   cmake -G "NMake Makefiles" ..
   ```
   > **Note**: You can change the default target by using the command:
   >  ```
   >  cmake -G "NMake Makefiles" .. -DFPGA_DEVICE=<FPGA device family or FPGA part number>
-  >  ``` 
+  >  ```
   >
-  > Alternatively, you can target an explicit FPGA board variant and BSP by using the following command: 
+  > Alternatively, you can target an explicit FPGA board variant and BSP by using the following command:
   >  ```
   >  cmake -G "NMake Makefiles" .. -DFPGA_DEVICE=<board-support-package>:<board-variant>
-  >  ``` 
+  >  ```
   >
   > You will only be able to run an executable on the FPGA if you specified a BSP.
 

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/kernel_args_restrict/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/kernel_args_restrict/README.md
@@ -5,7 +5,7 @@ This tutorial explains the  `kernel_args_restrict` attribute and its effect on t
 | Optimized for                     | Description
 |:---                               |:---
 | OS                                | Linux* Ubuntu* 18.04/20.04 <br> RHEL*/CentOS* 8 <br> SUSE* 15 <br> Windows* 10
-| Hardware                          | Intel® Agilex 7®, Arria® 10, and Stratix® 10 FPGAs
+| Hardware                          | Intel® Agilex® 7, Arria® 10, and Stratix® 10 FPGAs
 | Software                          | Intel® oneAPI DPC++/C++ Compiler
 | What you will learn               |  The problem of *pointer aliasing* and its impact on compiler optimizations. <br> The behavior of the `kernel_args_restrict` attribute and when to use it on your kernel. <br> The effect this attribute can have on your kernel's performance on FPGA.
 | Time to complete                  | 20 minutes
@@ -114,7 +114,7 @@ In this tutorial, we will show how to use the `kernel_args_restrict` attribute f
   mkdir build
   cd build
   ```
-  To compile for the default target (the Agilex 7® device family), run `cmake` using the command:
+  To compile for the default target (the Agilex® 7 device family), run `cmake` using the command:
   ```
   cmake ..
   ```
@@ -165,7 +165,7 @@ In this tutorial, we will show how to use the `kernel_args_restrict` attribute f
   mkdir build
   cd build
   ```
-  To compile for the default target (the Agilex 7® device family), run `cmake` using the command:
+  To compile for the default target (the Agilex® 7 device family), run `cmake` using the command:
   ```
   cmake -G "NMake Makefiles" ..
   ```

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/kernel_args_restrict/src/CMakeLists.txt
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/kernel_args_restrict/src/CMakeLists.txt
@@ -6,7 +6,7 @@ set(FPGA_TARGET ${TARGET_NAME}.fpga)
 
 # FPGA board selection
 if(NOT DEFINED FPGA_DEVICE)
-    set(FPGA_DEVICE "Agilex")
+    set(FPGA_DEVICE "Agilex 7")
     message(STATUS "FPGA_DEVICE was not specified.\
                     \nConfiguring the design to the default FPGA family: ${FPGA_DEVICE}\
                     \nPlease refer to the README for information on target selection.")

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/kernel_args_restrict/src/CMakeLists.txt
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/kernel_args_restrict/src/CMakeLists.txt
@@ -6,7 +6,7 @@ set(FPGA_TARGET ${TARGET_NAME}.fpga)
 
 # FPGA board selection
 if(NOT DEFINED FPGA_DEVICE)
-    set(FPGA_DEVICE "Agilex 7")
+    set(FPGA_DEVICE "Agilex7")
     message(STATUS "FPGA_DEVICE was not specified.\
                     \nConfiguring the design to the default FPGA family: ${FPGA_DEVICE}\
                     \nPlease refer to the README for information on target selection.")

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/loop_coalesce/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/loop_coalesce/README.md
@@ -5,7 +5,7 @@ This FPGA tutorial demonstrates applying the `loop_coalesce` attribute to a nest
 | Optimized for                     | Description
 ---                                 |---
 | OS                                | Linux* Ubuntu* 18.04/20.04 <br> RHEL*/CentOS* 8 <br> SUSE* 15 <br> Windows* 10
-| Hardware                          | Intel® Agilex®, Arria® 10, and Stratix® 10 FPGAs
+| Hardware                          | Intel® Agilex 7®, Arria® 10, and Stratix® 10 FPGAs
 | Software                          | Intel® oneAPI DPC++/C++ Compiler
 | What you will learn               |  What the `loop_coalesce` attribute does <br> How `loop_coalesce` attribute affects resource usage and loop throughput <br> How to apply the `loop_coalesce` attribute to loops in your program <br> Which loops make good candidates for coalescing
 | Time to complete                  | 15 minutes
@@ -32,9 +32,9 @@ flowchart LR
    tier2("Tier 2: Explore the Fundamentals")
    tier3("Tier 3: Explore the Advanced Techniques")
    tier4("Tier 4: Explore the Reference Designs")
-   
+
    tier1 --> tier2 --> tier3 --> tier4
-   
+
    style tier1 fill:#0071c1,stroke:#0071c1,stroke-width:1px,color:#fff
    style tier2 fill:#f96,stroke:#333,stroke-width:1px,color:#fff
    style tier3 fill:#0071c1,stroke:#0071c1,stroke-width:1px,color:#fff
@@ -88,8 +88,8 @@ If the innermost coalesced loop has a very small trip count, `loop_coalesce` mig
 
 ## Building the `loop_coalesce` Tutorial
 
-> **Note**: When working with the command-line interface (CLI), you should configure the oneAPI toolkits using environment variables. 
-> Set up your CLI environment by sourcing the `setvars` script located in the root of your oneAPI installation every time you open a new terminal window. 
+> **Note**: When working with the command-line interface (CLI), you should configure the oneAPI toolkits using environment variables.
+> Set up your CLI environment by sourcing the `setvars` script located in the root of your oneAPI installation every time you open a new terminal window.
 > This practice ensures that your compiler, libraries, and tools are ready for development.
 >
 > Linux*:
@@ -110,7 +110,7 @@ If the innermost coalesced loop has a very small trip count, `loop_coalesce` mig
   mkdir build
   cd build
   ```
-  To compile for the default target (the Agilex® device family), run `cmake` using the command:
+  To compile for the default target (the Agilex 7® device family), run `cmake` using the command:
   ```
   cmake ..
   ```
@@ -118,12 +118,12 @@ If the innermost coalesced loop has a very small trip count, `loop_coalesce` mig
   > **Note**: You can change the default target by using the command:
   >  ```
   >  cmake .. -DFPGA_DEVICE=<FPGA device family or FPGA part number>
-  >  ``` 
+  >  ```
   >
-  > Alternatively, you can target an explicit FPGA board variant and BSP by using the following command: 
+  > Alternatively, you can target an explicit FPGA board variant and BSP by using the following command:
   >  ```
   >  cmake .. -DFPGA_DEVICE=<board-support-package>:<board-variant>
-  >  ``` 
+  >  ```
   >
   > You will only be able to run an executable on the FPGA if you specified a BSP.
 
@@ -153,19 +153,19 @@ If the innermost coalesced loop has a very small trip count, `loop_coalesce` mig
   mkdir build
   cd build
   ```
-  To compile for the default target (the Agilex® device family), run `cmake` using the command:
+  To compile for the default target (the Agilex 7® device family), run `cmake` using the command:
   ```
   cmake -G "NMake Makefiles" ..
   ```
   > **Note**: You can change the default target by using the command:
   >  ```
   >  cmake -G "NMake Makefiles" .. -DFPGA_DEVICE=<FPGA device family or FPGA part number>
-  >  ``` 
+  >  ```
   >
-  > Alternatively, you can target an explicit FPGA board variant and BSP by using the following command: 
+  > Alternatively, you can target an explicit FPGA board variant and BSP by using the following command:
   >  ```
   >  cmake -G "NMake Makefiles" .. -DFPGA_DEVICE=<board-support-package>:<board-variant>
-  >  ``` 
+  >  ```
   >
   > You will only be able to run an executable on the FPGA if you specified a BSP.
 

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/loop_coalesce/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/loop_coalesce/README.md
@@ -5,7 +5,7 @@ This FPGA tutorial demonstrates applying the `loop_coalesce` attribute to a nest
 | Optimized for                     | Description
 ---                                 |---
 | OS                                | Linux* Ubuntu* 18.04/20.04 <br> RHEL*/CentOS* 8 <br> SUSE* 15 <br> Windows* 10
-| Hardware                          | Intel® Agilex 7®, Arria® 10, and Stratix® 10 FPGAs
+| Hardware                          | Intel® Agilex® 7, Arria® 10, and Stratix® 10 FPGAs
 | Software                          | Intel® oneAPI DPC++/C++ Compiler
 | What you will learn               |  What the `loop_coalesce` attribute does <br> How `loop_coalesce` attribute affects resource usage and loop throughput <br> How to apply the `loop_coalesce` attribute to loops in your program <br> Which loops make good candidates for coalescing
 | Time to complete                  | 15 minutes
@@ -110,7 +110,7 @@ If the innermost coalesced loop has a very small trip count, `loop_coalesce` mig
   mkdir build
   cd build
   ```
-  To compile for the default target (the Agilex 7® device family), run `cmake` using the command:
+  To compile for the default target (the Agilex® 7 device family), run `cmake` using the command:
   ```
   cmake ..
   ```
@@ -153,7 +153,7 @@ If the innermost coalesced loop has a very small trip count, `loop_coalesce` mig
   mkdir build
   cd build
   ```
-  To compile for the default target (the Agilex 7® device family), run `cmake` using the command:
+  To compile for the default target (the Agilex® 7 device family), run `cmake` using the command:
   ```
   cmake -G "NMake Makefiles" ..
   ```

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/loop_coalesce/src/CMakeLists.txt
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/loop_coalesce/src/CMakeLists.txt
@@ -6,7 +6,7 @@ set(FPGA_TARGET ${TARGET_NAME}.fpga)
 
 # FPGA board selection
 if(NOT DEFINED FPGA_DEVICE)
-    set(FPGA_DEVICE "Agilex")
+    set(FPGA_DEVICE "Agilex 7")
     message(STATUS "FPGA_DEVICE was not specified.\
                     \nConfiguring the design to the default FPGA family: ${FPGA_DEVICE}\
                     \nPlease refer to the README for information on target selection.")

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/loop_coalesce/src/CMakeLists.txt
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/loop_coalesce/src/CMakeLists.txt
@@ -6,7 +6,7 @@ set(FPGA_TARGET ${TARGET_NAME}.fpga)
 
 # FPGA board selection
 if(NOT DEFINED FPGA_DEVICE)
-    set(FPGA_DEVICE "Agilex 7")
+    set(FPGA_DEVICE "Agilex7")
     message(STATUS "FPGA_DEVICE was not specified.\
                     \nConfiguring the design to the default FPGA family: ${FPGA_DEVICE}\
                     \nPlease refer to the README for information on target selection.")

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/loop_fusion/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/loop_fusion/README.md
@@ -4,7 +4,7 @@ This FPGA tutorial demonstrates how loop fusion is used and how it affects perfo
 | Optimized for                     | Description
 |:---                               |:---
 | OS                                | Linux* Ubuntu* 18.04/20.04, RHEL*/CentOS* 8, SUSE* 15; Windows* 10
-| Hardware                          | Intel® Agilex®, Arria® 10, and Stratix® 10 FPGAs
+| Hardware                          | Intel® Agilex 7®, Arria® 10, and Stratix® 10 FPGAs
 | Software                          | Intel® oneAPI DPC++/C++ Compiler
 | What you will learn               | Basics of loop fusion<br/>The reasons for loop fusion<br/>How to use loop fusion to increase performance<br/>Understanding safe application of loop fusion
 | Time to complete                  | 20 minutes
@@ -31,9 +31,9 @@ flowchart LR
    tier2("Tier 2: Explore the Fundamentals")
    tier3("Tier 3: Explore the Advanced Techniques")
    tier4("Tier 4: Explore the Reference Designs")
-   
+
    tier1 --> tier2 --> tier3 --> tier4
-   
+
    style tier1 fill:#0071c1,stroke:#0071c1,stroke-width:1px,color:#fff
    style tier2 fill:#f96,stroke:#333,stroke-width:1px,color:#fff
    style tier3 fill:#0071c1,stroke:#0071c1,stroke-width:1px,color:#fff
@@ -102,8 +102,8 @@ The file `loop_fusion.cpp` contains four kernels, all of which contain an outer 
 
 ## Building the Loop Fusion Tutorial
 
-> **Note**: When working with the command-line interface (CLI), you should configure the oneAPI toolkits using environment variables. 
-> Set up your CLI environment by sourcing the `setvars` script located in the root of your oneAPI installation every time you open a new terminal window. 
+> **Note**: When working with the command-line interface (CLI), you should configure the oneAPI toolkits using environment variables.
+> Set up your CLI environment by sourcing the `setvars` script located in the root of your oneAPI installation every time you open a new terminal window.
 > This practice ensures that your compiler, libraries, and tools are ready for development.
 >
 > Linux*:
@@ -124,7 +124,7 @@ The file `loop_fusion.cpp` contains four kernels, all of which contain an outer 
   mkdir build
   cd build
   ```
-  To compile for the default target (the Agilex® device family), run `cmake` using the command:
+  To compile for the default target (the Agilex 7® device family), run `cmake` using the command:
   ```
   cmake ..
   ```
@@ -132,12 +132,12 @@ The file `loop_fusion.cpp` contains four kernels, all of which contain an outer 
   > **Note**: You can change the default target by using the command:
   >  ```
   >  cmake .. -DFPGA_DEVICE=<FPGA device family or FPGA part number>
-  >  ``` 
+  >  ```
   >
-  > Alternatively, you can target an explicit FPGA board variant and BSP by using the following command: 
+  > Alternatively, you can target an explicit FPGA board variant and BSP by using the following command:
   >  ```
   >  cmake .. -DFPGA_DEVICE=<board-support-package>:<board-variant>
-  >  ``` 
+  >  ```
   >
   > You will only be able to run an executable on the FPGA if you specified a BSP.
 
@@ -167,19 +167,19 @@ The file `loop_fusion.cpp` contains four kernels, all of which contain an outer 
   mkdir build
   cd build
   ```
-  To compile for the default target (the Agilex® device family), run `cmake` using the command:
+  To compile for the default target (the Agilex 7® device family), run `cmake` using the command:
   ```
   cmake -G "NMake Makefiles" ..
   ```
   > **Note**: You can change the default target by using the command:
   >  ```
   >  cmake -G "NMake Makefiles" .. -DFPGA_DEVICE=<FPGA device family or FPGA part number>
-  >  ``` 
+  >  ```
   >
-  > Alternatively, you can target an explicit FPGA board variant and BSP by using the following command: 
+  > Alternatively, you can target an explicit FPGA board variant and BSP by using the following command:
   >  ```
   >  cmake -G "NMake Makefiles" .. -DFPGA_DEVICE=<board-support-package>:<board-variant>
-  >  ``` 
+  >  ```
   >
   > You will only be able to run an executable on the FPGA if you specified a BSP.
 

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/loop_fusion/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/loop_fusion/README.md
@@ -4,7 +4,7 @@ This FPGA tutorial demonstrates how loop fusion is used and how it affects perfo
 | Optimized for                     | Description
 |:---                               |:---
 | OS                                | Linux* Ubuntu* 18.04/20.04, RHEL*/CentOS* 8, SUSE* 15; Windows* 10
-| Hardware                          | Intel® Agilex 7®, Arria® 10, and Stratix® 10 FPGAs
+| Hardware                          | Intel® Agilex® 7, Arria® 10, and Stratix® 10 FPGAs
 | Software                          | Intel® oneAPI DPC++/C++ Compiler
 | What you will learn               | Basics of loop fusion<br/>The reasons for loop fusion<br/>How to use loop fusion to increase performance<br/>Understanding safe application of loop fusion
 | Time to complete                  | 20 minutes
@@ -124,7 +124,7 @@ The file `loop_fusion.cpp` contains four kernels, all of which contain an outer 
   mkdir build
   cd build
   ```
-  To compile for the default target (the Agilex 7® device family), run `cmake` using the command:
+  To compile for the default target (the Agilex® 7 device family), run `cmake` using the command:
   ```
   cmake ..
   ```
@@ -167,7 +167,7 @@ The file `loop_fusion.cpp` contains four kernels, all of which contain an outer 
   mkdir build
   cd build
   ```
-  To compile for the default target (the Agilex 7® device family), run `cmake` using the command:
+  To compile for the default target (the Agilex® 7 device family), run `cmake` using the command:
   ```
   cmake -G "NMake Makefiles" ..
   ```

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/loop_fusion/src/CMakeLists.txt
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/loop_fusion/src/CMakeLists.txt
@@ -6,7 +6,7 @@ set(FPGA_TARGET ${TARGET_NAME}.fpga)
 
 # FPGA board selection
 if(NOT DEFINED FPGA_DEVICE)
-    set(FPGA_DEVICE "Agilex")
+    set(FPGA_DEVICE "Agilex 7")
     message(STATUS "FPGA_DEVICE was not specified.\
                     \nConfiguring the design to the default FPGA family: ${FPGA_DEVICE}\
                     \nPlease refer to the README for information on target selection.")

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/loop_fusion/src/CMakeLists.txt
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/loop_fusion/src/CMakeLists.txt
@@ -6,7 +6,7 @@ set(FPGA_TARGET ${TARGET_NAME}.fpga)
 
 # FPGA board selection
 if(NOT DEFINED FPGA_DEVICE)
-    set(FPGA_DEVICE "Agilex 7")
+    set(FPGA_DEVICE "Agilex7")
     message(STATUS "FPGA_DEVICE was not specified.\
                     \nConfiguring the design to the default FPGA family: ${FPGA_DEVICE}\
                     \nPlease refer to the README for information on target selection.")

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/loop_initiation_interval/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/loop_initiation_interval/README.md
@@ -5,7 +5,7 @@ This FPGA tutorial demonstrates how a user can use the `intel::initiation_interv
 | Optimized for                     | Description
 |:---                               |:---
 | OS                                | Linux* Ubuntu* 18.04/20.04 <br> RHEL*/CentOS* 8 <br> SUSE* 15 <br> Windows* 10
-| Hardware                          | Intel® Agilex®, Arria® 10, and Stratix® 10 FPGAs
+| Hardware                          | Intel® Agilex 7®, Arria® 10, and Stratix® 10 FPGAs
 | Software                          | Intel® oneAPI DPC++/C++ Compiler
 | What you will learn               | The f<sub>MAX</sub>-II tradeoff <br>Default behavior of the compiler when scheduling loops <br> How to use `intel::initiation_interval` to attempt to set the II for a loop <br> Scenarios in which `intel::initiation_interval` can be helpful in optimizing kernel performance
 | Time to complete                  | 20 minutes
@@ -32,9 +32,9 @@ flowchart LR
    tier2("Tier 2: Explore the Fundamentals")
    tier3("Tier 3: Explore the Advanced Techniques")
    tier4("Tier 4: Explore the Reference Designs")
-   
+
    tier1 --> tier2 --> tier3 --> tier4
-   
+
    style tier1 fill:#0071c1,stroke:#0071c1,stroke-width:1px,color:#fff
    style tier2 fill:#f96,stroke:#333,stroke-width:1px,color:#fff
    style tier3 fill:#0071c1,stroke:#0071c1,stroke-width:1px,color:#fff
@@ -84,7 +84,7 @@ By default, the compiler attempts to schedule each loop with the optimal minimum
 
 The `intel::initiation_interval` attribute can be used to specify an II for a particular loop. It informs the compiler to ignore the default heuristic and to try and schedule the loop that the attribute is applied to with the specific II the user provides.
 
-The targeted f<sub>MAX</sub> can be specified using the [-Xsclock](https://software.intel.com/content/www/us/en/develop/documentation/oneapi-fpga-optimization-guide/top/fpga-optimization-flags-attributes-pragmas-and-extensions/optimization-flags/specify-schedule-fmax-target-for-kernels-xsclock-clock-target.html) compiler argument. The argument determines the pipelining effort of the compiler, which uses an internal model of the FPGA fabric to estimate f<sub>MAX</sub>. The true f<sub>MAX</sub> is known only after compiling to hardware. Without the argument, the default target f<sub>MAX</sub> is 240MHz for the Intel® Arria® 10 FPGAs and 480MHz for the Intel® Stratix® 10 and Agilex® FPGAs, but the compiler will not strictly enforce reaching that default target when scheduling loops.
+The targeted f<sub>MAX</sub> can be specified using the [-Xsclock](https://software.intel.com/content/www/us/en/develop/documentation/oneapi-fpga-optimization-guide/top/fpga-optimization-flags-attributes-pragmas-and-extensions/optimization-flags/specify-schedule-fmax-target-for-kernels-xsclock-clock-target.html) compiler argument. The argument determines the pipelining effort of the compiler, which uses an internal model of the FPGA fabric to estimate f<sub>MAX</sub>. The true f<sub>MAX</sub> is known only after compiling to hardware. Without the argument, the default target f<sub>MAX</sub> is 240MHz for the Intel® Arria® 10 FPGAs and 480MHz for the Intel® Stratix® 10 and Agilex 7® FPGAs, but the compiler will not strictly enforce reaching that default target when scheduling loops.
 
 >**Note:** The scheduler prioritizes II over f<sub>MAX</sub> if **both** *-Xsclock* and `intel::initiation_interval` are used. Your kernel may be able to achieve a lower II for the loop with the `intel::initiation_interval` attribute while targeting a specific f<sub>MAX</sub>, but the loop will not be scheduled with the lower II.
 
@@ -135,7 +135,7 @@ Depending on the feedback path in the long-running loop, the rest of the kernel 
 
 In this part, `intel::initiation_interval` is used for both the short and long running loops to show the two scenarios where using the attribute is appropriate.
 
-The first `intel::initiation_interval` declaration sets an II value of 3 for the Intel® Arria® 10 FPGA, and an II value of 5 for the Intel® Stratix® 10 and Agilex® FPGAs. Since the initialization loop has a low trip count compared to the long-running loop, a higher II for the initialization loop is a reasonable tradeoff to allow for a higher overall f<sub>MAX</sub> for the entire kernel.
+The first `intel::initiation_interval` declaration sets an II value of 3 for the Intel® Arria® 10 FPGA, and an II value of 5 for the Intel® Stratix® 10 and Agilex 7® FPGAs. Since the initialization loop has a low trip count compared to the long-running loop, a higher II for the initialization loop is a reasonable tradeoff to allow for a higher overall f<sub>MAX</sub> for the entire kernel.
 
 >**Note:** For Intel® Stratix® 10 FPGA, the estimated f<sub>MAX</sub> of the long-running loop is not able to reach the default targeted f<sub>MAX</sub> of 480MHz while maintaining an II of 1. This is due to the nature of the feedback path that exists in the long running loop. Setting the II of the initialization loop to 5 ensures that the initialization loop is not the bottleneck when finding the maximum operating frequency.
 
@@ -150,8 +150,8 @@ The second `intel::initiation_interval` declaration sets an II of 1 for the long
 
 ## Building the `loop_initiation_interval` Tutorial
 
-> **Note**: When working with the command-line interface (CLI), you should configure the oneAPI toolkits using environment variables. 
-> Set up your CLI environment by sourcing the `setvars` script located in the root of your oneAPI installation every time you open a new terminal window. 
+> **Note**: When working with the command-line interface (CLI), you should configure the oneAPI toolkits using environment variables.
+> Set up your CLI environment by sourcing the `setvars` script located in the root of your oneAPI installation every time you open a new terminal window.
 > This practice ensures that your compiler, libraries, and tools are ready for development.
 >
 > Linux*:
@@ -172,7 +172,7 @@ The second `intel::initiation_interval` declaration sets an II of 1 for the long
   mkdir build
   cd build
   ```
-  To compile for the default target (the Agilex® device family), run `cmake` using the command:
+  To compile for the default target (the Agilex 7® device family), run `cmake` using the command:
   ```
   cmake ..
   ```
@@ -180,12 +180,12 @@ The second `intel::initiation_interval` declaration sets an II of 1 for the long
   > **Note**: You can change the default target by using the command:
   >  ```
   >  cmake .. -DFPGA_DEVICE=<FPGA device family or FPGA part number>
-  >  ``` 
+  >  ```
   >
-  > Alternatively, you can target an explicit FPGA board variant and BSP by using the following command: 
+  > Alternatively, you can target an explicit FPGA board variant and BSP by using the following command:
   >  ```
   >  cmake .. -DFPGA_DEVICE=<board-support-package>:<board-variant>
-  >  ``` 
+  >  ```
   >
   > You will only be able to run an executable on the FPGA if you specified a BSP.
 
@@ -222,19 +222,19 @@ The second `intel::initiation_interval` declaration sets an II of 1 for the long
   mkdir build
   cd build
   ```
-  To compile for the default target (the Agilex® device family), run `cmake` using the command:
+  To compile for the default target (the Agilex 7® device family), run `cmake` using the command:
   ```
   cmake -G "NMake Makefiles" ..
   ```
   > **Note**: You can change the default target by using the command:
   >  ```
   >  cmake -G "NMake Makefiles" .. -DFPGA_DEVICE=<FPGA device family or FPGA part number>
-  >  ``` 
+  >  ```
   >
-  > Alternatively, you can target an explicit FPGA board variant and BSP by using the following command: 
+  > Alternatively, you can target an explicit FPGA board variant and BSP by using the following command:
   >  ```
   >  cmake -G "NMake Makefiles" .. -DFPGA_DEVICE=<board-support-package>:<board-variant>
-  >  ``` 
+  >  ```
   >
   > You will only be able to run an executable on the FPGA if you specified a BSP.
 

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/loop_initiation_interval/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/loop_initiation_interval/README.md
@@ -5,7 +5,7 @@ This FPGA tutorial demonstrates how a user can use the `intel::initiation_interv
 | Optimized for                     | Description
 |:---                               |:---
 | OS                                | Linux* Ubuntu* 18.04/20.04 <br> RHEL*/CentOS* 8 <br> SUSE* 15 <br> Windows* 10
-| Hardware                          | Intel® Agilex 7®, Arria® 10, and Stratix® 10 FPGAs
+| Hardware                          | Intel® Agilex® 7, Arria® 10, and Stratix® 10 FPGAs
 | Software                          | Intel® oneAPI DPC++/C++ Compiler
 | What you will learn               | The f<sub>MAX</sub>-II tradeoff <br>Default behavior of the compiler when scheduling loops <br> How to use `intel::initiation_interval` to attempt to set the II for a loop <br> Scenarios in which `intel::initiation_interval` can be helpful in optimizing kernel performance
 | Time to complete                  | 20 minutes
@@ -84,7 +84,7 @@ By default, the compiler attempts to schedule each loop with the optimal minimum
 
 The `intel::initiation_interval` attribute can be used to specify an II for a particular loop. It informs the compiler to ignore the default heuristic and to try and schedule the loop that the attribute is applied to with the specific II the user provides.
 
-The targeted f<sub>MAX</sub> can be specified using the [-Xsclock](https://software.intel.com/content/www/us/en/develop/documentation/oneapi-fpga-optimization-guide/top/fpga-optimization-flags-attributes-pragmas-and-extensions/optimization-flags/specify-schedule-fmax-target-for-kernels-xsclock-clock-target.html) compiler argument. The argument determines the pipelining effort of the compiler, which uses an internal model of the FPGA fabric to estimate f<sub>MAX</sub>. The true f<sub>MAX</sub> is known only after compiling to hardware. Without the argument, the default target f<sub>MAX</sub> is 240MHz for the Intel® Arria® 10 FPGAs and 480MHz for the Intel® Stratix® 10 and Agilex 7® FPGAs, but the compiler will not strictly enforce reaching that default target when scheduling loops.
+The targeted f<sub>MAX</sub> can be specified using the [-Xsclock](https://software.intel.com/content/www/us/en/develop/documentation/oneapi-fpga-optimization-guide/top/fpga-optimization-flags-attributes-pragmas-and-extensions/optimization-flags/specify-schedule-fmax-target-for-kernels-xsclock-clock-target.html) compiler argument. The argument determines the pipelining effort of the compiler, which uses an internal model of the FPGA fabric to estimate f<sub>MAX</sub>. The true f<sub>MAX</sub> is known only after compiling to hardware. Without the argument, the default target f<sub>MAX</sub> is 240MHz for the Intel® Arria® 10 FPGAs and 480MHz for the Intel® Stratix® 10 and Agilex® 7 FPGAs, but the compiler will not strictly enforce reaching that default target when scheduling loops.
 
 >**Note:** The scheduler prioritizes II over f<sub>MAX</sub> if **both** *-Xsclock* and `intel::initiation_interval` are used. Your kernel may be able to achieve a lower II for the loop with the `intel::initiation_interval` attribute while targeting a specific f<sub>MAX</sub>, but the loop will not be scheduled with the lower II.
 
@@ -135,7 +135,7 @@ Depending on the feedback path in the long-running loop, the rest of the kernel 
 
 In this part, `intel::initiation_interval` is used for both the short and long running loops to show the two scenarios where using the attribute is appropriate.
 
-The first `intel::initiation_interval` declaration sets an II value of 3 for the Intel® Arria® 10 FPGA, and an II value of 5 for the Intel® Stratix® 10 and Agilex 7® FPGAs. Since the initialization loop has a low trip count compared to the long-running loop, a higher II for the initialization loop is a reasonable tradeoff to allow for a higher overall f<sub>MAX</sub> for the entire kernel.
+The first `intel::initiation_interval` declaration sets an II value of 3 for the Intel® Arria® 10 FPGA, and an II value of 5 for the Intel® Stratix® 10 and Agilex® 7 FPGAs. Since the initialization loop has a low trip count compared to the long-running loop, a higher II for the initialization loop is a reasonable tradeoff to allow for a higher overall f<sub>MAX</sub> for the entire kernel.
 
 >**Note:** For Intel® Stratix® 10 FPGA, the estimated f<sub>MAX</sub> of the long-running loop is not able to reach the default targeted f<sub>MAX</sub> of 480MHz while maintaining an II of 1. This is due to the nature of the feedback path that exists in the long running loop. Setting the II of the initialization loop to 5 ensures that the initialization loop is not the bottleneck when finding the maximum operating frequency.
 
@@ -172,7 +172,7 @@ The second `intel::initiation_interval` declaration sets an II of 1 for the long
   mkdir build
   cd build
   ```
-  To compile for the default target (the Agilex 7® device family), run `cmake` using the command:
+  To compile for the default target (the Agilex® 7 device family), run `cmake` using the command:
   ```
   cmake ..
   ```
@@ -222,7 +222,7 @@ The second `intel::initiation_interval` declaration sets an II of 1 for the long
   mkdir build
   cd build
   ```
-  To compile for the default target (the Agilex 7® device family), run `cmake` using the command:
+  To compile for the default target (the Agilex® 7 device family), run `cmake` using the command:
   ```
   cmake -G "NMake Makefiles" ..
   ```

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/loop_initiation_interval/src/CMakeLists.txt
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/loop_initiation_interval/src/CMakeLists.txt
@@ -9,8 +9,8 @@ set(FPGA_TARGET_ENABLE_II ${TARGET_NAME_ENABLE_II}.fpga)
 
 # FPGA board selection
 if(NOT DEFINED FPGA_DEVICE)
-    set(FPGA_DEVICE "Agilex")
-    set(DEVICE_FLAG "Agilex")
+    set(FPGA_DEVICE "Agilex 7")
+    set(DEVICE_FLAG "Agilex 7")
     message(STATUS "FPGA_DEVICE was not specified.\
                     \nConfiguring the design to the default FPGA family: ${FPGA_DEVICE}\
                     \nPlease refer to the README for information on target selection.")
@@ -21,7 +21,7 @@ else()
     elseif(FPGA_DEVICE_NAME MATCHES ".*s10.*" OR FPGA_DEVICE_NAME MATCHES ".*stratix10.*")
       set(DEVICE_FLAG "S10")
     elseif(FPGA_DEVICE_NAME MATCHES ".*agilex.*")
-      set(DEVICE_FLAG "Agilex")
+      set(DEVICE_FLAG "Agilex 7")
     endif()
     message(STATUS "Configuring the design with the following target: ${FPGA_DEVICE}")
 endif()
@@ -29,7 +29,7 @@ endif()
 if(NOT DEFINED DEVICE_FLAG)
     message(FATAL_ERROR "An unrecognized or custom board was passed, but DEVICE_FLAG was not specified. \
                          Please make sure you have set -DDEVICE_FLAG=-A10, -DDEVICE_FLAG=-S10 or \
-                         -DDEVICE_FLAG=-Agilex.")
+                         -DDEVICE_FLAG=-Agilex 7.")
 endif()
 
 # This is a Windows-specific flag that enables exception handling in host code

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/loop_initiation_interval/src/CMakeLists.txt
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/loop_initiation_interval/src/CMakeLists.txt
@@ -9,8 +9,8 @@ set(FPGA_TARGET_ENABLE_II ${TARGET_NAME_ENABLE_II}.fpga)
 
 # FPGA board selection
 if(NOT DEFINED FPGA_DEVICE)
-    set(FPGA_DEVICE "Agilex 7")
-    set(DEVICE_FLAG "Agilex 7")
+    set(FPGA_DEVICE "Agilex7")
+    set(DEVICE_FLAG "Agilex7")
     message(STATUS "FPGA_DEVICE was not specified.\
                     \nConfiguring the design to the default FPGA family: ${FPGA_DEVICE}\
                     \nPlease refer to the README for information on target selection.")
@@ -21,7 +21,7 @@ else()
     elseif(FPGA_DEVICE_NAME MATCHES ".*s10.*" OR FPGA_DEVICE_NAME MATCHES ".*stratix10.*")
       set(DEVICE_FLAG "S10")
     elseif(FPGA_DEVICE_NAME MATCHES ".*agilex.*")
-      set(DEVICE_FLAG "Agilex 7")
+      set(DEVICE_FLAG "Agilex7")
     endif()
     message(STATUS "Configuring the design with the following target: ${FPGA_DEVICE}")
 endif()
@@ -29,7 +29,7 @@ endif()
 if(NOT DEFINED DEVICE_FLAG)
     message(FATAL_ERROR "An unrecognized or custom board was passed, but DEVICE_FLAG was not specified. \
                          Please make sure you have set -DDEVICE_FLAG=-A10, -DDEVICE_FLAG=-S10 or \
-                         -DDEVICE_FLAG=-Agilex 7.")
+                         -DDEVICE_FLAG=-Agilex7.")
 endif()
 
 # This is a Windows-specific flag that enables exception handling in host code

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/loop_initiation_interval/src/CMakeLists.txt
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/loop_initiation_interval/src/CMakeLists.txt
@@ -28,8 +28,8 @@ endif()
 
 if(NOT DEFINED DEVICE_FLAG)
     message(FATAL_ERROR "An unrecognized or custom board was passed, but DEVICE_FLAG was not specified. \
-                         Please make sure you have set -DDEVICE_FLAG=-A10, -DDEVICE_FLAG=-S10 or \
-                         -DDEVICE_FLAG=-Agilex7.")
+                         Please make sure you have set -DDEVICE_FLAG=A10, -DDEVICE_FLAG=S10 or \
+                         -DDEVICE_FLAG=Agilex7.")
 endif()
 
 # This is a Windows-specific flag that enables exception handling in host code

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/loop_initiation_interval/src/loop_initiation_interval.cpp
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/loop_initiation_interval/src/loop_initiation_interval.cpp
@@ -120,7 +120,7 @@ void RunKernel(std::vector<int> &in, std::vector<int> &out) {
           [[intel::initiation_interval(3)]]
 #elif defined(S10)
           [[intel::initiation_interval(5)]]
-#elif defined(Agilex)
+#elif defined(Agilex 7)
           [[intel::initiation_interval(5)]]
 #else
           static_assert(false, "Unknown FPGA Architecture!");

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/loop_initiation_interval/src/loop_initiation_interval.cpp
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/loop_initiation_interval/src/loop_initiation_interval.cpp
@@ -120,7 +120,7 @@ void RunKernel(std::vector<int> &in, std::vector<int> &out) {
           [[intel::initiation_interval(3)]]
 #elif defined(S10)
           [[intel::initiation_interval(5)]]
-#elif defined(Agilex 7)
+#elif defined(Agilex7)
           [[intel::initiation_interval(5)]]
 #else
           static_assert(false, "Unknown FPGA Architecture!");
@@ -156,7 +156,7 @@ void RunKernel(std::vector<int> &in, std::vector<int> &out) {
 
           // The intel::initiation_interval attribute is added here to "assert"
           // that II=1 for this loop. Even though we fully expect the compiler
-          // to achieve II=1 here by default, some developers find it helful to
+          // to achieve II=1 here by default, some developers find it helpful to
           // include the attribute to "document" this expectation. If a future
           // code change causes an unexpected II regression, the compiler will
           // error out. Without the intel::initiation_interval attribute, an II

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/loop_ivdep/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/loop_ivdep/README.md
@@ -4,7 +4,7 @@ This FPGA tutorial demonstrates how to apply the `ivdep` attribute to a loop to 
 | Optimized for                     | Description
 |:---                               |:---
 | OS                                | Linux* Ubuntu* 18.04/20.04 <br> RHEL*/CentOS* 8 <br> SUSE* 15 <br> Windows* 10
-| Hardware                          | Intel® Agilex 7®, Arria® 10, and Stratix® 10 FPGAs
+| Hardware                          | Intel® Agilex® 7, Arria® 10, and Stratix® 10 FPGAs
 | Software                          | Intel® oneAPI DPC++/C++ Compiler
 | What you will learn               |  Basics of loop-carried dependencies <br> The notion of a loop-carried dependence distance <br> What constitutes a *safe* dependence distance <br> How to aid the compiler's dependence analysis to maximize performance
 | Time to complete                  | 30 minutes
@@ -185,7 +185,7 @@ Observe that the indexing expression on `temp_buffer` evaluates to the same inde
   mkdir build
   cd build
   ```
-  To compile for the default target (the Agilex 7® device family), run `cmake` using the command:
+  To compile for the default target (the Agilex® 7 device family), run `cmake` using the command:
   ```
   cmake ..
   ```
@@ -228,7 +228,7 @@ Observe that the indexing expression on `temp_buffer` evaluates to the same inde
   mkdir build
   cd build
   ```
-  To compile for the default target (the Agilex 7® device family), run `cmake` using the command:
+  To compile for the default target (the Agilex® 7 device family), run `cmake` using the command:
   ```
   cmake -G "NMake Makefiles" ..
   ```

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/loop_ivdep/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/loop_ivdep/README.md
@@ -4,7 +4,7 @@ This FPGA tutorial demonstrates how to apply the `ivdep` attribute to a loop to 
 | Optimized for                     | Description
 |:---                               |:---
 | OS                                | Linux* Ubuntu* 18.04/20.04 <br> RHEL*/CentOS* 8 <br> SUSE* 15 <br> Windows* 10
-| Hardware                          | Intel® Agilex®, Arria® 10, and Stratix® 10 FPGAs
+| Hardware                          | Intel® Agilex 7®, Arria® 10, and Stratix® 10 FPGAs
 | Software                          | Intel® oneAPI DPC++/C++ Compiler
 | What you will learn               |  Basics of loop-carried dependencies <br> The notion of a loop-carried dependence distance <br> What constitutes a *safe* dependence distance <br> How to aid the compiler's dependence analysis to maximize performance
 | Time to complete                  | 30 minutes
@@ -31,9 +31,9 @@ flowchart LR
    tier2("Tier 2: Explore the Fundamentals")
    tier3("Tier 3: Explore the Advanced Techniques")
    tier4("Tier 4: Explore the Reference Designs")
-   
+
    tier1 --> tier2 --> tier3 --> tier4
-   
+
    style tier1 fill:#0071c1,stroke:#0071c1,stroke-width:1px,color:#fff
    style tier2 fill:#f96,stroke:#333,stroke-width:1px,color:#fff
    style tier3 fill:#0071c1,stroke:#0071c1,stroke-width:1px,color:#fff
@@ -163,8 +163,8 @@ Observe that the indexing expression on `temp_buffer` evaluates to the same inde
 
 ## Building the `loop_ivdep` Tutorial
 
-> **Note**: When working with the command-line interface (CLI), you should configure the oneAPI toolkits using environment variables. 
-> Set up your CLI environment by sourcing the `setvars` script located in the root of your oneAPI installation every time you open a new terminal window. 
+> **Note**: When working with the command-line interface (CLI), you should configure the oneAPI toolkits using environment variables.
+> Set up your CLI environment by sourcing the `setvars` script located in the root of your oneAPI installation every time you open a new terminal window.
 > This practice ensures that your compiler, libraries, and tools are ready for development.
 >
 > Linux*:
@@ -185,7 +185,7 @@ Observe that the indexing expression on `temp_buffer` evaluates to the same inde
   mkdir build
   cd build
   ```
-  To compile for the default target (the Agilex® device family), run `cmake` using the command:
+  To compile for the default target (the Agilex 7® device family), run `cmake` using the command:
   ```
   cmake ..
   ```
@@ -193,12 +193,12 @@ Observe that the indexing expression on `temp_buffer` evaluates to the same inde
   > **Note**: You can change the default target by using the command:
   >  ```
   >  cmake .. -DFPGA_DEVICE=<FPGA device family or FPGA part number>
-  >  ``` 
+  >  ```
   >
-  > Alternatively, you can target an explicit FPGA board variant and BSP by using the following command: 
+  > Alternatively, you can target an explicit FPGA board variant and BSP by using the following command:
   >  ```
   >  cmake .. -DFPGA_DEVICE=<board-support-package>:<board-variant>
-  >  ``` 
+  >  ```
   >
   > You will only be able to run an executable on the FPGA if you specified a BSP.
 
@@ -228,19 +228,19 @@ Observe that the indexing expression on `temp_buffer` evaluates to the same inde
   mkdir build
   cd build
   ```
-  To compile for the default target (the Agilex® device family), run `cmake` using the command:
+  To compile for the default target (the Agilex 7® device family), run `cmake` using the command:
   ```
   cmake -G "NMake Makefiles" ..
   ```
   > **Note**: You can change the default target by using the command:
   >  ```
   >  cmake -G "NMake Makefiles" .. -DFPGA_DEVICE=<FPGA device family or FPGA part number>
-  >  ``` 
+  >  ```
   >
-  > Alternatively, you can target an explicit FPGA board variant and BSP by using the following command: 
+  > Alternatively, you can target an explicit FPGA board variant and BSP by using the following command:
   >  ```
   >  cmake -G "NMake Makefiles" .. -DFPGA_DEVICE=<board-support-package>:<board-variant>
-  >  ``` 
+  >  ```
   >
   > You will only be able to run an executable on the FPGA if you specified a BSP.
 

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/loop_ivdep/src/CMakeLists.txt
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/loop_ivdep/src/CMakeLists.txt
@@ -6,7 +6,7 @@ set(FPGA_TARGET ${TARGET_NAME}.fpga)
 
 # FPGA board selection
 if(NOT DEFINED FPGA_DEVICE)
-    set(FPGA_DEVICE "Agilex")
+    set(FPGA_DEVICE "Agilex 7")
     message(STATUS "FPGA_DEVICE was not specified.\
                     \nConfiguring the design to the default FPGA family: ${FPGA_DEVICE}\
                     \nPlease refer to the README for information on target selection.")

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/loop_ivdep/src/CMakeLists.txt
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/loop_ivdep/src/CMakeLists.txt
@@ -6,7 +6,7 @@ set(FPGA_TARGET ${TARGET_NAME}.fpga)
 
 # FPGA board selection
 if(NOT DEFINED FPGA_DEVICE)
-    set(FPGA_DEVICE "Agilex 7")
+    set(FPGA_DEVICE "Agilex7")
     message(STATUS "FPGA_DEVICE was not specified.\
                     \nConfiguring the design to the default FPGA family: ${FPGA_DEVICE}\
                     \nPlease refer to the README for information on target selection.")

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/loop_unroll/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/loop_unroll/README.md
@@ -4,7 +4,7 @@ This tutorial demonstrates a simple example of unrolling loops to improve throug
 | Optimized for                     | Description
 |:---                               |:---
 | OS                                | Linux* Ubuntu* 18.04/20.04 <br> RHEL*/CentOS* 8 <br> SUSE* 15 <br> Windows* 10
-| Hardware                          | Intel® Agilex 7®, Arria® 10, and Stratix® 10 FPGAs
+| Hardware                          | Intel® Agilex® 7, Arria® 10, and Stratix® 10 FPGAs
 | Software                          | Intel® oneAPI DPC++/C++ Compiler
 | What you will learn               |  Basics of loop unrolling. <br> How to unroll loops in your program. <br> Determining the optimal unroll factor for your program.
 | Time to complete                  | 15 minutes
@@ -138,7 +138,7 @@ On an Intel® Programmable Acceleration Card with Intel Arria® 10 GX FPGA, it i
   mkdir build
   cd build
   ```
-  To compile for the default target (the Agilex 7® device family), run `cmake` using the command:
+  To compile for the default target (the Agilex® 7 device family), run `cmake` using the command:
   ```
   cmake ..
   ```
@@ -181,7 +181,7 @@ On an Intel® Programmable Acceleration Card with Intel Arria® 10 GX FPGA, it i
   mkdir build
   cd build
   ```
-  To compile for the default target (the Agilex 7® device family), run `cmake` using the command:
+  To compile for the default target (the Agilex® 7 device family), run `cmake` using the command:
   ```
   cmake -G "NMake Makefiles" ..
   ```

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/loop_unroll/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/loop_unroll/README.md
@@ -4,7 +4,7 @@ This tutorial demonstrates a simple example of unrolling loops to improve throug
 | Optimized for                     | Description
 |:---                               |:---
 | OS                                | Linux* Ubuntu* 18.04/20.04 <br> RHEL*/CentOS* 8 <br> SUSE* 15 <br> Windows* 10
-| Hardware                          | Intel® Agilex®, Arria® 10, and Stratix® 10 FPGAs
+| Hardware                          | Intel® Agilex 7®, Arria® 10, and Stratix® 10 FPGAs
 | Software                          | Intel® oneAPI DPC++/C++ Compiler
 | What you will learn               |  Basics of loop unrolling. <br> How to unroll loops in your program. <br> Determining the optimal unroll factor for your program.
 | Time to complete                  | 15 minutes
@@ -31,9 +31,9 @@ flowchart LR
    tier2("Tier 2: Explore the Fundamentals")
    tier3("Tier 3: Explore the Advanced Techniques")
    tier4("Tier 4: Explore the Reference Designs")
-   
+
    tier1 --> tier2 --> tier3 --> tier4
-   
+
    style tier1 fill:#0071c1,stroke:#0071c1,stroke-width:1px,color:#fff
    style tier2 fill:#f96,stroke:#333,stroke-width:1px,color:#fff
    style tier3 fill:#0071c1,stroke:#0071c1,stroke-width:1px,color:#fff
@@ -116,8 +116,8 @@ On an Intel® Programmable Acceleration Card with Intel Arria® 10 GX FPGA, it i
 
 ## Building the `loop_unroll` Tutorial
 
-> **Note**: When working with the command-line interface (CLI), you should configure the oneAPI toolkits using environment variables. 
-> Set up your CLI environment by sourcing the `setvars` script located in the root of your oneAPI installation every time you open a new terminal window. 
+> **Note**: When working with the command-line interface (CLI), you should configure the oneAPI toolkits using environment variables.
+> Set up your CLI environment by sourcing the `setvars` script located in the root of your oneAPI installation every time you open a new terminal window.
 > This practice ensures that your compiler, libraries, and tools are ready for development.
 >
 > Linux*:
@@ -138,7 +138,7 @@ On an Intel® Programmable Acceleration Card with Intel Arria® 10 GX FPGA, it i
   mkdir build
   cd build
   ```
-  To compile for the default target (the Agilex® device family), run `cmake` using the command:
+  To compile for the default target (the Agilex 7® device family), run `cmake` using the command:
   ```
   cmake ..
   ```
@@ -146,12 +146,12 @@ On an Intel® Programmable Acceleration Card with Intel Arria® 10 GX FPGA, it i
   > **Note**: You can change the default target by using the command:
   >  ```
   >  cmake .. -DFPGA_DEVICE=<FPGA device family or FPGA part number>
-  >  ``` 
+  >  ```
   >
-  > Alternatively, you can target an explicit FPGA board variant and BSP by using the following command: 
+  > Alternatively, you can target an explicit FPGA board variant and BSP by using the following command:
   >  ```
   >  cmake .. -DFPGA_DEVICE=<board-support-package>:<board-variant>
-  >  ``` 
+  >  ```
   >
   > You will only be able to run an executable on the FPGA if you specified a BSP.
 
@@ -181,19 +181,19 @@ On an Intel® Programmable Acceleration Card with Intel Arria® 10 GX FPGA, it i
   mkdir build
   cd build
   ```
-  To compile for the default target (the Agilex® device family), run `cmake` using the command:
+  To compile for the default target (the Agilex 7® device family), run `cmake` using the command:
   ```
   cmake -G "NMake Makefiles" ..
   ```
   > **Note**: You can change the default target by using the command:
   >  ```
   >  cmake -G "NMake Makefiles" .. -DFPGA_DEVICE=<FPGA device family or FPGA part number>
-  >  ``` 
+  >  ```
   >
-  > Alternatively, you can target an explicit FPGA board variant and BSP by using the following command: 
+  > Alternatively, you can target an explicit FPGA board variant and BSP by using the following command:
   >  ```
   >  cmake -G "NMake Makefiles" .. -DFPGA_DEVICE=<board-support-package>:<board-variant>
-  >  ``` 
+  >  ```
   >
   > You will only be able to run an executable on the FPGA if you specified a BSP.
 

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/loop_unroll/src/CMakeLists.txt
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/loop_unroll/src/CMakeLists.txt
@@ -6,7 +6,7 @@ set(FPGA_TARGET ${TARGET_NAME}.fpga)
 
 # FPGA board selection
 if(NOT DEFINED FPGA_DEVICE)
-    set(FPGA_DEVICE "Agilex")
+    set(FPGA_DEVICE "Agilex 7")
     message(STATUS "FPGA_DEVICE was not specified.\
                     \nConfiguring the design to the default FPGA family: ${FPGA_DEVICE}\
                     \nPlease refer to the README for information on target selection.")

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/loop_unroll/src/CMakeLists.txt
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/loop_unroll/src/CMakeLists.txt
@@ -6,7 +6,7 @@ set(FPGA_TARGET ${TARGET_NAME}.fpga)
 
 # FPGA board selection
 if(NOT DEFINED FPGA_DEVICE)
-    set(FPGA_DEVICE "Agilex 7")
+    set(FPGA_DEVICE "Agilex7")
     message(STATUS "FPGA_DEVICE was not specified.\
                     \nConfiguring the design to the default FPGA family: ${FPGA_DEVICE}\
                     \nPlease refer to the README for information on target selection.")

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/lsu_control/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/lsu_control/README.md
@@ -5,7 +5,7 @@ This FPGA tutorial demonstrates how to configure the load-store units (LSU) in S
 | Optimized for                     | Description
 |:---                               |:---
 | OS                                | Linux* Ubuntu* 18.04/20.04 <br> RHEL*/CentOS* 8 <br> SUSE* 15 <br> Windows* 10
-| Hardware                          | Intel® Agilex®, Arria® 10, and Stratix® 10 FPGAs
+| Hardware                          | Intel® Agilex 7®, Arria® 10, and Stratix® 10 FPGAs
 | Software                          | Intel® oneAPI DPC++/C++ Compiler
 | What you will learn               | The basic concepts of LSU styles and LSU modifiers <br>  How to use the LSU controls extension to request specific configurations <br>  How to confirm what LSU configurations are implemented <br> A case study of the type of area trade-offs enabled by LSU
 | Time to complete                  | 30 minutes
@@ -32,9 +32,9 @@ flowchart LR
    tier2("Tier 2: Explore the Fundamentals")
    tier3("Tier 3: Explore the Advanced Techniques")
    tier4("Tier 4: Explore the Reference Designs")
-   
+
    tier1 --> tier2 --> tier3 --> tier4
-   
+
    style tier1 fill:#0071c1,stroke:#0071c1,stroke-width:1px,color:#fff
    style tier2 fill:#0071c1,stroke:#0071c1,stroke-width:1px,color:#fff
    style tier3 fill:#f96,stroke:#333,stroke-width:1px,color:#fff
@@ -123,8 +123,8 @@ The kernel design requests data from global memory in a contiguous manner. There
 
 ## Building the `lsu_control` Tutorial
 
-> **Note**: When working with the command-line interface (CLI), you should configure the oneAPI toolkits using environment variables. 
-> Set up your CLI environment by sourcing the `setvars` script located in the root of your oneAPI installation every time you open a new terminal window. 
+> **Note**: When working with the command-line interface (CLI), you should configure the oneAPI toolkits using environment variables.
+> Set up your CLI environment by sourcing the `setvars` script located in the root of your oneAPI installation every time you open a new terminal window.
 > This practice ensures that your compiler, libraries, and tools are ready for development.
 >
 > Linux*:
@@ -147,7 +147,7 @@ The kernel design requests data from global memory in a contiguous manner. There
    cd build
    ```
 
-   To compile for the default target (the Agilex® device family), run `cmake` using the command:
+   To compile for the default target (the Agilex 7® device family), run `cmake` using the command:
    ```
    cmake ..
    ```
@@ -155,12 +155,12 @@ The kernel design requests data from global memory in a contiguous manner. There
    > **Note**: You can change the default target by using the command:
    >  ```
    >  cmake .. -DFPGA_DEVICE=<FPGA device family or FPGA part number>
-   >  ``` 
+   >  ```
    >
-   > Alternatively, you can target an explicit FPGA board variant and BSP by using the following command: 
+   > Alternatively, you can target an explicit FPGA board variant and BSP by using the following command:
    >  ```
    >  cmake .. -DFPGA_DEVICE=<board-support-package>:<board-variant>
-   >  ``` 
+   >  ```
    >
    > You will only be able to run an executable on the FPGA if you specified a BSP.
 
@@ -193,19 +193,19 @@ The kernel design requests data from global memory in a contiguous manner. There
    cd build
    ```
 
-   To compile for the default target (the Agilex® device family), run `cmake` using the command:
+   To compile for the default target (the Agilex 7® device family), run `cmake` using the command:
    ```
    cmake -G "NMake Makefiles" ..
    ```
    > **Note**: You can change the default target by using the command:
    >  ```
    >  cmake -G "NMake Makefiles" .. -DFPGA_DEVICE=<FPGA device family or FPGA part number>
-   >  ``` 
+   >  ```
    >
-   > Alternatively, you can target an explicit FPGA board variant and BSP by using the following command: 
+   > Alternatively, you can target an explicit FPGA board variant and BSP by using the following command:
    >  ```
    >  cmake -G "NMake Makefiles" .. -DFPGA_DEVICE=<board-support-package>:<board-variant>
-   >  ``` 
+   >  ```
    >
    > You will only be able to run an executable on the FPGA if you specified a BSP.
 

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/lsu_control/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/lsu_control/README.md
@@ -5,7 +5,7 @@ This FPGA tutorial demonstrates how to configure the load-store units (LSU) in S
 | Optimized for                     | Description
 |:---                               |:---
 | OS                                | Linux* Ubuntu* 18.04/20.04 <br> RHEL*/CentOS* 8 <br> SUSE* 15 <br> Windows* 10
-| Hardware                          | Intel® Agilex 7®, Arria® 10, and Stratix® 10 FPGAs
+| Hardware                          | Intel® Agilex® 7, Arria® 10, and Stratix® 10 FPGAs
 | Software                          | Intel® oneAPI DPC++/C++ Compiler
 | What you will learn               | The basic concepts of LSU styles and LSU modifiers <br>  How to use the LSU controls extension to request specific configurations <br>  How to confirm what LSU configurations are implemented <br> A case study of the type of area trade-offs enabled by LSU
 | Time to complete                  | 30 minutes
@@ -147,7 +147,7 @@ The kernel design requests data from global memory in a contiguous manner. There
    cd build
    ```
 
-   To compile for the default target (the Agilex 7® device family), run `cmake` using the command:
+   To compile for the default target (the Agilex® 7 device family), run `cmake` using the command:
    ```
    cmake ..
    ```
@@ -193,7 +193,7 @@ The kernel design requests data from global memory in a contiguous manner. There
    cd build
    ```
 
-   To compile for the default target (the Agilex 7® device family), run `cmake` using the command:
+   To compile for the default target (the Agilex® 7 device family), run `cmake` using the command:
    ```
    cmake -G "NMake Makefiles" ..
    ```

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/lsu_control/src/CMakeLists.txt
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/lsu_control/src/CMakeLists.txt
@@ -6,7 +6,7 @@ set(FPGA_TARGET ${TARGET_NAME}.fpga)
 
 # FPGA board selection
 if(NOT DEFINED FPGA_DEVICE)
-    set(FPGA_DEVICE "Agilex")
+    set(FPGA_DEVICE "Agilex 7")
     message(STATUS "FPGA_DEVICE was not specified.\
                     \nConfiguring the design to the default FPGA family: ${FPGA_DEVICE}\
                     \nPlease refer to the README for information on target selection.")

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/lsu_control/src/CMakeLists.txt
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/lsu_control/src/CMakeLists.txt
@@ -6,7 +6,7 @@ set(FPGA_TARGET ${TARGET_NAME}.fpga)
 
 # FPGA board selection
 if(NOT DEFINED FPGA_DEVICE)
-    set(FPGA_DEVICE "Agilex 7")
+    set(FPGA_DEVICE "Agilex7")
     message(STATUS "FPGA_DEVICE was not specified.\
                     \nConfiguring the design to the default FPGA family: ${FPGA_DEVICE}\
                     \nPlease refer to the README for information on target selection.")

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/max_interleaving/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/max_interleaving/README.md
@@ -4,7 +4,7 @@ This FPGA tutorial explains how to use the `max_interleaving` attribute for loop
 | Optimized for                     | Description
 |:---                               |:---
 | OS                                | Linux* Ubuntu* 18.04/20.04 <br> RHEL*/CentOS* 8 <br> SUSE* 15 <br> Windows* 10
-| Hardware                          | Intel® Agilex 7®, Arria® 10, and Stratix® 10 FPGAs
+| Hardware                          | Intel® Agilex® 7, Arria® 10, and Stratix® 10 FPGAs
 | Software                          | Intel® oneAPI DPC++/C++ Compiler
 | What you will learn               | The basic usage of the `max_interleaving` attribute <br> How the `max_interleaving` attribute affects loop resource use <br> How to apply the `max_interleaving` attribute to loops in your program
 | Time to complete                  | 15 minutes
@@ -94,7 +94,7 @@ In this loop nest, pipelined iterations of L1 are serialized across L2 to preser
   mkdir build
   cd build
   ```
-  To compile for the default target (the Agilex 7® device family), run `cmake` using the command:
+  To compile for the default target (the Agilex® 7 device family), run `cmake` using the command:
   ```
   cmake ..
   ```
@@ -137,7 +137,7 @@ In this loop nest, pipelined iterations of L1 are serialized across L2 to preser
   mkdir build
   cd build
   ```
-  To compile for the default target (the Agilex 7® device family), run `cmake` using the command:
+  To compile for the default target (the Agilex® 7 device family), run `cmake` using the command:
   ```
   cmake -G "NMake Makefiles" ..
   ```

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/max_interleaving/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/max_interleaving/README.md
@@ -4,7 +4,7 @@ This FPGA tutorial explains how to use the `max_interleaving` attribute for loop
 | Optimized for                     | Description
 |:---                               |:---
 | OS                                | Linux* Ubuntu* 18.04/20.04 <br> RHEL*/CentOS* 8 <br> SUSE* 15 <br> Windows* 10
-| Hardware                          | Intel® Agilex®, Arria® 10, and Stratix® 10 FPGAs
+| Hardware                          | Intel® Agilex 7®, Arria® 10, and Stratix® 10 FPGAs
 | Software                          | Intel® oneAPI DPC++/C++ Compiler
 | What you will learn               | The basic usage of the `max_interleaving` attribute <br> How the `max_interleaving` attribute affects loop resource use <br> How to apply the `max_interleaving` attribute to loops in your program
 | Time to complete                  | 15 minutes
@@ -31,9 +31,9 @@ flowchart LR
    tier2("Tier 2: Explore the Fundamentals")
    tier3("Tier 3: Explore the Advanced Techniques")
    tier4("Tier 4: Explore the Reference Designs")
-   
+
    tier1 --> tier2 --> tier3 --> tier4
-   
+
    style tier1 fill:#0071c1,stroke:#0071c1,stroke-width:1px,color:#fff
    style tier2 fill:#f96,stroke:#333,stroke-width:1px,color:#fff
    style tier3 fill:#0071c1,stroke:#0071c1,stroke-width:1px,color:#fff
@@ -72,8 +72,8 @@ In this loop nest, pipelined iterations of L1 are serialized across L2 to preser
 
 ## Building the `max_interleaving` Tutorial
 
-> **Note**: When working with the command-line interface (CLI), you should configure the oneAPI toolkits using environment variables. 
-> Set up your CLI environment by sourcing the `setvars` script located in the root of your oneAPI installation every time you open a new terminal window. 
+> **Note**: When working with the command-line interface (CLI), you should configure the oneAPI toolkits using environment variables.
+> Set up your CLI environment by sourcing the `setvars` script located in the root of your oneAPI installation every time you open a new terminal window.
 > This practice ensures that your compiler, libraries, and tools are ready for development.
 >
 > Linux*:
@@ -94,7 +94,7 @@ In this loop nest, pipelined iterations of L1 are serialized across L2 to preser
   mkdir build
   cd build
   ```
-  To compile for the default target (the Agilex® device family), run `cmake` using the command:
+  To compile for the default target (the Agilex 7® device family), run `cmake` using the command:
   ```
   cmake ..
   ```
@@ -102,12 +102,12 @@ In this loop nest, pipelined iterations of L1 are serialized across L2 to preser
   > **Note**: You can change the default target by using the command:
   >  ```
   >  cmake .. -DFPGA_DEVICE=<FPGA device family or FPGA part number>
-  >  ``` 
+  >  ```
   >
-  > Alternatively, you can target an explicit FPGA board variant and BSP by using the following command: 
+  > Alternatively, you can target an explicit FPGA board variant and BSP by using the following command:
   >  ```
   >  cmake .. -DFPGA_DEVICE=<board-support-package>:<board-variant>
-  >  ``` 
+  >  ```
   >
   > You will only be able to run an executable on the FPGA if you specified a BSP.
 
@@ -137,19 +137,19 @@ In this loop nest, pipelined iterations of L1 are serialized across L2 to preser
   mkdir build
   cd build
   ```
-  To compile for the default target (the Agilex® device family), run `cmake` using the command:
+  To compile for the default target (the Agilex 7® device family), run `cmake` using the command:
   ```
   cmake -G "NMake Makefiles" ..
   ```
   > **Note**: You can change the default target by using the command:
   >  ```
   >  cmake -G "NMake Makefiles" .. -DFPGA_DEVICE=<FPGA device family or FPGA part number>
-  >  ``` 
+  >  ```
   >
-  > Alternatively, you can target an explicit FPGA board variant and BSP by using the following command: 
+  > Alternatively, you can target an explicit FPGA board variant and BSP by using the following command:
   >  ```
   >  cmake -G "NMake Makefiles" .. -DFPGA_DEVICE=<board-support-package>:<board-variant>
-  >  ``` 
+  >  ```
   >
   > You will only be able to run an executable on the FPGA if you specified a BSP.
 

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/max_interleaving/src/CMakeLists.txt
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/max_interleaving/src/CMakeLists.txt
@@ -6,7 +6,7 @@ set(FPGA_TARGET ${TARGET_NAME}.fpga)
 
 # FPGA board selection
 if(NOT DEFINED FPGA_DEVICE)
-    set(FPGA_DEVICE "Agilex")
+    set(FPGA_DEVICE "Agilex 7")
     message(STATUS "FPGA_DEVICE was not specified.\
                     \nConfiguring the design to the default FPGA family: ${FPGA_DEVICE}\
                     \nPlease refer to the README for information on target selection.")

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/max_interleaving/src/CMakeLists.txt
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/max_interleaving/src/CMakeLists.txt
@@ -6,7 +6,7 @@ set(FPGA_TARGET ${TARGET_NAME}.fpga)
 
 # FPGA board selection
 if(NOT DEFINED FPGA_DEVICE)
-    set(FPGA_DEVICE "Agilex 7")
+    set(FPGA_DEVICE "Agilex7")
     message(STATUS "FPGA_DEVICE was not specified.\
                     \nConfiguring the design to the default FPGA family: ${FPGA_DEVICE}\
                     \nPlease refer to the README for information on target selection.")

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/mem_channel/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/mem_channel/README.md
@@ -7,7 +7,7 @@ SYCL*-compliant FPGA design.
 | Optimized for                     | Description
 |:---                               |:---
 | OS                                | Linux* Ubuntu* 18.04/20.04 <br> RHEL*/CentOS* 8 <br> SUSE* 15 <br> Windows* 10
-| Hardware                          | Intel® Agilex 7®, Arria® 10, and Stratix® 10 FPGAs
+| Hardware                          | Intel® Agilex® 7, Arria® 10, and Stratix® 10 FPGAs
 | Software                          | Intel® oneAPI DPC++/C++ Compiler
 | What you will learn               | How and when to use the `mem_channel` buffer property and the `-Xsno-interleaving` flag
 | Time to complete                  | 30 minutes
@@ -141,7 +141,7 @@ defined when the design is compiled for an Intel® Arria® GX FPGA as the
 Intel® PAC with Arria® 10 GX FPGA has an external memory with two available
 channels. In that case, the 4 buffers are evenly assigned to the available
 channels on that board. When the design is compiled for an Intel® Stratix® or
-Agilex 7® FPGA, the 4 buffers are assigned to the 4 available channels.
+Agilex® 7 FPGA, the 4 buffers are assigned to the 4 available channels.
 This can be parametrize by setting the correct macro (or create your
 own) that clearly matches the number of channels available on your specific
 board.
@@ -176,7 +176,7 @@ board.
   mkdir build
   cd build
   ```
-  To compile for the default target (the Agilex 7® device family), run `cmake` using the command:
+  To compile for the default target (the Agilex® 7 device family), run `cmake` using the command:
   ```
   cmake ..
   ```
@@ -220,7 +220,7 @@ board.
   mkdir build
   cd build
   ```
-  To compile for the default target (the Agilex 7® device family), run `cmake` using the command:
+  To compile for the default target (the Agilex® 7 device family), run `cmake` using the command:
   ```
   cmake -G "NMake Makefiles" ..
   ```

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/mem_channel/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/mem_channel/README.md
@@ -7,7 +7,7 @@ SYCL*-compliant FPGA design.
 | Optimized for                     | Description
 |:---                               |:---
 | OS                                | Linux* Ubuntu* 18.04/20.04 <br> RHEL*/CentOS* 8 <br> SUSE* 15 <br> Windows* 10
-| Hardware                          | Intel® Agilex®, Arria® 10, and Stratix® 10 FPGAs
+| Hardware                          | Intel® Agilex 7®, Arria® 10, and Stratix® 10 FPGAs
 | Software                          | Intel® oneAPI DPC++/C++ Compiler
 | What you will learn               | How and when to use the `mem_channel` buffer property and the `-Xsno-interleaving` flag
 | Time to complete                  | 30 minutes
@@ -34,9 +34,9 @@ flowchart LR
    tier2("Tier 2: Explore the Fundamentals")
    tier3("Tier 3: Explore the Advanced Techniques")
    tier4("Tier 4: Explore the Reference Designs")
-   
+
    tier1 --> tier2 --> tier3 --> tier4
-   
+
    style tier1 fill:#0071c1,stroke:#0071c1,stroke-width:1px,color:#fff
    style tier2 fill:#0071c1,stroke:#0071c1,stroke-width:1px,color:#fff
    style tier3 fill:#f96,stroke:#333,stroke-width:1px,color:#fff
@@ -81,11 +81,11 @@ Otherwise, the global memory bandwidth utilization may be reduced, which will
 negatively impact the throughput of your design.
 
 To disable burst-interleaving, you need to pass the
-`-Xsno-interleaving=<global_memory_type>` flag to your `icpx` command. In the 
-case of targeting a BSP, the global memory type is indicated in the board 
-specification XML file for the Board Support Package (BSP) that you're using. 
-The board specification XML file, called `board_spec.xml`, can be found in the 
-root directory of your BSP. For example, for the Intel® PAC with Intel Arria® 10 
+`-Xsno-interleaving=<global_memory_type>` flag to your `icpx` command. In the
+case of targeting a BSP, the global memory type is indicated in the board
+specification XML file for the Board Support Package (BSP) that you're using.
+The board specification XML file, called `board_spec.xml`, can be found in the
+root directory of your BSP. For example, for the Intel® PAC with Intel Arria® 10
 GX FPGA BSP, the location of this file is:
 `$INTELFPGAOCLSDKROOT/board/intel_a10gx_pac/hardware/pac_a10/board_spec.xml`.
 Note that this BSP only has a single memory type available as indicated in its
@@ -137,11 +137,11 @@ created with our without the `mem_channel` property.
 
 To decide what channel IDs to select in the source code, the macros
 `TWO_CHANNELS` and `FOUR_CHANNELS` are also used. The macro `TWO_CHANNELS` is
-defined when the design is compiled for an Intel® Arria® GX FPGA as the 
-Intel® PAC with Arria® 10 GX FPGA has an external memory with two available 
-channels. In that case, the 4 buffers are evenly assigned to the available 
+defined when the design is compiled for an Intel® Arria® GX FPGA as the
+Intel® PAC with Arria® 10 GX FPGA has an external memory with two available
+channels. In that case, the 4 buffers are evenly assigned to the available
 channels on that board. When the design is compiled for an Intel® Stratix® or
-Agilex® FPGA, the 4 buffers are assigned to the 4 available channels.
+Agilex 7® FPGA, the 4 buffers are assigned to the 4 available channels.
 This can be parametrize by setting the correct macro (or create your
 own) that clearly matches the number of channels available on your specific
 board.
@@ -154,8 +154,8 @@ board.
 
 ## Building the `mem_channel` Tutorial
 
-> **Note**: When working with the command-line interface (CLI), you should configure the oneAPI toolkits using environment variables. 
-> Set up your CLI environment by sourcing the `setvars` script located in the root of your oneAPI installation every time you open a new terminal window. 
+> **Note**: When working with the command-line interface (CLI), you should configure the oneAPI toolkits using environment variables.
+> Set up your CLI environment by sourcing the `setvars` script located in the root of your oneAPI installation every time you open a new terminal window.
 > This practice ensures that your compiler, libraries, and tools are ready for development.
 >
 > Linux*:
@@ -176,7 +176,7 @@ board.
   mkdir build
   cd build
   ```
-  To compile for the default target (the Agilex® device family), run `cmake` using the command:
+  To compile for the default target (the Agilex 7® device family), run `cmake` using the command:
   ```
   cmake ..
   ```
@@ -184,12 +184,12 @@ board.
   > **Note**: You can change the default target by using the command:
   >  ```
   >  cmake .. -DFPGA_DEVICE=<FPGA device family or FPGA part number>
-  >  ``` 
+  >  ```
   >
-  > Alternatively, you can target an explicit FPGA board variant and BSP by using the following command: 
+  > Alternatively, you can target an explicit FPGA board variant and BSP by using the following command:
   >  ```
   >  cmake .. -DFPGA_DEVICE=<board-support-package>:<board-variant>
-  >  ``` 
+  >  ```
   >
   > You will only be able to run an executable on the FPGA if you specified a BSP.
 
@@ -220,19 +220,19 @@ board.
   mkdir build
   cd build
   ```
-  To compile for the default target (the Agilex® device family), run `cmake` using the command:
+  To compile for the default target (the Agilex 7® device family), run `cmake` using the command:
   ```
   cmake -G "NMake Makefiles" ..
   ```
   > **Note**: You can change the default target by using the command:
   >  ```
   >  cmake -G "NMake Makefiles" .. -DFPGA_DEVICE=<FPGA device family or FPGA part number>
-  >  ``` 
+  >  ```
   >
-  > Alternatively, you can target an explicit FPGA board variant and BSP by using the following command: 
+  > Alternatively, you can target an explicit FPGA board variant and BSP by using the following command:
   >  ```
   >  cmake -G "NMake Makefiles" .. -DFPGA_DEVICE=<board-support-package>:<board-variant>
-  >  ``` 
+  >  ```
   >
   > You will only be able to run an executable on the FPGA if you specified a BSP.
 
@@ -263,7 +263,7 @@ provide cmake with the full path to your sample directory.
 
 ## Examining the Reports
 Locate the pair of `report.html` files in the `mem_channel_interleaving.prj`
-and `mem_channel_no_interleaving.prj` directories. Open the reports in 
+and `mem_channel_no_interleaving.prj` directories. Open the reports in
 Chrome*, Firefox*, Edge*, or Internet Explorer*. In the "Summary" tab, locate
 the "Quartus Fitter Resource Utilization Summary" entry and expand it to see
 the table showing the FPGA resources that were allocated for the design. Notice
@@ -330,14 +330,14 @@ Intel® Programmable Acceleration Card with Intel® Arria® 10 GX FPGA. The tabl
 below shows the performance of the design as well as the resources consumed by
 the kernel system.
 Configuration | Execution Time (ms) | Throughput (MB/s) | ALM | REG | MLAB | RAM | DSP
-|:--- |:--- |:--- |:--- |:--- |:--- |:--- |:--- 
+|:--- |:--- |:--- |:--- |:--- |:--- |:--- |:---
 |Without `-Xsno-interleaving` | 4.004 | 749.23 | 23,815.4 | 26,727  | 1094 | 53 | 0
 |With `-Xsno-interleaving` | 3.767 | 796.38 | 7,060.7  | 16,396  | 38 | 41  | 0
 
 Similarly, when compiled for the Intel® Programmable Acceleration Card with
 Intel® Stratix® 10 SX FPGA, the tutorial design achieved the following results:
 Configuration | Execution Time (ms) | Throughput (MB/s) | ALM | REG | MLAB | RAM | DSP
-|:--- |:--- |:--- |:--- |:--- |:--- |:--- |:--- 
+|:--- |:--- |:--- |:--- |:--- |:--- |:--- |:---
 |Without `-Xsno-interleaving` | 2.913  | 1029.90 | 14,999.6 | 47,532 | 11 | 345 | 0
 |With `-Xsno-interleaving` | 2.913 | 1029.77 | 9,564.1 | 28,616 | 11 | 186 | 0
 

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/mem_channel/src/CMakeLists.txt
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/mem_channel/src/CMakeLists.txt
@@ -7,7 +7,7 @@ set(FPGA_TARGET_NO_INTERLEAVING ${TARGET_NAME}_no_interleaving.fpga)
 
 # FPGA board selection
 if(NOT DEFINED FPGA_DEVICE)
-    set(FPGA_DEVICE "Agilex")
+    set(FPGA_DEVICE "Agilex 7")
     message(STATUS "FPGA_DEVICE was not specified.\
                     \nConfiguring the design to the default FPGA family: ${FPGA_DEVICE}\
                     \nPlease refer to the README for information on target selection.")

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/mem_channel/src/CMakeLists.txt
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/mem_channel/src/CMakeLists.txt
@@ -7,7 +7,7 @@ set(FPGA_TARGET_NO_INTERLEAVING ${TARGET_NAME}_no_interleaving.fpga)
 
 # FPGA board selection
 if(NOT DEFINED FPGA_DEVICE)
-    set(FPGA_DEVICE "Agilex 7")
+    set(FPGA_DEVICE "Agilex7")
     message(STATUS "FPGA_DEVICE was not specified.\
                     \nConfiguring the design to the default FPGA family: ${FPGA_DEVICE}\
                     \nPlease refer to the README for information on target selection.")

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/memory_attributes/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/memory_attributes/README.md
@@ -4,7 +4,7 @@ This FPGA tutorial demonstrates how to use on-chip memory attributes to control 
 | Optimized for                     | Description
 |:---                               |:---
 | OS                                | Linux* Ubuntu* 18.04/20.04 <br> RHEL*/CentOS* 8 <br> SUSE* 15 <br> Windows* 10
-| Hardware                          | Intel® Agilex®, Arria® 10, and Stratix® 10 FPGAs
+| Hardware                          | Intel® Agilex 7®, Arria® 10, and Stratix® 10 FPGAs
 | Software                          | Intel® oneAPI DPC++/C++ Compiler
 | What you will learn               |  The basic concepts of on-chip memory attributes <br> How to apply memory attributes in your program <br> How to confirm that the memory attributes were respected by the compiler <br> A case study of the type of performance/area trade-offs enabled by memory attributes
 | Time to complete                  | 30 minutes
@@ -31,9 +31,9 @@ flowchart LR
    tier2("Tier 2: Explore the Fundamentals")
    tier3("Tier 3: Explore the Advanced Techniques")
    tier4("Tier 4: Explore the Reference Designs")
-   
+
    tier1 --> tier2 --> tier3 --> tier4
-   
+
    style tier1 fill:#0071c1,stroke:#0071c1,stroke-width:1px,color:#fff
    style tier2 fill:#f96,stroke:#333,stroke-width:1px,color:#fff
    style tier3 fill:#0071c1,stroke:#0071c1,stroke-width:1px,color:#fff
@@ -162,8 +162,8 @@ The choice of attributes will be further discussed in the [Examining the Reports
 
 ## Building the `memory_attributes` Tutorial
 
-> **Note**: When working with the command-line interface (CLI), you should configure the oneAPI toolkits using environment variables. 
-> Set up your CLI environment by sourcing the `setvars` script located in the root of your oneAPI installation every time you open a new terminal window. 
+> **Note**: When working with the command-line interface (CLI), you should configure the oneAPI toolkits using environment variables.
+> Set up your CLI environment by sourcing the `setvars` script located in the root of your oneAPI installation every time you open a new terminal window.
 > This practice ensures that your compiler, libraries, and tools are ready for development.
 >
 > Linux*:
@@ -184,7 +184,7 @@ The choice of attributes will be further discussed in the [Examining the Reports
   mkdir build
   cd build
   ```
-  To compile for the default target (the Agilex® device family), run `cmake` using the command:
+  To compile for the default target (the Agilex 7® device family), run `cmake` using the command:
   ```
   cmake ..
   ```
@@ -192,12 +192,12 @@ The choice of attributes will be further discussed in the [Examining the Reports
   > **Note**: You can change the default target by using the command:
   >  ```
   >  cmake .. -DFPGA_DEVICE=<FPGA device family or FPGA part number>
-  >  ``` 
+  >  ```
   >
-  > Alternatively, you can target an explicit FPGA board variant and BSP by using the following command: 
+  > Alternatively, you can target an explicit FPGA board variant and BSP by using the following command:
   >  ```
   >  cmake .. -DFPGA_DEVICE=<board-support-package>:<board-variant>
-  >  ``` 
+  >  ```
   >
   > You will only be able to run an executable on the FPGA if you specified a BSP.
 
@@ -227,19 +227,19 @@ The choice of attributes will be further discussed in the [Examining the Reports
   mkdir build
   cd build
   ```
-  To compile for the default target (the Agilex® device family), run `cmake` using the command:
+  To compile for the default target (the Agilex 7® device family), run `cmake` using the command:
   ```
   cmake -G "NMake Makefiles" ..
   ```
   > **Note**: You can change the default target by using the command:
   >  ```
   >  cmake -G "NMake Makefiles" .. -DFPGA_DEVICE=<FPGA device family or FPGA part number>
-  >  ``` 
+  >  ```
   >
-  > Alternatively, you can target an explicit FPGA board variant and BSP by using the following command: 
+  > Alternatively, you can target an explicit FPGA board variant and BSP by using the following command:
   >  ```
   >  cmake -G "NMake Makefiles" .. -DFPGA_DEVICE=<board-support-package>:<board-variant>
-  >  ``` 
+  >  ```
   >
   > You will only be able to run an executable on the FPGA if you specified a BSP.
 

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/memory_attributes/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/memory_attributes/README.md
@@ -4,7 +4,7 @@ This FPGA tutorial demonstrates how to use on-chip memory attributes to control 
 | Optimized for                     | Description
 |:---                               |:---
 | OS                                | Linux* Ubuntu* 18.04/20.04 <br> RHEL*/CentOS* 8 <br> SUSE* 15 <br> Windows* 10
-| Hardware                          | Intel® Agilex 7®, Arria® 10, and Stratix® 10 FPGAs
+| Hardware                          | Intel® Agilex® 7, Arria® 10, and Stratix® 10 FPGAs
 | Software                          | Intel® oneAPI DPC++/C++ Compiler
 | What you will learn               |  The basic concepts of on-chip memory attributes <br> How to apply memory attributes in your program <br> How to confirm that the memory attributes were respected by the compiler <br> A case study of the type of performance/area trade-offs enabled by memory attributes
 | Time to complete                  | 30 minutes
@@ -184,7 +184,7 @@ The choice of attributes will be further discussed in the [Examining the Reports
   mkdir build
   cd build
   ```
-  To compile for the default target (the Agilex 7® device family), run `cmake` using the command:
+  To compile for the default target (the Agilex® 7 device family), run `cmake` using the command:
   ```
   cmake ..
   ```
@@ -227,7 +227,7 @@ The choice of attributes will be further discussed in the [Examining the Reports
   mkdir build
   cd build
   ```
-  To compile for the default target (the Agilex 7® device family), run `cmake` using the command:
+  To compile for the default target (the Agilex® 7 device family), run `cmake` using the command:
   ```
   cmake -G "NMake Makefiles" ..
   ```

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/memory_attributes/src/CMakeLists.txt
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/memory_attributes/src/CMakeLists.txt
@@ -6,7 +6,7 @@ set(FPGA_TARGET ${TARGET_NAME}.fpga)
 
 # FPGA board selection
 if(NOT DEFINED FPGA_DEVICE)
-    set(FPGA_DEVICE "Agilex")
+    set(FPGA_DEVICE "Agilex 7")
     message(STATUS "FPGA_DEVICE was not specified.\
                     \nConfiguring the design to the default FPGA family: ${FPGA_DEVICE}\
                     \nPlease refer to the README for information on target selection.")

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/memory_attributes/src/CMakeLists.txt
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/memory_attributes/src/CMakeLists.txt
@@ -6,7 +6,7 @@ set(FPGA_TARGET ${TARGET_NAME}.fpga)
 
 # FPGA board selection
 if(NOT DEFINED FPGA_DEVICE)
-    set(FPGA_DEVICE "Agilex 7")
+    set(FPGA_DEVICE "Agilex7")
     message(STATUS "FPGA_DEVICE was not specified.\
                     \nConfiguring the design to the default FPGA family: ${FPGA_DEVICE}\
                     \nPlease refer to the README for information on target selection.")

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/optimization_levels/minimum_latency/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/optimization_levels/minimum_latency/README.md
@@ -23,7 +23,7 @@ This FPGA tutorial demonstrates how to compile your design with the minimum late
 | Optimized for                     | Description
 |:---                               |:---
 | OS                                | Ubuntu* 18.04/20.04 <br> RHEL*/CentOS* 8 <br> SUSE* 15 <br> Windows* 10
-| Hardware                          | Intel® Agilex 7®, Arria® 10, and Stratix® 10 FPGAs
+| Hardware                          | Intel® Agilex® 7, Arria® 10, and Stratix® 10 FPGAs
 | Software                          | Intel® oneAPI DPC++/C++ Compiler
 
 This sample is part of the FPGA code samples.
@@ -54,7 +54,7 @@ This FPGA tutorial demonstrates how to use the minimum latency flow to compile l
 To compile your design with the minimum latency flow, pass the `-Xsoptimize=latency` flag to the `icpx` command.
 
 The minimum latency flow implies the following compiler controls:
-- Disable hyper-optimized handshaking on Intel Stratix® 10 and Intel Agilex 7&trade; devices
+- Disable hyper-optimized handshaking on Intel Stratix® 10 and Intel Agilex® 7 devices
 - Use zero-latency stall-free clusters exit FIFO
 - Disable loop speculation
 - Remove the 1-cycle delay on the pipelined loop limiter
@@ -108,7 +108,7 @@ Part 3 also compiles the design with the minimum latency flow, as well as manual
    mkdir build
    cd build
    ```
-   To compile for the default target (the Agilex 7® device family), run `cmake` using the command:
+   To compile for the default target (the Agilex® 7 device family), run `cmake` using the command:
    ```
    cmake ..
    ```
@@ -159,7 +159,7 @@ Part 3 also compiles the design with the minimum latency flow, as well as manual
    mkdir build
    cd build
    ```
-   To compile for the default target (the Agilex 7® device family), run `cmake` using the command:
+   To compile for the default target (the Agilex® 7 device family), run `cmake` using the command:
    ```
    cmake -G "NMake Makefiles" ..
    ```
@@ -271,7 +271,7 @@ PASSED: all kernel results are correct
 
 ### Discussion of Results
 
-Comparing to Intel Arria® 10 GX FPGA, it is more notable on Intel Stratix® 10 SX FPGA that the minimum latency flow significantly reduces the latency, along with the f<sub>MAX</sub> and the throughput. That is because the minimum latency flow disables the hyper-optimized handshaking, which achieves higher f<sub>MAX</sub> at the cost of increased latency. For more information on the hyper-optimized handshaking protocol on Intel Stratix® 10 and Intel Agilex 7&trade; devices, see [Modify the Handshaking Protocol Between Clusters](https://www.intel.com/content/www/us/en/develop/documentation/oneapi-fpga-optimization-guide/top/flags-attr-prag-ext/optimization-flags/hyper-opt-handshaking.html).
+Comparing to Intel Arria® 10 GX FPGA, it is more notable on Intel Stratix® 10 SX FPGA that the minimum latency flow significantly reduces the latency, along with the f<sub>MAX</sub> and the throughput. That is because the minimum latency flow disables the hyper-optimized handshaking, which achieves higher f<sub>MAX</sub> at the cost of increased latency. For more information on the hyper-optimized handshaking protocol on Intel Stratix® 10 and Intel Agilex® 7 devices, see [Modify the Handshaking Protocol Between Clusters](https://www.intel.com/content/www/us/en/develop/documentation/oneapi-fpga-optimization-guide/top/flags-attr-prag-ext/optimization-flags/hyper-opt-handshaking.html).
 
 ## License
 

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/optimization_levels/minimum_latency/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/optimization_levels/minimum_latency/README.md
@@ -23,7 +23,7 @@ This FPGA tutorial demonstrates how to compile your design with the minimum late
 | Optimized for                     | Description
 |:---                               |:---
 | OS                                | Ubuntu* 18.04/20.04 <br> RHEL*/CentOS* 8 <br> SUSE* 15 <br> Windows* 10
-| Hardware                          | Intel® Agilex®, Arria® 10, and Stratix® 10 FPGAs
+| Hardware                          | Intel® Agilex 7®, Arria® 10, and Stratix® 10 FPGAs
 | Software                          | Intel® oneAPI DPC++/C++ Compiler
 
 This sample is part of the FPGA code samples.
@@ -54,7 +54,7 @@ This FPGA tutorial demonstrates how to use the minimum latency flow to compile l
 To compile your design with the minimum latency flow, pass the `-Xsoptimize=latency` flag to the `icpx` command.
 
 The minimum latency flow implies the following compiler controls:
-- Disable hyper-optimized handshaking on Intel Stratix® 10 and Intel Agilex&trade; devices
+- Disable hyper-optimized handshaking on Intel Stratix® 10 and Intel Agilex 7&trade; devices
 - Use zero-latency stall-free clusters exit FIFO
 - Disable loop speculation
 - Remove the 1-cycle delay on the pipelined loop limiter
@@ -86,8 +86,8 @@ Part 3 also compiles the design with the minimum latency flow, as well as manual
 
 ## Building the `minimum_latency` Tutorial
 
-> **Note**: When working with the command-line interface (CLI), you should configure the oneAPI toolkits using environment variables. 
-> Set up your CLI environment by sourcing the `setvars` script located in the root of your oneAPI installation every time you open a new terminal window. 
+> **Note**: When working with the command-line interface (CLI), you should configure the oneAPI toolkits using environment variables.
+> Set up your CLI environment by sourcing the `setvars` script located in the root of your oneAPI installation every time you open a new terminal window.
 > This practice ensures that your compiler, libraries, and tools are ready for development.
 >
 > Linux*:
@@ -108,7 +108,7 @@ Part 3 also compiles the design with the minimum latency flow, as well as manual
    mkdir build
    cd build
    ```
-   To compile for the default target (the Agilex® device family), run `cmake` using the command:
+   To compile for the default target (the Agilex 7® device family), run `cmake` using the command:
    ```
    cmake ..
    ```
@@ -159,7 +159,7 @@ Part 3 also compiles the design with the minimum latency flow, as well as manual
    mkdir build
    cd build
    ```
-   To compile for the default target (the Agilex® device family), run `cmake` using the command:
+   To compile for the default target (the Agilex 7® device family), run `cmake` using the command:
    ```
    cmake -G "NMake Makefiles" ..
    ```
@@ -271,7 +271,7 @@ PASSED: all kernel results are correct
 
 ### Discussion of Results
 
-Comparing to Intel Arria® 10 GX FPGA, it is more notable on Intel Stratix® 10 SX FPGA that the minimum latency flow significantly reduces the latency, along with the f<sub>MAX</sub> and the throughput. That is because the minimum latency flow disables the hyper-optimized handshaking, which achieves higher f<sub>MAX</sub> at the cost of increased latency. For more information on the hyper-optimized handshaking protocol on Intel Stratix® 10 and Intel Agilex&trade; devices, see [Modify the Handshaking Protocol Between Clusters](https://www.intel.com/content/www/us/en/develop/documentation/oneapi-fpga-optimization-guide/top/flags-attr-prag-ext/optimization-flags/hyper-opt-handshaking.html).
+Comparing to Intel Arria® 10 GX FPGA, it is more notable on Intel Stratix® 10 SX FPGA that the minimum latency flow significantly reduces the latency, along with the f<sub>MAX</sub> and the throughput. That is because the minimum latency flow disables the hyper-optimized handshaking, which achieves higher f<sub>MAX</sub> at the cost of increased latency. For more information on the hyper-optimized handshaking protocol on Intel Stratix® 10 and Intel Agilex 7&trade; devices, see [Modify the Handshaking Protocol Between Clusters](https://www.intel.com/content/www/us/en/develop/documentation/oneapi-fpga-optimization-guide/top/flags-attr-prag-ext/optimization-flags/hyper-opt-handshaking.html).
 
 ## License
 

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/optimization_levels/minimum_latency/src/CMakeLists.txt
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/optimization_levels/minimum_latency/src/CMakeLists.txt
@@ -19,8 +19,8 @@ set(FPGA_TARGET_MANUAL_REVERT ${TARGET_NAME_MANUAL_REVERT}.fpga)
 
 # FPGA board selection
 if(NOT DEFINED FPGA_DEVICE)
-    set(FPGA_DEVICE "Agilex")
-    set(DEVICE_FLAG "Agilex")
+    set(FPGA_DEVICE "Agilex 7")
+    set(DEVICE_FLAG "Agilex 7")
     set(MANUAL_REVERT_FLAGS "-Xshyper-optimized-handshaking=on -Xssfc-exit-fifo-type=default")
     message(STATUS "FPGA_DEVICE was not specified.\
                     \nConfiguring the design to the default FPGA family: ${FPGA_DEVICE}\
@@ -34,7 +34,7 @@ else()
         set(DEVICE_FLAG "S10")
         set(MANUAL_REVERT_FLAGS "-Xshyper-optimized-handshaking=on -Xssfc-exit-fifo-type=default")
     elseif(FPGA_DEVICE_NAME MATCHES ".*agilex*")
-        set(DEVICE_FLAG "Agilex")
+        set(DEVICE_FLAG "Agilex 7")
         set(MANUAL_REVERT_FLAGS "-Xshyper-optimized-handshaking=on -Xssfc-exit-fifo-type=default")
     endif()
     message(STATUS "Configuring the design with the following target: ${FPGA_DEVICE}")
@@ -43,7 +43,7 @@ endif()
 if(NOT DEFINED DEVICE_FLAG)
     message(FATAL_ERROR "An unrecognized or custom board was passed, but DEVICE_FLAG was not specified. \
                          Please make sure you have set -DDEVICE_FLAG=A10, -DDEVICE_FLAG=S10 or \
-                         -DDEVICE_FLAG=Agilex.")
+                         -DDEVICE_FLAG=Agilex 7.")
 endif()
 
 # This is a Windows-specific flag that enables exception handling in host code

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/optimization_levels/minimum_latency/src/CMakeLists.txt
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/optimization_levels/minimum_latency/src/CMakeLists.txt
@@ -19,8 +19,8 @@ set(FPGA_TARGET_MANUAL_REVERT ${TARGET_NAME_MANUAL_REVERT}.fpga)
 
 # FPGA board selection
 if(NOT DEFINED FPGA_DEVICE)
-    set(FPGA_DEVICE "Agilex 7")
-    set(DEVICE_FLAG "Agilex 7")
+    set(FPGA_DEVICE "Agilex7")
+    set(DEVICE_FLAG "Agilex7")
     set(MANUAL_REVERT_FLAGS "-Xshyper-optimized-handshaking=on -Xssfc-exit-fifo-type=default")
     message(STATUS "FPGA_DEVICE was not specified.\
                     \nConfiguring the design to the default FPGA family: ${FPGA_DEVICE}\
@@ -34,7 +34,7 @@ else()
         set(DEVICE_FLAG "S10")
         set(MANUAL_REVERT_FLAGS "-Xshyper-optimized-handshaking=on -Xssfc-exit-fifo-type=default")
     elseif(FPGA_DEVICE_NAME MATCHES ".*agilex*")
-        set(DEVICE_FLAG "Agilex 7")
+        set(DEVICE_FLAG "Agilex7")
         set(MANUAL_REVERT_FLAGS "-Xshyper-optimized-handshaking=on -Xssfc-exit-fifo-type=default")
     endif()
     message(STATUS "Configuring the design with the following target: ${FPGA_DEVICE}")
@@ -43,7 +43,7 @@ endif()
 if(NOT DEFINED DEVICE_FLAG)
     message(FATAL_ERROR "An unrecognized or custom board was passed, but DEVICE_FLAG was not specified. \
                          Please make sure you have set -DDEVICE_FLAG=A10, -DDEVICE_FLAG=S10 or \
-                         -DDEVICE_FLAG=Agilex 7.")
+                         -DDEVICE_FLAG=Agilex7.")
 endif()
 
 # This is a Windows-specific flag that enables exception handling in host code

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/pipes/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/pipes/README.md
@@ -4,7 +4,7 @@ This FPGA tutorial shows how to use pipes to transfer data between kernels.
 | Optimized for                     | Description
 ---                                 |---
 | OS                                | Linux* Ubuntu* 18.04/20.04 <br> RHEL*/CentOS* 8 <br> SUSE* 15 <br> Windows* 10
-| Hardware                          | Intel® Agilex 7®, Arria® 10, and Stratix® 10 FPGAs
+| Hardware                          | Intel® Agilex® 7, Arria® 10, and Stratix® 10 FPGAs
 | Software                          | Intel® oneAPI DPC++/C++ Compiler
 | What you will learn               | The basics of using SYCL*-compliant pipes extension for FPGA<br> How to declare and use pipes
 | Time to complete                  | 15 minutes
@@ -202,7 +202,7 @@ void Consumer(queue &q, buffer<int, 1> &output_buffer) {
   mkdir build
   cd build
   ```
-  To compile for the default target (the Agilex 7® device family), run `cmake` using the command:
+  To compile for the default target (the Agilex® 7 device family), run `cmake` using the command:
   ```
   cmake ..
   ```
@@ -244,7 +244,7 @@ void Consumer(queue &q, buffer<int, 1> &output_buffer) {
   mkdir build
   cd build
   ```
-  To compile for the default target (the Agilex 7® device family), run `cmake` using the command:
+  To compile for the default target (the Agilex® 7 device family), run `cmake` using the command:
   ```
   cmake -G "NMake Makefiles" ..
   ```

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/pipes/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/pipes/README.md
@@ -4,7 +4,7 @@ This FPGA tutorial shows how to use pipes to transfer data between kernels.
 | Optimized for                     | Description
 ---                                 |---
 | OS                                | Linux* Ubuntu* 18.04/20.04 <br> RHEL*/CentOS* 8 <br> SUSE* 15 <br> Windows* 10
-| Hardware                          | Intel® Agilex®, Arria® 10, and Stratix® 10 FPGAs
+| Hardware                          | Intel® Agilex 7®, Arria® 10, and Stratix® 10 FPGAs
 | Software                          | Intel® oneAPI DPC++/C++ Compiler
 | What you will learn               | The basics of using SYCL*-compliant pipes extension for FPGA<br> How to declare and use pipes
 | Time to complete                  | 15 minutes
@@ -31,9 +31,9 @@ flowchart LR
    tier2("Tier 2: Explore the Fundamentals")
    tier3("Tier 3: Explore the Advanced Techniques")
    tier4("Tier 4: Explore the Reference Designs")
-   
+
    tier1 --> tier2 --> tier3 --> tier4
-   
+
    style tier1 fill:#0071c1,stroke:#0071c1,stroke-width:1px,color:#fff
    style tier2 fill:#f96,stroke:#333,stroke-width:1px,color:#fff
    style tier3 fill:#0071c1,stroke:#0071c1,stroke-width:1px,color:#fff
@@ -180,8 +180,8 @@ void Consumer(queue &q, buffer<int, 1> &output_buffer) {
 
 ## Building the `pipes` Tutorial
 
-> **Note**: When working with the command-line interface (CLI), you should configure the oneAPI toolkits using environment variables. 
-> Set up your CLI environment by sourcing the `setvars` script located in the root of your oneAPI installation every time you open a new terminal window. 
+> **Note**: When working with the command-line interface (CLI), you should configure the oneAPI toolkits using environment variables.
+> Set up your CLI environment by sourcing the `setvars` script located in the root of your oneAPI installation every time you open a new terminal window.
 > This practice ensures that your compiler, libraries, and tools are ready for development.
 >
 > Linux*:
@@ -202,7 +202,7 @@ void Consumer(queue &q, buffer<int, 1> &output_buffer) {
   mkdir build
   cd build
   ```
-  To compile for the default target (the Agilex® device family), run `cmake` using the command:
+  To compile for the default target (the Agilex 7® device family), run `cmake` using the command:
   ```
   cmake ..
   ```
@@ -210,12 +210,12 @@ void Consumer(queue &q, buffer<int, 1> &output_buffer) {
   > **Note**: You can change the default target by using the command:
   >  ```
   >  cmake .. -DFPGA_DEVICE=<FPGA device family or FPGA part number>
-  >  ``` 
+  >  ```
   >
-  > Alternatively, you can target an explicit FPGA board variant and BSP by using the following command: 
+  > Alternatively, you can target an explicit FPGA board variant and BSP by using the following command:
   >  ```
   >  cmake .. -DFPGA_DEVICE=<board-support-package>:<board-variant>
-  >  ``` 
+  >  ```
   >
   > You will only be able to run an executable on the FPGA if you specified a BSP.
 2. Compile the design through the generated `Makefile`. The following build targets are provided, matching the recommended development flow:
@@ -244,19 +244,19 @@ void Consumer(queue &q, buffer<int, 1> &output_buffer) {
   mkdir build
   cd build
   ```
-  To compile for the default target (the Agilex® device family), run `cmake` using the command:
+  To compile for the default target (the Agilex 7® device family), run `cmake` using the command:
   ```
   cmake -G "NMake Makefiles" ..
   ```
   > **Note**: You can change the default target by using the command:
   >  ```
   >  cmake -G "NMake Makefiles" .. -DFPGA_DEVICE=<FPGA device family or FPGA part number>
-  >  ``` 
+  >  ```
   >
-  > Alternatively, you can target an explicit FPGA board variant and BSP by using the following command: 
+  > Alternatively, you can target an explicit FPGA board variant and BSP by using the following command:
   >  ```
   >  cmake -G "NMake Makefiles" .. -DFPGA_DEVICE=<board-support-package>:<board-variant>
-  >  ``` 
+  >  ```
   >
   > You will only be able to run an executable on the FPGA if you specified a BSP.
 

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/pipes/src/CMakeLists.txt
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/pipes/src/CMakeLists.txt
@@ -6,7 +6,7 @@ set(FPGA_TARGET ${TARGET_NAME}.fpga)
 
 # FPGA board selection
 if(NOT DEFINED FPGA_DEVICE)
-    set(FPGA_DEVICE "Agilex")
+    set(FPGA_DEVICE "Agilex 7")
     message(STATUS "FPGA_DEVICE was not specified.\
                     \nConfiguring the design to the default FPGA family: ${FPGA_DEVICE}\
                     \nPlease refer to the README for information on target selection.")

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/pipes/src/CMakeLists.txt
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/pipes/src/CMakeLists.txt
@@ -6,7 +6,7 @@ set(FPGA_TARGET ${TARGET_NAME}.fpga)
 
 # FPGA board selection
 if(NOT DEFINED FPGA_DEVICE)
-    set(FPGA_DEVICE "Agilex 7")
+    set(FPGA_DEVICE "Agilex7")
     message(STATUS "FPGA_DEVICE was not specified.\
                     \nConfiguring the design to the default FPGA family: ${FPGA_DEVICE}\
                     \nPlease refer to the README for information on target selection.")

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/printf/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/printf/README.md
@@ -5,7 +5,7 @@ This FPGA tutorial explains how to use the `sycl::ext::oneapi::experimental::pri
 | Optimized for                     | Description
 |:---                               |:---
 | OS                                | Linux* Ubuntu* 18.04/20.04 <br> RHEL*/CentOS* 8 <br> SUSE* 15 <br> Windows* 10
-| Hardware                          | Intel® Agilex®, Arria® 10, and Stratix® 10 FPGAs
+| Hardware                          | Intel® Agilex 7®, Arria® 10, and Stratix® 10 FPGAs
 | Software                          | Intel® oneAPI DPC++/C++ Compiler
 | What you will learn               | How to declare and use printf in program
 | Time to complete                  | 10 minutes
@@ -32,9 +32,9 @@ flowchart LR
    tier2("Tier 2: Explore the Fundamentals")
    tier3("Tier 3: Explore the Advanced Techniques")
    tier4("Tier 4: Explore the Reference Designs")
-   
+
    tier1 --> tier2 --> tier3 --> tier4
-   
+
    style tier1 fill:#0071c1,stroke:#0071c1,stroke-width:1px,color:#fff
    style tier2 fill:#f96,stroke:#333,stroke-width:1px,color:#fff
    style tier3 fill:#0071c1,stroke:#0071c1,stroke-width:1px,color:#fff
@@ -85,8 +85,8 @@ PRINTF("Hello: %d\n", 123);
 
 ## Building the `printf` Tutorial
 
-> **Note**: When working with the command-line interface (CLI), you should configure the oneAPI toolkits using environment variables. 
-> Set up your CLI environment by sourcing the `setvars` script located in the root of your oneAPI installation every time you open a new terminal window. 
+> **Note**: When working with the command-line interface (CLI), you should configure the oneAPI toolkits using environment variables.
+> Set up your CLI environment by sourcing the `setvars` script located in the root of your oneAPI installation every time you open a new terminal window.
 > This practice ensures that your compiler, libraries, and tools are ready for development.
 >
 > Linux*:
@@ -107,7 +107,7 @@ PRINTF("Hello: %d\n", 123);
     mkdir build
     cd build
     ```
-    To compile for the default target (the Agilex® device family), run `cmake` using the command:
+    To compile for the default target (the Agilex 7® device family), run `cmake` using the command:
     ```
     cmake ..
     ```
@@ -115,12 +115,12 @@ PRINTF("Hello: %d\n", 123);
     > **Note**: You can change the default target by using the command:
     >  ```
     >  cmake .. -DFPGA_DEVICE=<FPGA device family or FPGA part number>
-    >  ``` 
+    >  ```
     >
-    > Alternatively, you can target an explicit FPGA board variant and BSP by using the following command: 
+    > Alternatively, you can target an explicit FPGA board variant and BSP by using the following command:
     >  ```
     >  cmake .. -DFPGA_DEVICE=<board-support-package>:<board-variant> -DIS_BSP=1
-    >  ``` 
+    >  ```
     >
     > You will only be able to run an executable on the FPGA if you specified a BSP.
 
@@ -150,19 +150,19 @@ PRINTF("Hello: %d\n", 123);
     mkdir build
     cd build
     ```
-    To compile for the default target (the Agilex® device family), run `cmake` using the command:
+    To compile for the default target (the Agilex 7® device family), run `cmake` using the command:
     ```
     cmake -G "NMake Makefiles" ..
     ```
     > **Note**: You can change the default target by using the command:
     >  ```
     >  cmake -G "NMake Makefiles" .. -DFPGA_DEVICE=<FPGA device family or FPGA part number>
-    >  ``` 
+    >  ```
     >
-    > Alternatively, you can target an explicit FPGA board variant and BSP by using the following command: 
+    > Alternatively, you can target an explicit FPGA board variant and BSP by using the following command:
     >  ```
     >  cmake -G "NMake Makefiles" .. -DFPGA_DEVICE=<board-support-package>:<board-variant> -DIS_BSP=1
-    >  ``` 
+    >  ```
     >
     > You will only be able to run an executable on the FPGA if you specified a BSP.
 

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/printf/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/printf/README.md
@@ -5,7 +5,7 @@ This FPGA tutorial explains how to use the `sycl::ext::oneapi::experimental::pri
 | Optimized for                     | Description
 |:---                               |:---
 | OS                                | Linux* Ubuntu* 18.04/20.04 <br> RHEL*/CentOS* 8 <br> SUSE* 15 <br> Windows* 10
-| Hardware                          | Intel® Agilex 7®, Arria® 10, and Stratix® 10 FPGAs
+| Hardware                          | Intel® Agilex® 7, Arria® 10, and Stratix® 10 FPGAs
 | Software                          | Intel® oneAPI DPC++/C++ Compiler
 | What you will learn               | How to declare and use printf in program
 | Time to complete                  | 10 minutes
@@ -107,7 +107,7 @@ PRINTF("Hello: %d\n", 123);
     mkdir build
     cd build
     ```
-    To compile for the default target (the Agilex 7® device family), run `cmake` using the command:
+    To compile for the default target (the Agilex® 7 device family), run `cmake` using the command:
     ```
     cmake ..
     ```
@@ -150,7 +150,7 @@ PRINTF("Hello: %d\n", 123);
     mkdir build
     cd build
     ```
-    To compile for the default target (the Agilex 7® device family), run `cmake` using the command:
+    To compile for the default target (the Agilex® 7 device family), run `cmake` using the command:
     ```
     cmake -G "NMake Makefiles" ..
     ```

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/printf/src/CMakeLists.txt
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/printf/src/CMakeLists.txt
@@ -6,7 +6,7 @@ set(FPGA_TARGET ${TARGET_NAME}.fpga)
 
 # FPGA board selection
 if(NOT DEFINED FPGA_DEVICE)
-    set(FPGA_DEVICE "Agilex 7")
+    set(FPGA_DEVICE "Agilex7")
     message(STATUS "FPGA_DEVICE was not specified.\
                     \nConfiguring the design to the default FPGA family: ${FPGA_DEVICE}\
                     \nPlease refer to the README for information on target selection.")

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/printf/src/CMakeLists.txt
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/printf/src/CMakeLists.txt
@@ -6,7 +6,7 @@ set(FPGA_TARGET ${TARGET_NAME}.fpga)
 
 # FPGA board selection
 if(NOT DEFINED FPGA_DEVICE)
-    set(FPGA_DEVICE "Agilex")
+    set(FPGA_DEVICE "Agilex 7")
     message(STATUS "FPGA_DEVICE was not specified.\
                     \nConfiguring the design to the default FPGA family: ${FPGA_DEVICE}\
                     \nPlease refer to the README for information on target selection.")
@@ -59,7 +59,7 @@ set_target_properties(${EMULATOR_TARGET} PROPERTIES COMPILE_FLAGS "${EMULATOR_CO
 set_target_properties(${EMULATOR_TARGET} PROPERTIES LINK_FLAGS "${EMULATOR_LINK_FLAGS}")
 add_custom_target(fpga_emu DEPENDS ${EMULATOR_TARGET})
 
-# The HW related targets are only supported if an BSP is being targeted 
+# The HW related targets are only supported if an BSP is being targeted
 if(IS_BSP STREQUAL "1")
 ###############################################################################
 ### FPGA Simulator

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/private_copies/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/private_copies/README.md
@@ -4,7 +4,7 @@ This FPGA tutorial explains how to use the `private_copies` attribute to trade o
 | Optimized for                     | Description
 |:---                               |:---
 | OS                                | Linux* Ubuntu* 18.04/20.04 <br> RHEL*/CentOS* 8 <br> SUSE* 15 <br> Windows* 10
-| Hardware                          | Intel® Agilex 7®, Arria® 10, and Stratix® 10 FPGAs
+| Hardware                          | Intel® Agilex® 7, Arria® 10, and Stratix® 10 FPGAs
 | Software                          | Intel® oneAPI DPC++/C++ Compiler
 | What you will learn               | The basic usage of the `private_copies` attribute <br> How the `private_copies` attribute affects the throughput and resource use of your FPGA program <br> How to apply the `private_copies` attribute to variables or arrays in your program <br> How to identify the correct `private_copies` factor for your program
 | Time to complete                  | 15 minutes
@@ -108,7 +108,7 @@ A typical design flow may be to:
   mkdir build
   cd build
   ```
-  To compile for the default target (the Agilex 7® device family), run `cmake` using the command:
+  To compile for the default target (the Agilex® 7 device family), run `cmake` using the command:
   ```
   cmake ..
   ```
@@ -151,7 +151,7 @@ A typical design flow may be to:
   mkdir build
   cd build
   ```
-  To compile for the default target (the Agilex 7® device family), run `cmake` using the command:
+  To compile for the default target (the Agilex® 7 device family), run `cmake` using the command:
   ```
   cmake -G "NMake Makefiles" ..
   ```

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/private_copies/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/private_copies/README.md
@@ -4,7 +4,7 @@ This FPGA tutorial explains how to use the `private_copies` attribute to trade o
 | Optimized for                     | Description
 |:---                               |:---
 | OS                                | Linux* Ubuntu* 18.04/20.04 <br> RHEL*/CentOS* 8 <br> SUSE* 15 <br> Windows* 10
-| Hardware                          | Intel® Agilex®, Arria® 10, and Stratix® 10 FPGAs
+| Hardware                          | Intel® Agilex 7®, Arria® 10, and Stratix® 10 FPGAs
 | Software                          | Intel® oneAPI DPC++/C++ Compiler
 | What you will learn               | The basic usage of the `private_copies` attribute <br> How the `private_copies` attribute affects the throughput and resource use of your FPGA program <br> How to apply the `private_copies` attribute to variables or arrays in your program <br> How to identify the correct `private_copies` factor for your program
 | Time to complete                  | 15 minutes
@@ -31,9 +31,9 @@ flowchart LR
    tier2("Tier 2: Explore the Fundamentals")
    tier3("Tier 3: Explore the Advanced Techniques")
    tier4("Tier 4: Explore the Reference Designs")
-   
+
    tier1 --> tier2 --> tier3 --> tier4
-   
+
    style tier1 fill:#0071c1,stroke:#0071c1,stroke-width:1px,color:#fff
    style tier2 fill:#0071c1,stroke:#0071c1,stroke-width:1px,color:#fff
    style tier3 fill:#f96,stroke:#333,stroke-width:1px,color:#fff
@@ -86,8 +86,8 @@ A typical design flow may be to:
 
 ## Building the `private_copies` Tutorial
 
-> **Note**: When working with the command-line interface (CLI), you should configure the oneAPI toolkits using environment variables. 
-> Set up your CLI environment by sourcing the `setvars` script located in the root of your oneAPI installation every time you open a new terminal window. 
+> **Note**: When working with the command-line interface (CLI), you should configure the oneAPI toolkits using environment variables.
+> Set up your CLI environment by sourcing the `setvars` script located in the root of your oneAPI installation every time you open a new terminal window.
 > This practice ensures that your compiler, libraries, and tools are ready for development.
 >
 > Linux*:
@@ -108,7 +108,7 @@ A typical design flow may be to:
   mkdir build
   cd build
   ```
-  To compile for the default target (the Agilex® device family), run `cmake` using the command:
+  To compile for the default target (the Agilex 7® device family), run `cmake` using the command:
   ```
   cmake ..
   ```
@@ -116,12 +116,12 @@ A typical design flow may be to:
   > **Note**: You can change the default target by using the command:
   >  ```
   >  cmake .. -DFPGA_DEVICE=<FPGA device family or FPGA part number>
-  >  ``` 
+  >  ```
   >
-  > Alternatively, you can target an explicit FPGA board variant and BSP by using the following command: 
+  > Alternatively, you can target an explicit FPGA board variant and BSP by using the following command:
   >  ```
   >  cmake .. -DFPGA_DEVICE=<board-support-package>:<board-variant>
-  >  ``` 
+  >  ```
   >
   > You will only be able to run an executable on the FPGA if you specified a BSP.
 
@@ -151,19 +151,19 @@ A typical design flow may be to:
   mkdir build
   cd build
   ```
-  To compile for the default target (the Agilex® device family), run `cmake` using the command:
+  To compile for the default target (the Agilex 7® device family), run `cmake` using the command:
   ```
   cmake -G "NMake Makefiles" ..
   ```
   > **Note**: You can change the default target by using the command:
   >  ```
   >  cmake -G "NMake Makefiles" .. -DFPGA_DEVICE=<FPGA device family or FPGA part number>
-  >  ``` 
+  >  ```
   >
-  > Alternatively, you can target an explicit FPGA board variant and BSP by using the following command: 
+  > Alternatively, you can target an explicit FPGA board variant and BSP by using the following command:
   >  ```
   >  cmake -G "NMake Makefiles" .. -DFPGA_DEVICE=<board-support-package>:<board-variant>
-  >  ``` 
+  >  ```
   >
   > You will only be able to run an executable on the FPGA if you specified a BSP.
 

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/private_copies/src/CMakeLists.txt
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/private_copies/src/CMakeLists.txt
@@ -6,7 +6,7 @@ set(FPGA_TARGET ${TARGET_NAME}.fpga)
 
 # FPGA board selection
 if(NOT DEFINED FPGA_DEVICE)
-    set(FPGA_DEVICE "Agilex")
+    set(FPGA_DEVICE "Agilex 7")
     message(STATUS "FPGA_DEVICE was not specified.\
                     \nConfiguring the design to the default FPGA family: ${FPGA_DEVICE}\
                     \nPlease refer to the README for information on target selection.")

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/private_copies/src/CMakeLists.txt
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/private_copies/src/CMakeLists.txt
@@ -6,7 +6,7 @@ set(FPGA_TARGET ${TARGET_NAME}.fpga)
 
 # FPGA board selection
 if(NOT DEFINED FPGA_DEVICE)
-    set(FPGA_DEVICE "Agilex 7")
+    set(FPGA_DEVICE "Agilex7")
     message(STATUS "FPGA_DEVICE was not specified.\
                     \nConfiguring the design to the default FPGA family: ${FPGA_DEVICE}\
                     \nPlease refer to the README for information on target selection.")

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/read_only_cache/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/read_only_cache/README.md
@@ -6,7 +6,7 @@ memory in a non-contiguous manner.
 | Optimized for                     | Description
 |:---                               |:---
 | OS                                | Linux* Ubuntu* 18.04/20.04 <br> RHEL*/CentOS* 8 <br> SUSE* 15 <br> Windows* 10
-| Hardware                          | Intel® Agilex 7®, Arria® 10, and Stratix® 10 FPGAs
+| Hardware                          | Intel® Agilex® 7, Arria® 10, and Stratix® 10 FPGAs
 | Software                          | Intel® oneAPI DPC++/C++ Compiler
 | What you will learn               | How and when to use the read-only cache feature
 | Time to complete                  | 30 minutes
@@ -115,7 +115,7 @@ size of the cache is `512*4 bytes = 2048 bytes`, and so, the flag
   mkdir build
   cd build
   ```
-  To compile for the default target (the Agilex 7® device family), run `cmake` using the command:
+  To compile for the default target (the Agilex® 7 device family), run `cmake` using the command:
   ```
   cmake ..
   ```
@@ -159,7 +159,7 @@ size of the cache is `512*4 bytes = 2048 bytes`, and so, the flag
   mkdir build
   cd build
   ```
-  To compile for the default target (the Agilex 7® device family), run `cmake` using the command:
+  To compile for the default target (the Agilex® 7 device family), run `cmake` using the command:
   ```
   cmake -G "NMake Makefiles" ..
   ```

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/read_only_cache/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/read_only_cache/README.md
@@ -6,7 +6,7 @@ memory in a non-contiguous manner.
 | Optimized for                     | Description
 |:---                               |:---
 | OS                                | Linux* Ubuntu* 18.04/20.04 <br> RHEL*/CentOS* 8 <br> SUSE* 15 <br> Windows* 10
-| Hardware                          | Intel® Agilex®, Arria® 10, and Stratix® 10 FPGAs
+| Hardware                          | Intel® Agilex 7®, Arria® 10, and Stratix® 10 FPGAs
 | Software                          | Intel® oneAPI DPC++/C++ Compiler
 | What you will learn               | How and when to use the read-only cache feature
 | Time to complete                  | 30 minutes
@@ -33,9 +33,9 @@ flowchart LR
    tier2("Tier 2: Explore the Fundamentals")
    tier3("Tier 3: Explore the Advanced Techniques")
    tier4("Tier 4: Explore the Reference Designs")
-   
+
    tier1 --> tier2 --> tier3 --> tier4
-   
+
    style tier1 fill:#0071c1,stroke:#0071c1,stroke-width:1px,color:#fff
    style tier2 fill:#0071c1,stroke:#0071c1,stroke-width:1px,color:#fff
    style tier3 fill:#f96,stroke:#333,stroke-width:1px,color:#fff
@@ -93,8 +93,8 @@ size of the cache is `512*4 bytes = 2048 bytes`, and so, the flag
 
 ## Building the `read_only_cache` Tutorial
 
-> **Note**: When working with the command-line interface (CLI), you should configure the oneAPI toolkits using environment variables. 
-> Set up your CLI environment by sourcing the `setvars` script located in the root of your oneAPI installation every time you open a new terminal window. 
+> **Note**: When working with the command-line interface (CLI), you should configure the oneAPI toolkits using environment variables.
+> Set up your CLI environment by sourcing the `setvars` script located in the root of your oneAPI installation every time you open a new terminal window.
 > This practice ensures that your compiler, libraries, and tools are ready for development.
 >
 > Linux*:
@@ -115,7 +115,7 @@ size of the cache is `512*4 bytes = 2048 bytes`, and so, the flag
   mkdir build
   cd build
   ```
-  To compile for the default target (the Agilex® device family), run `cmake` using the command:
+  To compile for the default target (the Agilex 7® device family), run `cmake` using the command:
   ```
   cmake ..
   ```
@@ -123,12 +123,12 @@ size of the cache is `512*4 bytes = 2048 bytes`, and so, the flag
   > **Note**: You can change the default target by using the command:
   >  ```
   >  cmake .. -DFPGA_DEVICE=<FPGA device family or FPGA part number>
-  >  ``` 
+  >  ```
   >
-  > Alternatively, you can target an explicit FPGA board variant and BSP by using the following command: 
+  > Alternatively, you can target an explicit FPGA board variant and BSP by using the following command:
   >  ```
   >  cmake .. -DFPGA_DEVICE=<board-support-package>:<board-variant>
-  >  ``` 
+  >  ```
   >
   > You will only be able to run an executable on the FPGA if you specified a BSP.
 
@@ -159,19 +159,19 @@ size of the cache is `512*4 bytes = 2048 bytes`, and so, the flag
   mkdir build
   cd build
   ```
-  To compile for the default target (the Agilex® device family), run `cmake` using the command:
+  To compile for the default target (the Agilex 7® device family), run `cmake` using the command:
   ```
   cmake -G "NMake Makefiles" ..
   ```
   > **Note**: You can change the default target by using the command:
   >  ```
   >  cmake -G "NMake Makefiles" .. -DFPGA_DEVICE=<FPGA device family or FPGA part number>
-  >  ``` 
+  >  ```
   >
-  > Alternatively, you can target an explicit FPGA board variant and BSP by using the following command: 
+  > Alternatively, you can target an explicit FPGA board variant and BSP by using the following command:
   >  ```
   >  cmake -G "NMake Makefiles" .. -DFPGA_DEVICE=<board-support-package>:<board-variant>
-  >  ``` 
+  >  ```
   >
   > You will only be able to run an executable on the FPGA if you specified a BSP.
 
@@ -232,10 +232,10 @@ cache has been created.
     read_only_cache.fpga_sim.exe
     set CL_CONTEXT_MPSIM_DEVICE_INTELFPGA=
     ```
-    
-    Note although the circuit for the read-only cache is implemented in 
-    simulation, one cannot see consistent performance increase with the cache 
-    enabled as each clock cycle in the simulator doesn't have a consistent 
+
+    Note although the circuit for the read-only cache is implemented in
+    simulation, one cannot see consistent performance increase with the cache
+    enabled as each clock cycle in the simulator doesn't have a consistent
     latency, as it does in the hardware. For this reason there is just a single
     executable for this flow.
 3. Run the sample on the FPGA device (only if you ran `cmake` with `-DFPGA_DEVICE=<board-support-package>:<board-variant>`):

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/read_only_cache/src/CMakeLists.txt
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/read_only_cache/src/CMakeLists.txt
@@ -7,7 +7,7 @@ set(FPGA_TARGET_CACHE_ENABLED ${TARGET_NAME}_enabled.fpga)
 
 # FPGA board selection
 if(NOT DEFINED FPGA_DEVICE)
-    set(FPGA_DEVICE "Agilex 7")
+    set(FPGA_DEVICE "Agilex7")
     message(STATUS "FPGA_DEVICE was not specified.\
                     \nConfiguring the design to the default FPGA family: ${FPGA_DEVICE}\
                     \nPlease refer to the README for information on target selection.")

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/read_only_cache/src/CMakeLists.txt
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/read_only_cache/src/CMakeLists.txt
@@ -7,7 +7,7 @@ set(FPGA_TARGET_CACHE_ENABLED ${TARGET_NAME}_enabled.fpga)
 
 # FPGA board selection
 if(NOT DEFINED FPGA_DEVICE)
-    set(FPGA_DEVICE "Agilex")
+    set(FPGA_DEVICE "Agilex 7")
     message(STATUS "FPGA_DEVICE was not specified.\
                     \nConfiguring the design to the default FPGA family: ${FPGA_DEVICE}\
                     \nPlease refer to the README for information on target selection.")

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/scheduler_target_fmax/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/scheduler_target_fmax/README.md
@@ -5,7 +5,7 @@ This tutorial explains the `scheduler_target_fmax_mhz` attribute and its effect 
 | Optimized for                     | Description
 |:---                               |:---
 | OS                                | Linux* Ubuntu* 18.04/20.04 <br> RHEL*/CentOS* 8 <br> SUSE* 15 <br> Windows* 10
-| Hardware                          | Intel® Agilex®, Arria® 10, and Stratix® 10 FPGAs
+| Hardware                          | Intel® Agilex 7®, Arria® 10, and Stratix® 10 FPGAs
 | Software                          | Intel® oneAPI DPC++/C++ Compiler
 | What you will learn               |  The behavior of the `scheduler_target_fmax_mhz` attribute and when to use it. <br> The effect this attribute can have on kernel performance on FPGA.
 | Time to complete                  | 15 minutes
@@ -32,9 +32,9 @@ flowchart LR
    tier2("Tier 2: Explore the Fundamentals")
    tier3("Tier 3: Explore the Advanced Techniques")
    tier4("Tier 4: Explore the Reference Designs")
-   
+
    tier1 --> tier2 --> tier3 --> tier4
-   
+
    style tier1 fill:#0071c1,stroke:#0071c1,stroke-width:1px,color:#fff
    style tier2 fill:#0071c1,stroke:#0071c1,stroke-width:1px,color:#fff
    style tier3 fill:#f96,stroke:#333,stroke-width:1px,color:#fff
@@ -84,8 +84,8 @@ In kernel `Fmax240IIAttr`, the `[[intel::scheduler_target_fmax_mhz(240)]]` attri
 
 ## Building the `scheduler_target_fmax` Tutorial
 
-> **Note**: When working with the command-line interface (CLI), you should configure the oneAPI toolkits using environment variables. 
-> Set up your CLI environment by sourcing the `setvars` script located in the root of your oneAPI installation every time you open a new terminal window. 
+> **Note**: When working with the command-line interface (CLI), you should configure the oneAPI toolkits using environment variables.
+> Set up your CLI environment by sourcing the `setvars` script located in the root of your oneAPI installation every time you open a new terminal window.
 > This practice ensures that your compiler, libraries, and tools are ready for development.
 >
 > Linux*:
@@ -108,7 +108,7 @@ In kernel `Fmax240IIAttr`, the `[[intel::scheduler_target_fmax_mhz(240)]]` attri
   cd build
   ```
 
-  To compile for the default target (the Agilex® device family), run `cmake` using the command:
+  To compile for the default target (the Agilex 7® device family), run `cmake` using the command:
   ```
   cmake ..
   ```
@@ -116,12 +116,12 @@ In kernel `Fmax240IIAttr`, the `[[intel::scheduler_target_fmax_mhz(240)]]` attri
   > **Note**: You can change the default target by using the command:
   >  ```
   >  cmake .. -DFPGA_DEVICE=<FPGA device family or FPGA part number>
-  >  ``` 
+  >  ```
   >
-  > Alternatively, you can target an explicit FPGA board variant and BSP by using the following command: 
+  > Alternatively, you can target an explicit FPGA board variant and BSP by using the following command:
   >  ```
   >  cmake .. -DFPGA_DEVICE=<board-support-package>:<board-variant>
-  >  ``` 
+  >  ```
   >
   > You will only be able to run an executable on the FPGA if you specified a BSP.
 
@@ -160,19 +160,19 @@ In kernel `Fmax240IIAttr`, the `[[intel::scheduler_target_fmax_mhz(240)]]` attri
   cd build
   ```
 
-  To compile for the default target (the Agilex® device family), run `cmake` using the command:
+  To compile for the default target (the Agilex 7® device family), run `cmake` using the command:
   ```
   cmake -G "NMake Makefiles" ..
   ```
   > **Note**: You can change the default target by using the command:
   >  ```
   >  cmake -G "NMake Makefiles" .. -DFPGA_DEVICE=<FPGA device family or FPGA part number>
-  >  ``` 
+  >  ```
   >
-  > Alternatively, you can target an explicit FPGA board variant and BSP by using the following command: 
+  > Alternatively, you can target an explicit FPGA board variant and BSP by using the following command:
   >  ```
   >  cmake -G "NMake Makefiles" .. -DFPGA_DEVICE=<board-support-package>:<board-variant>
-  >  ``` 
+  >  ```
   >
   > You will only be able to run an executable on the FPGA if you specified a BSP.
 

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/scheduler_target_fmax/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/scheduler_target_fmax/README.md
@@ -5,7 +5,7 @@ This tutorial explains the `scheduler_target_fmax_mhz` attribute and its effect 
 | Optimized for                     | Description
 |:---                               |:---
 | OS                                | Linux* Ubuntu* 18.04/20.04 <br> RHEL*/CentOS* 8 <br> SUSE* 15 <br> Windows* 10
-| Hardware                          | Intel® Agilex 7®, Arria® 10, and Stratix® 10 FPGAs
+| Hardware                          | Intel® Agilex® 7, Arria® 10, and Stratix® 10 FPGAs
 | Software                          | Intel® oneAPI DPC++/C++ Compiler
 | What you will learn               |  The behavior of the `scheduler_target_fmax_mhz` attribute and when to use it. <br> The effect this attribute can have on kernel performance on FPGA.
 | Time to complete                  | 15 minutes
@@ -108,7 +108,7 @@ In kernel `Fmax240IIAttr`, the `[[intel::scheduler_target_fmax_mhz(240)]]` attri
   cd build
   ```
 
-  To compile for the default target (the Agilex 7® device family), run `cmake` using the command:
+  To compile for the default target (the Agilex® 7 device family), run `cmake` using the command:
   ```
   cmake ..
   ```
@@ -160,7 +160,7 @@ In kernel `Fmax240IIAttr`, the `[[intel::scheduler_target_fmax_mhz(240)]]` attri
   cd build
   ```
 
-  To compile for the default target (the Agilex 7® device family), run `cmake` using the command:
+  To compile for the default target (the Agilex® 7 device family), run `cmake` using the command:
   ```
   cmake -G "NMake Makefiles" ..
   ```

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/scheduler_target_fmax/src/CMakeLists.txt
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/scheduler_target_fmax/src/CMakeLists.txt
@@ -6,7 +6,7 @@ set(FPGA_TARGET ${TARGET_NAME}.fpga)
 
 # FPGA board selection
 if(NOT DEFINED FPGA_DEVICE)
-    set(FPGA_DEVICE "Agilex")
+    set(FPGA_DEVICE "Agilex 7")
     message(STATUS "FPGA_DEVICE was not specified.\
                     \nConfiguring the design to the default FPGA family: ${FPGA_DEVICE}\
                     \nPlease refer to the README for information on target selection.")

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/scheduler_target_fmax/src/CMakeLists.txt
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/scheduler_target_fmax/src/CMakeLists.txt
@@ -6,7 +6,7 @@ set(FPGA_TARGET ${TARGET_NAME}.fpga)
 
 # FPGA board selection
 if(NOT DEFINED FPGA_DEVICE)
-    set(FPGA_DEVICE "Agilex 7")
+    set(FPGA_DEVICE "Agilex7")
     message(STATUS "FPGA_DEVICE was not specified.\
                     \nConfiguring the design to the default FPGA family: ${FPGA_DEVICE}\
                     \nPlease refer to the README for information on target selection.")

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/speculated_iterations/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/speculated_iterations/README.md
@@ -5,7 +5,7 @@ This FPGA tutorial demonstrates applying the `speculated_iterations` attribute t
 | Optimized for                     | Description
 |:---                               |:---
 | OS                                | Linux* Ubuntu* 18.04/20.04 <br> RHEL*/CentOS* 8 <br> SUSE* 15 <br> Windows* 10
-| Hardware                          | Intel® Agilex®, Arria® 10, and Stratix® 10 FPGAs
+| Hardware                          | Intel® Agilex 7®, Arria® 10, and Stratix® 10 FPGAs
 | Software                          | Intel® oneAPI DPC++/C++ Compiler
 | What you will learn               | What the `speculated_iterations` attribute does <br> How to apply the `speculated_iterations` attribute to loops in your program <br> How to determine the optimal number of speculated iterations
 | Time to complete                  | 15 minutes
@@ -32,9 +32,9 @@ flowchart LR
    tier2("Tier 2: Explore the Fundamentals")
    tier3("Tier 3: Explore the Advanced Techniques")
    tier4("Tier 4: Explore the Reference Designs")
-   
+
    tier1 --> tier2 --> tier3 --> tier4
-   
+
    style tier1 fill:#0071c1,stroke:#0071c1,stroke-width:1px,color:#fff
    style tier2 fill:#0071c1,stroke:#0071c1,stroke-width:1px,color:#fff
    style tier3 fill:#f96,stroke:#333,stroke-width:1px,color:#fff
@@ -80,7 +80,7 @@ In both increasing and decreasing cases, some experimentation is usually necessa
 ### Tutorial example
 In the tutorial design's kernel, the loop's exit condition involves a logarithm and a compare operation. This complex exit condition prevents the loop from achieving ```II=1```.
 
-The design enqueues variants of the kernel with 0, 10, and 27 speculated iterations, respectively, to demonstrate the effect of the `speculated_iterations` attribute on an Intel® Arria® 10 FPGA. Different numbers are chosen for the Intel® Stratix® 10 and Intel Agilex® targets accordingly.
+The design enqueues variants of the kernel with 0, 10, and 27 speculated iterations, respectively, to demonstrate the effect of the `speculated_iterations` attribute on an Intel® Arria® 10 FPGA. Different numbers are chosen for the Intel® Stratix® 10 and Intel Agilex 7® targets accordingly.
 
 ## Key Concepts
 * Description of the `speculated_iterations` attribute.
@@ -89,8 +89,8 @@ The design enqueues variants of the kernel with 0, 10, and 27 speculated iterati
 
 ## Building the `speculated_iterations` Tutorial
 
-> **Note**: When working with the command-line interface (CLI), you should configure the oneAPI toolkits using environment variables. 
-> Set up your CLI environment by sourcing the `setvars` script located in the root of your oneAPI installation every time you open a new terminal window. 
+> **Note**: When working with the command-line interface (CLI), you should configure the oneAPI toolkits using environment variables.
+> Set up your CLI environment by sourcing the `setvars` script located in the root of your oneAPI installation every time you open a new terminal window.
 > This practice ensures that your compiler, libraries, and tools are ready for development.
 >
 > Linux*:
@@ -111,7 +111,7 @@ The design enqueues variants of the kernel with 0, 10, and 27 speculated iterati
   mkdir build
   cd build
   ```
-  To compile for the default target (the Agilex® device family), run `cmake` using the command:
+  To compile for the default target (the Agilex 7® device family), run `cmake` using the command:
   ```
   cmake ..
   ```
@@ -119,12 +119,12 @@ The design enqueues variants of the kernel with 0, 10, and 27 speculated iterati
   > **Note**: You can change the default target by using the command:
   >  ```
   >  cmake .. -DFPGA_DEVICE=<FPGA device family or FPGA part number>
-  >  ``` 
+  >  ```
   >
-  > Alternatively, you can target an explicit FPGA board variant and BSP by using the following command: 
+  > Alternatively, you can target an explicit FPGA board variant and BSP by using the following command:
   >  ```
   >  cmake .. -DFPGA_DEVICE=<board-support-package>:<board-variant>
-  >  ``` 
+  >  ```
   >
   > You will only be able to run an executable on the FPGA if you specified a BSP.
 
@@ -154,19 +154,19 @@ The design enqueues variants of the kernel with 0, 10, and 27 speculated iterati
   mkdir build
   cd build
   ```
-  To compile for the default target (the Agilex® device family), run `cmake` using the command:
+  To compile for the default target (the Agilex 7® device family), run `cmake` using the command:
   ```
   cmake -G "NMake Makefiles" ..
   ```
   > **Note**: You can change the default target by using the command:
   >  ```
   >  cmake -G "NMake Makefiles" .. -DFPGA_DEVICE=<FPGA device family or FPGA part number>
-  >  ``` 
+  >  ```
   >
-  > Alternatively, you can target an explicit FPGA board variant and BSP by using the following command: 
+  > Alternatively, you can target an explicit FPGA board variant and BSP by using the following command:
   >  ```
   >  cmake -G "NMake Makefiles" .. -DFPGA_DEVICE=<board-support-package>:<board-variant>
-  >  ``` 
+  >  ```
   >
   > You will only be able to run an executable on the FPGA if you specified a BSP.
 

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/speculated_iterations/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/speculated_iterations/README.md
@@ -5,7 +5,7 @@ This FPGA tutorial demonstrates applying the `speculated_iterations` attribute t
 | Optimized for                     | Description
 |:---                               |:---
 | OS                                | Linux* Ubuntu* 18.04/20.04 <br> RHEL*/CentOS* 8 <br> SUSE* 15 <br> Windows* 10
-| Hardware                          | Intel® Agilex 7®, Arria® 10, and Stratix® 10 FPGAs
+| Hardware                          | Intel® Agilex® 7, Arria® 10, and Stratix® 10 FPGAs
 | Software                          | Intel® oneAPI DPC++/C++ Compiler
 | What you will learn               | What the `speculated_iterations` attribute does <br> How to apply the `speculated_iterations` attribute to loops in your program <br> How to determine the optimal number of speculated iterations
 | Time to complete                  | 15 minutes
@@ -80,7 +80,7 @@ In both increasing and decreasing cases, some experimentation is usually necessa
 ### Tutorial example
 In the tutorial design's kernel, the loop's exit condition involves a logarithm and a compare operation. This complex exit condition prevents the loop from achieving ```II=1```.
 
-The design enqueues variants of the kernel with 0, 10, and 27 speculated iterations, respectively, to demonstrate the effect of the `speculated_iterations` attribute on an Intel® Arria® 10 FPGA. Different numbers are chosen for the Intel® Stratix® 10 and Intel Agilex 7® targets accordingly.
+The design enqueues variants of the kernel with 0, 10, and 27 speculated iterations, respectively, to demonstrate the effect of the `speculated_iterations` attribute on an Intel® Arria® 10 FPGA. Different numbers are chosen for the Intel® Stratix® 10 and Intel Agilex® 7 targets accordingly.
 
 ## Key Concepts
 * Description of the `speculated_iterations` attribute.
@@ -111,7 +111,7 @@ The design enqueues variants of the kernel with 0, 10, and 27 speculated iterati
   mkdir build
   cd build
   ```
-  To compile for the default target (the Agilex 7® device family), run `cmake` using the command:
+  To compile for the default target (the Agilex® 7 device family), run `cmake` using the command:
   ```
   cmake ..
   ```
@@ -154,7 +154,7 @@ The design enqueues variants of the kernel with 0, 10, and 27 speculated iterati
   mkdir build
   cd build
   ```
-  To compile for the default target (the Agilex 7® device family), run `cmake` using the command:
+  To compile for the default target (the Agilex® 7 device family), run `cmake` using the command:
   ```
   cmake -G "NMake Makefiles" ..
   ```

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/speculated_iterations/src/CMakeLists.txt
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/speculated_iterations/src/CMakeLists.txt
@@ -7,8 +7,8 @@ set(SIMULATOR_TARGET ${TARGET_NAME}.fpga_sim)
 
 # FPGA board selection
 if(NOT DEFINED FPGA_DEVICE)
-    set(FPGA_DEVICE "Agilex")
-    set(DEVICE_FLAG "Agilex")
+    set(FPGA_DEVICE "Agilex 7")
+    set(DEVICE_FLAG "Agilex 7")
     message(STATUS "FPGA_DEVICE was not specified.\
                     \nConfiguring the design to the default FPGA family: ${FPGA_DEVICE}\
                     \nPlease refer to the README for information on target selection.")
@@ -19,7 +19,7 @@ else()
     elseif(FPGA_DEVICE_NAME MATCHES ".*s10.*" OR FPGA_DEVICE_NAME MATCHES ".*stratix10.*")
       set(DEVICE_FLAG "S10")
     elseif(FPGA_DEVICE_NAME MATCHES ".*agilex.*")
-      set(DEVICE_FLAG "Agilex")
+      set(DEVICE_FLAG "Agilex 7")
     endif()
     message(STATUS "Configuring the design with the following target: ${FPGA_DEVICE}")
 endif()
@@ -27,7 +27,7 @@ endif()
 if(NOT DEFINED DEVICE_FLAG)
     message(FATAL_ERROR "An unrecognized or custom board was passed, but DEVICE_FLAG was not specified. \
                          Please make sure you have set -DDEVICE_FLAG=-A10, -DDEVICE_FLAG=-S10 or \
-                         -DDEVICE_FLAG=-Agilex.")
+                         -DDEVICE_FLAG=-Agilex 7.")
 endif()
 
 # This is a Windows-specific flag that enables exception handling in host code

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/speculated_iterations/src/CMakeLists.txt
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/speculated_iterations/src/CMakeLists.txt
@@ -7,8 +7,8 @@ set(SIMULATOR_TARGET ${TARGET_NAME}.fpga_sim)
 
 # FPGA board selection
 if(NOT DEFINED FPGA_DEVICE)
-    set(FPGA_DEVICE "Agilex 7")
-    set(DEVICE_FLAG "Agilex 7")
+    set(FPGA_DEVICE "Agilex7")
+    set(DEVICE_FLAG "Agilex7")
     message(STATUS "FPGA_DEVICE was not specified.\
                     \nConfiguring the design to the default FPGA family: ${FPGA_DEVICE}\
                     \nPlease refer to the README for information on target selection.")
@@ -19,7 +19,7 @@ else()
     elseif(FPGA_DEVICE_NAME MATCHES ".*s10.*" OR FPGA_DEVICE_NAME MATCHES ".*stratix10.*")
       set(DEVICE_FLAG "S10")
     elseif(FPGA_DEVICE_NAME MATCHES ".*agilex.*")
-      set(DEVICE_FLAG "Agilex 7")
+      set(DEVICE_FLAG "Agilex7")
     endif()
     message(STATUS "Configuring the design with the following target: ${FPGA_DEVICE}")
 endif()
@@ -27,7 +27,7 @@ endif()
 if(NOT DEFINED DEVICE_FLAG)
     message(FATAL_ERROR "An unrecognized or custom board was passed, but DEVICE_FLAG was not specified. \
                          Please make sure you have set -DDEVICE_FLAG=-A10, -DDEVICE_FLAG=-S10 or \
-                         -DDEVICE_FLAG=-Agilex 7.")
+                         -DDEVICE_FLAG=-Agilex7.")
 endif()
 
 # This is a Windows-specific flag that enables exception handling in host code

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/speculated_iterations/src/CMakeLists.txt
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/speculated_iterations/src/CMakeLists.txt
@@ -26,8 +26,8 @@ endif()
 
 if(NOT DEFINED DEVICE_FLAG)
     message(FATAL_ERROR "An unrecognized or custom board was passed, but DEVICE_FLAG was not specified. \
-                         Please make sure you have set -DDEVICE_FLAG=-A10, -DDEVICE_FLAG=-S10 or \
-                         -DDEVICE_FLAG=-Agilex7.")
+                         Please make sure you have set -DDEVICE_FLAG=A10, -DDEVICE_FLAG=S10 or \
+                         -DDEVICE_FLAG=Agilex7.")
 endif()
 
 # This is a Windows-specific flag that enables exception handling in host code

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/speculated_iterations/src/speculated_iterations.cpp
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/speculated_iterations/src/speculated_iterations.cpp
@@ -136,7 +136,7 @@ int main(int argc, char *argv[]) {
   ComplexExit<0, true>(bound, r0);
   ComplexExit<10>(bound, r1);
   ComplexExit<54>(bound, r2);
-#elif defined(Agilex 7)
+#elif defined(Agilex7)
   ComplexExit<0, true>(bound, r0);
   ComplexExit<10>(bound, r1);
   ComplexExit<50>(bound, r2);

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/speculated_iterations/src/speculated_iterations.cpp
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/speculated_iterations/src/speculated_iterations.cpp
@@ -136,7 +136,7 @@ int main(int argc, char *argv[]) {
   ComplexExit<0, true>(bound, r0);
   ComplexExit<10>(bound, r1);
   ComplexExit<54>(bound, r2);
-#elif defined(Agilex)
+#elif defined(Agilex 7)
   ComplexExit<0, true>(bound, r0);
   ComplexExit<10>(bound, r1);
   ComplexExit<50>(bound, r2);

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/stall_enable/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/stall_enable/README.md
@@ -4,7 +4,7 @@ This FPGA tutorial demonstrates how to use the `use_stall_enable_clusters` attri
 | Optimized for                     | Description
 |:---                               |:---
 | OS                                | Linux* Ubuntu* 18.04/20.04 <br> RHEL*/CentOS* 8 <br> SUSE* 15 <br> Windows* 10
-| Hardware                          | Intel® Agilex 7®, Arria® 10, and Stratix® 10 FPGAs
+| Hardware                          | Intel® Agilex® 7, Arria® 10, and Stratix® 10 FPGAs
 | Software                          | Intel® oneAPI DPC++/C++ Compiler
 | What you will learn               |  What the `use_stall_enable_clusters` attribute does <br> How `use_stall_enable_clusters` attribute affects resource usage and latency <br> How to apply the `use_stall_enable_clusters` attribute to kernels in your program
 | Time to complete                  | 15 minutes (emulator and report) <br> several hours (fpga bitstream generation)
@@ -89,7 +89,7 @@ The FPGA compiler will use *Stall Enable Clusters* for the kernel when possible.
   mkdir build
   cd build
   ```
-  To compile for the default target (the Agilex 7® device family), run `cmake` using the command:
+  To compile for the default target (the Agilex® 7 device family), run `cmake` using the command:
   ```
   cmake ..
   ```
@@ -134,7 +134,7 @@ The FPGA compiler will use *Stall Enable Clusters* for the kernel when possible.
   mkdir build
   cd build
   ```
-  To compile for the default target (the Agilex 7® device family), run `cmake` using the command:
+  To compile for the default target (the Agilex® 7 device family), run `cmake` using the command:
   ```
   cmake -G "NMake Makefiles" ..
   ```

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/stall_enable/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/stall_enable/README.md
@@ -4,7 +4,7 @@ This FPGA tutorial demonstrates how to use the `use_stall_enable_clusters` attri
 | Optimized for                     | Description
 |:---                               |:---
 | OS                                | Linux* Ubuntu* 18.04/20.04 <br> RHEL*/CentOS* 8 <br> SUSE* 15 <br> Windows* 10
-| Hardware                          | Intel® Agilex®, Arria® 10, and Stratix® 10 FPGAs
+| Hardware                          | Intel® Agilex 7®, Arria® 10, and Stratix® 10 FPGAs
 | Software                          | Intel® oneAPI DPC++/C++ Compiler
 | What you will learn               |  What the `use_stall_enable_clusters` attribute does <br> How `use_stall_enable_clusters` attribute affects resource usage and latency <br> How to apply the `use_stall_enable_clusters` attribute to kernels in your program
 | Time to complete                  | 15 minutes (emulator and report) <br> several hours (fpga bitstream generation)
@@ -31,9 +31,9 @@ flowchart LR
    tier2("Tier 2: Explore the Fundamentals")
    tier3("Tier 3: Explore the Advanced Techniques")
    tier4("Tier 4: Explore the Reference Designs")
-   
+
    tier1 --> tier2 --> tier3 --> tier4
-   
+
    style tier1 fill:#0071c1,stroke:#0071c1,stroke-width:1px,color:#fff
    style tier2 fill:#0071c1,stroke:#0071c1,stroke-width:1px,color:#fff
    style tier3 fill:#f96,stroke:#333,stroke-width:1px,color:#fff
@@ -67,8 +67,8 @@ The FPGA compiler will use *Stall Enable Clusters* for the kernel when possible.
 
 ## Building the `stall_enable` Tutorial
 
-> **Note**: When working with the command-line interface (CLI), you should configure the oneAPI toolkits using environment variables. 
-> Set up your CLI environment by sourcing the `setvars` script located in the root of your oneAPI installation every time you open a new terminal window. 
+> **Note**: When working with the command-line interface (CLI), you should configure the oneAPI toolkits using environment variables.
+> Set up your CLI environment by sourcing the `setvars` script located in the root of your oneAPI installation every time you open a new terminal window.
 > This practice ensures that your compiler, libraries, and tools are ready for development.
 >
 > Linux*:
@@ -89,7 +89,7 @@ The FPGA compiler will use *Stall Enable Clusters* for the kernel when possible.
   mkdir build
   cd build
   ```
-  To compile for the default target (the Agilex® device family), run `cmake` using the command:
+  To compile for the default target (the Agilex 7® device family), run `cmake` using the command:
   ```
   cmake ..
   ```
@@ -97,12 +97,12 @@ The FPGA compiler will use *Stall Enable Clusters* for the kernel when possible.
   > **Note**: You can change the default target by using the command:
   >  ```
   >  cmake .. -DFPGA_DEVICE=<FPGA device family or FPGA part number>
-  >  ``` 
+  >  ```
   >
-  > Alternatively, you can target an explicit FPGA board variant and BSP by using the following command: 
+  > Alternatively, you can target an explicit FPGA board variant and BSP by using the following command:
   >  ```
   >  cmake .. -DFPGA_DEVICE=<board-support-package>:<board-variant>
-  >  ``` 
+  >  ```
   >
   > You will only be able to run an executable on the FPGA if you specified a BSP.
 
@@ -134,19 +134,19 @@ The FPGA compiler will use *Stall Enable Clusters* for the kernel when possible.
   mkdir build
   cd build
   ```
-  To compile for the default target (the Agilex® device family), run `cmake` using the command:
+  To compile for the default target (the Agilex 7® device family), run `cmake` using the command:
   ```
   cmake -G "NMake Makefiles" ..
   ```
   > **Note**: You can change the default target by using the command:
   >  ```
   >  cmake -G "NMake Makefiles" .. -DFPGA_DEVICE=<FPGA device family or FPGA part number>
-  >  ``` 
+  >  ```
   >
-  > Alternatively, you can target an explicit FPGA board variant and BSP by using the following command: 
+  > Alternatively, you can target an explicit FPGA board variant and BSP by using the following command:
   >  ```
   >  cmake -G "NMake Makefiles" .. -DFPGA_DEVICE=<board-support-package>:<board-variant>
-  >  ``` 
+  >  ```
   >
   > You will only be able to run an executable on the FPGA if you specified a BSP.
 

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/stall_enable/src/CMakeLists.txt
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/stall_enable/src/CMakeLists.txt
@@ -12,7 +12,7 @@ set(FPGA_TARGET_STALL_FREE ${STALL_FREE_TARGET_NAME}.fpga)
 
 # FPGA board selection
 if(NOT DEFINED FPGA_DEVICE)
-    set(FPGA_DEVICE "Agilex")
+    set(FPGA_DEVICE "Agilex 7")
     message(STATUS "FPGA_DEVICE was not specified.\
                     \nConfiguring the design to the default FPGA family: ${FPGA_DEVICE}\
                     \nPlease refer to the README for information on target selection.")
@@ -20,7 +20,7 @@ else()
     message(STATUS "Configuring the design with the following target: ${FPGA_DEVICE}")
 endif()
 
-# Allow disabling of hyper-optimization for S10 and Agilex
+# Allow disabling of hyper-optimization for S10 and Agilex 7
 if (${NO_HYPER_OPTIMIZATION})
     set(HYPER_FLAG -Xshyper-optimized-handshaking=off)
 endif(${NO_HYPER_OPTIMIZATION})

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/stall_enable/src/CMakeLists.txt
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/stall_enable/src/CMakeLists.txt
@@ -12,7 +12,7 @@ set(FPGA_TARGET_STALL_FREE ${STALL_FREE_TARGET_NAME}.fpga)
 
 # FPGA board selection
 if(NOT DEFINED FPGA_DEVICE)
-    set(FPGA_DEVICE "Agilex 7")
+    set(FPGA_DEVICE "Agilex7")
     message(STATUS "FPGA_DEVICE was not specified.\
                     \nConfiguring the design to the default FPGA family: ${FPGA_DEVICE}\
                     \nPlease refer to the README for information on target selection.")
@@ -20,7 +20,7 @@ else()
     message(STATUS "Configuring the design with the following target: ${FPGA_DEVICE}")
 endif()
 
-# Allow disabling of hyper-optimization for S10 and Agilex 7
+# Allow disabling of hyper-optimization for S10 and Agilex7
 if (${NO_HYPER_OPTIMIZATION})
     set(HYPER_FLAG -Xshyper-optimized-handshaking=off)
 endif(${NO_HYPER_OPTIMIZATION})

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/GettingStarted/fast_recompile/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/GettingStarted/fast_recompile/README.md
@@ -5,7 +5,7 @@ This FPGA tutorial demonstrates how to separate the compilation of a program's h
 | Optimized for                     | Description
 ---                                 |---
 | OS                                | Linux* Ubuntu* 18.04/20.04 <br> RHEL*/CentOS* 8 <br> SUSE* 15 <br> Windows* 10
-| Hardware                          | Intel® Agilex®, Arria® 10, and Stratix® 10 FPGAs
+| Hardware                          | Intel® Agilex 7®, Arria® 10, and Stratix® 10 FPGAs
 | Software                          | Intel® oneAPI DPC++/C++ Compiler
 | What you will learn               | Why to separate host and device code compilation in your FPGA project <br> How to use the `-reuse-exe` and device link methods <br> Which method to choose for your project
 | Time to complete                  | 15 minutes
@@ -32,9 +32,9 @@ flowchart LR
    tier2("Tier 2: Explore the Fundamentals")
    tier3("Tier 3: Explore the Advanced Techniques")
    tier4("Tier 4: Explore the Reference Designs")
-   
+
    tier1 --> tier2 --> tier3 --> tier4
-   
+
    style tier1 fill:#f96,stroke:#333,stroke-width:1px,color:#fff
    style tier2 fill:#0071c1,stroke:#0071c1,stroke-width:1px,color:#fff
    style tier3 fill:#0071c1,stroke:#0071c1,stroke-width:1px,color:#fff
@@ -146,8 +146,8 @@ For larger and more complex projects, the device link method has the advantage o
 
 ## Building the `fast_recompile` Tutorial
 
-> **Note**: When working with the command-line interface (CLI), you should configure the oneAPI toolkits using environment variables. 
-> Set up your CLI environment by sourcing the `setvars` script located in the root of your oneAPI installation every time you open a new terminal window. 
+> **Note**: When working with the command-line interface (CLI), you should configure the oneAPI toolkits using environment variables.
+> Set up your CLI environment by sourcing the `setvars` script located in the root of your oneAPI installation every time you open a new terminal window.
 > This practice ensures that your compiler, libraries, and tools are ready for development.
 >
 > Linux*:
@@ -168,7 +168,7 @@ For larger and more complex projects, the device link method has the advantage o
     mkdir build
     cd build
     ```
-    To compile for the default target (the Agilex® device family), run `cmake` using the command:
+    To compile for the default target (the Agilex 7® device family), run `cmake` using the command:
     ```
     cmake ..
     ```
@@ -176,12 +176,12 @@ For larger and more complex projects, the device link method has the advantage o
     > **Note**: You can change the default target by using the command:
     >  ```
     >  cmake .. -DFPGA_DEVICE=<FPGA device family or FPGA part number>
-    >  ``` 
+    >  ```
     >
-    > Alternatively, you can target an explicit FPGA board variant and BSP by using the following command: 
+    > Alternatively, you can target an explicit FPGA board variant and BSP by using the following command:
     >  ```
     >  cmake .. -DFPGA_DEVICE=<board-support-package>:<board-variant>
-    >  ``` 
+    >  ```
     >
     > You will only be able to run an executable on the FPGA if you specified a BSP.
 
@@ -208,19 +208,19 @@ For larger and more complex projects, the device link method has the advantage o
     mkdir build
     cd build
     ```
-    To compile for the default target (the Agilex® device family), run `cmake` using the command:
+    To compile for the default target (the Agilex 7® device family), run `cmake` using the command:
     ```
     cmake -G "NMake Makefiles" ..
     ```
     > **Note**: You can change the default target by using the command:
     >  ```
     >  cmake -G "NMake Makefiles" .. -DFPGA_DEVICE=<FPGA device family or FPGA part number>
-    >  ``` 
+    >  ```
     >
-    > Alternatively, you can target an explicit FPGA board variant and BSP by using the following command: 
+    > Alternatively, you can target an explicit FPGA board variant and BSP by using the following command:
     >  ```
     >  cmake -G "NMake Makefiles" .. -DFPGA_DEVICE=<board-support-package>:<board-variant>
-    >  ``` 
+    >  ```
     >
     > You will only be able to run an executable on the FPGA if you specified a BSP.
 

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/GettingStarted/fast_recompile/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/GettingStarted/fast_recompile/README.md
@@ -5,7 +5,7 @@ This FPGA tutorial demonstrates how to separate the compilation of a program's h
 | Optimized for                     | Description
 ---                                 |---
 | OS                                | Linux* Ubuntu* 18.04/20.04 <br> RHEL*/CentOS* 8 <br> SUSE* 15 <br> Windows* 10
-| Hardware                          | Intel® Agilex 7®, Arria® 10, and Stratix® 10 FPGAs
+| Hardware                          | Intel® Agilex® 7, Arria® 10, and Stratix® 10 FPGAs
 | Software                          | Intel® oneAPI DPC++/C++ Compiler
 | What you will learn               | Why to separate host and device code compilation in your FPGA project <br> How to use the `-reuse-exe` and device link methods <br> Which method to choose for your project
 | Time to complete                  | 15 minutes
@@ -168,7 +168,7 @@ For larger and more complex projects, the device link method has the advantage o
     mkdir build
     cd build
     ```
-    To compile for the default target (the Agilex 7® device family), run `cmake` using the command:
+    To compile for the default target (the Agilex® 7 device family), run `cmake` using the command:
     ```
     cmake ..
     ```
@@ -208,7 +208,7 @@ For larger and more complex projects, the device link method has the advantage o
     mkdir build
     cd build
     ```
-    To compile for the default target (the Agilex 7® device family), run `cmake` using the command:
+    To compile for the default target (the Agilex® 7 device family), run `cmake` using the command:
     ```
     cmake -G "NMake Makefiles" ..
     ```

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/GettingStarted/fast_recompile/src/CMakeLists.txt
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/GettingStarted/fast_recompile/src/CMakeLists.txt
@@ -8,7 +8,7 @@ set(FPGA_TARGET ${TARGET_NAME}.fpga)
 
 # FPGA board selection
 if(NOT DEFINED FPGA_DEVICE)
-    set(FPGA_DEVICE "Agilex 7")
+    set(FPGA_DEVICE "Agilex7")
     message(STATUS "FPGA_DEVICE was not specified.\
                     \nConfiguring the design to the default FPGA family: ${FPGA_DEVICE}\
                     \nPlease refer to the README for information on target selection.")

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/GettingStarted/fast_recompile/src/CMakeLists.txt
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/GettingStarted/fast_recompile/src/CMakeLists.txt
@@ -8,7 +8,7 @@ set(FPGA_TARGET ${TARGET_NAME}.fpga)
 
 # FPGA board selection
 if(NOT DEFINED FPGA_DEVICE)
-    set(FPGA_DEVICE "Agilex")
+    set(FPGA_DEVICE "Agilex 7")
     message(STATUS "FPGA_DEVICE was not specified.\
                     \nConfiguring the design to the default FPGA family: ${FPGA_DEVICE}\
                     \nPlease refer to the README for information on target selection.")

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/GettingStarted/fpga_compile/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/GettingStarted/fpga_compile/README.md
@@ -4,7 +4,7 @@ This FPGA tutorial introduces how to compile SYCL*-compliant code for FPGAs thro
 | Optimized for                     | Description
 |:---                               |:---
 | OS                                | Linux* Ubuntu* 18.04/20.04 <br> RHEL*/CentOS* 8 <br> SUSE* 15 <br> Windows* 10
-| Hardware                          | Intel® Agilex 7®, Arria® 10, and Stratix® 10 FPGAs
+| Hardware                          | Intel® Agilex® 7, Arria® 10, and Stratix® 10 FPGAs
 | Software                          | Intel® oneAPI DPC++/C++ Compiler
 | What you will learn               | How and why compiling SYCL* code for FPGA differs from CPU or GPU <br> The compile options used to target FPGA devices
 | Time to complete                  | 60 minutes
@@ -159,7 +159,7 @@ Optimization Report
 
 ```bash
 # FPGA early image (with optimization report):
-icpx -fsycl -fintelfpga -DFPGA_HARDWARE -I../../../../include vector_add.cpp -Xshardware -fsycl-link=early -Xstarget=Agilex 7 -o vector_add_report.a
+icpx -fsycl -fintelfpga -DFPGA_HARDWARE -I../../../../include vector_add.cpp -Xshardware -fsycl-link=early -Xstarget=Agilex7 -o vector_add_report.a
 ```
 Use the`-Xstarget` flag to target a supported board, a device family, or a specific FPGA part number.
 
@@ -167,7 +167,7 @@ Simulator
 
 ```bash
 # FPGA simulator image:
-icpx -fsycl -fintelfpga -DFPGA_SIMULATOR -I../../../../include vector_add.cpp -Xssimulation -Xstarget=Agilex 7 -Xsghdl -o vector_add_sim.a
+icpx -fsycl -fintelfpga -DFPGA_SIMULATOR -I../../../../include vector_add.cpp -Xssimulation -Xstarget=Agilex7 -Xsghdl -o vector_add_sim.a
 ```
 Through `-Xstarget`, you can target an explicit board, a device family or a FPGA part number.
 
@@ -175,7 +175,7 @@ Hardware
 
 ```bash
 # FPGA hardware image:
-icpx -fsycl -fintelfpga -DFPGA_HARDWARE -I../../../../include vector_add.cpp -Xshardware -Xstarget=Agilex 7 -o vector_add.fpga
+icpx -fsycl -fintelfpga -DFPGA_HARDWARE -I../../../../include vector_add.cpp -Xshardware -Xstarget=Agilex7 -o vector_add.fpga
 ```
 Through `-Xstarget`, you can target an explicit board, a device family or a FPGA part number.
 
@@ -237,7 +237,7 @@ Generate the `Makefile` by running `cmake`.
   mkdir build
   cd build
   ```
-  To compile for the default target (the Agilex 7® device family), run `cmake` using the command:
+  To compile for the default target (the Agilex® 7 device family), run `cmake` using the command:
   ```
   cmake ..
   ```
@@ -269,7 +269,7 @@ Generate the `Makefile` by running `cmake`.
   mkdir build
   cd build
   ```
-  To compile for the default target (the Agilex 7® device family), run `cmake` using the command:
+  To compile for the default target (the Agilex® 7 device family), run `cmake` using the command:
   ```
   cmake -G "NMake Makefiles" ..
   ```

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/GettingStarted/fpga_compile/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/GettingStarted/fpga_compile/README.md
@@ -4,7 +4,7 @@ This FPGA tutorial introduces how to compile SYCL*-compliant code for FPGAs thro
 | Optimized for                     | Description
 |:---                               |:---
 | OS                                | Linux* Ubuntu* 18.04/20.04 <br> RHEL*/CentOS* 8 <br> SUSE* 15 <br> Windows* 10
-| Hardware                          | Intel® Agilex®, Arria® 10, and Stratix® 10 FPGAs
+| Hardware                          | Intel® Agilex 7®, Arria® 10, and Stratix® 10 FPGAs
 | Software                          | Intel® oneAPI DPC++/C++ Compiler
 | What you will learn               | How and why compiling SYCL* code for FPGA differs from CPU or GPU <br> The compile options used to target FPGA devices
 | Time to complete                  | 60 minutes
@@ -17,9 +17,9 @@ This FPGA tutorial introduces how to compile SYCL*-compliant code for FPGAs thro
 > - ModelSim® SE
 >
 > When using the hardware compile flow, Intel® Quartus® Prime Pro Edition must be installed and accessible through your PATH.
-> 
+>
 > When using the hardware compile flow, Intel® Quartus® Prime Pro Edition must be installed and accessible through your PATH.
-> 
+>
 > :warning: Make sure you add the device files associated with the FPGA that you are targeting to your Intel® Quartus® Prime installation.
 
 > **Note**: SYCL USM allocations, used in `part2` and `part3` of this tutorial, are only supported on FPGA boards that have a USM capable BSP (e.g. the Intel® FPGA PAC D5005 with Intel Stratix® 10 SX with USM support: intel_s10sx_pac:pac_s10_usm) or when targeting an FPGA family/part number.
@@ -33,9 +33,9 @@ flowchart LR
    tier2("Tier 2: Explore the Fundamentals")
    tier3("Tier 3: Explore the Advanced Techniques")
    tier4("Tier 4: Explore the Reference Designs")
-   
+
    tier1 --> tier2 --> tier3 --> tier4
-   
+
    style tier1 fill:#f96,stroke:#333,stroke-width:1px,color:#fff
    style tier2 fill:#0071c1,stroke:#0071c1,stroke-width:1px,color:#fff
    style tier3 fill:#0071c1,stroke:#0071c1,stroke-width:1px,color:#fff
@@ -62,7 +62,7 @@ Field-programmable gate arrays (FPGAs) are configurable integrated circuits that
 While SYCL* code can be compiled for CPU, GPU, or FPGA, compiling to FPGA is somewhat different. This tutorial explains these differences and shows how to compile a "Hello World" style vector addition kernel for FPGA, following the recommended workflow.
 
 ### Why is compilation different for FPGA?
-FPGAs differ from CPUs and GPUs in many interesting ways. 
+FPGAs differ from CPUs and GPUs in many interesting ways.
 
 Compared to CPU or GPU, generating a device image for FPGA hardware is a computationally intensive and time-consuming process. It is usual for an FPGA compile to take several hours to complete. For this reason, only ahead-of-time (or "offline") kernel compilation mode is supported for FPGA. The long compile time for FPGA hardware makes just-in-time (or "online") compilation impractical.
 
@@ -72,7 +72,7 @@ Long compile times are detrimental to developer productivity. The Intel® oneAPI
 
 In the FPGA multiarchitecture binary generation flow, you can generate an executable host application and accelerator for a PCIe FPGA board if you have a compatible board support package (BSP). Intel provides BSPs for the Intel® PAC with Intel Arria® 10 GX FPGA, and the Intel® FPGA PAC D5005 (with Intel Stratix® 10 SX). If you have a different board, check with your vendor to see if they supply a BSP.
 
-In the FPGA IP component generation flow, you can generate an IP component that you can import into an Intel® Quartus® Prime project. You can generate an IP by targeting your compilation to a supported Intel® FPGA device family or part number (for example, `Agilex` or `AGFA014R24B1E1V`) instead of a named board (for example, `intel_a10gx_pac:pac_a10`). 
+In the FPGA IP component generation flow, you can generate an IP component that you can import into an Intel® Quartus® Prime project. You can generate an IP by targeting your compilation to a supported Intel® FPGA device family or part number (for example, `Agilex 7` or `AGFA014R24B1E1V`) instead of a named board (for example, `intel_a10gx_pac:pac_a10`).
 
 The FPGA IP component generation flow does not generate any FPGA accelerated executable, only RTL (Register Transfer Level) IP component files. The host application is treated only as a 'testbench' that exercises and validates your IP component in emulation and simulation.
 
@@ -98,9 +98,9 @@ There are two important caveats to remember when using the FPGA emulator.
 
 #### Optimization Report (Early Image)
 
-For this compilation type, your SYCL device code is optimized and converted into an FPGA design specified in Verilog RTL (a low-level, native entry language for FPGAs). This intermediate compilation result is also called the *FPGA early device image*, which is **not** executable. 
+For this compilation type, your SYCL device code is optimized and converted into an FPGA design specified in Verilog RTL (a low-level, native entry language for FPGAs). This intermediate compilation result is also called the *FPGA early device image*, which is **not** executable.
 
-The optimization report contains significant information about how the compiler has transformed your device code into an FPGA design. The report includes visualizations of structures generated on the FPGA, performance and expected performance bottleneck information, and estimated resource utilization. Optimization reports are generated for the "optimization report", "simulator" and "hardware" compilation types. 
+The optimization report contains significant information about how the compiler has transformed your device code into an FPGA design. The report includes visualizations of structures generated on the FPGA, performance and expected performance bottleneck information, and estimated resource utilization. Optimization reports are generated for the "optimization report", "simulator" and "hardware" compilation types.
 
 The [FPGA Optimization Guide for Intel® oneAPI Toolkits Developer Guide](https://software.intel.com/content/www/us/en/develop/documentation/oneapi-fpga-optimization-guide/top/analyze-your-design.html) contains a chapter about how to analyze the reports generated after the FPGA early image and FPGA image.
 
@@ -113,7 +113,7 @@ The Intel oneAPI DPC++/C++ Compiler links your design C++ testbench with an RTL-
 
 #### FPGA Hardware (Hardware Image)
 
-The generated Verilog RTL is mapped onto the FPGA hardware resources by the Intel® Quartus® Prime software. The estimated performance and resource utilization is therefore much more accurate than the estimates obtained in the optimization report compilation type. 
+The generated Verilog RTL is mapped onto the FPGA hardware resources by the Intel® Quartus® Prime software. The estimated performance and resource utilization is therefore much more accurate than the estimates obtained in the optimization report compilation type.
 
 If you compile a multiarchitecture binary, the resulting binary will include an FPGA hardware image (also referred to as a bitstream) that is executable on an FPGA accelerator card with a supported BSP. The compiler will interface your design with the BSP, and your host application will seamlessly make the system calls to launch kernels on the FPGA.
 
@@ -148,7 +148,7 @@ int main() {
 This section includes a helpful list of commands and options to compile this design for the FPGA emulator, generate the FPGA early image optimization reports, and compile for FPGA hardware.
 >**Note**: In this sample, the compiler is refered to as `icpx`. On Windows, you should use `icx-cl`.
 
-FPGA Emulator 
+FPGA Emulator
 
 ```bash
 # FPGA emulator image
@@ -159,7 +159,7 @@ Optimization Report
 
 ```bash
 # FPGA early image (with optimization report):
-icpx -fsycl -fintelfpga -DFPGA_HARDWARE -I../../../../include vector_add.cpp -Xshardware -fsycl-link=early -Xstarget=Agilex -o vector_add_report.a
+icpx -fsycl -fintelfpga -DFPGA_HARDWARE -I../../../../include vector_add.cpp -Xshardware -fsycl-link=early -Xstarget=Agilex 7 -o vector_add_report.a
 ```
 Use the`-Xstarget` flag to target a supported board, a device family, or a specific FPGA part number.
 
@@ -167,7 +167,7 @@ Simulator
 
 ```bash
 # FPGA simulator image:
-icpx -fsycl -fintelfpga -DFPGA_SIMULATOR -I../../../../include vector_add.cpp -Xssimulation -Xstarget=Agilex -Xsghdl -o vector_add_sim.a
+icpx -fsycl -fintelfpga -DFPGA_SIMULATOR -I../../../../include vector_add.cpp -Xssimulation -Xstarget=Agilex 7 -Xsghdl -o vector_add_sim.a
 ```
 Through `-Xstarget`, you can target an explicit board, a device family or a FPGA part number.
 
@@ -175,7 +175,7 @@ Hardware
 
 ```bash
 # FPGA hardware image:
-icpx -fsycl -fintelfpga -DFPGA_HARDWARE -I../../../../include vector_add.cpp -Xshardware -Xstarget=Agilex -o vector_add.fpga
+icpx -fsycl -fintelfpga -DFPGA_HARDWARE -I../../../../include vector_add.cpp -Xshardware -Xstarget=Agilex 7 -o vector_add.fpga
 ```
 Through `-Xstarget`, you can target an explicit board, a device family or a FPGA part number.
 
@@ -204,8 +204,8 @@ h.single_task<...>([=]() {
 Part 4 shows the vector addition in SYCL* C++ with a 'function' coding style and buffer & accessor interface. This code style will be familiar to users who are already experienced with SYCL*. Observe how `vec_a`, `vec_b`, and `vec_c` are copied into buffers before the `VectorAdd` function is called.
 
 ## Building the `fpga_compile` Tutorial
-> **Note**: When working with the command-line interface (CLI), you should configure the oneAPI toolkits using environment variables. 
-> Set up your CLI environment by sourcing the `setvars` script located in the root of your oneAPI installation every time you open a new terminal window. 
+> **Note**: When working with the command-line interface (CLI), you should configure the oneAPI toolkits using environment variables.
+> Set up your CLI environment by sourcing the `setvars` script located in the root of your oneAPI installation every time you open a new terminal window.
 > This practice ensures that your compiler, libraries, and tools are ready for development.
 >
 > Linux*:
@@ -237,19 +237,19 @@ Generate the `Makefile` by running `cmake`.
   mkdir build
   cd build
   ```
-  To compile for the default target (the Agilex® device family), run `cmake` using the command:
+  To compile for the default target (the Agilex 7® device family), run `cmake` using the command:
   ```
   cmake ..
   ```
   > **Note**: You can change the default target by using the command:
   >  ```
   >  cmake .. -DFPGA_DEVICE=<FPGA device family or FPGA part number>
-  >  ``` 
+  >  ```
   >
-  > Alternatively, you can target an explicit FPGA board variant and BSP by using the following command: 
+  > Alternatively, you can target an explicit FPGA board variant and BSP by using the following command:
   >  ```
   >  cmake .. -DFPGA_DEVICE=<board-support-package>:<board-variant>
-  >  ``` 
+  >  ```
   >
   > You will only be able to run an executable on the FPGA if you specified a BSP.
 
@@ -269,19 +269,19 @@ Generate the `Makefile` by running `cmake`.
   mkdir build
   cd build
   ```
-  To compile for the default target (the Agilex® device family), run `cmake` using the command:
+  To compile for the default target (the Agilex 7® device family), run `cmake` using the command:
   ```
   cmake -G "NMake Makefiles" ..
   ```
   > **Note**: You can change the default target by using the command:
   >  ```
   >  cmake -G "NMake Makefiles" .. -DFPGA_DEVICE=<FPGA device family or FPGA part number>
-  >  ``` 
+  >  ```
   >
-  > Alternatively, you can target an explicit FPGA board variant and BSP by using the following command: 
+  > Alternatively, you can target an explicit FPGA board variant and BSP by using the following command:
   >  ```
   >  cmake -G "NMake Makefiles" .. -DFPGA_DEVICE=<board-support-package>:<board-variant>
-  >  ``` 
+  >  ```
   >
   > You will only be able to run an executable on the FPGA if you specified a BSP.
 

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/GettingStarted/fpga_compile/part2_dpcpp_functor_usm/src/CMakeLists.txt
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/GettingStarted/fpga_compile/part2_dpcpp_functor_usm/src/CMakeLists.txt
@@ -6,7 +6,7 @@ set(FPGA_TARGET ${TARGET_NAME}.fpga)
 
 # FPGA board selection
 if(NOT DEFINED FPGA_DEVICE)
-    set(FPGA_DEVICE "Agilex")
+    set(FPGA_DEVICE "Agilex 7")
     message(STATUS "FPGA_DEVICE was not specified.\
                     \nConfiguring the design to the default FPGA family: ${FPGA_DEVICE}\
                     \nPlease refer to the README for information on target selection.")

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/GettingStarted/fpga_compile/part2_dpcpp_functor_usm/src/CMakeLists.txt
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/GettingStarted/fpga_compile/part2_dpcpp_functor_usm/src/CMakeLists.txt
@@ -6,7 +6,7 @@ set(FPGA_TARGET ${TARGET_NAME}.fpga)
 
 # FPGA board selection
 if(NOT DEFINED FPGA_DEVICE)
-    set(FPGA_DEVICE "Agilex 7")
+    set(FPGA_DEVICE "Agilex7")
     message(STATUS "FPGA_DEVICE was not specified.\
                     \nConfiguring the design to the default FPGA family: ${FPGA_DEVICE}\
                     \nPlease refer to the README for information on target selection.")

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/GettingStarted/fpga_compile/part3_dpcpp_lambda_usm/src/CMakeLists.txt
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/GettingStarted/fpga_compile/part3_dpcpp_lambda_usm/src/CMakeLists.txt
@@ -6,7 +6,7 @@ set(FPGA_TARGET ${TARGET_NAME}.fpga)
 
 # FPGA board selection
 if(NOT DEFINED FPGA_DEVICE)
-    set(FPGA_DEVICE "Agilex")
+    set(FPGA_DEVICE "Agilex 7")
     message(STATUS "FPGA_DEVICE was not specified.\
                     \nConfiguring the design to the default FPGA family: ${FPGA_DEVICE}\
                     \nPlease refer to the README for information on target selection.")

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/GettingStarted/fpga_compile/part3_dpcpp_lambda_usm/src/CMakeLists.txt
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/GettingStarted/fpga_compile/part3_dpcpp_lambda_usm/src/CMakeLists.txt
@@ -6,7 +6,7 @@ set(FPGA_TARGET ${TARGET_NAME}.fpga)
 
 # FPGA board selection
 if(NOT DEFINED FPGA_DEVICE)
-    set(FPGA_DEVICE "Agilex 7")
+    set(FPGA_DEVICE "Agilex7")
     message(STATUS "FPGA_DEVICE was not specified.\
                     \nConfiguring the design to the default FPGA family: ${FPGA_DEVICE}\
                     \nPlease refer to the README for information on target selection.")

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/GettingStarted/fpga_compile/part4_dpcpp_lambda_buffers/src/CMakeLists.txt
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/GettingStarted/fpga_compile/part4_dpcpp_lambda_buffers/src/CMakeLists.txt
@@ -6,7 +6,7 @@ set(FPGA_TARGET ${TARGET_NAME}.fpga)
 
 # FPGA board selection
 if(NOT DEFINED FPGA_DEVICE)
-    set(FPGA_DEVICE "Agilex")
+    set(FPGA_DEVICE "Agilex 7")
     message(STATUS "FPGA_DEVICE was not specified.\
                     \nConfiguring the design to the default FPGA family: ${FPGA_DEVICE}\
                     \nPlease refer to the README for information on target selection.")

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/GettingStarted/fpga_compile/part4_dpcpp_lambda_buffers/src/CMakeLists.txt
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/GettingStarted/fpga_compile/part4_dpcpp_lambda_buffers/src/CMakeLists.txt
@@ -6,7 +6,7 @@ set(FPGA_TARGET ${TARGET_NAME}.fpga)
 
 # FPGA board selection
 if(NOT DEFINED FPGA_DEVICE)
-    set(FPGA_DEVICE "Agilex 7")
+    set(FPGA_DEVICE "Agilex7")
     message(STATUS "FPGA_DEVICE was not specified.\
                     \nConfiguring the design to the default FPGA family: ${FPGA_DEVICE}\
                     \nPlease refer to the README for information on target selection.")

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/GettingStarted/fpga_template/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/GettingStarted/fpga_template/README.md
@@ -1,11 +1,11 @@
 # `FPGA Template` Sample
 
-This project serves as a template for Intel® oneAPI FPGA designs. 
+This project serves as a template for Intel® oneAPI FPGA designs.
 
 | Optimized for                     | Description
 |:---                               |:---
 | OS                                | Linux* Ubuntu* 18.04/20.04 <br> RHEL*/CentOS* 8 <br> SUSE* 15 <br> Windows* 10
-| Hardware                          | Intel® Agilex®, Arria® 10, and Stratix® 10 FPGAs
+| Hardware                          | Intel® Agilex 7®, Arria® 10, and Stratix® 10 FPGAs
 | Software                          | Intel® oneAPI DPC++/C++ Compiler
 | What you will learn               | Best practices for creating and managing a oneAPI FPGA project
 | Time to complete                  | 10 minutes
@@ -34,9 +34,9 @@ flowchart LR
    tier2("Tier 2: Explore the Fundamentals")
    tier3("Tier 3: Explore the Advanced Techniques")
    tier4("Tier 4: Explore the Reference Designs")
-   
+
    tier1 --> tier2 --> tier3 --> tier4
-   
+
    style tier1 fill:#f96,stroke:#333,stroke-width:1px,color:#fff
    style tier2 fill:#0071c1,stroke:#0071c1,stroke-width:1px,color:#fff
    style tier3 fill:#0071c1,stroke:#0071c1,stroke-width:1px,color:#fff
@@ -71,8 +71,8 @@ set(TARGET_NAME fpga_template)
 #   intel_s10sx_pac:pac_s10
 #   intel_s10sx_pac:pac_s10_usm
 #   intel_a10gx_pac:pac_a10
-# Note that depending on your installation, you may need to specify the full 
-# path to the board support package (BSP), this usually is in your install 
+# Note that depending on your installation, you may need to specify the full
+# path to the board support package (BSP), this usually is in your install
 # folder.
 #
 # You can also specify a device family (E.g. "Arria10" or "Stratix10") or a
@@ -82,7 +82,7 @@ if(NOT DEFINED FPGA_DEVICE)
 endif()
 
 # Use cmake -DUSER_FPGA_FLAGS=<flags> to set extra flags for FPGA backend
-# compilation. 
+# compilation.
 set(USER_FPGA_FLAGS ${USER_FPGA_FLAGS})
 
 # Use cmake -DUSER_FLAGS=<flags> to set extra flags for general compilation.
@@ -97,8 +97,8 @@ Everything below this in the `CMakeLists.txt` is necessary for selecting the com
 
 ## Building the `fpga_template` Tutorial
 
-> **Note**: When working with the command-line interface (CLI), you should configure the oneAPI toolkits using environment variables. 
-> Set up your CLI environment by sourcing the `setvars` script located in the root of your oneAPI installation every time you open a new terminal window. 
+> **Note**: When working with the command-line interface (CLI), you should configure the oneAPI toolkits using environment variables.
+> Set up your CLI environment by sourcing the `setvars` script located in the root of your oneAPI installation every time you open a new terminal window.
 > This practice ensures that your compiler, libraries, and tools are ready for development.
 >
 > Linux*:
@@ -114,12 +114,12 @@ Everything below this in the `CMakeLists.txt` is necessary for selecting the com
 
 Use these commands to run the design, depending on your OS.
 
-### On a Linux* System 
+### On a Linux* System
 This design uses CMake to generate a build script for GNU/make.
 
 1. Change to the sample directory.
 
-2. Configure the build system for the Agilex® device family, which is the default.
+2. Configure the build system for the Agilex 7® device family, which is the default.
 
    ```
    mkdir build
@@ -130,12 +130,12 @@ This design uses CMake to generate a build script for GNU/make.
    > **Note**: You can change the default target by using the command:
    >  ```
    >  cmake .. -DFPGA_DEVICE=<FPGA device family or FPGA part number>
-   >  ``` 
+   >  ```
    >
-   > Alternatively, you can target an explicit FPGA board variant and BSP by using the following command: 
+   > Alternatively, you can target an explicit FPGA board variant and BSP by using the following command:
    >  ```
    >  cmake .. -DFPGA_DEVICE=<board-support-package>:<board-variant>
-   >  ``` 
+   >  ```
    >
    > You will only be able to run an executable on the FPGA if you specified a BSP.
 
@@ -156,7 +156,7 @@ This design uses CMake to generate a build script for  `nmake`.
 
 1. Change to the sample directory.
 
-2. Configure the build system for the Agilex® device family, which is the default.
+2. Configure the build system for the Agilex 7® device family, which is the default.
    ```
    mkdir build
    cd build
@@ -166,12 +166,12 @@ This design uses CMake to generate a build script for  `nmake`.
    > **Note**: You can change the default target by using the command:
    >  ```
    >  cmake -G "NMake Makefiles" .. -DFPGA_DEVICE=<FPGA device family or FPGA part number>
-   >  ``` 
+   >  ```
    >
-   > Alternatively, you can target an explicit FPGA board variant and BSP by using the following command: 
+   > Alternatively, you can target an explicit FPGA board variant and BSP by using the following command:
    >  ```
    >  cmake -G "NMake Makefiles" .. -DFPGA_DEVICE=<board-support-package>:<board-variant>
-   >  ``` 
+   >  ```
    >
    > You will only be able to run an executable on the FPGA if you specified a BSP.
 

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/GettingStarted/fpga_template/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/GettingStarted/fpga_template/README.md
@@ -5,7 +5,7 @@ This project serves as a template for Intel® oneAPI FPGA designs.
 | Optimized for                     | Description
 |:---                               |:---
 | OS                                | Linux* Ubuntu* 18.04/20.04 <br> RHEL*/CentOS* 8 <br> SUSE* 15 <br> Windows* 10
-| Hardware                          | Intel® Agilex 7®, Arria® 10, and Stratix® 10 FPGAs
+| Hardware                          | Intel® Agilex® 7, Arria® 10, and Stratix® 10 FPGAs
 | Software                          | Intel® oneAPI DPC++/C++ Compiler
 | What you will learn               | Best practices for creating and managing a oneAPI FPGA project
 | Time to complete                  | 10 minutes
@@ -119,7 +119,7 @@ This design uses CMake to generate a build script for GNU/make.
 
 1. Change to the sample directory.
 
-2. Configure the build system for the Agilex 7® device family, which is the default.
+2. Configure the build system for the Agilex® 7 device family, which is the default.
 
    ```
    mkdir build
@@ -156,7 +156,7 @@ This design uses CMake to generate a build script for  `nmake`.
 
 1. Change to the sample directory.
 
-2. Configure the build system for the Agilex 7® device family, which is the default.
+2. Configure the build system for the Agilex® 7 device family, which is the default.
    ```
    mkdir build
    cd build

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Tools/dynamic_profiler/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Tools/dynamic_profiler/README.md
@@ -7,7 +7,7 @@ This FPGA tutorial demonstrates how to use the Intel® FPGA Dynamic Profiler for
 | Optimized for                     | Description
 |:---                               |:---
 | OS                                | Linux* Ubuntu* 18.04/20.04 <br> RHEL*/CentOS* 8 <br> SUSE* 15
-| Hardware                          | Intel® Agilex®, Arria® 10, and Stratix® 10 FPGAs
+| Hardware                          | Intel® Agilex 7®, Arria® 10, and Stratix® 10 FPGAs
 | Software                          | Intel® oneAPI DPC++/C++ Compiler
 | What you will learn               | About the Intel® FPGA Dynamic Profiler for DPC++ <br> How to set up and use this tool <br> A case study of using this tool to identify performance bottlenecks in pipes.
 | Time to complete                  | 15 minutes
@@ -36,9 +36,9 @@ flowchart LR
    tier2("Tier 2: Explore the Fundamentals")
    tier3("Tier 3: Explore the Advanced Techniques")
    tier4("Tier 4: Explore the Reference Designs")
-   
+
    tier1 --> tier2 --> tier3 --> tier4
-   
+
    style tier1 fill:#0071c1,stroke:#0071c1,stroke-width:1px,color:#fff
    style tier2 fill:#0071c1,stroke:#0071c1,stroke-width:1px,color:#fff
    style tier3 fill:#f96,stroke:#333,stroke-width:1px,color:#fff
@@ -172,8 +172,8 @@ When looking at the performance data for the two "after optimization" kernels in
 
 ## Building the Tutorial
 
-> **Note**: When working with the command-line interface (CLI), you should configure the oneAPI toolkits using environment variables. 
-> Set up your CLI environment by sourcing the `setvars` script located in the root of your oneAPI installation every time you open a new terminal window. 
+> **Note**: When working with the command-line interface (CLI), you should configure the oneAPI toolkits using environment variables.
+> Set up your CLI environment by sourcing the `setvars` script located in the root of your oneAPI installation every time you open a new terminal window.
 > This practice ensures that your compiler, libraries, and tools are ready for development.
 >
 > Linux*:
@@ -194,7 +194,7 @@ When looking at the performance data for the two "after optimization" kernels in
   mkdir build
   cd build
   ```
-  To compile for the default target (the Agilex® device family), run `cmake` using the command:
+  To compile for the default target (the Agilex 7® device family), run `cmake` using the command:
   ```
   cmake ..
   ```
@@ -202,12 +202,12 @@ When looking at the performance data for the two "after optimization" kernels in
   > **Note**: You can change the default target by using the command:
   >  ```
   >  cmake .. -DFPGA_DEVICE=<FPGA device family or FPGA part number>
-  >  ``` 
+  >  ```
   >
-  > Alternatively, you can target an explicit FPGA board variant and BSP by using the following command: 
+  > Alternatively, you can target an explicit FPGA board variant and BSP by using the following command:
   >  ```
   >  cmake .. -DFPGA_DEVICE=<board-support-package>:<board-variant>
-  >  ``` 
+  >  ```
   >
   > You will only be able to run an executable on the FPGA if you specified a BSP.
 

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Tools/dynamic_profiler/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Tools/dynamic_profiler/README.md
@@ -7,7 +7,7 @@ This FPGA tutorial demonstrates how to use the Intel® FPGA Dynamic Profiler for
 | Optimized for                     | Description
 |:---                               |:---
 | OS                                | Linux* Ubuntu* 18.04/20.04 <br> RHEL*/CentOS* 8 <br> SUSE* 15
-| Hardware                          | Intel® Agilex 7®, Arria® 10, and Stratix® 10 FPGAs
+| Hardware                          | Intel® Agilex® 7, Arria® 10, and Stratix® 10 FPGAs
 | Software                          | Intel® oneAPI DPC++/C++ Compiler
 | What you will learn               | About the Intel® FPGA Dynamic Profiler for DPC++ <br> How to set up and use this tool <br> A case study of using this tool to identify performance bottlenecks in pipes.
 | Time to complete                  | 15 minutes
@@ -194,7 +194,7 @@ When looking at the performance data for the two "after optimization" kernels in
   mkdir build
   cd build
   ```
-  To compile for the default target (the Agilex 7® device family), run `cmake` using the command:
+  To compile for the default target (the Agilex® 7 device family), run `cmake` using the command:
   ```
   cmake ..
   ```

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Tools/dynamic_profiler/src/CMakeLists.txt
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Tools/dynamic_profiler/src/CMakeLists.txt
@@ -6,7 +6,7 @@ set(FPGA_TARGET ${TARGET_NAME}.fpga)
 
 # FPGA board selection
 if(NOT DEFINED FPGA_DEVICE)
-    set(FPGA_DEVICE "Agilex")
+    set(FPGA_DEVICE "Agilex 7")
     message(STATUS "FPGA_DEVICE was not specified.\
                     \nConfiguring the design to the default FPGA family: ${FPGA_DEVICE}\
                     \nPlease refer to the README for information on target selection.")

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Tools/dynamic_profiler/src/CMakeLists.txt
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Tools/dynamic_profiler/src/CMakeLists.txt
@@ -6,7 +6,7 @@ set(FPGA_TARGET ${TARGET_NAME}.fpga)
 
 # FPGA board selection
 if(NOT DEFINED FPGA_DEVICE)
-    set(FPGA_DEVICE "Agilex 7")
+    set(FPGA_DEVICE "Agilex7")
     message(STATUS "FPGA_DEVICE was not specified.\
                     \nConfiguring the design to the default FPGA family: ${FPGA_DEVICE}\
                     \nPlease refer to the README for information on target selection.")

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Tools/system_profiling/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Tools/system_profiling/README.md
@@ -8,7 +8,7 @@ The [Intercept Layer for OpenCL™ Applications](https://github.com/intel/opencl
 | Optimized for                     | Description
 ---                                 |---
 | OS                                | Linux* Ubuntu* 18.04/20.04 <br> RHEL*/CentOS* 8 <br> SUSE* 15
-| Hardware                          | Intel® Agilex 7®, Arria® 10, and Stratix® 10 FPGAs
+| Hardware                          | Intel® Agilex® 7, Arria® 10, and Stratix® 10 FPGAs
 | Software                          | Intel® oneAPI DPC++/C++ Compiler
 | What you will learn               | Summary of profiling tools available for performance optimization <br> About the Intercept Layer for OpenCL™ Applications <br> How to set up and use this tool <br> A case study of using this tool to identify when the double buffering system-level optimization is beneficial
 | Time to complete                  | 30 minutes
@@ -244,7 +244,7 @@ The Intercept Layer for OpenCL™ Applications makes it clear why the double buf
     mkdir build
     cd build
     ```
-    To compile for the default target (the Agilex 7® device family), run `cmake` using the command:
+    To compile for the default target (the Agilex® 7 device family), run `cmake` using the command:
     ```
     cmake ..
     ```

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Tools/system_profiling/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Tools/system_profiling/README.md
@@ -8,7 +8,7 @@ The [Intercept Layer for OpenCL™ Applications](https://github.com/intel/opencl
 | Optimized for                     | Description
 ---                                 |---
 | OS                                | Linux* Ubuntu* 18.04/20.04 <br> RHEL*/CentOS* 8 <br> SUSE* 15
-| Hardware                          | Intel® Agilex®, Arria® 10, and Stratix® 10 FPGAs
+| Hardware                          | Intel® Agilex 7®, Arria® 10, and Stratix® 10 FPGAs
 | Software                          | Intel® oneAPI DPC++/C++ Compiler
 | What you will learn               | Summary of profiling tools available for performance optimization <br> About the Intercept Layer for OpenCL™ Applications <br> How to set up and use this tool <br> A case study of using this tool to identify when the double buffering system-level optimization is beneficial
 | Time to complete                  | 30 minutes
@@ -35,9 +35,9 @@ flowchart LR
    tier2("Tier 2: Explore the Fundamentals")
    tier3("Tier 3: Explore the Advanced Techniques")
    tier4("Tier 4: Explore the Reference Designs")
-   
+
    tier1 --> tier2 --> tier3 --> tier4
-   
+
    style tier1 fill:#0071c1,stroke:#0071c1,stroke-width:1px,color:#fff
    style tier2 fill:#0071c1,stroke:#0071c1,stroke-width:1px,color:#fff
    style tier3 fill:#f96,stroke:#333,stroke-width:1px,color:#fff
@@ -153,7 +153,7 @@ To set up the Intercept Layer for OpenCL™ Applications, perform the following 
 
     For this tutorial, set the following options:
 
-| Options/Variables |Description 
+| Options/Variables |Description
 |:--- |:---
 | `DllName=$CMPLR_ROOT/linux/lib/libOpenCL.so`                  | The intercept layer must know where `libOpenCL.so` file from the original oneAPI build is. If using this option in a conf file, expand `$CMPLR_ROOT` and pass in the absolute path.                           |
 | `DevicePerformanceTiming=1` and `DevicePerformanceTimelineLogging=1`                    | These options print out runtime timeline information in the output of the executable run.                           |
@@ -222,8 +222,8 @@ The Intercept Layer for OpenCL™ Applications makes it clear why the double buf
 
 ## Building the Tutorial
 
-> **Note**: When working with the command-line interface (CLI), you should configure the oneAPI toolkits using environment variables. 
-> Set up your CLI environment by sourcing the `setvars` script located in the root of your oneAPI installation every time you open a new terminal window. 
+> **Note**: When working with the command-line interface (CLI), you should configure the oneAPI toolkits using environment variables.
+> Set up your CLI environment by sourcing the `setvars` script located in the root of your oneAPI installation every time you open a new terminal window.
 > This practice ensures that your compiler, libraries, and tools are ready for development.
 >
 > Linux*:
@@ -244,7 +244,7 @@ The Intercept Layer for OpenCL™ Applications makes it clear why the double buf
     mkdir build
     cd build
     ```
-    To compile for the default target (the Agilex® device family), run `cmake` using the command:
+    To compile for the default target (the Agilex 7® device family), run `cmake` using the command:
     ```
     cmake ..
     ```
@@ -252,12 +252,12 @@ The Intercept Layer for OpenCL™ Applications makes it clear why the double buf
     > **Note**: You can change the default target by using the command:
     >  ```
     >  cmake .. -DFPGA_DEVICE=<FPGA device family or FPGA part number>
-    >  ``` 
+    >  ```
     >
-    > Alternatively, you can target an explicit FPGA board variant and BSP by using the following command: 
+    > Alternatively, you can target an explicit FPGA board variant and BSP by using the following command:
     >  ```
     >  cmake .. -DFPGA_DEVICE=<board-support-package>:<board-variant>
-    >  ``` 
+    >  ```
     >
     > You will only be able to run an executable on the FPGA if you specified a BSP.
 

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Tools/system_profiling/src/CMakeLists.txt
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Tools/system_profiling/src/CMakeLists.txt
@@ -6,7 +6,7 @@ set(FPGA_TARGET ${TARGET_NAME}.fpga)
 
 # FPGA board selection
 if(NOT DEFINED FPGA_DEVICE)
-    set(FPGA_DEVICE "Agilex")
+    set(FPGA_DEVICE "Agilex 7")
     message(STATUS "FPGA_DEVICE was not specified.\
                     \nConfiguring the design to the default FPGA family: ${FPGA_DEVICE}\
                     \nPlease refer to the README for information on target selection.")

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Tools/system_profiling/src/CMakeLists.txt
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Tools/system_profiling/src/CMakeLists.txt
@@ -6,7 +6,7 @@ set(FPGA_TARGET ${TARGET_NAME}.fpga)
 
 # FPGA board selection
 if(NOT DEFINED FPGA_DEVICE)
-    set(FPGA_DEVICE "Agilex 7")
+    set(FPGA_DEVICE "Agilex7")
     message(STATUS "FPGA_DEVICE was not specified.\
                     \nConfiguring the design to the default FPGA family: ${FPGA_DEVICE}\
                     \nPlease refer to the README for information on target selection.")

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Tools/use_library/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Tools/use_library/README.md
@@ -5,7 +5,7 @@ This FPGA tutorial demonstrates how to build SYCL device libraries from RTL sour
 | Optimized for                     | Description
 |:---                               |:---
 | OS                                | CentOS* Linux 8 <br> Red Hat* Enterprise Linux* 8 <br> SUSE* Linux Enterprise Server 15 <br> Ubuntu* 18.04 LTS <br> Ubuntu 20.04 <br>Windows* 10
-| Hardware                          | Intel® Agilex 7®, Arria® 10, and Stratix® 10 FPGAs
+| Hardware                          | Intel® Agilex® 7, Arria® 10, and Stratix® 10 FPGAs
 | Software                          | Intel® oneAPI DPC++/C++ Compiler
 | What you will learn               | How to integrate Verilog directly into your oneAPI program and emulate it using a C model, as well as pulling the RTL directly into your full system design.
 | Time to complete                  | 30 minutes
@@ -119,7 +119,7 @@ icpx -fsycl -fintelfpga use_library.cpp lib.a -o use_library.fpga -Xshardware -D
     cd build
     ```
 
-    To compile for the default target (the Agilex 7® device family), run `cmake` using the command:
+    To compile for the default target (the Agilex® 7 device family), run `cmake` using the command:
     ```
     cmake ..
     ```
@@ -171,7 +171,7 @@ icpx -fsycl -fintelfpga use_library.cpp lib.a -o use_library.fpga -Xshardware -D
     cd build
     ```
 
-    To compile for the default target (the Agilex 7® device family), run `cmake` using the command:
+    To compile for the default target (the Agilex® 7 device family), run `cmake` using the command:
     ```
     cmake -G "NMake Makefiles" ..
     ```

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Tools/use_library/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Tools/use_library/README.md
@@ -5,7 +5,7 @@ This FPGA tutorial demonstrates how to build SYCL device libraries from RTL sour
 | Optimized for                     | Description
 |:---                               |:---
 | OS                                | CentOS* Linux 8 <br> Red Hat* Enterprise Linux* 8 <br> SUSE* Linux Enterprise Server 15 <br> Ubuntu* 18.04 LTS <br> Ubuntu 20.04 <br>Windows* 10
-| Hardware                          | Intel® Agilex®, Arria® 10, and Stratix® 10 FPGAs
+| Hardware                          | Intel® Agilex 7®, Arria® 10, and Stratix® 10 FPGAs
 | Software                          | Intel® oneAPI DPC++/C++ Compiler
 | What you will learn               | How to integrate Verilog directly into your oneAPI program and emulate it using a C model, as well as pulling the RTL directly into your full system design.
 | Time to complete                  | 30 minutes
@@ -35,9 +35,9 @@ flowchart LR
    tier2("Tier 2: Explore the Fundamentals")
    tier3("Tier 3: Explore the Advanced Techniques")
    tier4("Tier 4: Explore the Reference Designs")
-   
+
    tier1 --> tier2 --> tier3 --> tier4
-   
+
    style tier1 fill:#0071c1,stroke:#0071c1,stroke-width:1px,color:#fff
    style tier2 fill:#0071c1,stroke:#0071c1,stroke-width:1px,color:#fff
    style tier3 fill:#f96,stroke:#333,stroke-width:1px,color:#fff
@@ -95,8 +95,8 @@ icpx -fsycl -fintelfpga use_library.cpp lib.a -o use_library.fpga -Xshardware -D
 
 ## Building the `use_library` Tutorial
 
-> **Note**: When working with the command-line interface (CLI), you should configure the oneAPI toolkits using environment variables. 
-> Set up your CLI environment by sourcing the `setvars` script located in the root of your oneAPI installation every time you open a new terminal window. 
+> **Note**: When working with the command-line interface (CLI), you should configure the oneAPI toolkits using environment variables.
+> Set up your CLI environment by sourcing the `setvars` script located in the root of your oneAPI installation every time you open a new terminal window.
 > This practice ensures that your compiler, libraries, and tools are ready for development.
 >
 > Linux*:
@@ -119,7 +119,7 @@ icpx -fsycl -fintelfpga use_library.cpp lib.a -o use_library.fpga -Xshardware -D
     cd build
     ```
 
-    To compile for the default target (the Agilex® device family), run `cmake` using the command:
+    To compile for the default target (the Agilex 7® device family), run `cmake` using the command:
     ```
     cmake ..
     ```
@@ -127,12 +127,12 @@ icpx -fsycl -fintelfpga use_library.cpp lib.a -o use_library.fpga -Xshardware -D
     > **Note**: You can change the default target by using the command:
     >  ```
     >  cmake .. -DFPGA_DEVICE=<FPGA device family or FPGA part number>
-    >  ``` 
+    >  ```
     >
-    > Alternatively, you can target an explicit FPGA board variant and BSP by using the following command: 
+    > Alternatively, you can target an explicit FPGA board variant and BSP by using the following command:
     >  ```
     >  cmake .. -DFPGA_DEVICE=<board-support-package>:<board-variant>
-    >  ``` 
+    >  ```
     >
     > You will only be able to run an executable on the FPGA if you specified a BSP.
 
@@ -171,19 +171,19 @@ icpx -fsycl -fintelfpga use_library.cpp lib.a -o use_library.fpga -Xshardware -D
     cd build
     ```
 
-    To compile for the default target (the Agilex® device family), run `cmake` using the command:
+    To compile for the default target (the Agilex 7® device family), run `cmake` using the command:
     ```
     cmake -G "NMake Makefiles" ..
     ```
     > **Note**: You can change the default target by using the command:
     >  ```
     >  cmake -G "NMake Makefiles" .. -DFPGA_DEVICE=<FPGA device family or FPGA part number>
-    >  ``` 
+    >  ```
     >
-    > Alternatively, you can target an explicit FPGA board variant and BSP by using the following command: 
+    > Alternatively, you can target an explicit FPGA board variant and BSP by using the following command:
     >  ```
     >  cmake -G "NMake Makefiles" .. -DFPGA_DEVICE=<board-support-package>:<board-variant>
-    >  ``` 
+    >  ```
     >
     > You will only be able to run an executable on the FPGA if you specified a BSP.
 

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Tools/use_library/src/CMakeLists.txt
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Tools/use_library/src/CMakeLists.txt
@@ -8,7 +8,7 @@ set(REPORT_TARGET ${TARGET_NAME}_report.a)
 
 # FPGA board selection
 if(NOT DEFINED FPGA_DEVICE)
-    set(FPGA_DEVICE "Agilex")
+    set(FPGA_DEVICE "Agilex 7")
     message(STATUS "FPGA_DEVICE was not specified.\
                     \nConfiguring the design to the default FPGA family: ${FPGA_DEVICE}\
                     \nPlease refer to the README for information on target selection.")

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Tools/use_library/src/CMakeLists.txt
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Tools/use_library/src/CMakeLists.txt
@@ -8,7 +8,7 @@ set(REPORT_TARGET ${TARGET_NAME}_report.a)
 
 # FPGA board selection
 if(NOT DEFINED FPGA_DEVICE)
-    set(FPGA_DEVICE "Agilex 7")
+    set(FPGA_DEVICE "Agilex7")
     message(STATUS "FPGA_DEVICE was not specified.\
                     \nConfiguring the design to the default FPGA family: ${FPGA_DEVICE}\
                     \nPlease refer to the README for information on target selection.")


### PR DESCRIPTION
## Description

Rebrand Agilex to Agilex 7 in all of the FPGA code samples. 

Fixes Issue #15013220309

## External Dependencies

List any external dependencies created as a result of this change.

## Type of change

Please delete options that are not relevant. Add a 'X' to the one that is applicable. 

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Implement fixes for ONSAM Jiras

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Command Line
- [ ] oneapi-cli
- [ ] Visual Studio
- [ ] Eclipse IDE
- [ ] VSCode
- [ ] When compiling the compliler flag "-Wall -Wformat-security -Werror=format-security" was used

