### PR TITLE
Fix of errors reported by the sample aggregator. Invalid sample.json 

### DIFF
--- a/DirectProgramming/C++SYCL/MapReduce/guided_quasirandomGenerator_SYCLMigration/sample.json
+++ b/DirectProgramming/C++SYCL/MapReduce/guided_quasirandomGenerator_SYCLMigration/sample.json
@@ -1,7 +1,7 @@
 {
   "guid": "9B936C49-3AF8-444B-865E-1395C636AE54",
   "name": "quasirandomGenerator",
-  "categories": ["Toolkit/oneAPI-samples/DirectProgramming/C++SYCL/MapReduce/"],
+  "categories": ["Toolkit/oneAPI-samples/DirectProgramming/C++SYCL/MapReduce"],
   "description": "Implements Niederreiter Quasirandom Sequence Generator and Inverse Cumulative Normal Distribution functions for the generation of Standard Normal Distributions.",
   "toolchain": [ "dpcpp" ],
   "languages": [ { "cpp": {} } ],

--- a/DirectProgramming/C++SYCL/guided_convolutionSeparable_SYCLmigration/sample.json
+++ b/DirectProgramming/C++SYCL/guided_convolutionSeparable_SYCLmigration/sample.json
@@ -1,7 +1,7 @@
 {
   "guid": "842EBEB9-B902-4706-8C08-02E4EB550FC1",
   "name": "convolutionSeparable",
-  "categories": ["Toolkit/oneAPI Direct Programming/C++SYCL/"],
+  "categories": ["Toolkit/oneAPI Direct Programming/C++SYCL"],
   "description": "This sample implements a separable convolution filter of a 2D signal with a gaussian kernel.",
   "toolchain": [ "dpcpp" ],
   "languages": [ { "cpp": {} } ],


### PR DESCRIPTION
# Existing Sample Changes
## Description

After adding some samples, the sample aggregator started reporting errors in the validation of sample.json files. In two samples, due to a _categories_ field that doesn't fit the format, json files turned out to be invalid:
```
iotdk-ninja
iotdk-ninja
10.64.105.26 10.64.69.172 172.17.0.1 
Sample branch/tag: development

The following error was seen in function isValid()

In the sample named:
convolutionSeparable

The error message is:
[{"instancePath":"/categories/0","schemaPath":"#/properties/categories/items/pattern","keyword":"pattern","params":{"pattern":"^(Toolkit/.*[^/])$"},"message":"must match pattern \"^(Toolkit/.*[^/])$\""}]

```
```
iotdk-ninja
iotdk-ninja
10.64.105.26 10.64.69.172 172.17.0.1 
Sample branch/tag: development

The following error was seen in function isValid()

In the sample named:
quasirandomGenerator

The error message is:
[{"instancePath":"/categories/0","schemaPath":"#/properties/categories/items/pattern","keyword":"pattern","params":{"pattern":"^(Toolkit/.*[^/])$"},"message":"must match pattern \"^(Toolkit/.*[^/])$\""}]

```
Samples:
quasirandomGenerator
convolutionSeparable
Fixes Issue# 
https://jira.devtools.intel.com/browse/ONSAM-1601
https://jira.devtools.intel.com/browse/ONSAM-1599

## External Dependencies

List any external dependencies created as a result of this change.

## Type of change

- [X] Implement fixes for ONSAM Jiras

## How Has This Been Tested?

Manual testing. Debugging with sample-aggregator

- [X] oneapi-cli
