### PR TITLE
clear all the ouutput of ipynb

### DIFF
--- a/AI-and-Analytics/Features-and-Functionality/IntelPytorch_Quantization/IntelPytorch_Quantization.ipynb
+++ b/AI-and-Analytics/Features-and-Functionality/IntelPytorch_Quantization/IntelPytorch_Quantization.ipynb
@@ -16,7 +16,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -31,17 +31,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Files already downloaded and verified\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Hyperparameters and constants\n",
     "LR = 0.001\n",
@@ -76,195 +68,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "ResNet(\n",
-       "  (conv1): Conv2d(3, 64, kernel_size=(7, 7), stride=(2, 2), padding=(3, 3), bias=False)\n",
-       "  (bn1): BatchNorm2d(64, eps=1e-05, momentum=0.1, affine=True, track_running_stats=True)\n",
-       "  (relu): ReLU(inplace=True)\n",
-       "  (maxpool): MaxPool2d(kernel_size=3, stride=2, padding=1, dilation=1, ceil_mode=False)\n",
-       "  (layer1): Sequential(\n",
-       "    (0): Bottleneck(\n",
-       "      (conv1): Conv2d(64, 64, kernel_size=(1, 1), stride=(1, 1), bias=False)\n",
-       "      (bn1): BatchNorm2d(64, eps=1e-05, momentum=0.1, affine=True, track_running_stats=True)\n",
-       "      (conv2): Conv2d(64, 64, kernel_size=(3, 3), stride=(1, 1), padding=(1, 1), bias=False)\n",
-       "      (bn2): BatchNorm2d(64, eps=1e-05, momentum=0.1, affine=True, track_running_stats=True)\n",
-       "      (conv3): Conv2d(64, 256, kernel_size=(1, 1), stride=(1, 1), bias=False)\n",
-       "      (bn3): BatchNorm2d(256, eps=1e-05, momentum=0.1, affine=True, track_running_stats=True)\n",
-       "      (relu): ReLU(inplace=True)\n",
-       "      (downsample): Sequential(\n",
-       "        (0): Conv2d(64, 256, kernel_size=(1, 1), stride=(1, 1), bias=False)\n",
-       "        (1): BatchNorm2d(256, eps=1e-05, momentum=0.1, affine=True, track_running_stats=True)\n",
-       "      )\n",
-       "    )\n",
-       "    (1): Bottleneck(\n",
-       "      (conv1): Conv2d(256, 64, kernel_size=(1, 1), stride=(1, 1), bias=False)\n",
-       "      (bn1): BatchNorm2d(64, eps=1e-05, momentum=0.1, affine=True, track_running_stats=True)\n",
-       "      (conv2): Conv2d(64, 64, kernel_size=(3, 3), stride=(1, 1), padding=(1, 1), bias=False)\n",
-       "      (bn2): BatchNorm2d(64, eps=1e-05, momentum=0.1, affine=True, track_running_stats=True)\n",
-       "      (conv3): Conv2d(64, 256, kernel_size=(1, 1), stride=(1, 1), bias=False)\n",
-       "      (bn3): BatchNorm2d(256, eps=1e-05, momentum=0.1, affine=True, track_running_stats=True)\n",
-       "      (relu): ReLU(inplace=True)\n",
-       "    )\n",
-       "    (2): Bottleneck(\n",
-       "      (conv1): Conv2d(256, 64, kernel_size=(1, 1), stride=(1, 1), bias=False)\n",
-       "      (bn1): BatchNorm2d(64, eps=1e-05, momentum=0.1, affine=True, track_running_stats=True)\n",
-       "      (conv2): Conv2d(64, 64, kernel_size=(3, 3), stride=(1, 1), padding=(1, 1), bias=False)\n",
-       "      (bn2): BatchNorm2d(64, eps=1e-05, momentum=0.1, affine=True, track_running_stats=True)\n",
-       "      (conv3): Conv2d(64, 256, kernel_size=(1, 1), stride=(1, 1), bias=False)\n",
-       "      (bn3): BatchNorm2d(256, eps=1e-05, momentum=0.1, affine=True, track_running_stats=True)\n",
-       "      (relu): ReLU(inplace=True)\n",
-       "    )\n",
-       "  )\n",
-       "  (layer2): Sequential(\n",
-       "    (0): Bottleneck(\n",
-       "      (conv1): Conv2d(256, 128, kernel_size=(1, 1), stride=(1, 1), bias=False)\n",
-       "      (bn1): BatchNorm2d(128, eps=1e-05, momentum=0.1, affine=True, track_running_stats=True)\n",
-       "      (conv2): Conv2d(128, 128, kernel_size=(3, 3), stride=(2, 2), padding=(1, 1), bias=False)\n",
-       "      (bn2): BatchNorm2d(128, eps=1e-05, momentum=0.1, affine=True, track_running_stats=True)\n",
-       "      (conv3): Conv2d(128, 512, kernel_size=(1, 1), stride=(1, 1), bias=False)\n",
-       "      (bn3): BatchNorm2d(512, eps=1e-05, momentum=0.1, affine=True, track_running_stats=True)\n",
-       "      (relu): ReLU(inplace=True)\n",
-       "      (downsample): Sequential(\n",
-       "        (0): Conv2d(256, 512, kernel_size=(1, 1), stride=(2, 2), bias=False)\n",
-       "        (1): BatchNorm2d(512, eps=1e-05, momentum=0.1, affine=True, track_running_stats=True)\n",
-       "      )\n",
-       "    )\n",
-       "    (1): Bottleneck(\n",
-       "      (conv1): Conv2d(512, 128, kernel_size=(1, 1), stride=(1, 1), bias=False)\n",
-       "      (bn1): BatchNorm2d(128, eps=1e-05, momentum=0.1, affine=True, track_running_stats=True)\n",
-       "      (conv2): Conv2d(128, 128, kernel_size=(3, 3), stride=(1, 1), padding=(1, 1), bias=False)\n",
-       "      (bn2): BatchNorm2d(128, eps=1e-05, momentum=0.1, affine=True, track_running_stats=True)\n",
-       "      (conv3): Conv2d(128, 512, kernel_size=(1, 1), stride=(1, 1), bias=False)\n",
-       "      (bn3): BatchNorm2d(512, eps=1e-05, momentum=0.1, affine=True, track_running_stats=True)\n",
-       "      (relu): ReLU(inplace=True)\n",
-       "    )\n",
-       "    (2): Bottleneck(\n",
-       "      (conv1): Conv2d(512, 128, kernel_size=(1, 1), stride=(1, 1), bias=False)\n",
-       "      (bn1): BatchNorm2d(128, eps=1e-05, momentum=0.1, affine=True, track_running_stats=True)\n",
-       "      (conv2): Conv2d(128, 128, kernel_size=(3, 3), stride=(1, 1), padding=(1, 1), bias=False)\n",
-       "      (bn2): BatchNorm2d(128, eps=1e-05, momentum=0.1, affine=True, track_running_stats=True)\n",
-       "      (conv3): Conv2d(128, 512, kernel_size=(1, 1), stride=(1, 1), bias=False)\n",
-       "      (bn3): BatchNorm2d(512, eps=1e-05, momentum=0.1, affine=True, track_running_stats=True)\n",
-       "      (relu): ReLU(inplace=True)\n",
-       "    )\n",
-       "    (3): Bottleneck(\n",
-       "      (conv1): Conv2d(512, 128, kernel_size=(1, 1), stride=(1, 1), bias=False)\n",
-       "      (bn1): BatchNorm2d(128, eps=1e-05, momentum=0.1, affine=True, track_running_stats=True)\n",
-       "      (conv2): Conv2d(128, 128, kernel_size=(3, 3), stride=(1, 1), padding=(1, 1), bias=False)\n",
-       "      (bn2): BatchNorm2d(128, eps=1e-05, momentum=0.1, affine=True, track_running_stats=True)\n",
-       "      (conv3): Conv2d(128, 512, kernel_size=(1, 1), stride=(1, 1), bias=False)\n",
-       "      (bn3): BatchNorm2d(512, eps=1e-05, momentum=0.1, affine=True, track_running_stats=True)\n",
-       "      (relu): ReLU(inplace=True)\n",
-       "    )\n",
-       "  )\n",
-       "  (layer3): Sequential(\n",
-       "    (0): Bottleneck(\n",
-       "      (conv1): Conv2d(512, 256, kernel_size=(1, 1), stride=(1, 1), bias=False)\n",
-       "      (bn1): BatchNorm2d(256, eps=1e-05, momentum=0.1, affine=True, track_running_stats=True)\n",
-       "      (conv2): Conv2d(256, 256, kernel_size=(3, 3), stride=(2, 2), padding=(1, 1), bias=False)\n",
-       "      (bn2): BatchNorm2d(256, eps=1e-05, momentum=0.1, affine=True, track_running_stats=True)\n",
-       "      (conv3): Conv2d(256, 1024, kernel_size=(1, 1), stride=(1, 1), bias=False)\n",
-       "      (bn3): BatchNorm2d(1024, eps=1e-05, momentum=0.1, affine=True, track_running_stats=True)\n",
-       "      (relu): ReLU(inplace=True)\n",
-       "      (downsample): Sequential(\n",
-       "        (0): Conv2d(512, 1024, kernel_size=(1, 1), stride=(2, 2), bias=False)\n",
-       "        (1): BatchNorm2d(1024, eps=1e-05, momentum=0.1, affine=True, track_running_stats=True)\n",
-       "      )\n",
-       "    )\n",
-       "    (1): Bottleneck(\n",
-       "      (conv1): Conv2d(1024, 256, kernel_size=(1, 1), stride=(1, 1), bias=False)\n",
-       "      (bn1): BatchNorm2d(256, eps=1e-05, momentum=0.1, affine=True, track_running_stats=True)\n",
-       "      (conv2): Conv2d(256, 256, kernel_size=(3, 3), stride=(1, 1), padding=(1, 1), bias=False)\n",
-       "      (bn2): BatchNorm2d(256, eps=1e-05, momentum=0.1, affine=True, track_running_stats=True)\n",
-       "      (conv3): Conv2d(256, 1024, kernel_size=(1, 1), stride=(1, 1), bias=False)\n",
-       "      (bn3): BatchNorm2d(1024, eps=1e-05, momentum=0.1, affine=True, track_running_stats=True)\n",
-       "      (relu): ReLU(inplace=True)\n",
-       "    )\n",
-       "    (2): Bottleneck(\n",
-       "      (conv1): Conv2d(1024, 256, kernel_size=(1, 1), stride=(1, 1), bias=False)\n",
-       "      (bn1): BatchNorm2d(256, eps=1e-05, momentum=0.1, affine=True, track_running_stats=True)\n",
-       "      (conv2): Conv2d(256, 256, kernel_size=(3, 3), stride=(1, 1), padding=(1, 1), bias=False)\n",
-       "      (bn2): BatchNorm2d(256, eps=1e-05, momentum=0.1, affine=True, track_running_stats=True)\n",
-       "      (conv3): Conv2d(256, 1024, kernel_size=(1, 1), stride=(1, 1), bias=False)\n",
-       "      (bn3): BatchNorm2d(1024, eps=1e-05, momentum=0.1, affine=True, track_running_stats=True)\n",
-       "      (relu): ReLU(inplace=True)\n",
-       "    )\n",
-       "    (3): Bottleneck(\n",
-       "      (conv1): Conv2d(1024, 256, kernel_size=(1, 1), stride=(1, 1), bias=False)\n",
-       "      (bn1): BatchNorm2d(256, eps=1e-05, momentum=0.1, affine=True, track_running_stats=True)\n",
-       "      (conv2): Conv2d(256, 256, kernel_size=(3, 3), stride=(1, 1), padding=(1, 1), bias=False)\n",
-       "      (bn2): BatchNorm2d(256, eps=1e-05, momentum=0.1, affine=True, track_running_stats=True)\n",
-       "      (conv3): Conv2d(256, 1024, kernel_size=(1, 1), stride=(1, 1), bias=False)\n",
-       "      (bn3): BatchNorm2d(1024, eps=1e-05, momentum=0.1, affine=True, track_running_stats=True)\n",
-       "      (relu): ReLU(inplace=True)\n",
-       "    )\n",
-       "    (4): Bottleneck(\n",
-       "      (conv1): Conv2d(1024, 256, kernel_size=(1, 1), stride=(1, 1), bias=False)\n",
-       "      (bn1): BatchNorm2d(256, eps=1e-05, momentum=0.1, affine=True, track_running_stats=True)\n",
-       "      (conv2): Conv2d(256, 256, kernel_size=(3, 3), stride=(1, 1), padding=(1, 1), bias=False)\n",
-       "      (bn2): BatchNorm2d(256, eps=1e-05, momentum=0.1, affine=True, track_running_stats=True)\n",
-       "      (conv3): Conv2d(256, 1024, kernel_size=(1, 1), stride=(1, 1), bias=False)\n",
-       "      (bn3): BatchNorm2d(1024, eps=1e-05, momentum=0.1, affine=True, track_running_stats=True)\n",
-       "      (relu): ReLU(inplace=True)\n",
-       "    )\n",
-       "    (5): Bottleneck(\n",
-       "      (conv1): Conv2d(1024, 256, kernel_size=(1, 1), stride=(1, 1), bias=False)\n",
-       "      (bn1): BatchNorm2d(256, eps=1e-05, momentum=0.1, affine=True, track_running_stats=True)\n",
-       "      (conv2): Conv2d(256, 256, kernel_size=(3, 3), stride=(1, 1), padding=(1, 1), bias=False)\n",
-       "      (bn2): BatchNorm2d(256, eps=1e-05, momentum=0.1, affine=True, track_running_stats=True)\n",
-       "      (conv3): Conv2d(256, 1024, kernel_size=(1, 1), stride=(1, 1), bias=False)\n",
-       "      (bn3): BatchNorm2d(1024, eps=1e-05, momentum=0.1, affine=True, track_running_stats=True)\n",
-       "      (relu): ReLU(inplace=True)\n",
-       "    )\n",
-       "  )\n",
-       "  (layer4): Sequential(\n",
-       "    (0): Bottleneck(\n",
-       "      (conv1): Conv2d(1024, 512, kernel_size=(1, 1), stride=(1, 1), bias=False)\n",
-       "      (bn1): BatchNorm2d(512, eps=1e-05, momentum=0.1, affine=True, track_running_stats=True)\n",
-       "      (conv2): Conv2d(512, 512, kernel_size=(3, 3), stride=(2, 2), padding=(1, 1), bias=False)\n",
-       "      (bn2): BatchNorm2d(512, eps=1e-05, momentum=0.1, affine=True, track_running_stats=True)\n",
-       "      (conv3): Conv2d(512, 2048, kernel_size=(1, 1), stride=(1, 1), bias=False)\n",
-       "      (bn3): BatchNorm2d(2048, eps=1e-05, momentum=0.1, affine=True, track_running_stats=True)\n",
-       "      (relu): ReLU(inplace=True)\n",
-       "      (downsample): Sequential(\n",
-       "        (0): Conv2d(1024, 2048, kernel_size=(1, 1), stride=(2, 2), bias=False)\n",
-       "        (1): BatchNorm2d(2048, eps=1e-05, momentum=0.1, affine=True, track_running_stats=True)\n",
-       "      )\n",
-       "    )\n",
-       "    (1): Bottleneck(\n",
-       "      (conv1): Conv2d(2048, 512, kernel_size=(1, 1), stride=(1, 1), bias=False)\n",
-       "      (bn1): BatchNorm2d(512, eps=1e-05, momentum=0.1, affine=True, track_running_stats=True)\n",
-       "      (conv2): Conv2d(512, 512, kernel_size=(3, 3), stride=(1, 1), padding=(1, 1), bias=False)\n",
-       "      (bn2): BatchNorm2d(512, eps=1e-05, momentum=0.1, affine=True, track_running_stats=True)\n",
-       "      (conv3): Conv2d(512, 2048, kernel_size=(1, 1), stride=(1, 1), bias=False)\n",
-       "      (bn3): BatchNorm2d(2048, eps=1e-05, momentum=0.1, affine=True, track_running_stats=True)\n",
-       "      (relu): ReLU(inplace=True)\n",
-       "    )\n",
-       "    (2): Bottleneck(\n",
-       "      (conv1): Conv2d(2048, 512, kernel_size=(1, 1), stride=(1, 1), bias=False)\n",
-       "      (bn1): BatchNorm2d(512, eps=1e-05, momentum=0.1, affine=True, track_running_stats=True)\n",
-       "      (conv2): Conv2d(512, 512, kernel_size=(3, 3), stride=(1, 1), padding=(1, 1), bias=False)\n",
-       "      (bn2): BatchNorm2d(512, eps=1e-05, momentum=0.1, affine=True, track_running_stats=True)\n",
-       "      (conv3): Conv2d(512, 2048, kernel_size=(1, 1), stride=(1, 1), bias=False)\n",
-       "      (bn3): BatchNorm2d(2048, eps=1e-05, momentum=0.1, affine=True, track_running_stats=True)\n",
-       "      (relu): ReLU(inplace=True)\n",
-       "    )\n",
-       "  )\n",
-       "  (avgpool): AdaptiveAvgPool2d(output_size=(1, 1))\n",
-       "  (fc): Linear(in_features=2048, out_features=1000, bias=True)\n",
-       ")"
-      ]
-     },
-     "execution_count": 3,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "data = torch.rand(1, 3, 224, 224)\n",
     "model_fp32 = torchvision.models.resnet50(weights=torchvision.models.ResNet50_Weights.DEFAULT)\n",
@@ -283,7 +89,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -316,7 +122,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -356,7 +162,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -387,7 +193,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -399,7 +205,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -419,20 +225,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Inference with FP32\n",
-      "Warmup before benchmark ...\n",
-      "Inference ...\n",
-      "Inference Time Avg:  0.029211766719818115\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "print(\"Inference with FP32\")\n",
     "fp32_inference_time = inference(model_fp32, WARMUP, ITERS, data)"
@@ -440,20 +235,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Inference with Static INT8\n",
-      "Warmup before benchmark ...\n",
-      "Inference ...\n",
-      "Inference Time Avg:  0.0024858975410461427\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "print(\"Inference with Static INT8\")\n",
     "traced_model_static = torch.jit.load('quantized_model_static.pt')\n",
@@ -464,20 +248,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Inference with Dynamic INT8\n",
-      "Warmup before benchmark ...\n",
-      "Inference ...\n",
-      "Inference Time Avg:  0.012564747333526612\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "print(\"Inference with Dynamic INT8\")\n",
     "traced_model_dynamic = torch.jit.load('quantized_model_dynamic.pt')\n",
@@ -496,52 +269,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Summary\n",
-      "FP32 inference time: 0.029\n",
-      "INT8 static quantization inference time: 0.002\n",
-      "INT8 dynamic quantization inference time: 0.013\n",
-      "Staic INT8 11.75X faster than FP32\n",
-      "Dynamic INT8 2.32X faster than FP32\n"
-     ]
-    },
-    {
-     "data": {
-      "text/plain": [
-       "<BarContainer object of 3 artists>"
-      ]
-     },
-     "execution_count": 15,
-     "metadata": {},
-     "output_type": "execute_result"
-    },
-    {
-     "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAY4AAAE8CAYAAADXBlYCAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjYuMywgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy/P9b71AAAACXBIWXMAAA9hAAAPYQGoP6dpAABGgklEQVR4nO3de1yO9/8H8Nfd6S4dRUciJguliBImVpOxQxuTmENrMZtj5tCGYoeSIcM0jGbj6zxfM2tLw1ALhc35MDSHClGKDro/vz/8ur5u3XFfqZV6PR+P+8H9uT7X53pf1133u+v6XNfnoxBCCBAREWlJp6YDICKiZwsTBxERycLEQUREsjBxEBGRLEwcREQkCxMHERHJwsRBRESyMHEQEZEsTBxERCQLEwfRv+y7776Ds7Mz9PX1YWFhUdPhPBMcHR0xYsSImg6D/h8TB8kSHx8PhUIhvfT09NCkSROMGDECV65cqbbtRkZGQqFQwMbGBnfv3i233NHREa+88kql2v7qq68QHx+vdX2FQoExY8ZUalunTp3CiBEj8Nxzz2H58uVYtmxZpdp51u3evVvt5+hxL6p99Go6AHo2zZ49Gy1atEBhYSH++OMPxMfHY9++fTh27BgMDQ2rbbvZ2dlYunQpJk2aVGVtfvXVV2jcuPG/8hft7t27oVKpsHDhQrRq1arat1dbtWnTBt99951aWXh4OExMTPDxxx+Xq3/69Gno6PDv3NqCiYMq5eWXX0anTp0AAO+++y4aN26MOXPmYNu2bRg4cGC1bdfd3R1z587F+++/DyMjo2rbTnXJzs4GgCq9RFVQUABjY+Mqa+/fYGNjg7ffflutLDo6Go0bNy5XDgBKpfLfCo20wBROVeKFF14AAJw/f16t/NSpUxgwYAAsLS1haGiITp06Ydu2bWp1SkpKMGvWLDg5OcHQ0BCNGjVC9+7dkZiYWG47M2fORFZWFpYuXfrEmFQqFWJjY9GuXTsYGhrCxsYGo0aNwq1bt6Q6jo6OOH78OPbs2SNdGunZs6esfS+77LJhwwZ89tlnaNq0KQwNDeHr64tz586pbSsiIgIAYGVlBYVCgcjISGn5zz//jBdeeAHGxsYwNTVFv379cPz4cbVtjRgxAiYmJjh//jz69u0LU1NTDBkyROv9LYvjlVdewb59++Dp6QlDQ0O0bNkSq1evLrdvt2/fxsSJE+Ho6AilUommTZti2LBhuHHjhlSnqKgIERERaNWqFZRKJRwcHDBlyhQUFRXJOo6P82gfR9kl03379mHcuHGwsrKChYUFRo0aheLiYty+fRvDhg1Dw4YN0bBhQ0yZMgWPDgSu7fGi8njGQVXi4sWLAICGDRtKZcePH0e3bt3QpEkTTJs2DcbGxtiwYQMCAgKwefNmvPHGGwAe9F9ERUXh3XffhaenJ/Ly8nDo0CGkp6fjpZdeUtvOCy+8gBdffBExMTEYPXr0Y886Ro0ahfj4eAQHB2PcuHG4cOECFi9ejMOHD2P//v3Q19dHbGwsxo4dq3aJxMbGplLHIDo6Gjo6Ovjwww+Rm5uLmJgYDBkyBKmpqQCA2NhYrF69Gj/88AOWLl0KExMTtG/fHsCDDvPhw4fD398fc+bMwd27d7F06VJ0794dhw8fhqOjo7Sd+/fvw9/fH927d8cXX3yBBg0aaL2/Zc6dO4cBAwYgJCQEw4cPx8qVKzFixAh4eHigXbt2AID8/Hy88MILOHnyJN555x107NgRN27cwLZt23D58mU0btwYKpUKr732Gvbt24eRI0eiTZs2+Ouvv7BgwQKcOXMGW7durdSx1NbYsWNha2uLWbNm4Y8//sCyZctgYWGB5ORkNGvWDJ9//jl27NiBuXPnwsXFBcOGDZPWlXO86BGCSIZVq1YJAGLnzp3i+vXr4p9//hGbNm0SVlZWQqlUin/++Ueq6+vrK1xdXUVhYaFUplKpRNeuXYWTk5NU5ubmJvr16/fY7UZERAgA4vr162LPnj0CgJg/f760vHnz5mpt7N27VwAQa9asUWsnISGhXHm7du2Ej4+P1scAgPjggw+k97t27RIARJs2bURRUZFUvnDhQgFA/PXXXxr3o8ydO3eEhYWFCA0NVdtOZmamMDc3VysfPny4ACCmTZumVlfO/jZv3lwAEL///rtUlp2dLZRKpZg0aZJUNnPmTAFAbNmypdwxUKlUQgghvvvuO6GjoyP27t2rtjwuLk4AEPv37y+3bkUe9zk0b95cDB8+XHpf9nPo7+8vxSKEEN7e3kKhUIj33ntPKrt//75o2rSpWttyjheVx0tVVCl+fn6wsrKCg4MDBgwYAGNjY2zbtg1NmzYFAOTk5OC3337DwIEDcefOHdy4cQM3btzAzZs34e/vj7Nnz0p3YVlYWOD48eM4e/asVtvu0aMHevXqhZiYGNy7d09jnY0bN8Lc3BwvvfSStO0bN27Aw8MDJiYm2LVrV9UciIcEBwfDwMBAel92+e7vv/9+7HqJiYm4ffs2goKC1GLV1dWFl5eXxlhHjx6t9l7u/rZt21aKD3hw6ez5559Xi3Xz5s1wc3OTzgwfVna308aNG9GmTRs4OzurbffFF18EgGo5zg8LCQlRu/PKy8sLQgiEhIRIZbq6uujUqZPavtXEz0ddwktVVClLlixB69atkZubi5UrV+L3339X68A8d+4chBCYMWMGZsyYobGN7OxsNGnSBLNnz8brr7+O1q1bw8XFBX369MHQoUOlyziaREZGwsfHB3FxcZg4cWK55WfPnkVubi6sra0r3HZVa9asmdr7sst2T7pmXpYwy75sH2VmZqb2Xk9PT0rQD7chZ38fjbUs3odjPX/+PPr37//E2E+ePAkrKyuttlvVHt0Pc3NzAICDg0O58of3rSZ+PuoSJg6qFE9PT+muqoCAAHTv3h2DBw/G6dOnYWJiApVKBQD48MMP4e/vr7GNsttRe/TogfPnz+O///0vfv31V6xYsQILFixAXFwc3n33XY3r9ujRAz179kRMTAzee++9cstVKhWsra2xZs0ajetX9EX3NHR1dTWWiyfMzlx2rL777jvY2tqWW66np/5rqlQqy92aKnd/Kxvro1QqFVxdXTF//nyNyx/9Aq9qFe2HpvKH960mfj7qEiYOemq6urqIiopCr169sHjxYkybNg0tW7YEAOjr68PPz++JbVhaWiI4OBjBwcHIz89Hjx49EBkZWWHiAB6cdfTs2RNff/11uWXPPfccdu7ciW7duj3xtt2afsjsueeeAwBYW1trdawqakPb/ZXT5rFjx55Y5+jRo/D19a3x4yhHdRyv+oR9HFQlevbsCU9PT8TGxqKwsBDW1tbSl/q1a9fK1b9+/br0/5s3b6otMzExQatWrZ54O6ePjw969uyJOXPmoLCwUG3ZwIEDUVpaik8++aTcevfv38ft27el98bGxmrv/23+/v4wMzPD559/jpKSknLLHz5WFZGzv9rq378/jh49ih9++KHcsrK/3gcOHIgrV65g+fLl5ercu3cPBQUFsrf7b6iO41Wf8IyDqszkyZPx1ltvIT4+Hu+99x6WLFmC7t27w9XVFaGhoWjZsiWysrKQkpKCy5cv4+jRowAedNT27NkTHh4esLS0xKFDh7Bp0yathvWIiIhAr169ypX7+Phg1KhRiIqKwpEjR9C7d2/o6+vj7Nmz2LhxIxYuXIgBAwYAADw8PLB06VJ8+umnaNWqFaytrSvsb6gOZmZmWLp0KYYOHYqOHTti0KBBsLKyQkZGBn766Sd069YNixcvfmwbcvZXW5MnT8amTZvw1ltv4Z133oGHhwdycnKwbds2xMXFwc3NDUOHDsWGDRvw3nvvYdeuXejWrRtKS0tx6tQpbNiwAb/88ot0SbM2qY7jVZ8wcVCVefPNN/Hcc8/hiy++QGhoKNq2bYtDhw5h1qxZiI+Px82bN2FtbY0OHTpg5syZ0nrjxo3Dtm3b8Ouvv6KoqAjNmzfHp59+ismTJz9xmz179oSPjw/27NlTbllcXBw8PDzw9ddf46OPPoKenh4cHR3x9ttvo1u3blK9mTNn4tKlS4iJicGdO3fg4+PzryYOABg8eDDs7e0RHR2NuXPnoqioCE2aNMELL7yA4OBgrdrQdn+1ZWJigr179yIiIgI//PADvv32W1hbW8PX11fqnNfR0cHWrVuxYMEC6RmVBg0aoGXLlhg/fjxat24te7v/lqo+XvWJQsjtDSMionqNfRxERCQLEwcREcnCxEFERLIwcRARkSxMHEREJAsTBxERycLnOCpJpVLh6tWrMDU1faaGWiAiqogQAnfu3IG9vf1jp+pl4qikq1evVvsAbkRENeGff/4pNwLzw2pF4liyZAnmzp2LzMxMuLm5YdGiRfD09Kyw/saNGzFjxgxcvHgRTk5OmDNnDvr27Sstj4yMxLp16/DPP//AwMAAHh4e+Oyzz+Dl5SXVycnJwdixY/Hjjz9CR0cH/fv3x8KFC2FiYqJVzKampgAeHOBHh70mInoW5eXlwcHBQfp+q1CNTSH1/9atWycMDAzEypUrxfHjx0VoaKiwsLAQWVlZGuvv379f6OrqipiYGHHixAkxffp0oa+vrzbL2po1a0RiYqI4f/68OHbsmAgJCRFmZmYiOztbqtOnTx/h5uYm/vjjD7F3717RqlUrERQUpHXcubm5AoDIzc2t/M4TEdUi2n6v1Xji8PT0VJuGs7S0VNjb24uoqCiN9QcOHFhumlEvLy8xatSoCrdRdjB27twphBDixIkTAoA4ePCgVOfnn38WCoVCXLlyRau4mTiIqK7R9nutRu+qKi4uRlpamtocBDo6OvDz80NKSorGdVJSUsrNWeDv719h/eLiYixbtgzm5uZwc3OT2rCwsFAbtdPPzw86OjpITU3V2E5RURHy8vLUXkRE9VGNJo4bN26gtLQUNjY2auU2NjbIzMzUuE5mZqZW9bdv3w4TExMYGhpiwYIFSExMROPGjaU2Hp0yUk9PD5aWlhVuNyoqCubm5tKLHeNEVF/V2ec4evXqhSNHjiA5ORl9+vTBwIEDn2oe4fDwcOTm5kqvf/75pwqjJSJ6dtRo4mjcuDF0dXWRlZWlVp6VlaVx7mUAsLW11aq+sbExWrVqhS5duuCbb76Bnp4evvnmG6mNR5PI/fv3kZOTU+F2lUolzMzM1F5ERPVRjSaOsltlk5KSpDKVSoWkpCR4e3trXMfb21utPgAkJiZWWP/hdsumIvX29sbt27eRlpYmLf/tt9+gUqnUbtklIiIN/qXO+gqtW7dOKJVKER8fL06cOCFGjhwpLCwsRGZmphBCiKFDh4pp06ZJ9ffv3y/09PTEF198IU6ePCkiIiLUbsfNz88X4eHhIiUlRVy8eFEcOnRIBAcHC6VSKY4dOya106dPH9GhQweRmpoq9u3bJ5ycnHg7LhHVa8/M7bhCCLFo0SLRrFkzYWBgIDw9PcUff/whLfPx8RHDhw9Xq79hwwbRunVrYWBgINq1ayd++uknadm9e/fEG2+8Iezt7YWBgYGws7MTr732mjhw4IBaGzdv3hRBQUHCxMREmJmZieDgYHHnzh2tY2biIKK6RtvvNU4dW0l5eXkwNzdHbm6u7P4Ox2k/VVNU9cPF6H41HQJRnaTt91qdvauKiIiqBxMHERHJwsRBRESyMHEQEZEsTBxERCQLEwcREcnCxEFERLIwcRARkSxMHEREJAsTBxERycLEQUREsjBxEBGRLEwcREQkCxMHERHJwsRBRESyMHEQEZEsTBxERCTLUyWOoqKiqoqDiIieEbISx88//4zhw4ejZcuW0NfXR4MGDWBmZgYfHx989tlnuHr1anXFSUREtYRWieOHH35A69at8c4770BPTw9Tp07Fli1b8Msvv2DFihXw8fHBzp070bJlS7z33nu4fv16dcdNREQ1RE+bSjExMViwYAFefvll6OiUzzUDBw4EAFy5cgWLFi3C999/j4kTJ1ZtpEREVCtolThSUlK0aqxJkyaIjo5+qoCIiKh2e+q7qkpLS3HkyBHcunWrKuIhIqJaTnbimDBhAr755hsAD5KGj48POnbsCAcHB+zevbuq4yMiolpGduLYtGkT3NzcAAA//vgjLly4gFOnTmHixIn4+OOPqzxAIiKqXWQnjhs3bsDW1hYAsGPHDrz11lvSHVd//fVXlQdIRES1i+zEYWNjgxMnTqC0tBQJCQl46aWXAAB3796Frq5ulQdIRES1i+zEERwcjIEDB8LFxQUKhQJ+fn4AgNTUVDg7O1cqiCVLlsDR0RGGhobw8vLCgQMHHlt/48aNcHZ2hqGhIVxdXbFjxw5pWUlJCaZOnQpXV1cYGxvD3t4ew4YNK/dwoqOjIxQKhdqLd4QRET2Z7MQRGRmJFStWYOTIkdi/fz+USiUAQFdXF9OmTZMdwPr16xEWFoaIiAikp6fDzc0N/v7+yM7O1lg/OTkZQUFBCAkJweHDhxEQEICAgAAcO3YMwIMzn/T0dMyYMQPp6enYsmULTp8+jddee61cW7Nnz8a1a9ek19ixY2XHT0RU3yiEEKImA/Dy8kLnzp2xePFiAIBKpYKDgwPGjh2rMREFBgaioKAA27dvl8q6dOkCd3d3xMXFadzGwYMH4enpiUuXLqFZs2YAHpxxTJgwARMmTNAqzqKiIrWxufLy8uDg4IDc3FyYmZlpu7sPtj3tJ1n1Sd3F6H41HQJRnZSXlwdzc/Mnfq9p9QDgl19+qfWGx40bp3Xd4uJipKWlITw8XCrT0dGBn59fhQ8dpqSkICwsTK3M398fW7durXA7ubm5UCgUsLCwUCuPjo7GJ598gmbNmmHw4MGYOHEi9PQ0H5KoqCjMmjVLux0jIqrDtEocCxYsUHt//fp13L17V/oivn37Nho0aABra2tZiePGjRsoLS2FjY2NWrmNjQ1OnTqlcZ3MzEyN9TMzMzXWLywsxNSpUxEUFKSWQceNG4eOHTvC0tISycnJCA8Px7Vr1zB//nyN7YSHh6slrLIzDiKi+karxHHhwgXp/2vXrsVXX32Fb775Bs8//zwA4PTp0wgNDcWoUaOqJ8pKKikpwcCBAyGEwNKlS9WWPZwE2rdvDwMDA4waNQpRUVFSv83DlEqlxnIiovpGduf4jBkzsGjRIilpAMDzzz+PBQsWYPr06bLaaty4MXR1dZGVlaVWnpWVJT0r8ihbW1ut6pcljUuXLiExMfGJ/RBeXl64f/8+Ll68KGsfiIjqG9mJ49q1a7h//3658tLS0nJf6E9iYGAADw8PJCUlSWUqlQpJSUnw9vbWuI63t7dafQBITExUq1+WNM6ePYudO3eiUaNGT4zlyJEj0NHRgbW1tax9ICKqb7S6VPUwX19fjBo1CitWrEDHjh0BAGlpaRg9erT0TIccYWFhGD58ODp16gRPT0/ExsaioKAAwcHBAIBhw4ahSZMmiIqKAgCMHz8ePj4+mDdvHvr164d169bh0KFDWLZsGYAHSWPAgAFIT0/H9u3bUVpaKvV/WFpawsDAACkpKUhNTUWvXr1gamqKlJQUTJw4EW+//TYaNmwoex+IiOoT2Ylj5cqV0he9vr4+AOD+/fvw9/fHihUrZAcQGBiI69evY+bMmcjMzIS7uzsSEhKkDvCMjAy1OUC6du2KtWvXYvr06fjoo4/g5OSErVu3wsXFBcCDOUG2bdsGAHB3d1fb1q5du9CzZ08olUqsW7cOkZGRKCoqQosWLTBx4sRyd2sREVF5lX6O48yZM9KdT87OzmjdunWVBlbbaXu/syZ8juPp8DkOoupRpc9xaNK6det6lyyIiKgSiaO0tBTx8fFISkpCdnY2VCqV2vLffvutyoIjIqLaR3biGD9+POLj49GvXz9poEMiIqo/ZCeOdevWYcOGDejbt291xENERLWc7Oc4DAwM0KpVq+qIhYiIngGyE8ekSZOwcOFC1PCgukREVENkX6rat28fdu3ahZ9//hnt2rWTnuUos2XLlioLjoiIah/ZicPCwgJvvPFGdcRCRETPANmJY9WqVdURBxERPSMq/QDg9evXcfr0aQAPRse1srKqsqCIiKj2kt05XlBQgHfeeQd2dnbo0aMHevToAXt7e4SEhODu3bvVESMREdUishNHWFgY9uzZgx9//BG3b9/G7du38d///hd79uzBpEmTqiNGIiKqRWRfqtq8eTM2bdqEnj17SmV9+/aFkZERBg4cWG6mPSIiqltkn3HcvXu33JzfAGBtbc1LVURE9YDsxOHt7Y2IiAgUFhZKZffu3cOsWbMqnLWPiIjqDtmXqhYuXAh/f380bdoUbm5uAICjR4/C0NAQv/zyS5UHSEREtYvsxOHi4oKzZ89izZo10kROQUFBGDJkCIyMjKo8QCIiql0q9RxHgwYNEBoaWtWxEBHRM0B2H0dUVBRWrlxZrnzlypWYM2dOlQRFRES1l+zE8fXXX8PZ2blcebt27RAXF1clQRERUe0lO3FkZmbCzs6uXLmVlRWuXbtWJUEREVHtJTtxODg4YP/+/eXK9+/fD3t7+yoJioiIai/ZneOhoaGYMGECSkpK8OKLLwIAkpKSMGXKFA45QkRUD8hOHJMnT8bNmzfx/vvvo7i4GABgaGiIqVOnIjw8vMoDJCKi2kV24lAoFJgzZw5mzJiBkydPwsjICE5OTlAqldURHxER1TKy+zjKZGZmIicnB8899xyUSiXnICciqidkJ46bN2/C19cXrVu3Rt++faU7qUJCQirdx7FkyRI4OjrC0NAQXl5eOHDgwGPrb9y4Ec7OzjA0NISrqyt27NghLSspKcHUqVPh6uoKY2Nj2NvbY9iwYbh69apaGzk5ORgyZAjMzMxgYWGBkJAQ5OfnVyp+IqL6RHbimDhxIvT19ZGRkYEGDRpI5YGBgUhISJAdwPr16xEWFoaIiAikp6fDzc0N/v7+yM7O1lg/OTkZQUFBCAkJweHDhxEQEICAgAAcO3YMwIPRe9PT0zFjxgykp6djy5YtOH36NF577TW1doYMGYLjx48jMTER27dvx++//46RI0fKjp+IqL5RCJnXmGxtbfHLL7/Azc0NpqamOHr0KFq2bIm///4b7du3l/1Xu5eXFzp37ozFixcDAFQqFRwcHDB27FhMmzatXP3AwEAUFBRg+/btUlmXLl3g7u5e4QOIBw8ehKenJy5duoRmzZrh5MmTaNu2LQ4ePIhOnToBABISEtC3b19cvnxZq9uK8/LyYG5ujtzcXJiZmcnaZ8dpP8mqT+ouRver6RCI6iRtv9cqNXXsw2caZXJycmR3kBcXFyMtLQ1+fn7/C0hHB35+fkhJSdG4TkpKilp9APD396+wPgDk5uZCoVDAwsJCasPCwkJKGgDg5+cHHR0dpKamamyjqKgIeXl5ai8iovpIduJ44YUXsHr1aum9QqGASqVCTEwMevXqJautGzduoLS0tNzEUDY2NsjMzNS4TmZmpqz6hYWFmDp1KoKCgqQMmpmZCWtra7V6enp6sLS0rLCdqKgomJubSy8HBwet9pGIqK6RfTtuTEwMfH19cejQIRQXF2PKlCk4fvw4cnJyND5RXpNKSkowcOBACCGeekrb8PBwhIWFSe/z8vKYPIioXqrUfBxnzpzB4sWLYWpqivz8fLz55pv44IMPNI5h9TiNGzeGrq4usrKy1MqzsrJga2urcR1bW1ut6pcljUuXLuG3335Tu15na2tbrvP9/v37yMnJqXC7SqWSz6oQEaGS83GYm5vj448/fuqNGxgYwMPDA0lJSQgICADwoHM8KSkJY8aM0biOt7c3kpKSMGHCBKksMTFRbdrasqRx9uxZ7Nq1C40aNSrXxu3bt5GWlgYPDw8AwG+//QaVSgUvL6+n3i8iorpMdh9HQkIC9u3bJ71fsmQJ3N3dMXjwYNy6dUt2AGFhYVi+fDm+/fZbnDx5EqNHj0ZBQQGCg4MBAMOGDVMbymT8+PFISEjAvHnzcOrUKURGRuLQoUNSoikpKcGAAQNw6NAhrFmzBqWlpcjMzERmZqY0REqbNm3Qp08fhIaG4sCBA9i/fz/GjBmDQYMGcaBGIqInkJ04Jk+eLN1R9NdffyEsLAx9+/bFhQsX1PoAtBUYGIgvvvgCM2fOhLu7O44cOYKEhASpAzwjI0NtuPauXbti7dq1WLZsGdzc3LBp0yZs3boVLi4uAIArV65g27ZtuHz5Mtzd3WFnZye9kpOTpXbWrFkDZ2dn+Pr6om/fvujevTuWLVsmO34iovpG9nMcJiYmOHbsGBwdHREZGYljx45h06ZNSE9PR9++fSu8K6mu4XMcNYfPcRBVj2p7jsPAwAB3794FAOzcuRO9e/cGAFhaWvLZBiKiekB253j37t0RFhaGbt264cCBA1i/fj0A4MyZM2jatGmVB0hERLWL7DOOxYsXQ09PD5s2bcLSpUvRpEkTAMDPP/+MPn36VHmARERUu8g+42jWrJnaOFFlFixYUCUBERFR7abVGUdBQYGsRuXWJyKiZ4dWiaNVq1aIjo5Wuy32UUIIJCYm4uWXX8aXX35ZZQESEVHtotWlqt27d+Ojjz5CZGQk3Nzc0KlTJ9jb28PQ0BC3bt3CiRMnkJKSAj09PYSHh2PUqFHVHTcREdUQrRLH888/j82bNyMjIwMbN27E3r17kZycjHv37qFx48bo0KEDli9fjpdffhm6urrVHTMREdUgWZ3jzZo1w6RJkyo9RSwRET37ZN+OS0RE9RsTBxERycLEQUREsjBxEBGRLEwcREQkS6USx969e/H222/D29sbV65cAQB89913ahM8ERFR3SQ7cWzevBn+/v4wMjLC4cOHUVRUBADIzc3F559/XuUBEhFR7SI7cXz66aeIi4vD8uXLoa+vL5V369YN6enpVRocERHVPrITx+nTp9GjR49y5ebm5rh9+3ZVxERERLWY7MRha2uLc+fOlSvft28fWrZsWSVBERFR7SU7cYSGhmL8+PFITU2FQqHA1atXsWbNGnz44YcYPXp0dcRIRES1iOyJnKZNmwaVSgVfX1/cvXsXPXr0gFKpxIcffoixY8dWR4xERFSLyE4cCoUCH3/8MSZPnoxz584hPz8fbdu2hYmJSXXER0REtYzsxFHGwMAAbdu2rcpYiIjoGSA7cRQWFmLRokXYtWsXsrOzoVKp1JbzllwiorpNduIICQnBr7/+igEDBsDT0xMKhaI64iIiolpKduLYvn07duzYgW7dulVHPEREVMvJvh23SZMmMDU1rY5YiIjoGSA7ccybNw9Tp07FpUuXqiSAJUuWwNHREYaGhvDy8sKBAwceW3/jxo1wdnaGoaEhXF1dsWPHDrXlW7ZsQe/evdGoUSMoFAocOXKkXBs9e/aEQqFQe7333ntVsj9ERHWd7MTRqVMnFBYWomXLljA1NYWlpaXaS47169cjLCwMERERSE9Ph5ubG/z9/ZGdna2xfnJyMoKCghASEoLDhw8jICAAAQEBOHbsmFSnoKAA3bt3x5w5cx677dDQUFy7dk16xcTEyIqdiKi+UgghhJwV/Pz8kJGRgZCQENjY2JTrHB8+fLjWbXl5eaFz585YvHgxAEClUsHBwQFjx47FtGnTytUPDAxEQUEBtm/fLpV16dIF7u7uiIuLU6t78eJFtGjRAocPH4a7u7vasp49e8Ld3R2xsbFax/qovLw8mJubIzc3F2ZmZrLWdZz2U6W3S8DF6H41HQJRnaTt95rszvHk5GSkpKTAzc3tqQIsLi5GWloawsPDpTIdHR34+fkhJSVF4zopKSkICwtTK/P398fWrVtlb3/NmjX4/vvvYWtri1dffRUzZsxAgwYNKqxfVFQkDSEPPDjARET1kezE4ezsjHv37j31hm/cuIHS0lLY2NioldvY2ODUqVMa18nMzNRYPzMzU9a2Bw8ejObNm8Pe3h5//vknpk6ditOnT2PLli0VrhMVFYVZs2bJ2g4RUV0kO3FER0dj0qRJ+Oyzz+Dq6qo2JwcA2ZdtasLIkSOl/7u6usLOzg6+vr44f/48nnvuOY3rhIeHq53t5OXlwcHBodpjJSKqbWQnjj59+gAAfH191cqFEFAoFCgtLdWqncaNG0NXVxdZWVlq5VlZWbC1tdW4jq2traz62vLy8gIAnDt3rsLEoVQqoVQqn2o7RER1gezEsWvXrirZsIGBATw8PJCUlISAgAAADzrHk5KSMGbMGI3reHt7IykpCRMmTJDKEhMT4e3t/VSxlN2ya2dn91TtEBHVB7ITh4+PT5VtPCwsDMOHD0enTp3g6emJ2NhYFBQUIDg4GAAwbNgwNGnSBFFRUQCA8ePHw8fHB/PmzUO/fv2wbt06HDp0CMuWLZPazMnJQUZGBq5evQrgwYyFwIOzFVtbW5w/fx5r165F37590ahRI/z555+YOHEievTogfbt21fZvhER1VVaJY4///wTLi4u0NHRwZ9//vnYunK+fAMDA3H9+nXMnDkTmZmZcHd3R0JCgtQBnpGRAR2d/z1q0rVrV6xduxbTp0/HRx99BCcnJ2zduhUuLi5SnW3btkmJBwAGDRoEAIiIiEBkZCQMDAywc+dOKUk5ODigf//+mD59utZxExHVZ1o9x6Gjo4PMzExYW1tDR0cHCoUCmlaT08fxrONzHDWHz3EQVY8qfY7jwoULsLKykv5PRET1l1aJo3nz5tDV1cW1a9fQvHnz6o6JiIhqMa3HqpI5MgkREdVRsgc5JCKi+k3W7bgrVqyAiYnJY+uMGzfuqQIiIqLaTVbiiIuLg66uboXLFQoFEwcRUR0nK3EcOnQI1tbW1RULERE9A7Tu43h03g0iIqqfeFcVERHJonXiiIiIeGLHOBER1X1a93FERERUZxxERPSMkD06LhFRdeN4bk+vOsd04wOAREQkCxMHERHJUqnEcf/+fezcuRNff/017ty5AwC4evUq8vPzqzQ4IiKqfWT3cVy6dAl9+vRBRkYGioqK8NJLL8HU1BRz5sxBUVER4uLiqiNOIiKqJWSfcYwfPx6dOnXCrVu3YGRkJJW/8cYbSEpKqtLgiIio9pF9xrF3714kJyfDwMBArdzR0RFXrlypssCIiKh2kn3GoVKpNE4Pe/nyZZiamlZJUEREVHvJThy9e/dGbGys9F6hUCA/Px8RERHo27dvVcZGRES1kOxLVfPmzYO/vz/atm2LwsJCDB48GGfPnkXjxo3xn//8pzpiJCKiWkR24mjatCmOHj2K9evX4+jRo8jPz0dISAiGDBmi1llORER1U6WGHNHT08OQIUMwZMiQqo6HiIhqOdl9HFFRUVi5cmW58pUrV2LOnDlVEhQREdVeshPH119/DWdn53Ll7dq148N/RET1gOzEkZmZCTs7u3LlVlZWuHbtWpUERUREtZfsxOHg4ID9+/eXK9+/fz/s7e2rJCgiIqq9ZCeO0NBQTJgwAatWrcKlS5dw6dIlrFy5EhMnTkRoaKjsAJYsWQJHR0cYGhrCy8sLBw4ceGz9jRs3wtnZGYaGhnB1dcWOHTvUlm/ZsgW9e/dGo0aNoFAocOTIkXJtFBYW4oMPPkCjRo1gYmKC/v37IysrS3bsRET1kezEMXnyZISEhOD9999Hy5Yt0bJlS4wdOxbjxo1DeHi4rLbWr1+PsLAwREREID09HW5ubvD390d2drbG+snJyQgKCkJISAgOHz6MgIAABAQE4NixY1KdgoICdO/e/bEd9RMnTsSPP/6IjRs3Ys+ePbh69SrefPNNWbETEdVXCiGEqMyK+fn5OHnyJIyMjODk5ASlUim7DS8vL3Tu3BmLFy8G8GA4EwcHB4wdOxbTpk0rVz8wMBAFBQXYvn27VNalSxe4u7uX65i/ePEiWrRogcOHD8Pd3V0qz83NhZWVFdauXYsBAwYAAE6dOoU2bdogJSUFXbp00RhrUVERioqKpPd5eXlwcHBAbm4uzMzMZO03Zzd7OtU5sxnVDvwdeXqV+T3Jy8uDubn5E7/XKj2Rk4mJCTp37gwXF5dKJY3i4mKkpaXBz8/vf8Ho6MDPzw8pKSka10lJSVGrDwD+/v4V1tckLS0NJSUlau04OzujWbNmj20nKioK5ubm0svBwUHrbRIR1SWyHwAsKChAdHQ0kpKSkJ2dDZVKpbb877//1qqdGzduoLS0FDY2NmrlNjY2OHXqlMZ1MjMzNdbPzMzUOv7MzEwYGBjAwsJCVjvh4eEICwuT3pedcRAR1TeyE8e7776LPXv2YOjQobCzs4NCoaiOuGodpVJZqTMrIqK6Rnbi+Pnnn/HTTz+hW7duT7Xhxo0bQ1dXt9zdTFlZWbC1tdW4jq2traz6FbVRXFyM27dvq511yG2HiKi+kt3H0bBhQ1haWj71hg0MDODh4aE2a6BKpUJSUhK8vb01ruPt7V1ulsHExMQK62vi4eEBfX19tXZOnz6NjIwMWe0QEdVXss84PvnkE8ycORPffvstGjRo8FQbDwsLw/Dhw9GpUyd4enoiNjYWBQUFCA4OBgAMGzYMTZo0QVRUFIAH09b6+Phg3rx56NevH9atW4dDhw5h2bJlUps5OTnIyMjA1atXATxICsCDMw1bW1uYm5sjJCQEYWFhsLS0hJmZGcaOHQtvb+8K76giIqL/qdR8HOfPn4eNjQ0cHR2hr6+vtjw9PV3rtgIDA3H9+nXMnDkTmZmZcHd3R0JCgtQBnpGRAR2d/50Ude3aFWvXrsX06dPx0UcfwcnJCVu3boWLi4tUZ9u2bVLiAYBBgwYBACIiIhAZGQkAWLBgAXR0dNC/f38UFRXB398fX331ldxDQURUL8l+jmPWrFmPXR4REfFUAT0rtL3fWRPeo/50+BxH3cffkadXnc9xyD7jqC+JgYiINKvUA4C3b9/GihUrEB4ejpycHAAPLlFduXKlSoMjIqLaR/YZx59//gk/Pz+Ym5vj4sWLCA0NhaWlJbZs2YKMjAysXr26OuIkIqJaQvYZR1hYGEaMGIGzZ8/C0NBQKu/bty9+//33Kg2OiIhqH9mJ4+DBgxg1alS58iZNmsga+oOIiJ5NshOHUqlEXl5eufIzZ87AysqqSoIiIqLaS3bieO211zB79myUlJQAABQKBTIyMjB16lT079+/ygMkIqLaRXbimDdvHvLz82FtbY179+7Bx8cHrVq1gqmpKT777LPqiJGIiGoR2XdVmZubIzExEfv378fRo0eRn5+Pjh07lpsng4iI6iZZiaOkpARGRkY4cuQIunXr9tQj5BIR0bNH1qUqfX19NGvWDKWlpdUVDxER1XKy+zg+/vhjfPTRR9IT40REVL/I7uNYvHgxzp07B3t7ezRv3hzGxsZqy+WMjktERM8e2YkjICCgGsIgIqJnBUfHJSIiWTg6LhERycLRcYmISBaOjktERLJwdFwiIpKFo+MSEZEsHB2XiIhk4ei4REQkC0fHJSIiWbRKHJaWljhz5gwaN26Md955BwsXLuTouERE9ZRWl6qKi4ulDvFvv/0WhYWF1RoUERHVXlqdcXh7eyMgIAAeHh4QQmDcuHEwMjLSWHflypVVGiAREdUuWp1xfP/99+jbty/y8/OhUCiQm5uLW7duaXxVxpIlS+Do6AhDQ0N4eXnhwIEDj62/ceNGODs7w9DQEK6urtixY4faciEEZs6cCTs7OxgZGcHPzw9nz55Vq+Po6AiFQqH2io6OrlT8RET1iVZnHDY2NtKXaosWLfDdd9+hUaNGVRLA+vXrERYWhri4OHh5eSE2Nhb+/v44ffo0rK2ty9VPTk5GUFAQoqKi8Morr2Dt2rUICAhAeno6XFxcAAAxMTH48ssv8e2336JFixaYMWMG/P39ceLECbWn3WfPno3Q0FDpvampaZXsExFRXSb7dtwLFy5UWdIAgPnz5yM0NBTBwcFo27Yt4uLi0KBBgwoveS1cuBB9+vTB5MmT0aZNG3zyySfo2LEjFi9eDODB2UZsbCymT5+O119/He3bt8fq1atx9epVbN26Va0tU1NT2NraSq9H5xYhIqLyZN+OCwBJSUlISkpCdnY2VCqV2jI5fRzFxcVIS0tDeHi4VKajowM/Pz+kpKRoXCclJQVhYWFqZf7+/lJSuHDhAjIzM9VuDzY3N4eXlxdSUlIwaNAgqTw6OhqffPIJmjVrhsGDB2PixInQ09N8SIqKilBUVCS91/T0PBFRfSA7ccyaNQuzZ89Gp06dYGdnB4VCUemN37hxA6WlpbCxsVErt7GxwalTpzSuk5mZqbF+2ThZZf8+rg4AjBs3Dh07doSlpSWSk5MRHh6Oa9euYf78+Rq3GxUVhVmzZsnbQSKiOkh24oiLi0N8fDyGDh1aHfH8ax4+a2nfvj0MDAwwatQoREVFQalUlqsfHh6utk5eXh4cHBz+lViJiGoT2X0cxcXF6Nq1a5VsvHHjxtDV1UVWVpZaeVZWFmxtbTWuY2tr+9j6Zf/KaRMAvLy8cP/+fVy8eFHjcqVSCTMzM7UXEVF9JDtxvPvuu1i7dm2VbNzAwAAeHh5ISkqSylQqFZKSkuDt7a1xHW9vb7X6AJCYmCjVb9GiBWxtbdXq5OXlITU1tcI2AeDIkSPQ0dHReCcXERH9j+xLVYWFhVi2bBl27tyJ9u3bQ19fX215RX0EFQkLC8Pw4cPRqVMneHp6IjY2FgUFBQgODgYADBs2DE2aNEFUVBQAYPz48fDx8cG8efPQr18/rFu3DocOHcKyZcsAPBitd8KECfj000/h5OQk3Y5rb2+PgIAAAA862FNTU9GrVy+YmpoiJSUFEydOxNtvv42GDRvKPSRERPVKpaaOdXd3BwAcO3ZMbVllOsoDAwNx/fp1zJw5E5mZmXB3d0dCQoLUuZ2RkQEdnf+dGHXt2hVr167F9OnT8dFHH8HJyQlbt26VnuEAgClTpqCgoAAjR47E7du30b17dyQkJEjPcCiVSqxbtw6RkZEoKipCixYtMHHixHJ3axERUXkKIYSo6SCeRXl5eTA3N0dubq7s/g7HaT9VU1T1w8XofjUdAlUz/o48vcr8nmj7vSa7j4OIiOo3rS9Vvfnmm1rV27JlS6WDISKi2k/rxGFubl6dcRAR0TNC68SxatWq6oyDiIieEezjICIiWZg4iIhIFiYOIiKShYmDiIhkYeIgIiJZmDiIiEgWJg4iIpKFiYOIiGSp1JzjRHUNB9V7Ohx4sn7hGQcREcnCxEFERLIwcRARkSxMHEREJAsTBxERycLEQUREsjBxEBGRLEwcREQkCxMHERHJwsRBRESyMHEQEZEsTBxERCQLEwcREcnCxEFERLLUisSxZMkSODo6wtDQEF5eXjhw4MBj62/cuBHOzs4wNDSEq6srduzYobZcCIGZM2fCzs4ORkZG8PPzw9mzZ9Xq5OTkYMiQITAzM4OFhQVCQkKQn59f5ftGRFTX1HjiWL9+PcLCwhAREYH09HS4ubnB398f2dnZGusnJycjKCgIISEhOHz4MAICAhAQEIBjx45JdWJiYvDll18iLi4OqampMDY2hr+/PwoLC6U6Q4YMwfHjx5GYmIjt27fj999/x8iRI6t9f4mInnUKIYSoyQC8vLzQuXNnLF68GACgUqng4OCAsWPHYtq0aeXqBwYGoqCgANu3b5fKunTpAnd3d8TFxUEIAXt7e0yaNAkffvghACA3Nxc2NjaIj4/HoEGDcPLkSbRt2xYHDx5Ep06dAAAJCQno27cvLl++DHt7+yfGnZeXB3Nzc+Tm5sLMzEzWPnPSoKdTHZMG8TN5OlX9mfDzeHqV+Uy0/V6r0RkAi4uLkZaWhvDwcKlMR0cHfn5+SElJ0bhOSkoKwsLC1Mr8/f2xdetWAMCFCxeQmZkJPz8/abm5uTm8vLyQkpKCQYMGISUlBRYWFlLSAAA/Pz/o6OggNTUVb7zxRrntFhUVoaioSHqfm5sL4MGBlktVdFf2OvQ/lTnmT8LP5OlU9WfCz+PpVeYzKVvnSecTNZo4bty4gdLSUtjY2KiV29jY4NSpUxrXyczM1Fg/MzNTWl5W9rg61tbWasv19PRgaWkp1XlUVFQUZs2aVa7cwcGhot2jamIeW9MR0KP4mdQ+T/OZ3LlzB+bm5hUu55zjWgoPD1c701GpVMjJyUGjRo2gUChqMLKqlZeXBwcHB/zzzz+yL8FR9eBnUrvU5c9DCIE7d+488XJ9jSaOxo0bQ1dXF1lZWWrlWVlZsLW11biOra3tY+uX/ZuVlQU7Ozu1Ou7u7lKdRzvf79+/j5ycnAq3q1QqoVQq1cosLCwev4PPMDMzszr3S/Gs42dSu9TVz+NxZxplavSuKgMDA3h4eCApKUkqU6lUSEpKgre3t8Z1vL291eoDQGJiolS/RYsWsLW1VauTl5eH1NRUqY63tzdu376NtLQ0qc5vv/0GlUoFLy+vKts/IqI6SdSwdevWCaVSKeLj48WJEyfEyJEjhYWFhcjMzBRCCDF06FAxbdo0qf7+/fuFnp6e+OKLL8TJkydFRESE0NfXF3/99ZdUJzo6WlhYWIj//ve/4s8//xSvv/66aNGihbh3755Up0+fPqJDhw4iNTVV7Nu3Tzg5OYmgoKB/b8drqdzcXAFA5Obm1nQo9P/4mdQu/DyEqPHEIYQQixYtEs2aNRMGBgbC09NT/PHHH9IyHx8fMXz4cLX6GzZsEK1btxYGBgaiXbt24qefflJbrlKpxIwZM4SNjY1QKpXC19dXnD59Wq3OzZs3RVBQkDAxMRFmZmYiODhY3Llzp9r28VlRWFgoIiIiRGFhYU2HQv+Pn0ntws9DiBp/joOIiJ4tNf7kOBERPVuYOIiISBYmDiIikoWJg4jUODo6IjY2tqbDqDVGjBiBgICAmg5DK/9WrEwcddSIESOgUCjKvc6dO6e2zMDAAK1atcLs2bNx//59AMDp06fRq1cv2NjYwNDQEC1btsT06dNRUlIitb98+XK88MILaNiwIRo2bAg/P78nDof/LHn0F7DsmEVHR6vV27p1qzRyQEXHvOzl6OgIAMjPz8eYMWPQtGlTGBkZoW3btoiLi6t0rJGRkdLDrXLEx8drfIj14MGD/9pI0c/ScX4WLFy4EPHx8dW+HSaOOqxPnz64du2a2qtFixZqy86ePYtJkyYhMjISc+fOBQDo6+tj2LBh+PXXX3H69GnExsZi+fLliIiIkNrevXs3goKCsGvXLqSkpMDBwQG9e/fGlStXamRf/w2GhoaYM2cObt26pXH5woUL1Y41AKxatUp6f/DgQQBAWFgYEhIS8P333+PkyZOYMGECxowZg23btv1r+/I4VlZWaNCgQY1tv74c5+pgbm7+r4xowcRRhymVStja2qq9dHV11ZY1b94co0ePhp+fn/QL1bJlSwQHB8PNzQ3NmzfHa6+9hiFDhmDv3r1S22vWrMH7778Pd3d3ODs7Y8WKFdJT/3WVn58fbG1tERUVpXG5ubm52rEGHgxLU/beysoKwIM5ZYYPH46ePXvC0dERI0eOhJub22PP2Hbv3g1PT08YGxvDwsIC3bp1w6VLlxAfH49Zs2bh6NGj0l/cZX9xzp8/H66urjA2NoaDgwPef/99abKy3bt3Izg4GLm5udJ6kZGRAMpfqrp9+zZGjRolnYG6uLioTWtQ1WryOJeWliIsLAwWFhZo1KgRpkyZojZS7OrVq9GoUSO1kbIBICAgAEOHDgXwvzPA7777Do6OjjA3N8egQYNw584dqX5CQgK6d+8ubeeVV17B+fPnpeUXL16EQqHAhg0b8MILL8DIyAidO3fGmTNnpOkgTExM8PLLL+P69evSeo+ewalUKsTExKBVq1ZQKpVo1qwZPvvssyd9BE/ExEEAACMjIxQXF2tcdu7cOSQkJMDHx6fC9e/evYuSkhJYWlpWV4g1TldXF59//jkWLVqEy5cvV7qdrl27Ytu2bbhy5QqEENi1axfOnDmD3r17a6x///59BAQEwMfHB3/++SdSUlIwcuRIKBQKBAYGYtKkSWjXrp30F3dgYCCAB1MUfPnllzh+/Di+/fZb/Pbbb5gyZYoUQ2xsLMzMzKT1yuaveZhKpcLLL7+M/fv34/vvv8eJEycQHR0t/QFSHWrqOAPAvHnzEB8fj5UrV2Lfvn3IycnBDz/8IC1/6623UFpaqnbWkp2djZ9++gnvvPOOVHb+/Hls3boV27dvx/bt27Fnzx61y28FBQUICwvDoUOHkJSUBB0dHbzxxhtQqVRq8URERGD69OlIT0+Hnp4eBg8ejClTpmDhwoXYu3cvzp07h5kzZ1a4P+Hh4YiOjsaMGTNw4sQJrF27ttzI4ZVSo48fUrUZPny40NXVFcbGxtJrwIAB0rLXX39dCPHgKfvExEShVCrFhx9+qNaGt7e3UCqVAoAYOXKkKC0trXB7o0ePFi1btlQb1uVZ9vAxevR9ly5dxDvvvCOEEOKHH34QFf0aARA//PBDufLCwkIxbNgwAUDo6ekJAwMD8e2331YYy82bNwUAsXv3bo3LIyIihJub2xP3aePGjaJRo0bS+1WrVglzc/Ny9Zo3by4WLFgghBDil19+ETo6OuVGXqgqtek4CyGEnZ2diImJkd6XlJSIpk2bqsU4evRo8fLLL0vv582bJ1q2bClUKpUQ4sHn0aBBA5GXlyfVmTx5svDy8qpwu9evXxcApKGTLly4IACIFStWSHX+85//CAAiKSlJKouKihLPP/+89P7h45eXlyeUSqVYvnz5Y/e5Mjiseh3Wq1cvLF26VHpvbGws/X/79u0wMTFBSUkJVCoVBg8eLF2qKLN+/XrcuXMHR48exeTJk/HFF19If7E+LDo6GuvWrcPu3bthaGhYbftTW8yZMwcvvviixr/QtbFo0SL88ccf2LZtG5o3b47ff/8dH3zwAezt7dUmICtjaWmJESNGwN/fHy+99BL8/PwwcOBAtdGfNdm5cyeioqJw6tQp5OXl4f79+ygsLMTdu3e17sM4cuQImjZtitatW1dqX5/Gv32cc3Nzce3aNbWBTvX09NCpUye1y1WhoaHo3Lkzrly5giZNmiA+Pl7qsC/j6OgIU1NT6b2dnZ3aiNxnz57FzJkzkZqaihs3bkhnGhkZGXBxcZHqtW/fXvp/2ZmCq6urWllF02yfPHkSRUVF8PX1ffLBkomXquowY2NjtGrVSno9/EXTq1cvHDlyBGfPnsW9e/fw7bffqiUW4MEkVW3btkVQUBCio6MRGRmJ0tJStTpffPEFoqOj8euvv6r9kNdlPXr0gL+/v9rMldq6d+8ePvroI8yfPx+vvvoq2rdvjzFjxiAwMBBffPFFheutWrUKKSkp6Nq1K9avX4/WrVvjjz/+qLD+xYsX8corr6B9+/bYvHkz0tLSsGTJEgCo8JKkJkZGRtrvXBWrieOsjQ4dOsDNzQ2rV69GWloajh8/jhEjRqjV0dfXV3uvUCjULkO9+uqryMnJwfLly5GamorU1FQA5T+bh9spS0yPlj16eatMdX52TBz1VFlSadasGfT0nnziqVKppLOTMjExMfjkk0+QkJCgNg1vfRAdHY0ff/yxwimOK1JSUoKSkhLo6Kj/6unq6lb4BVCmQ4cOCA8PR3JyMlxcXLB27VoAD6YneDShp6WlQaVSYd68eejSpQtat26Nq1evqtXRtN6j2rdvj8uXL+PMmTPa7mKV+jePs7m5Oezs7KQvceBB/9LD0y+UeffddxEfH49Vq1bBz89P1kygN2/exOnTpzF9+nT4+vqiTZs2Fd5B9jScnJxgZGRULTes8FIVlbNmzRro6+vD1dUVSqUShw4dQnh4OAIDA6W/dubMmYOZM2di7dq1cHR0lKbcNTExgYmJSU2G/69wdXXFkCFD8OWXX8paz8zMDD4+Ppg8eTKMjIzQvHlz7NmzB6tXr8b8+fM1rnPhwgUsW7YMr732Guzt7XH69GmcPXsWw4YNA/DgssiFCxeky0qmpqZo1aoVSkpKsGjRIrz66qvYv39/uWcYHB0dkZ+fj6SkJLi5uaFBgwblLmH5+PigR48e6N+/P+bPn49WrVrh1KlTUCgU6NOnj6x9r4x/8zgDwPjx4xEdHQ0nJyc4Oztj/vz5uH37drl6gwcPxocffojly5dj9erVsmJr2LAhGjVqhGXLlsHOzg4ZGRmYNm2arDa0YWhoiKlTp2LKlCkwMDBAt27dcP36dRw/fhwhISFP1TbPOKgcPT09zJkzB56enmjfvj1mzZqFMWPGYMWKFVKdpUuXori4GAMGDICdnZ30etrLAM+S2bNnP/EsQZN169ahc+fOGDJkCNq2bYvo6Gh89tlneO+99zTWb9CgAU6dOoX+/fujdevWGDlyJD744AOMGjUKANC/f3/06dMHvXr1gpWVFf7zn//Azc0N8+fPx5w5c+Di4oI1a9aUu721a9eueO+99xAYGAgrKyvExMRo3P7mzZvRuXNnBAUFoW3btpgyZcoTz1Sq0r91nAFg0qRJGDp0KIYPHw5vb2+YmprijTfeKFfP3Nwc/fv3h4mJiewntXV0dLBu3TqkpaXBxcUFEydOlJ6hqmozZszApEmTMHPmTLRp0waBgYEV9onIwWHViYgqwdfXF+3atZN9NlQXMHEQEclw69Yt7N69GwMGDMCJEyfw/PPP13RI/zr2cRARydChQwfcunULc+bMqZdJA+AZBxERycTOcSIikoWJg4iIZGHiICIiWZg4iIhIFiYOIiKShYmDiIhkYeIgeoLHzW/98Mx5lW1769atWtXdtWsX+vbti0aNGqFBgwZo27YtJk2aVKen66XaiYmD6Akent/60VnzKpo5r6p9/fXX0pSqmzdvxokTJxAXF4fc3FzMmzev2rdPpKbKp4YiqsM0zZq3fPly4ezsLJRKpXj++efFkiVLpGVFRUXigw8+ELa2tkKpVIpmzZqJzz//XAjxYKY9ANKrefPmGrf5zz//CAMDAzFhwgSNy2/duiWEEOLGjRti0KBBwt7eXhgZGQkXFxexdu1atbobN24ULi4uwtDQUFhaWgpfX1+Rn5+v1b4QlWHiIJLh0cTx/fffCzs7O7F582bx999/i82bNwtLS0sRHx8vhBBi7ty5wsHBQfz+++/i4sWLYu/evdKXeXZ2tgAgVq1aJa5duyays7M1bnP+/PkCgLh69epjY7t8+bKYO3euOHz4sDh//rz48ssvha6urkhNTRVCCHH16lWhp6cn5s+fLy5cuCD+/PNPsWTJEnHnzh2t9oWoDBMHkQyPJo7nnnuu3F/1n3zyifD29hZCCDF27Fjx4osvSvNRPwoVzJf9sNGjRwszM7NKxduvXz8xadIkIYQQaWlpAoC4ePGixrpP2heiMhzkkKiSCgoKcP78eYSEhCA0NFQqv3//PszNzQEAI0aMwEsvvYTnn38effr0wSuvvILevXvL2o4QQm0+64qUlpbi888/x4YNG3DlyhUUFxejqKhImpzJzc0Nvr6+cHV1hb+/P3r37o0BAwagYcOGWu0LURkmDqJKys/PBwAsX74cXl5east0dXUBAB07dsSFCxfw888/Y+fOnRg4cCD8/PywadMmrbfTunVr5Obm4tq1a2rzxj9q7ty5WLhwIWJjY+Hq6gpjY2NMmDBBmsdaV1cXiYmJSE5Oxq+//opFixbh448/RmpqqpRcHrcvRJKaPuUhepY8eqnK3t5ezJ49W+v1ExISBABx8+ZNIYQQ+vr6YtOmTY9dJyMjQ6vO8VdeeUW88847UnlpaalwcnISr7/+usb17t+/L5o0aSLmzZtXqX2h+otnHERPYdasWRg3bhzMzc3Rp08fFBUV4dChQ7h16xbCwsIwf/582NnZoUOHDtDR0cHGjRtha2sLCwsLAA/m/U5KSkK3bt2gVCrRsGHDcttwcHDAggULMGbMGOTl5WHYsGFwdHTE5cuXsXr1apiYmGDevHlwcnLCpk2bkJycjIYNG2L+/PnIyspC27ZtAQCpqalISkpC7969YW1tjdTUVFy/fh1t2rTRal+IJDWduYieJZpux12zZo1wd3cXBgYGomHDhqJHjx5iy5YtQgghli1bJtzd3YWxsbEwMzMTvr6+Ij09XVp327ZtolWrVkJPT6/C23HLJCYmCn9/f9GwYUNhaGgonJ2dxYcffijdbXXz5k3x+uuvCxMTE2FtbS2mT58uhg0bJp1xnDhxQvj7+wsrKyuhVCpF69atxaJFi7TeF6IynMiJiIhk4ZPjREQkCxMHERHJwsRBRESyMHEQEZEsTBxERCQLEwcREcnCxEFERLIwcRARkSxMHEREJAsTBxERycLEQUREsvwfHrn6opbozYAAAAAASUVORK5CYII=",
-      "text/plain": [
-       "<Figure size 400x300 with 1 Axes>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAXgAAAE8CAYAAADKVKrcAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjYuMywgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy/P9b71AAAACXBIWXMAAA9hAAAPYQGoP6dpAAAzmklEQVR4nO3deXxM5/4H8E8SySSyjCCrrGKNJHZqqQQhlsTeolRiKXVja6rIvSLFraAVQW3N/clSlFqLalqCUtSSSGm1CAkpsVRjspGQPL8/7itzTTbJZJjJ8Xm/XvNqz3Oec873zIzPPDlz5hw9IYQAERFJjr62CyAiopeDAU9EJFEMeCIiiWLAExFJFAOeiEiiGPBERBLFgCcikigGPBGRRDHgiYgkigFPtYqPjw98fHxem+3Wdi4uLggKCtJ2Ga8tBvxr5LfffsPYsWPRqFEjyGQy2NvbY+zYsbh8+bK2S1Nx+fJlfPzxx0hPT38ttvsi6enpGD9+PNzc3GBsbAxbW1v06NED4eHh2i6NdJwer0Xzeti9ezdGjx6N+vXrY+LEiXB1dUV6ejr+7//+D3///Te2b9+OwYMHa7tMAMDOnTvx1ltv4ejRo2VGzYWFhQAAIyMjyWy3MqmpqejYsSNMTEwwYcIEuLi4IDMzE8nJyfjuu+/w5MmTV1pPdbm4uMDHxwexsbHaLuW1VEfbBdDLd/36dbz77rto3Lgxjh8/DisrK+W8mTNn4s0338TYsWNx8eJFuLq6arHSF3vVAavt7a5cuRK5ublISUmBs7Ozyrz79+9rpSaqRQRJ3pQpUwQAcfz48XLn//jjjwKAmDp1qrItMDBQODs7l+kbHh4uSr9tNm3aJHr27CmsrKyEkZGRaNmypVi3bl2ZZZ2dncXAgQPFiRMnRMeOHYVMJhOurq4iLi5O2ScmJkYAKPM4evSoEEIIb29v4e3trbLO8vo/v0x6erqYOnWqaNasmTA2Nhb169cXI0aMEGlpaWpvVwgh7t27JyZMmCCsra2FTCYTXl5eIjY2VqVPWlqaACA+/fRTsXHjRtG4cWNhZGQkOnToIM6ePVvu6/E8Pz8/4eLi8sJ+zz+/33//vWjdurWQyWSiZcuWYteuXWX6ZmVliZkzZwoHBwdhZGQk3NzcxNKlS0VRUZFKv6KiIrFy5Urh7u4uZDKZsLa2FpMnTxZ///23Sr/i4mKxePFi0ahRI2FiYiJ8fHzEr7/+KpydnUVgYKCyX3nvHyH+9/w//5pUZ3+ofBzBvwb2798PFxcXvPnmm+XO79GjB1xcXLB//36sW7eu2utfv349WrVqhUGDBqFOnTrYv38//vGPf6C4uBjBwcEqfVNTUzFixAhMnDgRgYGB2LRpE4KCgtC+fXu0atUKPXr0wIwZM7B69Wr885//RMuWLQFA+d/SoqKikJubq9K2cuVKpKSkoEGDBgCAc+fO4dSpUxg1ahQcHByQnp6O9evXw8fHB5cvX0bdunWrvd3Hjx/Dx8cHqampmDZtGlxdXbFjxw4EBQXh0aNHmDlzpkr/rVu3IicnB1OmTIGenh6WL1+OYcOG4caNGzA0NKzwuXV2dsbhw4dx5MgR9OrVq5JX4b+uXbuGkSNH4v3330dgYCBiYmLw1ltvISEhAX369AEA5Ofnw9vbG7dv38aUKVPg5OSEU6dOITQ0FJmZmYiKilKub8qUKYiNjcX48eMxY8YMpKWl4fPPP8eFCxdw8uRJZe0LFizAv//9bwwYMAADBgxAcnIy+vbtqzy0pa6q7A9VQtufMPRyPXr0SAAQgwcPrrTfoEGDBACRnZ0thKjeCD4/P79MPz8/P9G4cWOVtpLR9vN/Sdy/f1/IZDLx4YcfKtt27NihMnp+Xnkj6ed9/fXXAoBYtGhRpfWdPn1aABDx8fFqbTcqKkoAEJs3b1a2FRYWii5duggzMzPl81gygm/QoIHKqPebb74RAMT+/fsr3BchhPj111+FiYmJACDatGkjZs6cKfbu3Svy8vLK9C15fp8f4SoUCmFnZyfatm2rbFu8eLEwNTUVV69eVVl+3rx5wsDAQNy6dUsIIcSJEycEALFlyxaVfgkJCSrt9+/fF0ZGRmLgwIGiuLhY2e+f//ynAFCjEXxV9ocqxrNoJC4nJwcAYG5uXmm/kvkl/avDxMRE+f8KhQJ//fUXvL29cePGDSgUCpW+7u7uKn9JWFlZoXnz5rhx40a1t1va5cuXMWHCBAwePBjz588vt76nT5/i4cOHaNKkCerVq4fk5GS1tnXw4EHY2tpi9OjRyjZDQ0PMmDEDubm5+PHHH1X6jxw5EpaWlsrpkufgRfvdqlUrpKSkYOzYsUhPT8eqVaswZMgQ2NjYIDo6ukx/e3t7DB06VDltYWGBcePG4cKFC7h79y4AYMeOHXjzzTdhaWmJv/76S/nw9fVFUVERjh8/ruwnl8vRp08flX7t27eHmZkZjh49CgA4fPgwCgsLMX36dOjp6Sm3PWvWrKo8lZWqyv5QxXiIRuKqGtw5OTnQ09NDw4YNq72NkydPIjw8HKdPn0Z+fr7KPIVCAblcrpx2cnIqs7ylpSWysrKqvd3nZWdnY9iwYWjUqBHi4+NVgubx48eIiIhATEwMbt++DfHciWOlP4Cq6ubNm2jatCn09VXHSCWHdG7evKnSXnq/S8K+KvvdrFkzfPnllygqKsLly5dx4MABLF++HJMnT4arqyt8fX2VfZs0aaKy7yXLA/893dLW1hbXrl3DxYsXVb5sf17Jl7fXrl2DQqGAtbV1pf1K9rVp06Yq862srFQ+1NRRlf2hijHgJU4ul8Pe3h4XL16stN/Fixfh4OCgPFuk9D+qEkVFRSrT169fR+/evdGiRQtERkbC0dERRkZGOHjwIFauXIni4mKV/gYGBuWuV9TwbN2goCDcuXMHZ8+ehYWFhcq86dOnIyYmBrNmzUKXLl0gl8uhp6eHUaNGlanvZdHEfhsYGMDT0xOenp7o0qULevbsiS1btqgEfFUUFxejT58+mDNnTrnzSwK0uLgY1tbW2LJlS7n9KvqAqExV31ekGQz410BAQAA2btyIn376Cd27dy8z/8SJE0hPT0dISIiyzdLSEo8ePSrTt/TIdP/+/SgoKMC+fftURqklf76ro6IQqMjSpUuxd+9e7N69Gy1atCgzf+fOnQgMDMSKFSuUbU+ePCmzf9XZrrOzMy5evIji4mKVUfwff/yhnP8ydejQAQCQmZmp0p6amgohhMq+XL16FcB/z0kHADc3N+Tm5r7wg8HNzQ2HDx9Gt27dVA5zlVayr9euXUPjxo2V7Q8ePCjzF0rJiP7Ro0eoV6+esr30+6o6+0MV4zH418Ds2bNRt25dTJkyBQ8fPlSZ9/fff+P999+HhYUFpk2bpmx3c3ODQqFQGflnZmZiz549KsuXjExLH/aIiYlRu15TU1MAKPcDprTDhw9j/vz5+Ne//oUhQ4aU28fAwKDMSHnNmjVlRo3V2e6AAQNw9+5dbN++Xdn27NkzrFmzBmZmZvD29n7hOqrixIkTePr0aZn2gwcPAgCaN2+u0n7nzh2V1yg7Oxvx8fFo06aN8nDG22+/jdOnT+P7778vs95Hjx7h2bNnyn5FRUVYvHhxmX7Pnj1TPk++vr4wNDTEmjVrVJ7n58/GKeHm5gYAyuP8AJCXl4e4uLhy978q+0MV4wj+NdCkSRPEx8dj9OjR8PT0LPNL1qysLGzbtk3lR06jRo3C3LlzMXToUMyYMQP5+flYv349mjVrpvLFZN++fWFkZISAgABMmTIFubm5iI6OhrW1dZnRZVW1adMGBgYGWLZsGRQKBWQyGXr16lXuseDRo0fDysoKTZs2xebNm1Xm9enTBzY2NvD398eXX34JuVwOd3d3nD59GocPH1aeRqnOdidPnoyNGzciKCgISUlJcHFxwc6dO3Hy5ElERUW98Evtqlq2bBmSkpIwbNgweHl5AQCSk5MRHx+P+vXrl/kis1mzZpg4cSLOnTsHGxsbbNq0Cffu3VP5wP3oo4+wb98++Pv7K09RzcvLw6VLl7Bz506kp6ejYcOG8Pb2xpQpUxAREYGUlBT07dsXhoaGuHbtGnbs2IFVq1ZhxIgRsLKywuzZsxEREQF/f38MGDAAFy5cwHfffVfmO52+ffvCyckJEydOxEcffQQDAwNs2rQJVlZWuHXrVpn9r8r+UCW0dwIPvWqXLl0S77zzjrC1tRX6+voCgDA2Nha//fZbuf1/+OEH4eHhIYyMjETz5s3F5s2byz3Nbd++fcLLy0sYGxsLFxcXsWzZMrFp06YKf7hSWnmnPkZHR4vGjRsLAwODSn9whAp+5PT8MllZWWL8+PGiYcOGwszMTPj5+Yk//vijzI9wqrNdIf77Q6eS9RoZGQlPT08RExOj0uf5HzqVBkCEh4eXaX/eyZMnRXBwsPDw8BByuVwYGhoKJycnERQUJK5fv67S9/kfBnl5eQmZTCZatGghduzYUWa9OTk5IjQ0VDRp0kQYGRmJhg0biq5du4rPPvtMFBYWqvT94osvRPv27YWJiYkwNzcXnp6eYs6cOeLOnTvKPkVFRWLhwoXCzs6u0h86CSFEUlKS6Ny5szAyMhJOTk4iMjLyhT90etH+UPl4LZrXWHx8PIKCgjB27FjEx8druxyqIRcXF3h4eODAgQPaLkUjpLY/2sBDNK+xcePGITMzE/PmzYODgwOWLFmi7ZKISIMY8K+5uXPnYu7cudoug4heAp5FQ0QkUTwGT0QkURzBExFJFAOeiEiiJP8la3FxMe7cuQNzc/Nq/wSeiEgXCSGQk5MDe3v7Mhe8e57kA/7OnTtwdHTUdhlERBqXkZEBBweHCudLPuBLfjKekZFR5iqDRES1UXZ2NhwdHV94SQytBvzx48fx6aefIikpSXkhq5ILRj19+hTz58/HwYMHcePGDcjlcvj6+mLp0qWwt7ev8jZKDstYWFgw4IlIUl502FmrX7Lm5eWhdevWWLt2bZl5+fn5SE5ORlhYGJKTk7F7925cuXIFgwYN0kKlRES1j86cB6+np6cygi/PuXPn0KlTJ9y8ebPcOwOVJzs7G3K5HAqFgiN4IpKEquZarToGr1AooKenp3KjgNIKCgpQUFCgnM7Ozn4FlRER6Z5acx78kydPMHfuXIwePbrST6yIiAjI5XLlg2fQENHrqlYE/NOnT/H2229DCIH169dX2jc0NBQKhUL5yMjIeEVVEhHpFp0/RFMS7jdv3sSRI0deeBxdJpNBJpO9ouqIiHSXTgd8Sbhfu3YNR48eLXOLNSIiqphWAz43NxepqanK6bS0NKSkpKB+/fqws7PDiBEjkJycjAMHDqCoqAh3794FANSvXx9GRkbaKpuIqFbQ6mmSx44dQ8+ePcu0BwYG4uOPP1a5CfTzjh49Ch8fnyptg6dJSovLvG+1XUKtlr50oLZLIA2oFadJ+vj4oLLPFx05RZ+IqFaqFWfREBFR9THgiYgkigFPRCRRDHgiIoliwBMRSRQDnohIohjwREQSxYAnIpIoBjwRkUQx4ImIJIoBT0QkUQx4IiKJYsATEUkUA56ISKIY8EREEsWAJyKSKAY8EZFEMeCJiCSKAU9EJFEMeCIiiWLAExFJFAOeiEiiGPBERBLFgCcikigGPBGRRDHgiYgkigFPRCRRWg3448ePIyAgAPb29tDT08PevXtV5gshsGDBAtjZ2cHExAS+vr64du2adoolIqpltBrweXl5aN26NdauXVvu/OXLl2P16tXYsGEDzpw5A1NTU/j5+eHJkyevuFIiotqnjjY33r9/f/Tv37/ceUIIREVFYf78+Rg8eDAAID4+HjY2Nti7dy9GjRr1KkslIqp1dPYYfFpaGu7evQtfX19lm1wuR+fOnXH69OkKlysoKEB2drbKg4jodaSzAX/37l0AgI2NjUq7jY2Ncl55IiIiIJfLlQ9HR8eXWicRka7S2YBXV2hoKBQKhfKRkZGh7ZKIiLRCZwPe1tYWAHDv3j2V9nv37innlUcmk8HCwkLlQUT0OtLZgHd1dYWtrS0SExOVbdnZ2Thz5gy6dOmixcqIiGoHrZ5Fk5ubi9TUVOV0WloaUlJSUL9+fTg5OWHWrFn497//jaZNm8LV1RVhYWGwt7fHkCFDtFc0EVEtodWAP3/+PHr27KmcDgkJAQAEBgYiNjYWc+bMQV5eHiZPnoxHjx6he/fuSEhIgLGxsbZKJiKqNfSEEELbRbxM2dnZkMvlUCgUPB4vAS7zvtV2CbVa+tKB2i6BNKCquaazx+CJiKhmGPBERBLFgCcikigGPBGRRDHgiYgkigFPRCRRDHgiIoliwBMRSRQDnohIohjwREQSxYAnIpIoBjwRkUQx4ImIJIoBT0QkUQx4IiKJYsATEUkUA56ISKIY8EREEsWAJyKSKAY8EZFEMeCJiCSKAU9EJFEMeCIiiWLAExFJFAOeiEiiGPBERBKl0wFfVFSEsLAwuLq6wsTEBG5ubli8eDGEENoujYhI59XRdgGVWbZsGdavX4+4uDi0atUK58+fx/jx4yGXyzFjxgxtl0dEpNN0OuBPnTqFwYMHY+DAgQAAFxcXfPXVVzh79qyWKyMi0n06fYima9euSExMxNWrVwEAv/zyC3766Sf079+/wmUKCgqQnZ2t8iAieh3p9Ah+3rx5yM7ORosWLWBgYICioiJ88sknGDNmTIXLREREYOHCha+wSiIi3aTTI/ivv/4aW7ZswdatW5GcnIy4uDh89tlniIuLq3CZ0NBQKBQK5SMjI+MVVkxEpDt0egT/0UcfYd68eRg1ahQAwNPTEzdv3kRERAQCAwPLXUYmk0Emk73KMomIdJJOj+Dz8/Ohr69aooGBAYqLi7VUERFR7aHTI/iAgAB88skncHJyQqtWrXDhwgVERkZiwoQJ2i6NiEjn6XTAr1mzBmFhYfjHP/6B+/fvw97eHlOmTMGCBQu0XRoRkc6rUcDfv38fV65cAQA0b94c1tbWGimqhLm5OaKiohAVFaXR9RIRvQ7UOgafk5ODd999F40aNYK3tze8vb3RqFEjjB07FgqFQtM1EhGRGtQK+EmTJuHMmTM4cOAAHj16hEePHuHAgQM4f/48pkyZoukaiYhIDWodojlw4AC+//57dO/eXdnm5+eH6Oho9OvXT2PFERGR+tQawTdo0AByubxMu1wuh6WlZY2LIiKimlMr4OfPn4+QkBDcvXtX2Xb37l189NFHCAsL01hxRESkPrUO0axfvx6pqalwcnKCk5MTAODWrVuQyWR48OABNm7cqOybnJysmUqJiKha1Ar4IUOGaLgMIiLSNLUCPjw8XNN1EBGRhun0tWiIiEh9ao3g9fX1oaenV+H8oqIitQsiIiLNUCvg9+zZozL99OlTXLhwAXFxcbzZBhGRjlAr4AcPHlymbcSIEWjVqhW2b9+OiRMn1rgwIiKqGY0eg3/jjTeQmJioyVUSEZGaNBbwjx8/xurVq9GoUSNNrZKIiGpArUM0lpaWKl+yCiGQk5ODunXrYvPmzRorjoiI1KdWwK9cuVIl4PX19WFlZYXOnTvzWjRERDpCrYAPCgrScBlERKRpVQ74ixcvVnmlXl5eahVDRESaU+WAb9OmDfT09CCEAAD+0ImISMdV+SyatLQ03LhxA2lpadi9ezdcXV2xbt06XLhwARcuXMC6devg5uaGXbt2vcx6iYioiqo8gnd2dlb+/1tvvYXVq1djwIAByjYvLy84OjoiLCyMV5skItIBap0Hf+nSJbi6upZpd3V1xeXLl2tcFBER1ZxaAd+yZUtERESgsLBQ2VZYWIiIiAi0bNlSY8UREZH61DpNcsOGDQgICICDg4PyjJmLFy9CT08P+/fv12iBRESkHrUCvlOnTrhx4wa2bNmCP/74AwAwcuRIvPPOOzA1NdVogUREpB61Ah4ATE1NMXnyZE3WQkREGqT2xca+/PJLdO/eHfb29rh58yaA/17C4JtvvtFYcUREpD61An79+vUICQlB//79kZWVpfxhk6WlJaKiojRZH27fvo2xY8eiQYMGMDExgaenJ86fP6/RbRARSZFaAb9mzRpER0fjX//6F+rU+d9Rng4dOuDSpUsaKy4rKwvdunWDoaEhvvvuO1y+fBkrVqzgBc2IiKpArWPwaWlpaNu2bZl2mUyGvLy8GhdVYtmyZXB0dERMTIyyrbzz759XUFCAgoIC5XR2drbG6iEiqk3UGsG7uroiJSWlTHtCQoJGz4Pft28fOnTogLfeegvW1tZo27YtoqOjK10mIiICcrlc+XB0dNRYPUREtYlaAR8SEoLg4GBs374dQgicPXsWn3zyCUJDQzFnzhyNFXfjxg2sX78eTZs2xffff4+pU6dixowZiIuLq3CZ0NBQKBQK5SMjI0Nj9RAR1SZqHaKZNGkSTExMMH/+fOTn5+Odd96Bvb09Vq1ahVGjRmmsuOLiYnTo0AFLliwBALRt2xa//vorNmzYgMDAwHKXkclkkMlkGquBiKi2Uvs8+DFjxmDMmDHIz89Hbm4urK2tNVkXAMDOzg7u7u4qbS1btuQVK4mIqkDt8+CfPXuGw4cP48svv4SJiQkA4M6dO8jNzdVYcd26dcOVK1dU2q5evapyZUsiIiqfWiP4mzdvol+/frh16xYKCgrQp08fmJubY9myZSgoKMCGDRs0UtwHH3yArl27YsmSJXj77bdx9uxZfPHFF/jiiy80sn4iIilTawQ/c+ZMdOjQAVlZWcrROwAMHToUiYmJGiuuY8eO2LNnD7766it4eHhg8eLFiIqKwpgxYzS2DSIiqVJrBH/ixAmcOnUKRkZGKu0uLi64ffu2Rgor4e/vD39/f42uk4jodaDWCL64uLjc+67++eefMDc3r3FRRERUc2oFfN++fVWuOaOnp4fc3FyEh4er3MaPiIi0R61DNCtWrICfnx/c3d3x5MkTvPPOO7h27RoaNmyIr776StM1EhGRGtQKeAcHB/zyyy/Ytm0bLl68iNzcXEycOBFjxoxR+dKViIi0R+0fOtWpUwdjx47VZC1ERKRBagf8lStXsGbNGvz+++8A/vsL02nTpqFFixYaK46IiNSn1pesu3btgoeHB5KSktC6dWu0bt0aycnJ8PT05GUEiIh0hFoj+Dlz5iA0NBSLFi1SaQ8PD8ecOXMwfPhwjRRHRETqU2sEn5mZiXHjxpVpHzt2LDIzM2tcFBER1ZxaAe/j44MTJ06Uaf/pp5/w5ptv1rgoIiKqObUO0QwaNAhz585FUlIS3njjDQDAzz//jB07dmDhwoXYt2+fSl8iInr19IQQoroL6etXbeCvp6dX7iUNXqXs7GzI5XIoFApYWFhotRaqOZd532q7hFotfelAbZdAGlDVXFNrBF9cXKx2YURE9GpU6xj86dOnceDAAZW2+Ph4uLq6wtraGpMnT0ZBQYFGCyQiIvVUK+AXLVqE3377TTl96dIlTJw4Eb6+vpg3bx7279+PiIgIjRdJRETVV62AT0lJQe/evZXT27ZtQ+fOnREdHY2QkBCsXr0aX3/9tcaLJCKi6qtWwGdlZcHGxkY5/eOPP6J///7K6Y4dOyIjI0Nz1RERkdqqFfA2NjZIS0sDABQWFiI5OVl5miQA5OTkwNDQULMVEhGRWqoV8AMGDMC8efNw4sQJhIaGom7duio/bLp48SLc3Nw0XiQREVVftU6TXLx4MYYNGwZvb2+YmZkhLi5O5b6smzZtQt++fTVeJBERVV+1Ar5hw4Y4fvw4FAoFzMzMYGBgoDJ/x44dMDMz02iBRESkHrV+6CSXy8ttr1+/fo2KISIizVHrYmNERKT7GPBERBLFgCcikigGPBGRRNWqgF+6dCn09PQwa9YsbZdCRKTzak3Anzt3Dhs3boSXl5e2SyEiqhVqRcDn5uZizJgxiI6OhqWlpbbLISKqFWpFwAcHB2PgwIHw9fV9Yd+CggJkZ2erPIiIXkdq/dDpVdq2bRuSk5Nx7ty5KvWPiIjAwoULX3JVRES6T6dH8BkZGZg5cya2bNkCY2PjKi0TGhoKhUKhfPDyxUT0utLpEXxSUhLu37+Pdu3aKduKiopw/PhxfP755ygoKChzPRyZTAaZTPaqSyUi0jk6HfC9e/fGpUuXVNrGjx+PFi1aYO7cuWXCnYiI/kenA97c3BweHh4qbaampmjQoEGZdiIiUqXTx+CJiEh9Oj2CL8+xY8e0XQIRUa3AETwRkUQx4ImIJIoBT0QkUQx4IiKJYsATEUkUA56ISKIY8EREEsWAJyKSKAY8EZFEMeCJiCSKAU9EJFEMeCIiiWLAExFJFAOeiEiiGPBERBLFgCcikigGPBGRRDHgiYgkigFPRCRRDHgiIoliwBMRSRQDnohIohjwREQSxYAnIpKoOtougIhqL5d532q7hFovfenAl7ZujuCJiCRKpwM+IiICHTt2hLm5OaytrTFkyBBcuXJF22UREdUKOh3wP/74I4KDg/Hzzz/j0KFDePr0Kfr27Yu8vDxtl0ZEpPN0+hh8QkKCynRsbCysra2RlJSEHj16aKkqIqLaQacDvjSFQgEAqF+/foV9CgoKUFBQoJzOzs5+6XUREekinT5E87zi4mLMmjUL3bp1g4eHR4X9IiIiIJfLlQ9HR8dXWCURke6oNQEfHByMX3/9Fdu2bau0X2hoKBQKhfKRkZHxiiokItItteIQzbRp03DgwAEcP34cDg4OlfaVyWSQyWSvqDIiIt2l0wEvhMD06dOxZ88eHDt2DK6urtouiYio1tDpgA8ODsbWrVvxzTffwNzcHHfv3gUAyOVymJiYaLk6IiLdptPH4NevXw+FQgEfHx/Y2dkpH9u3b9d2aUREOk+nR/BCCG2XQERUa+n0CJ6IiNTHgCcikigGPBGRRDHgiYgkigFPRCRRDHgiIoliwBMRSRQDnohIohjwREQSxYAnIpIoBjwRkUQx4ImIJEqnLzambS7zvtV2CbVe+tKB2i6B6LXFETwRkUQx4ImIJIoBT0QkUQx4IiKJYsATEUkUA56ISKIY8EREEsWAJyKSKAY8EZFEMeCJiCSKAU9EJFEMeCIiiWLAExFJFAOeiEiiakXAr127Fi4uLjA2Nkbnzp1x9uxZbZdERKTzdD7gt2/fjpCQEISHhyM5ORmtW7eGn58f7t+/r+3SiIh0ms4HfGRkJN577z2MHz8e7u7u2LBhA+rWrYtNmzZpuzQiIp2m03d0KiwsRFJSEkJDQ5Vt+vr68PX1xenTp8tdpqCgAAUFBcpphUIBAMjOzq729osL8qu9DKlS53mvDF+TmuHroXvUeU1KlhFCVNpPpwP+r7/+QlFREWxsbFTabWxs8Mcff5S7TEREBBYuXFim3dHR8aXUSJWTR2m7AnoeXw/dU5PXJCcnB3K5vML5Oh3w6ggNDUVISIhyuri4GH///TcaNGgAPT09LVamWdnZ2XB0dERGRgYsLCy0XQ6Br4kukuprIoRATk4O7O3tK+2n0wHfsGFDGBgY4N69eyrt9+7dg62tbbnLyGQyyGQylbZ69eq9rBK1zsLCQlJvXCnga6J7pPiaVDZyL6HTX7IaGRmhffv2SExMVLYVFxcjMTERXbp00WJlRES6T6dH8AAQEhKCwMBAdOjQAZ06dUJUVBTy8vIwfvx4bZdGRKTTdD7gR44ciQcPHmDBggW4e/cu2rRpg4SEhDJfvL5uZDIZwsPDyxyOIu3ha6J7XvfXRE+86DwbIiKqlXT6GDwREamPAU9EJFEMeCIiiWLAE1VRbGyspH9TIXUuLi6IiorSdhmvFANey4KCgqCnp1fmkZqaqjLPyMgITZo0waJFi/Ds2TMAwJUrV9CzZ0/Y2NjA2NgYjRs3xvz58/H06VPl+qOjo/Hmm2/C0tISlpaW8PX1lczllh88eICpU6fCyckJMpkMtra28PPzw8mTJ5V99PT0sHfv3mqvu7wwGDlyJK5evap2vaU/IGJjY6Gnp4d+/fqp9Hv06BH09PRw7NgxZZ/KHunp6QCAqKgoNG/eHCYmJnB0dMQHH3yAJ0+eqF1vieffh4aGhrCxsUGfPn2wadMmFBcX13j9r8q5c+cwefJktZcv/Z5wcXGBnp4efv75Z5V+s2bNgo+Pj0qfih5BQUEAgKtXr2Lw4MFo2LAhLCws0L17dxw9elTtWkvo/GmSr4N+/fohJiZGpc3KykplXkFBAQ4ePIjg4GAYGhoiNDQUhoaGGDduHNq1a4d69erhl19+wXvvvYfi4mIsWbIEAHDs2DGMHj0aXbt2hbGxMZYtW4a+ffvit99+Q6NGjV75vmrS8OHDUVhYiLi4ODRu3Bj37t1DYmIiHj58+FK2Z2JiAhMTE42us06dOjh8+DCOHj2Knj17lpk/cuRIlQ+AYcOGwcPDA4sWLVK2WVlZYevWrZg3bx42bdqErl274urVq8pgjoyMrHGdJe/DoqIi3Lt3DwkJCZg5cyZ27tyJffv2oU4d3Y+Skn9TmmRsbIy5c+fixx9/LHf+uXPnUFRUBAA4deoUhg8fjitXrih/VVvyfvL390fTpk1x5MgRmJiYICoqCv7+/rh+/XqFv9qvEkFaFRgYKAYPHlzleX369BFvvPFGhev74IMPRPfu3Suc/+zZM2Fubi7i4uLUKVdnZGVlCQDi2LFjFfZxdnYWAJQPZ2dnIYQQqampYtCgQcLa2lqYmpqKDh06iEOHDimX8/b2Vlmu5J9JTEyMkMvlKtvYt2+f6NChg5DJZKJBgwZiyJAhFdZTevmS6ffee0906tSpzL4dPXq0zDq8vb3FzJkzy7QHBweLXr16qbSFhISIbt26VVhPVVX0Hk1MTBQARHR0tBBCiPHjx4uBAweq9CksLBRWVlbiP//5j7L+6dOni48++khYWloKGxsbER4errLMihUrhIeHh6hbt65wcHAQU6dOFTk5Ocr5Jc/b/v37RbNmzYSJiYkYPny4yMvLE7GxscLZ2VnUq1dPTJ8+XTx79ky5nLOzs1i5cqVyOisrS0yePFlYW1sLmUwmWrVqJfbv31/h81B6eWdnZzFjxgxhZGQkvv32W2X7zJkzhbe3d5nljx49KgCIrKwslfYHDx4IAOL48ePKtuzsbAFA5X2pDh6iqWVMTExQWFhY7rzU1FQkJCTA29u7wuXz8/Px9OlT1K9f/2WV+EqYmZnBzMwMe/fuVbk89PPOnTsHAIiJiUFmZqZyOjc3FwMGDEBiYiIuXLiAfv36ISAgALdu3QIA7N69Gw4ODli0aBEyMzORmZlZ7vq//fZbDB06FAMGDMCFCxeQmJiITp06VXtfPv74Y1y6dAk7d+6s9rIlunbtiqSkJOXhtxs3buDgwYMYMGCA2ut8kV69eqF169bYvXs3AGDSpElISEhQeb4OHDiA/Px8jBw5UtkWFxcHU1NTnDlzBsuXL8eiRYtw6NAh5Xx9fX2sXr0av/32G+Li4nDkyBHMmTNHZdv5+flYvXo1tm3bhoSEBBw7dgxDhw7FwYMHcfDgQXz55ZfYuHFjhc9pcXEx+vfvj5MnT2Lz5s24fPkyli5dCgMDg2o9B66urnj//fcRGhqq9uGqBg0aoHnz5oiPj0deXh6ePXuGjRs3wtraGu3bt1drnUo1+nigGgsMDBQGBgbC1NRU+RgxYoRyXsnIqbi4WBw6dEjIZDIxe/ZslXV06dJFyGQyAUBMnjxZFBUVVbi9qVOnisaNG4vHjx+/tH16VXbu3CksLS2FsbGx6Nq1qwgNDRW//PKLSh8AYs+ePS9cV6tWrcSaNWuU06VHa0KUHYF36dJFjBkzpsr1VjSCF0KIefPmiWbNmomnT5+qNYIXQohVq1YJQ0NDUadOHQFAvP/++1WurTKV/ZU5cuRI0bJlS+W0u7u7WLZsmXI6ICBABAUFqdRf+i/Mjh07irlz51a4/R07dogGDRoop2NiYgQAkZqaqmybMmWKqFu3rspI38/PT0yZMkU5/fxr+v333wt9fX1x5cqVCrdbWnkj+JUrV4r79+8Lc3NzER8fL4So/gheCCEyMjJE+/bthZ6enjAwMBB2dnYiOTm5yrVVhCN4HdCzZ0+kpKQoH6tXr1bOO3DgAMzMzGBsbIz+/ftj5MiR+Pjjj1WW3759O5KTk7F161Z8++23+Oyzz8rdztKlS7Ft2zbs2bMHxsbGL3OXXonhw4fjzp072LdvH/r164djx46hXbt2iI2NrXS53NxczJ49Gy1btkS9evVgZmaG33//XTmCr6qUlBT07t27BnvwP3PnzsWDBw/UvlPZsWPHsGTJEqxbtw7JycnYvXs3vv32WyxevFgj9VVECKFyGe5JkyYpv0+6d+8evvvuO0yYMEFlGS8vL5VpOzs7lVtwHj58GL1790ajRo1gbm6Od999Fw8fPkR+/v9uLlK3bl24ubkpp21sbODi4gIzMzOVtopu7ZmSkgIHBwc0a9ZMjb1WZWVlhdmzZ2PBggUV/nVdGSEEgoODYW1tjRMnTuDs2bMYMmQIAgICKvzrsaoY8DrA1NQUTZo0UT7s7OyU80rC/9q1a3j8+LHyz9vnOTo6wt3dHaNHj8bSpUvx8ccfK7/YKfHZZ59h6dKl+OGHH8r8A6vNjI2N0adPH4SFheHUqVMICgpCeHh4pcvMnj0be/bswZIlS3DixAmkpKTA09Oz2v84NfmFa7169RAaGoqFCxeqBFlVhYWF4d1338WkSZPg6emJoUOHYsmSJYiIiHipZ7r8/vvvcHV1VU6PGzcON27cwOnTp7F582a4urrizTffVFnG0NBQZVpPT09ZY3p6Ovz9/eHl5YVdu3YhKSkJa9euBQCV16e8dVS23tI0/WV5SEgIHj9+jHXr1lV72SNHjuDAgQPYtm0bunXrhnbt2mHdunUwMTFBXFxcjepiwOu4kvB3cnKq0pkKxcXFePr0qcobe/ny5Vi8eDESEhLQoUOHl1mu1rm7uyMvL085bWhoWObD7uTJkwgKCsLQoUPh6ekJW1tb5amGJYyMjMosV5qXl5fKpaxravr06dDX18eqVauqvWx+fj709VX/OZccTxYv6XJTR44cwaVLlzB8+HBlW4MGDTBkyBDExMQgNja22ld9TUpKQnFxMVasWIE33ngDzZo1w507dzRdOry8vPDnn3/W6LTX55mZmSEsLAyffPIJcnJyqrVsyQd66ddPX1+/xh/Oun9uE1Voy5YtMDQ0hKenJ2QyGc6fP4/Q0FCMHDlSOZpZtmwZFixYgK1bt8LFxQV3794F8L8vKWurhw8f4q233sKECRPg5eUFc3NznD9/HsuXL8fgwYOV/VxcXJCYmIhu3bpBJpPB0tISTZs2xe7duxEQEAA9PT2EhYWV+Yfk4uKC48ePY9SoUZDJZGjYsGGZGsLDw9G7d2+4ublh1KhRePbsGQ4ePIi5c+eqtU/GxsZYuHAhgoODq71sQEAAIiMj0bZtW3Tu3BmpqakICwtDQEBAtb84LE9BQQHu3r2rcppkREQE/P39MW7cOJW+kyZNgr+/P4qKihAYGFit7TRp0gRPnz7FmjVrEBAQgJMnT2LDhg01rr80b29v9OjRA8OHD0dkZCSaNGmCP/74o9zfJVTV5MmTsXLlSmzduhWdO3eu8nJdunSBpaUlAgMDsWDBApiYmCA6OhppaWkYOHCgWrWU4Ai+FqtTpw6WLVuGTp06wcvLCwsXLsS0adPwn//8R9ln/fr1KCwsxIgRI2BnZ6d8VHScvrYwMzND586dsXLlSvTo0QMeHh4ICwvDe++9h88//1zZb8WKFTh06BAcHR3Rtm1bAEBkZCQsLS3RtWtXBAQEwM/PD+3atVNZ/6JFi5Ceng43N7cKz5/28fHBjh07sG/fPrRp0wa9evWq8Y/IAgMD0bhx42ovN3/+fHz44YeYP38+3N3dMXHiRPj5+WHjxo01qqdEQkIC7Ozs4OLign79+uHo0aNYvXo1vvnmmzIfIL6+vrCzs4Ofn98LbylXWuvWrREZGYlly5bBw8MDW7ZsQUREhEb2obRdu3ahY8eOGD16NNzd3TFnzpwX/tVWGUNDQyxevLjaPy5r2LAhEhISkJubi169eqFDhw746aef8M0336B169Zq1wPwcsFEpGG5ublo1KgRYmJiMGzYMG2X81rjIRoi0oji4mL89ddfWLFiBerVq4dBgwZpu6TXHgOeiDTi1q1bcHV1hYODA2JjY2vF5QukjodoiIgkil+yEhFJFAOeiEiiGPBERBLFgCcikigGPBGRRDHgiYgkigFPkvGie5eWvsxydddd1Xu7Hj16FAMGDECDBg1Qt25duLu748MPP8Tt27fV3j6ROhjwJBkld1/KzMxEVFQULCwsVNpmz5790mvYuHEjfH19YWtri127duHy5cvYsGEDFAoFVqxY8dK3T6SixrcMIdJB5d0/NTo6WrRo0ULIZDLRvHlzsXbtWuW8goICERwcLGxtbYVMJhNOTk5iyZIlQoiK7+1aWkZGhjAyMhKzZs0qd37JnXz++usvMWrUKGFvby9MTEyEh4eH2Lp1q0rfHTt2CA8PD2FsbCzq168vevfuLXJzc6u0L0QlGPAkSaUDfvPmzcLOzk7s2rVL3LhxQ+zatUvUr19fxMbGCiGE+PTTT4Wjo6M4fvy4SE9PFydOnFCG7v379wUAERMTIzIzM8X9+/fL3WZkZKQAIO7cuVNpbX/++af49NNPxYULF8T169fF6tWrhYGBgThz5owQQog7d+6IOnXqiMjISJGWliYuXrwo1q5dq7wd3Yv2hagEA54kqXTAu7m5lRklL168WHTp0kUIIcT06dNFr169RHFxcbnrQxXu7Tp16lRhYWGhVr0DBw4UH374oRBCiKSkJAFApKenl9v3RftCVIJXAyLJy8vLw/Xr1zFx4kS89957yvZnz55BLpcDAIKCgtCnTx80b94c/fr1g7+/P/r27Vut7YhS9yetSFFREZYsWYKvv/4at2/fRmFhIQoKClC3bl0A/70meu/eveHp6Qk/Pz/07dsXI0aMgKWlZZX2hagEA54kLzc3FwAQHR1d5k47JTeraNeuHdLS0vDdd9/h8OHDePvtt+Hr64udO3dWeTvNmjWDQqFAZmamyn11S/v000+xatUqREVFwdPTE6amppg1a5bynqMGBgY4dOgQTp06hR9++AFr1qzBv/71L5w5c0b5IVDZvhApaftPCKKXofQhGnt7e7Fo0aIqL5+QkCAAiIcPHwohhDA0NBQ7d+6sdJlbt25V6UtWf39/MWHCBGV7UVGRaNq0qRg8eHC5yz179kw0atRIrFixQq19odcXR/D0Wli4cCFmzJgBuVyOfv36oaCgAOfPn0dWVhZCQkIQGRkJOzs7tG3bFvr6+tixYwdsbW1Rr149AOXf27U0R0dHrFy5EtOmTUN2djbGjRsHFxcX/Pnnn4iPj4eZmRlWrFiBpk2bYufOnTh16hQsLS0RGRmJe/fuwd3dHQBw5swZJCYmom/fvrC2tsaZM2fw4MEDtGzZskr7QqSk7U8YopehvNMkt2zZItq0aSOMjIyEpaWl6NGjh9i9e7cQQogvvvhCtGnTRpiamgoLCwvRu3dvkZycrFx23759okmTJqJOnToVniZZ4tChQ8LPz09YWloKY2Nj0aJFCzF79mzl2TUPHz4UgwcPFmZmZsLa2lrMnz9fjBs3TjmCv3z5svDz8xNWVlZCJpOJZs2aiTVr1lR5X4hK8IYfREQSxV+yEhFJFAOeiEiiGPBERBLFgCcikigGPBGRRDHgiYgkigFPRCRRDHgiIoliwBMRSRQDnohIohjwREQS9f/ax1+sz2ypqgAAAABJRU5ErkJggg==",
-      "text/plain": [
-       "<Figure size 400x300 with 1 Axes>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Inference time results\n",
     "print(\"Summary\")\n",
@@ -573,17 +303,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "[CODE_SAMPLE_COMPLETED_SUCCESFULLY]\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "print('[CODE_SAMPLE_COMPLETED_SUCCESFULLY]')"
    ]


### PR DESCRIPTION
# Existing Sample Changes
## Description

clear all the output of ipynb to avoid showing performance data which not go through PDT performance yet

Fixes Issue# 

## External Dependencies

List any external dependencies created as a result of this change.

## Type of change

Please delete options that are not relevant. Add a 'X' to the one that is applicable. 

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Implement fixes for ONSAM Jiras

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Command Line
- [ ] oneapi-cli
- [ ] Visual Studio
- [ ] Eclipse IDE
- [x] VSCode
- [ ] When compiling the compliler flag "-Wall -Wformat-security -Werror=format-security" was used
