### PR TITLE
Fix integer division bug in mem_channel

### DIFF
--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/mem_channel/src/mem_channel.cpp
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/mem_channel/src/mem_channel.cpp
@@ -145,7 +145,7 @@ int main() {
     std::cout.setf(std::ios::fixed);
 
     // Input size in MB
-    constexpr double num_mb = (vector_size * sizeof(uint32_t)) / (1024 * 1024);
+    constexpr double num_mb = (vector_size * 1.0 * sizeof(uint32_t)) / (1024 * 1024);
 
     // Report kernel execution time and throughput
     std::cout << "Kernel execution time: " << time_kernel << " seconds\n";


### PR DESCRIPTION
# Existing Sample Changes
## Description

Integer division will truncate the decimals, thus the throughput being presented is incorrect
Example (incorrect) output in regtest https://psg-sc-arc.sc.intel.com/p/psg/data/sys_hld_test/job/20230331/1000/1393654676/stdout.txt 

Demo:
![image](https://user-images.githubusercontent.com/105505114/231858123-c8c2ff82-857b-491a-9b8b-1a584cd78ac7.png)

![image](https://user-images.githubusercontent.com/105505114/231858089-650d4543-ba6f-4e7f-adea-f903fe7cf3bd.png)


Fixes Issue# 

## External Dependencies

List any external dependencies created as a result of this change.

## Type of change

Please delete options that are not relevant. Add a 'X' to the one that is applicable. 

- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [X] Command Line

This is a small change that only affects the output in stdout, tested the output result via the demo above