### PR TITLE
Changes in AMX mixed precision learning Transformers sample to reflect TensorFlow version 2.11 and above

### DIFF
--- a/AI-and-Analytics/Features-and-Functionality/IntelTensorFlow_Transformer_AMX_bfloat16_MixedPrecision/IntelTensorFlow_Transformer_AMX_bfloat16_MixedPrecision.ipynb
+++ b/AI-and-Analytics/Features-and-Functionality/IntelTensorFlow_Transformer_AMX_bfloat16_MixedPrecision/IntelTensorFlow_Transformer_AMX_bfloat16_MixedPrecision.ipynb
@@ -195,22 +195,20 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "71f6a9f6-e196-49ef-ba14-fb2c47b2a2c4",
    "metadata": {},
    "source": [
     "## Modification for mixed precision learning using bfloat16\n",
     "\n",
-    "To use bfloat16 mixed precision learning we need to add the following lines:\n",
+    "To use bfloat16 mixed precision learning we need to add the following line:\n",
     "\n",
     "```python\n",
-    "from tensorflow.keras import mixed_precision\n",
-    "\n",
-    "policy = mixed_precision.Policy('mixed_bfloat16')\n",
-    "mixed_precision.set_global_policy(policy)\n",
+    "tf.config.optimizer.set_experimental_options({'auto_mixed_precision_onednn_bfloat16':True})\n",
     "```\n",
     "\n",
-    "availabe in the prepared patch file `mixed_precision.patch` and the rest of the code should stay the same. So let's take a look what's in the prepared file."
+    "available in the prepared patch file `mixed_precision.patch` and the rest of the code should stay the same. So let's take a look what's in the prepared file."
    ]
   },
   {
@@ -321,13 +319,14 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "9bd0bdf9",
    "metadata": {},
    "source": [
     "### AMX run\n",
     "\n",
-    "First, we will run the same example on the maximum available CPU ISA, i.e., on AMX by setting `DNNL_MAX_CPU_ISA` to `AVX512_CORE_AMX` and also pointing to the corresponding file where the statistics of the execution of the example `./logs/log_cpu_bf16_avx512_amx.csv` will be saved."
+    "First, we will run the same example on the maximum available CPU ISA, i.e., on AMX by setting `DNNL_MAX_CPU_ISA` to `AMX_BF16` and also pointing to the corresponding file where the statistics of the execution of the example `./logs/log_cpu_bf16_amx.csv` will be saved."
    ]
   },
   {
@@ -349,7 +348,7 @@
     "# enable JIT Dump\n",
     "export DNNL_JIT_DUMP=1\n",
     "\n",
-    "DNNL_MAX_CPU_ISA=AVX512_CORE_AMX python ./text_classification_with_transformer.py cpu >> ./logs/log_cpu_bf16_avx512_amx.csv 2>&1\n",
+    "DNNL_MAX_CPU_ISA=AMX_BF16 python ./text_classification_with_transformer.py cpu >> ./logs/log_cpu_bf16_amx.csv 2>&1\n",
     "\n",
     "echo \"########## Done with the run\""
    ]
@@ -454,7 +453,7 @@
     "log1.load_log(logfile1)\n",
     "exec_data1 = log1.exec_data\n",
     "\n",
-    "logfile2 = './logs/log_cpu_bf16_avx512_amx.csv'\n",
+    "logfile2 = './logs/log_cpu_bf16_amx.csv'\n",
     "log2 = oneDNNLog()\n",
     "log2.load_log(logfile2)\n",
     "exec_data2 = log2.exec_data"
@@ -523,7 +522,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.11 (default, Jul  8 2021, 00:48:00) [MSC v.1916 64 bit (AMD64)]"
+   "version": "3.8.11"
   },
   "vscode": {
    "interpreter": {

--- a/AI-and-Analytics/Features-and-Functionality/IntelTensorFlow_Transformer_AMX_bfloat16_MixedPrecision/patch/mixed_precision.patch
+++ b/AI-and-Analytics/Features-and-Functionality/IntelTensorFlow_Transformer_AMX_bfloat16_MixedPrecision/patch/mixed_precision.patch
@@ -1,19 +1,15 @@
---- text_classification_with_transformer.py	2022-09-20 02:24:42.814605146 -0700
-+++ text_classification_with_transformer2.py	2022-09-20 02:24:48.489188611 -0700
-@@ -27,6 +27,16 @@
+--- text_classification_with_transformer2.py
++++ text_classification_with_transformer.py
+@@ -43,6 +43,12 @@
+ tf.config.threading.set_inter_op_parallelism_threads(inter_thread)
  
  
- """
++"""
 +## Bfloat16 mixed precision learning 
 +"""
 +
-+from tensorflow.keras import mixed_precision
++tf.config.optimizer.set_experimental_options({'auto_mixed_precision_onednn_bfloat16':True})
 +
-+policy = mixed_precision.Policy('mixed_bfloat16')
-+mixed_precision.set_global_policy(policy)
-+
-+
-+"""
+ """
  ## Implement a Transformer block as a layer
  """
- 

--- a/AI-and-Analytics/Features-and-Functionality/IntelTensorFlow_Transformer_AMX_bfloat16_MixedPrecision/patch/time.patch
+++ b/AI-and-Analytics/Features-and-Functionality/IntelTensorFlow_Transformer_AMX_bfloat16_MixedPrecision/patch/time.patch
@@ -1,6 +1,6 @@
---- text_classification_with_transformer.py	2022-10-17 04:04:37.455448493 -0700
-+++ text_classification_with_transformer2.py	2022-10-17 04:07:15.196716415 -0700
-@@ -9,10 +9,38 @@
+--- text_classification_with_transformer1.py
++++ text_classification_with_transformer.py
+@@ -10,10 +10,38 @@
  ## Setup
  """
  
@@ -39,7 +39,7 @@
  
  """
  ## Implement a Transformer block as a layer
-@@ -110,6 +138,11 @@
+@@ -111,6 +139,11 @@
  model.compile(
      optimizer="adam", loss="sparse_categorical_crossentropy", metrics=["accuracy"]
  )

--- a/AI-and-Analytics/Features-and-Functionality/IntelTensorFlow_Transformer_AMX_bfloat16_MixedPrecision/run_amx.sh
+++ b/AI-and-Analytics/Features-and-Functionality/IntelTensorFlow_Transformer_AMX_bfloat16_MixedPrecision/run_amx.sh
@@ -9,6 +9,6 @@ export DNNL_VERBOSE=2
 # enable JIT Dump
 export DNNL_JIT_DUMP=1
 
-DNNL_MAX_CPU_ISA=AVX512_CORE_AMX python ./text_classification_with_transformer.py cpu >> ./logs/log_cpu_bf16_avx512_amx.csv 2>&1
+DNNL_MAX_CPU_ISA=AMX_BF16 python ./text_classification_with_transformer.py cpu >> ./logs/log_cpu_bf16_amx.csv 2>&1
 
 echo "########## Done with the run"

--- a/AI-and-Analytics/Features-and-Functionality/IntelTensorFlow_Transformer_AMX_bfloat16_MixedPrecision/sample.json
+++ b/AI-and-Analytics/Features-and-Functionality/IntelTensorFlow_Transformer_AMX_bfloat16_MixedPrecision/sample.json
@@ -15,7 +15,7 @@
   		"steps": [
 			"conda activate tensorflow",
 			"conda install -y jupyter",
-			"jupyter nbconvert --execute IntelTensorFlow_Transformer_AMX_bfloat16_MixedPrecision.ipynb"
+			"jupyter nbconvert --execute --to notebook IntelTensorFlow_Transformer_AMX_bfloat16_MixedPrecision.ipynb"
   		]
   	}
     ]


### PR DESCRIPTION
# Existing Sample Changes
## Description

API related to mixed precision learning changed since TF 2.11. There was also changes in env variables related to oneDNN default ISA. The changes apply new API and system variables to the code sample.
Fixed few spelling issues. 

Fixes Issue# 

## External Dependencies

None.

## Type of change

Please delete options that are not relevant. Add a 'X' to the one that is applicable. 

- [X] Bug fix (non-breaking change which fixes an issue) - API compatibility 

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
When testing, make sure intel extension for tensorflow is installed and the code runs on SPR.

- [X] Command Line
- [ ] oneapi-cli
- [ ] Visual Studio
- [ ] Eclipse IDE
- [ ] VSCode
- [ ] When compiling the compliler flag "-Wall -Wformat-security -Werror=format-security" was used
