### PR TITLE
Fixed typo and broken hyperlinks

### DIFF
--- a/Libraries/oneMKL/fourier_correlation/README.md
+++ b/Libraries/oneMKL/fourier_correlation/README.md
@@ -22,8 +22,8 @@ The algorithm can be composed using SYCL, oneMKL, and/or oneDPL. SYCL provides t
 
 The following articles provide more detailed explanations of the implementations:
 
- - [Efficiently Implementing Fourier Correlation Using oneAPI Math Kernel Library](https://www.intel.com/content/www/us/en/develop/documentation/oneapi-gpu-optimization-guide/top/libraries/libraries-fcorr.html)
- - [Accelerating the 2D Fourier Correlation Algorithm with ArrayFire and oneAPI](https://www.intel.com/content/www/us/en/developer/articles/technical/accelerate-2d-fourier-correlation-algorithm.html#gs.1duy87)
+ - [Efficiently Implementing Fourier Correlation Using oneAPI Math Kernel Library](https://www.intel.com/content/www/us/en/docs/oneapi/optimization-guide-gpu/2023-1/efficiently-implementing-fourier-correlation-using.html)
+ - [Accelerating the 2D Fourier Correlation Algorithm with ArrayFire and oneAPI](https://www.intel.com/content/www/us/en/developer/articles/technical/accelerate-2d-fourier-correlation-algorithm.html)
 
 ## Key Implementation Details
 In many applications, only the final correlation result matters, so this is all that has to be transferred from the device back to the host. In this example, two artificial signals will be created on the device, transformed in-place, then correlated. The host will retrieve the final result (i.e., the location of the maximum value) and report the optimal translation and correlation score.
@@ -64,7 +64,8 @@ After learning how to use the extensions for Intel oneAPI Toolkits, return to th
 >
 > Windows: C:\Program Files(x86)\Intel\oneAPI\setvars.bat
 >
->For more information on environment variables, see Use the setvars Script for [Linux or macOS](https://www.intel.com/content/www/us/en/develop/documentation/oneapi-programming-guide/top/oneapi-development-environment-setup/use-the-setvars-script-with-linux-or-macos.html), or [Windows](https://www.intel.com/content/www/us/en/develop/documentation/oneapi-programming-guide/top/oneapi-development-environment-setup/use-the-setvars-script-with-windows.html).
+
+>For more information on environment variables, see Use the setvars Script for [Linux or macOS](https://www.intel.com/content/www/us/en/docs/oneapi/programming-guide/2023-1/use-the-setvars-script-with-linux-or-macos.html), or [Windows](https://www.intel.com/content/www/us/en/docs/oneapi/programming-guide/2023-1/use-the-setvars-script-with-windows.html).
 
 ### Running Samples on the DevCloud
 When running a sample in the Intel DevCloud, remember that you must specify the compute node (CPU, GPU, FPGA) as well whether to run in batch or interactive mode. For more information see the Intel® oneAPI Base Toolkit Get Started Guide (https://devcloud.intel.com/oneapi/get-started/base-toolkit/).
@@ -78,9 +79,7 @@ You can remove all generated files with `make clean`.
 ### On a Windows System
 Run `nmake` to build and run the sample.
 
-Note: To removes temporary files, run `nmake clean`.
-
-*Warning*: On Windows, static linking with oneMKL currently takes a very long time, due to a known compiler issue. This will be addressed in an upcoming oneMKL compiler release.
+Note: To remove temporary files, run `nmake clean`.
 
 ### Example of Output
 If everything is working correctly, the program will generate two artificial 1D signals, cross-correlate them, and report the relative shift that gives the maximum correlation score the output should be similar to this:
@@ -133,4 +132,4 @@ normalized correlation score of 4. Treat the images as circularly shifted versio
 
 ### Troubleshooting
 If an error occurs, troubleshoot the problem using the Diagnostics Utility for Intel® oneAPI Toolkits.
-[Learn more](https://www.intel.com/content/www/us/en/develop/documentation/diagnostic-utility-user-guide/top.html)
+[Learn more](https://www.intel.com/content/www/us/en/docs/oneapi/user-guide-diagnostic-utility/2023-1/overview.html)


### PR DESCRIPTION
# Existing Sample Changes
## Description

I fixed a typo and updated some hyperlinks that were broken because the URLs on Intel Developer Zone changed.

## External Dependencies

None.

## Type of change

Please delete options that are not relevant. Add a 'X' to the one that is applicable. 

- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [X] Command Line
