### PR TITLE
Add Tools/GPU-Occupancy-Calculator/index.html via file copy rather than network download

### DIFF
--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -50,9 +50,8 @@ jobs:
       env: 
         GPU_OCC_CALC: src/docs/_build/Tools/GPU-Occupancy-Calculator/
       run: |
-        mkdir -p ${GPU_OCC_CALC}   
-        cd ${GPU_OCC_CALC}
-        wget https://raw.githubusercontent.com/oneapi-src/oneAPI-samples/master/Tools/GPU-Occupancy-Calculator/index.html
+        mkdir -p ${GPU_OCC_CALC}
+        cp -v ${{ github.workspace }}/master/Tools/GPU-Occupancy-Calculator/index.html ${GPU_OCC_CALC}/index.html
 
     - name: Push docs
       if: ${{ github.ref == 'refs/heads/master' }} # only if this workflow is run from the master branch, push docs


### PR DESCRIPTION
Also [enables testing on pull request of github pages build](https://github.com/oneapi-src/oneAPI-samples/pull/1572/commits/ac90891613646380a80ddc93b05383f9d62c76c8)