### PR TITLE
[oneDNN][profile_utils.py] Warning message fix

### DIFF
--- a/Libraries/oneDNN/tutorials/profiling/profile_utils.py
+++ b/Libraries/oneDNN/tutorials/profiling/profile_utils.py
@@ -99,7 +99,7 @@ class oneDNNLog:
 
         exec_data = data[data['exec'] == 'exec']
         self.data = data
-        self.exec_data = exec_data
+        self.exec_data = exec_data.copy()
 
         if self.with_timestamp is True:
             import io


### PR DESCRIPTION
# Existing Sample Changes
### Description
Fix for warning message output in python_utils script when passing oneDNN verbose logs with *info* lines.

Fixes  #1368 
Currently, when passing a oneDNN verbose log to python_utils script with info lines the script outputs warning messages to the user:

```profile_utils.py:354: SettingWithCopyWarning:
A value is trying to be set on a copy of a slice from a DataFrame.
Try using .loc[row_indexer,col_indexer] = value instead

See the caveats in the documentation: https://pandas.pydata.org/pandas-docs/stable/user_guide/indexing.html#returning-a-view-versus-a-copy
  log.exec_data['time'] = log.exec_data['time'].astype(float)
Total MKLDNN time: 320.32668909200004
Total MKLDNN ops: 15340

 breakdown: type
C:\Users\orelyehu\profile_utils\oneAPI-samples\Libraries\oneDNN\tutorials\profiling\profile_utils.py:164: SettingWithCopyWarning:
A value is trying to be set on a copy of a slice from a DataFrame.
Try using .loc[row_indexer,col_indexer] = value instead

See the caveats in the documentation: https://pandas.pydata.org/pandas-docs/stable/user_guide/indexing.html#returning-a-view-versus-a-copy
  data['time'] = data['time'].astype(float)

```

After the fix:

```
mkldnn_log.csv
Total MKLDNN time: 220.32668
Total MKLDNN ops: 15240

 breakdown: type
type
softmax_v2         0.22695
inner_product      4.268556
lrn                8.655762
pooling_v2        12.065188
concat            15.833981
reorder           42.980974
convolution      126.259533
Name: time, dtype: float64

 breakdown: jit
jit
brgemm:avx512_core           4.268556
jit:blk                      6.717288
lrn_jit:avx512_core          8.655762
jit:avx512_core             12.327883
simple:any                  25.833981
brgconv_1x1:avx512_core     46.368657
jit:uni                     72263686
brgconv:avx512_core        100.890876
Name: time, dtype: float64

```

## External Dependencies

List any external dependencies created as a result of this change.

## Type of change

Please delete options that are not relevant. Add a 'X' to the one that is applicable. 

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Implement fixes for ONSAM Jiras

## How Has This Been Tested?

- [X] Command Line


