### PR TITLE
Fix path

### DIFF
--- a/DirectProgramming/Fortran/Jupyter/OpenMP-offload-training/USM/run.sh
+++ b/DirectProgramming/Fortran/Jupyter/OpenMP-offload-training/USM/run.sh
@@ -2,7 +2,7 @@
 source /opt/intel/oneapi/setvars.sh > /dev/null 2>&1
 /bin/echo "##" $(whoami) is running OMP_Offload Module4 1/2 -- USM main.cpp/main.f90
 echo "########## Compiling"
-ifx -fiopenmp -fopenmp-targets=spir64 lab/main.f90 -o bin/a.out || exit $?
+ifx -fiopenmp -fopenmp-targets=spir64 main.f90 -o bin/a.out || exit $?
 echo "########## Executing"
 cd bin
 ./a.out


### PR DESCRIPTION
The file main.f90 is in the current folder, not in lab

# Existing Sample Changes
## Description
Fix submission script

Fixes Issue#  https://github.com/oneapi-src/oneAPI-samples/issues/1659

## External Dependencies

No new external dependencies

## Type of change

Please delete options that are not relevant. Add a 'X' to the one that is applicable. 

- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Implement fixes for ONSAM Jiras

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Command Line
- [ ] oneapi-cli
- [ ] Visual Studio
- [ ] Eclipse IDE
- [ ] VSCode
- [ ] When compiling the compliler flag "-Wall -Wformat-security -Werror=format-security" was used
- [x] Tested on Dev cloud

