### PR TITLE
Fix OMP Reduction sample, on TGL GPU kernel use float, fix #755

### DIFF
--- a/DirectProgramming/C++/ParallelPatterns/openmp_reduction/src/main.cpp
+++ b/DirectProgramming/C++/ParallelPatterns/openmp_reduction/src/main.cpp
@@ -60,7 +60,7 @@ float openmp_device_calc_pi(int num_steps) {
 #pragma omp target teams distribute parallel for reduction(+ : sum)
   for (int i = 1; i < num_steps; i++) {
     float x = ((float)i - 0.5f) * step;
-    sum = sum + 4.0f / (1.0 + x * x);
+    sum = sum + 4.0f / (1.0f + x * x);
   }
   pi = sum * step;
   return pi;


### PR DESCRIPTION
# Existing Sample Changes
## Description

Fix OMP Reduction sample, on TGL GPU kernel use float

Fixes Issue #755

## External Dependencies

List any external dependencies created as a result of this change.

## Type of change

Please delete options that are not relevant. Add a 'X' to the one that is applicable. 

- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [X] Command Line