### PR TITLE
Fix C++SYCL iso3dfd sample run device selector wrong on TGL, fix #734

### DIFF
--- a/DirectProgramming/C++SYCL/StructuredGrids/iso3dfd_dpcpp/include/device_selector.hpp
+++ b/DirectProgramming/C++SYCL/StructuredGrids/iso3dfd_dpcpp/include/device_selector.hpp
@@ -36,6 +36,11 @@ class MyDeviceSelector {
     // std::cout << "  Vendor: " <<
     // device.get_info<sycl::info::device::vendor>() << std::endl;
 
+    if ((pattern == "Gen") && device.is_gpu()) {
+      return 200;
+    } else if ((pattern == "CPU") && device.is_cpu()) {
+      return 200;
+    }
     // Device with pattern in the name is prioritized:
     return (name.find(pattern) != std::string::npos) ? 100 : 1;
   }


### PR DESCRIPTION
# Existing Sample Changes
## Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes Issue# 734

## External Dependencies

List any external dependencies created as a result of this change.

## Type of change

Please delete options that are not relevant. Add a 'X' to the one that is applicable. 

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Implement fixes for ONSAM Jiras

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [X] Command Line
- [ ] oneapi-cli
- [ ] Visual Studio
- [ ] Eclipse IDE
- [ ] VSCode
- [ ] When compiling the compliler flag "-Wall -Wformat-security -Werror=format-security" was used