### PR TITLE
add sample catalog link to top-level readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,16 @@ The oneAPI-samples repository contains samples for the [Intel® oneAPI Toolkits]
 
 The contents of the default branch in this repository are meant to be used with the most recent released version of the Intel® oneAPI Toolkits.
 
+## Find oneAPI Samples
+
+You can find samples by browsing the *[oneAPI Samples Catalog](https://oneapi-src.github.io/oneAPI-samples/)*. Using the catalog you can search on the sample titles or descriptions.
+
+You can refine your browsing or searching through filtering on the following:
+
+- Expertise (Getting Started, Tutorial, etc.)
+- Programming language (C++, Python, or Fortran)
+- Target device (CPU GPU, and FPGA)
+
 ## Get the oneAPI Samples
 
 Clone the repository by entering the following command:


### PR DESCRIPTION
# Existing Sample Changes
## Description

Adding a section on the sample catalog to the top-level readme. I thought I had done this already, but it turns out that didn't work. Second attempt.

## External Dependencies

N/A
