### PR TITLE
FPGA: Only check for device USM support in BSP mode

### DIFF
--- a/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/anr/src/main.cpp
+++ b/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/anr/src/main.cpp
@@ -93,14 +93,14 @@ int main(int argc, char* argv[]) {
   queue q(selector, fpga_tools::exception_handler);
 
   // make sure the device supports USM device allocations
-  auto d = q.get_device();
-  if (!d.has(aspect::usm_device_allocations)) {
+  auto device = q.get_device();
+#if defined(IS_BSP)
+  if (!device.has(aspect::usm_device_allocations)) {
     std::cerr << "ERROR: The selected device does not support USM device"
               << " allocations\n";
     std::terminate();
   }
-
-  auto device = q.get_device();
+#endif
 
   std::cout << "Running on device: "
             << device.get_info<info::device::name>().c_str() 

--- a/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/merge_sort/src/main.cpp
+++ b/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/merge_sort/src/main.cpp
@@ -136,13 +136,16 @@ int main(int argc, char *argv[]) {
   // create the device queue
   queue q(selector, fpga_tools::exception_handler);
 
-  // make sure the device supports USM device allocations
   auto device = q.get_device();
+
+  // make sure the device supports USM device allocations in BSP mode
+#if defined(IS_BSP)
   if (!device.has(aspect::usm_device_allocations)) {
     std::cerr << "ERROR: The selected device does not support USM device"
               << " allocations\n";
     std::terminate();
   }
+#endif
 
   // make sure the device support USM host allocations if we chose to use them
   if (!device.has(aspect::usm_host_allocations) &&

--- a/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/mvdr_beamforming/src/FakeIOPipes.hpp
+++ b/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/mvdr_beamforming/src/FakeIOPipes.hpp
@@ -70,11 +70,15 @@ class ProducerConsumerBaseImpl {
                 << " allocations\n";
       std::terminate();
     }
+
+#if defined(IS_BSP)
+    // Device allocations are only used in BSP mode
     if (!q.get_device().has(aspect::usm_device_allocations)) {
       std::cerr << "ERROR: The selected device does not support USM device"
                 << " allocations\n";
       std::terminate();
     }
+#endif
 
     // Allocate the space the user requested. Calling a different malloc
     // based on whether the user wants to use USM host allocations or not.

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/io_streaming/src/FakeIOPipes.hpp
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/io_streaming/src/FakeIOPipes.hpp
@@ -65,11 +65,16 @@ class ProducerConsumerBaseImpl {
 
     // check for USM support
     device d = q.get_device();
+
+#if defined (IS_BSP)
+    // make sure the device supports USM device allocations in BSP mode
     if (!d.get_info<info::device::usm_host_allocations>() && use_host_alloc) {
       std::cerr << "ERROR: The selected device does not support USM host"
                 << " allocations\n";
       std::terminate();
     }
+#endif
+
     if (!d.get_info<info::device::usm_device_allocations>()) {
       std::cerr << "ERROR: The selected device does not support USM device"
                 << " allocations\n";


### PR DESCRIPTION
A recent simulator change made the device aspect to be disabled in the simulator when in an IP Authoring flow.
This makes sense as the IP Authoring flow does not support device allocations.
Therefore, we need to stop checking for this aspect when in IP Authoring flow (as the code does not use the device allocations in the case).