### PR TITLE
Update S10 seed for CRR

### DIFF
--- a/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/crr/src/CMakeLists.txt
+++ b/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/crr/src/CMakeLists.txt
@@ -46,7 +46,7 @@ elseif(DEVICE_FLAG MATCHES "S10")
     set(OUTER_UNROLL 2)
     set(INNER_UNROLL 64)
     set(OUTER_UNROLL_POW2 2)
-    set(SEED "-Xsseed=2")
+    set(SEED "-Xsseed=3")
 elseif(DEVICE_FLAG MATCHES "Agilex7")
     # Agilex 7
     set(OUTER_UNROLL 2)


### PR DESCRIPTION
# Existing Sample Changes

## Description

Change the Quartus seed from 2 to 3 for CRR on S10 devices.

Fixes Issue# 

## External Dependencies

None

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [X] Command Line