### PR TITLE
computed_tomography: improve error handling when double precision unavailable

### DIFF
--- a/Libraries/oneMKL/computed_tomography/computed_tomography.cpp
+++ b/Libraries/oneMKL/computed_tomography/computed_tomography.cpp
@@ -127,25 +127,20 @@ int main(int argc, char **argv)
     std::string radon_bmpname    = argc > 4 ? argv[4] : "radon.bmp";
     std::string restored_bmpname = argc > 5 ? argv[5] : "restored.bmp";
 
-    auto exception_handler = [](sycl::exception_list exceptions) {
-        for (std::exception_ptr const &e : exceptions) {
-            try {
-                std::rethrow_exception(e);
-            }
-            catch (sycl::exception const &e) {
-                std::cout << "Caught asynchronous SYCL exception:" << std::endl
-                          << e.what() << std::endl;
-            }
-        }
-    };
+    // Create execution queue.
+    // This sample requires double precision, so look for a device that supports it.
+    sycl::queue main_queue;
 
-    // create execution queue with asynchronous error handling
-    sycl::queue main_queue(sycl::device{sycl::default_selector_v}, exception_handler);
+    try {
+        main_queue = sycl::queue(sycl::aspect_selector({sycl::aspect::fp64}));
+    } catch (sycl::exception &e) {
+        std::cerr << "Could not find any device with double precision support. Exiting.\n";
+        return 0;
+    }
 
     std::cout << "Reading original image from " << original_bmpname << std::endl;
     matrix_r original_image(main_queue);
     bmp_read(original_image, original_bmpname);
-    // bmpWrite( "check-original.bmp", originalImage ); //For debugging purpose
 
     std::cout << "Allocating radonImage for backprojection" << std::endl;
     matrix_r radon_image(main_queue);


### PR DESCRIPTION
## Description

This PR improves error handling in the computed_tomography sample for devices that do not support double precision. This sample requires double precision, so this PR:

* Automatically looks for a device with double precision support
* If none found, returns an informative error message:

```
Could not find any device with double precision support. Exiting.
```

## External Dependencies

None

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [X] Command Line