### PR TITLE
Added note for erreta in README.md of RenderingToolkit

### DIFF
--- a/RenderingToolkit/GettingStarted/01_ospray_gsg/README.md
+++ b/RenderingToolkit/GettingStarted/01_ospray_gsg/README.md
@@ -52,6 +52,11 @@ Volume Kernel Library (Intel&reg; Open VKL), and Intel&reg; Open Image Denoise.
 
 ## Build and Run
 
+### Additional Notes
+
+oneAPI Rendering Toolkit 2023.1 version's cmake file contains an errata. The errata will produce an error while building the example. Please apply the following workaround described in the following page. 2023.1.1 version will address the issue.
+
+https://community.intel.com/t5/Intel-oneAPI-Rendering-Toolkit/2023-1-troubleshoot-errata-CMake-Error/m-p/1476040#M98
 ### Windows
 
 1. Run a new **x64 Native Tools Command Prompt for MSVS 2019**.


### PR DESCRIPTION
# Existing Sample Changes
## Description

oneAPI Rendering Toolkit 2023.1 version's cmake file contains an errata. The errata will produce an error while building the example. Please apply the workaround described in the following page. 2023.1.1 version will address the issue.

## Type of change

- [x] Update Instructions

## How Has This Been Tested?

- [x] Command Line
- [ ] oneapi-cli
- [ ] Visual Studio
- [ ] Eclipse IDE
- [x] VSCode
- [ ] When compiling the compliler flag "-Wall -Wformat-security -Werror=format-security" was used