### PR TITLE
add initialization for d_a

### DIFF
--- a/DirectProgramming/C++SYCL/guided_concurrentKernels_SYCLMigration/02_sycl_dpct_migrated/src/concurrentKernels.cpp
+++ b/DirectProgramming/C++SYCL/guided_concurrentKernels_SYCLMigration/02_sycl_dpct_migrated/src/concurrentKernels.cpp
@@ -162,6 +162,7 @@ int main(int argc, char **argv) {
   // queue nkernels in separate streams and record when they are done
   for (int i = 0; i < nkernels; ++i) {
     streams[i]->submit([&](sycl::handler &cgh) {
+      d_a[i] = 0;
       auto d_a_i_ct0 = &d_a[i];
 
       cgh.parallel_for(


### PR DESCRIPTION
The variables "d_a" are not initialized, so the result during reduction is uncertain and may overflow to a negative number, causing the test to fail.