### PR TITLE
FPGA: fix io_streaming sample USM check in IPA flow

### DIFF
--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/io_streaming/src/FakeIOPipes.hpp
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/io_streaming/src/FakeIOPipes.hpp
@@ -66,16 +66,13 @@ class ProducerConsumerBaseImpl {
     // check for USM support
     device d = q.get_device();
 
-#if defined (IS_BSP)
-    // make sure the device supports USM device allocations in BSP mode
-    if (!d.get_info<info::device::usm_host_allocations>() && use_host_alloc) {
+    if (use_host_alloc && !d.get_info<info::device::usm_host_allocations>()) {
       std::cerr << "ERROR: The selected device does not support USM host"
                 << " allocations\n";
       std::terminate();
     }
-#endif
 
-    if (!d.get_info<info::device::usm_device_allocations>()) {
+    if (!use_host_alloc && !d.get_info<info::device::usm_device_allocations>()) {
       std::cerr << "ERROR: The selected device does not support USM device"
                 << " allocations\n";
       std::terminate();


### PR DESCRIPTION
This change corrects when the check for device allocations is available for when running the IPA flow.