### PR TITLE
FPGA: replace `ulong` with `unsigned long`

### DIFF
--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/double_buffering/src/double_buffering.cpp
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/double_buffering/src/double_buffering.cpp
@@ -106,10 +106,10 @@ void SimplePow(sycl::queue &q, buffer<float, 1> &buffer_a,
 }
 
 // Returns kernel execution time for a given SYCL event from a queue.
-ulong SyclGetExecTimeNs(event e) {
-  ulong start_time =
+unsigned long SyclGetExecTimeNs(event e) {
+  unsigned long start_time =
       e.get_profiling_info<info::event_profiling::command_start>();
-  ulong end_time = e.get_profiling_info<info::event_profiling::command_end>();
+  unsigned long end_time = e.get_profiling_info<info::event_profiling::command_end>();
   return (end_time - start_time);
 }
 
@@ -129,7 +129,7 @@ float MyPow(float input, int pow) {
 */
 void ProcessOutput(buffer<float, 1> &input_buf, buffer<float, 1> &output_buf,
                    int exec_number, event e,
-                   ulong &total_kernel_time_per_slot) {
+                   unsigned long &total_kernel_time_per_slot) {
   host_accessor input_buf_acc(input_buf, read_only);
   host_accessor output_buf_acc(output_buf, read_only);
   int num_errors = 0;
@@ -244,10 +244,10 @@ int main() {
     event sycl_events[2];
 
     // In nanoseconds. Total execution time of kernels in a given slot.
-    ulong total_kernel_time_per_slot[2];
+    unsigned long total_kernel_time_per_slot[2];
 
     // Total execution time of all kernels.
-    ulong total_kernel_time = 0;
+    unsigned long total_kernel_time = 0;
 
     // Allocate vectors to store the host-side copies of the input data
     // Create and allocate the SYCL buffers

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/n_way_buffering/src/n_way_buffering.cpp
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/n_way_buffering/src/n_way_buffering.cpp
@@ -118,10 +118,10 @@ void SimplePow(sycl::queue &q, buffer<float, 1> &buffer_a,
 }
 
 // Returns kernel execution time for a given SYCL event from a queue.
-ulong SyclGetExecTimeNs(event e) {
-  ulong start_time =
+unsigned long SyclGetExecTimeNs(event e) {
+  unsigned long start_time =
       e.get_profiling_info<info::event_profiling::command_start>();
-  ulong end_time = e.get_profiling_info<info::event_profiling::command_end>();
+  unsigned long end_time = e.get_profiling_info<info::event_profiling::command_end>();
   return (end_time - start_time);
 }
 
@@ -140,7 +140,7 @@ float MyPow(float input, int pow) {
 */
 void ProcessOutput(buffer<float, 1> &output_buf, std::vector<float> &input_copy,
                    int exec_number, event e,
-                   ulong &total_kernel_time_per_slot) {
+                   unsigned long &total_kernel_time_per_slot) {
   host_accessor output_buf_acc(output_buf, read_only);
   int num_errors = 0;
   int num_errors_to_print = 10;
@@ -258,10 +258,10 @@ int main() {
     event sycl_events[kLocalN];
 
     // In nanoseconds. Total execution time of kernels in a given slot.
-    ulong total_kernel_time_per_slot[kLocalN];
+    unsigned long total_kernel_time_per_slot[kLocalN];
 
     // Total execution time of all kernels.
-    ulong total_kernel_time = 0;
+    unsigned long total_kernel_time = 0;
 
     // Threads to process the output from each kernel
     std::thread t_process_output[kLocalN];

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/simple_host_streaming/src/simple_host_streaming.cpp
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/simple_host_streaming/src/simple_host_streaming.cpp
@@ -24,7 +24,7 @@ using namespace std::chrono;
 // data types and constants
 // NOTE: this tutorial assumes you are using a sycl::vec datatype. Therefore, 
 // 'Type' can only be changed to a different vector datatype (e.g. int16,
-// ulong8, etc...)
+// long8, etc...)
 using Type = long8;
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/triangular_loop/src/triangular_loop.cpp
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/triangular_loop/src/triangular_loop.cpp
@@ -123,7 +123,7 @@ int main() {
 
   // Host and kernel profiling
   event e;
-  ulong t1_kernel, t2_kernel;
+  unsigned long t1_kernel, t2_kernel;
   double time_kernel;
 // Create queue, get platform and device
 #if FPGA_SIMULATOR

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/read_only_cache/src/read_only_cache.cpp
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/read_only_cache/src/read_only_cache.cpp
@@ -71,7 +71,7 @@ event runSqrtTest(sycl::queue &q, const std::vector<float> &sqrt_lut_vec,
 int main() {
   // Host and kernel profiling
   event e;
-  ulong t1_kernel, t2_kernel;
+  unsigned long t1_kernel, t2_kernel;
   double time_kernel;
 
   // Create input and output vectors

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Tools/system_profiling/src/double_buffering.cpp
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Tools/system_profiling/src/double_buffering.cpp
@@ -106,10 +106,10 @@ void SimplePow(sycl::queue &q, buffer<float, 1> &buffer_a,
 }
 
 // Returns kernel execution time for a given SYCL event from a queue.
-ulong SyclGetExecTimeNs(event e) {
-  ulong start_time =
+unsigned long SyclGetExecTimeNs(event e) {
+  unsigned long start_time =
       e.get_profiling_info<info::event_profiling::command_start>();
-  ulong end_time = e.get_profiling_info<info::event_profiling::command_end>();
+  unsigned long end_time = e.get_profiling_info<info::event_profiling::command_end>();
   return (end_time - start_time);
 }
 
@@ -129,7 +129,7 @@ float MyPow(float input, int pow) {
 */
 void ProcessOutput(buffer<float, 1> &input_buf, buffer<float, 1> &output_buf,
                    int exec_number, event e,
-                   ulong &total_kernel_time_per_slot) {
+                   unsigned long &total_kernel_time_per_slot) {
   host_accessor input_buf_acc(input_buf, read_only);
   host_accessor output_buf_acc(output_buf, read_only);
   int num_errors = 0;
@@ -242,10 +242,10 @@ int main() {
     event sycl_events[2];
 
     // In nanoseconds. Total execution time of kernels in a given slot.
-    ulong total_kernel_time_per_slot[2];
+    unsigned long total_kernel_time_per_slot[2];
 
     // Total execution time of all kernels.
-    ulong total_kernel_time = 0;
+    unsigned long total_kernel_time = 0;
 
     // Allocate vectors to store the host-side copies of the input data
     // Create and allocate the SYCL buffers


### PR DESCRIPTION
This change prevents the deprecation warning related to the `ulong` datatype to appear when compiling FPGA samples.