### PR TITLE
Fix [JIRA ONSAM-1594] no_init and readonly conflict 

### DIFF
--- a/Publications/GPU-Opt-Guide/joint-matrix/joint-matrix.cpp
+++ b/Publications/GPU-Opt-Guide/joint-matrix/joint-matrix.cpp
@@ -43,8 +43,8 @@ void matrix_multiply(big_matrix<T1, M, N> &C, big_matrix<T2, M, K> &A,
   sycl::queue q;
   q.submit([&](sycl::handler &cgh) {
      sycl::accessor accC(bufC, cgh, sycl::read_write, sycl::no_init);
-     sycl::accessor accA(bufA, cgh, sycl::read_only, sycl::no_init);
-     sycl::accessor accB(bufB, cgh, sycl::read_only, sycl::no_init);
+     sycl::accessor accA(bufA, cgh, sycl::read_only);
+     sycl::accessor accB(bufB, cgh, sycl::read_only);
 
      cgh.parallel_for(
          sycl::nd_range<2>({NDRangeM, NDRangeN * SG_SZ}, {1, 1 * SG_SZ}),


### PR DESCRIPTION
# Existing Sample Changes
## Description

Fix run failure of joint-matrix because accessor was created as no-init and readonly, removed the no-init from the accessor property list.

Fixes Issue# ONSAM-1954

## External Dependencies

List any external dependencies created as a result of this change.

## Type of change

Please delete options that are not relevant. Add a 'X' to the one that is applicable. 

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X ] Implement fixes for ONSAM Jiras

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [X] Command Line
- [ ] oneapi-cli
- [ ] Visual Studio
- [ ] Eclipse IDE
- [ ] VSCode
- [ ] When compiling the compliler flag "-Wall -Wformat-security -Werror=format-security" was used

