### PR TITLE
FPGA: fix use of uninitialized memory in streaming_qrd.hpp 

### DIFF
--- a/DirectProgramming/C++SYCL_FPGA/include/streaming_qrd.hpp
+++ b/DirectProgramming/C++SYCL_FPGA/include/streaming_qrd.hpp
@@ -313,7 +313,9 @@ struct StreamingQRD {
           }
 
           // Load a_i for reuse across j iterations
-          if (j_eq_i[fanout_bank_idx]) {
+          if (i_lt_0[fanout_bank_idx]) {
+            a_i[k] = 0;
+          } else if (j_eq_i[fanout_bank_idx]) {
             a_i[k] = col[k];
           }
         });


### PR DESCRIPTION
The `a_i` memory was used uninitialized and assumed to be 0.
This change initializes this memory to 0 prior to using it.