### PR TITLE
Fix oneVPL hello-decode, CMakeLists custom target run, fix #1395

### DIFF
--- a/Libraries/oneVPL/hello-decode/CMakeLists.txt
+++ b/Libraries/oneVPL/hello-decode/CMakeLists.txt
@@ -9,3 +9,8 @@ file(COPY $ENV{ONEAPI_ROOT}/vpl/latest/examples/hello/hello-decode/src DESTINATI
 file(COPY $ENV{ONEAPI_ROOT}/vpl/latest/examples/hello/hello-decode/CMakeLists.txt DESTINATION .)
 file(COPY $ENV{ONEAPI_ROOT}/vpl/latest/examples/hello/hello-decode/PreLoad.cmake DESTINATION .)
 add_subdirectory (${PROJECT_BINARY_DIR}/ bin)
+
+file(COPY $ENV{ONEAPI_ROOT}/vpl/latest/examples/content/cars_128x96.h265 DESTINATION .)
+set(TARGET hello-decode)
+set(RUNARGS -sw -i ./cars_128x96.h265)
+add_custom_target(run ${TARGET} ${RUNARGS})


### PR DESCRIPTION
# Existing Sample Changes
## Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes Issue# 1395

## External Dependencies

List any external dependencies created as a result of this change.

## Type of change

Please delete options that are not relevant. Add a 'X' to the one that is applicable. 

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Implement fixes for ONSAM Jiras

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [X] Command Line
- [ ] oneapi-cli
- [ ] Visual Studio
- [ ] Eclipse IDE
- [ ] VSCode
- [ ] When compiling the compliler flag "-Wall -Wformat-security -Werror=format-security" was used