### PR TITLE
Fix oneAPI-samples issue (#1333)

### DIFF
--- a/DirectProgramming/C++SYCL/DenseLinearAlgebra/vector-add/README.md
+++ b/DirectProgramming/C++SYCL/DenseLinearAlgebra/vector-add/README.md
@@ -114,7 +114,17 @@ To learn more about the extensions and how to configure the oneAPI environment, 
    >  ```
    >  cmake .. -DFPGA_DEVICE=<board-support-package>:<board-variant>
    >  ```
+   > Here are a few examples of FPGA board variant and BSP (this list is not exhaustive):
+   > 
+   > For Intel® PAC with Intel Arria® 10 GX FPGA, the USM is not supported, you can use below BSP:
+   > 
+   >     intel_a10gx_pac:pac_a10
    >
+   > For Intel® FPGA PAC D5005, use one of the following BSP based on the USM support:
+   >
+   >     intel_s10sx_pac:pac_s10
+   >     intel_s10sx_pac:pac_s10_usm
+   > 
    > You will only be able to run an executable on the FPGA if you specified a BSP.
 
 #### Build for CPU and GPU
@@ -186,7 +196,17 @@ time.)
    >  ```
    >  cmake -G "NMake Makefiles" .. -DFPGA_DEVICE=<board-support-package>:<board-variant>
    >  ```
+   > Here are a few examples of FPGA board variant and BSP (this list is not exhaustive):
+   > 
+   > For Intel® PAC with Intel Arria® 10 GX FPGA, the USM is not supported, you can use below BSP:
+   > 
+   >     intel_a10gx_pac:pac_a10
    >
+   > For Intel® FPGA PAC D5005, use one of the following BSP based on the USM support:
+   >
+   >     intel_s10sx_pac:pac_s10
+   >     intel_s10sx_pac:pac_s10_usm
+   > 
    > You will only be able to run an executable on the FPGA if you specified a BSP.
 
 #### Build for CPU and GPU


### PR DESCRIPTION
Add Intel(R) PAC with Intel Arria(R) 10 GX FPGA and Intel(R) FPGA PAC D5005 FPGA BSP information in the vector-add README.md to give beginner more hint to build and run this sample on above FPGA.

Update README

Fixes Issue #1333

