### PR TITLE
FPGA: Update memory_attributes sample to use IS_BSP flag

### DIFF
--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/memory_attributes/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/memory_attributes/README.md
@@ -196,7 +196,7 @@ The choice of attributes will be further discussed in the [Examining the Reports
   >
   > Alternatively, you can target an explicit FPGA board variant and BSP by using the following command: 
   >  ```
-  >  cmake .. -DFPGA_DEVICE=<board-support-package>:<board-variant>
+  >  cmake .. -DFPGA_DEVICE=<board-support-package>:<board-variant> -DIS_BSP=1
   >  ``` 
   >
   > You will only be able to run an executable on the FPGA if you specified a BSP.
@@ -238,7 +238,7 @@ The choice of attributes will be further discussed in the [Examining the Reports
   >
   > Alternatively, you can target an explicit FPGA board variant and BSP by using the following command: 
   >  ```
-  >  cmake -G "NMake Makefiles" .. -DFPGA_DEVICE=<board-support-package>:<board-variant>
+  >  cmake -G "NMake Makefiles" .. -DFPGA_DEVICE=<board-support-package>:<board-variant> -DIS_BSP=1
   >  ``` 
   >
   > You will only be able to run an executable on the FPGA if you specified a BSP.
@@ -327,7 +327,7 @@ There are often many ways to generate a stall-free memory system. As a programme
     memory_attributes.fpga_sim.exe
     set CL_CONTEXT_MPSIM_DEVICE_INTELFPGA=
     ```
-3. Run the sample on the FPGA device (only if you ran `cmake` with `-DFPGA_DEVICE=<board-support-package>:<board-variant>`):
+3. Run the sample on the FPGA device (only if you ran `cmake` with `-DFPGA_DEVICE=<board-support-package>:<board-variant> -DIS_BSP`):
   ```
   ./memory_attributes.fpga         (Linux)
   memory_attributes.fpga.exe       (Windows)

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/memory_attributes/src/CMakeLists.txt
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/memory_attributes/src/CMakeLists.txt
@@ -6,12 +6,21 @@ set(FPGA_TARGET ${TARGET_NAME}.fpga)
 
 # FPGA board selection
 if(NOT DEFINED FPGA_DEVICE)
-    set(FPGA_DEVICE "Agilex")
+    set(FPGA_DEVICE "Agilex7")
     message(STATUS "FPGA_DEVICE was not specified.\
                     \nConfiguring the design to the default FPGA family: ${FPGA_DEVICE}\
                     \nPlease refer to the README for information on target selection.")
 else()
     message(STATUS "Configuring the design with the following target: ${FPGA_DEVICE}")
+
+    # Check if the target is a BSP
+    if(IS_BSP MATCHES "1")
+        set(IS_BSP "1")
+    else()
+        set(IS_BSP "0")
+        message(STATUS "The selected target ${FPGA_DEVICE} is assumed to be an FPGA part number.")
+        message(STATUS "If the target is actually a BSP, run cmake with -DIS_BSP=1.")
+    endif()
 endif()
 
 # This is a Windows-specific flag that enables exception handling in host code
@@ -27,8 +36,13 @@ set(EMULATOR_COMPILE_FLAGS "-fsycl -fintelfpga -Wall ${WIN_FLAG} -DFPGA_EMULATOR
 set(EMULATOR_LINK_FLAGS "-fsycl -fintelfpga")
 set(SIMULATOR_COMPILE_FLAGS "-fsycl -fintelfpga -Wall ${WIN_FLAG} -Xssimulation -DFPGA_SIMULATOR")
 set(SIMULATOR_LINK_FLAGS "-fsycl -fintelfpga -Xssimulation -Xstarget=${FPGA_DEVICE} ${USER_HARDWARE_FLAGS}")
-set(HARDWARE_COMPILE_FLAGS "-fsycl -fintelfpga -Wall ${WIN_FLAG} -DFPGA_HARDWARE -Xsuse-2xclock")
-set(HARDWARE_LINK_FLAGS "-fsycl -fintelfpga -Xshardware -Xstarget=${FPGA_DEVICE} ${USER_HARDWARE_FLAGS} -Xsuse-2xclock")
+if ((IS_BSP STREQUAL "1"))
+    set(HARDWARE_COMPILE_FLAGS "-fsycl -fintelfpga -Wall ${WIN_FLAG} -DFPGA_HARDWARE")
+    set(HARDWARE_LINK_FLAGS "-fsycl -fintelfpga -Xshardware -Xstarget=${FPGA_DEVICE} ${USER_HARDWARE_FLAGS}")
+else()  
+    set(HARDWARE_COMPILE_FLAGS "-fsycl -fintelfpga -Wall ${WIN_FLAG} -DFPGA_HARDWARE -Xsuse-2xclock")
+    set(HARDWARE_LINK_FLAGS "-fsycl -fintelfpga -Xshardware -Xstarget=${FPGA_DEVICE} ${USER_HARDWARE_FLAGS} -Xsuse-2xclock")
+endif()
 # use cmake -D USER_HARDWARE_FLAGS=<flags> to set extra flags for FPGA backend compilation
 
 ###############################################################################


### PR DESCRIPTION
## Description

This change fixes some configuration issues that were causing the `-Xsuse-2xclock` flag to be wrongly passed in as a compile flag. The main issue was that we do not want to use the flag when doing Full-System compiles. To resolve this we now make use of the `IS_BSP` flag to distinguish between flows.

This change also updates the default board from `Agilex` -> `Agilex7` to suppress warnings that were showing up in the compiles.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

I ran the `make report` flow with the following combination of cmake commands to make sure that the `Xsuse-2xclock` was being passed in as intended:
* `cmake -DFPGA_DEVICE=pac_s10_usm -DIS_BSP=1 ..`
* `cmake -DFPGA_DEVICE=pac_s10_usm ..`
* `cmake -DFPGA_DEVICE=Arria10 ..`
* `cmake ..`

- [X] Command Line
- [ ] oneapi-cli
- [ ] Visual Studio
- [ ] Eclipse IDE
- [ ] VSCode
- [ ] When compiling the compliler flag "-Wall -Wformat-security -Werror=format-security" was used
