### PR TITLE
FPGA reference design: Board_test patch

### DIFF
--- a/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/board_test/src/board_test.hpp
+++ b/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/board_test/src/board_test.hpp
@@ -200,7 +200,7 @@ size_t ShimMetrics::TestGlobalMem(sycl::queue &q) {
 
     // Get time for copy operation using Sycl event information (return in
     // nanoseconds)
-    sum_time_ns += SyclGetQSubExecTimeNs(h2d_copy_e);
+    sum_time_ns += SyclGetQStExecTimeNs(h2d_copy_e);
 
     // Increment offset and decrement remaining bytes by size of transfer
     offset += chunk;
@@ -261,7 +261,7 @@ size_t ShimMetrics::TestGlobalMem(sycl::queue &q) {
 
     // Get time for copy operation using Sycl event information (return in
     // nanoseconds)
-    sum_time_ns += SyclGetQSubExecTimeNs(d2h_copy_e);  // Nanoseconds
+    sum_time_ns += SyclGetQStExecTimeNs(d2h_copy_e);  // Nanoseconds
 
     // **** Verification **** //
 
@@ -355,7 +355,7 @@ size_t ShimMetrics::TestGlobalMem(sycl::queue &q) {
 // 3. struct Speed ReadSpeed(queue &q, buffer<char,1> &device_buffer, char
 // *hostbuf_rd, size_t block_bytes, size_t total_bytes)
 // 4. bool CheckResults
-// 4. unsigned long SyclGetQSubExecTimeNs(event e)
+// 4. unsigned long SyclGetQStExecTimeNs(event e)
 // 5. unsigned long SyclGetTotalTimeNs(event first_evt, event last_evt)
 
 int ShimMetrics::HostSpeed(sycl::queue &q) {
@@ -729,7 +729,7 @@ int ShimMetrics::KernelClkFreq(sycl::queue &q, bool report_chk) {
 
   // **** Get time for kernel event **** //
 
-  float time = SyclGetQSubExecTimeNs(e);
+  float time = SyclGetQStExecTimeNs(e);
   kernel_freq_ =
       ((float)kGlobalSize) /
       (time / 1000.0f);  // Time is returned in nanoseconds,

--- a/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/board_test/src/helper.hpp
+++ b/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/board_test/src/helper.hpp
@@ -128,11 +128,11 @@ unsigned long SyclGetQStExecTimeNs(sycl::event e) {
 // returns the total execution time for all events between first and last
 
 unsigned long SyclGetTotalTimeNs(sycl::event first_evt, sycl::event last_evt) {
-  unsigned long first_evt_submit =
+  unsigned long first_evt_start =
       first_evt.get_profiling_info<sycl::info::event_profiling::command_start>();
   unsigned long last_evt_end =
       last_evt.get_profiling_info<sycl::info::event_profiling::command_end>();
-  return (last_evt_end - first_evt_submit);
+  return (last_evt_end - first_evt_start);
 }  // End of SyclGetTotalTimeNs
 
 /////////////////////////////////////////

--- a/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/board_test/src/helper.hpp
+++ b/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/board_test/src/helper.hpp
@@ -91,27 +91,6 @@ void PrintHelp(int details) {
   }
 }  // End of PrintHelp
 
-//////////////////////////////////////////////
-// **** SyclGetQSubExecTimeNs function **** //
-//////////////////////////////////////////////
-
-// Input:
-// event e - SYCL event with profiling information
-// Returns:
-// Difference in time from command submission to command end (in nanoseconds)
-
-// The function does the following task:
-// Gets profiling information from a SYCL event and
-// returns execution time for a given SYCL event from a queue
-
-unsigned long SyclGetQSubExecTimeNs(sycl::event e) {
-  unsigned long submit_time =
-      e.get_profiling_info<sycl::info::event_profiling::command_submit>();
-  unsigned long end_time =
-      e.get_profiling_info<sycl::info::event_profiling::command_end>();
-  return (end_time - submit_time);
-}  // End of SyclGetQSubExecTimeNs
-
 /////////////////////////////////////////////
 // **** SyclGetQStExecTimeNs function **** //
 /////////////////////////////////////////////
@@ -150,7 +129,7 @@ unsigned long SyclGetQStExecTimeNs(sycl::event e) {
 
 unsigned long SyclGetTotalTimeNs(sycl::event first_evt, sycl::event last_evt) {
   unsigned long first_evt_submit =
-      first_evt.get_profiling_info<sycl::info::event_profiling::command_submit>();
+      first_evt.get_profiling_info<sycl::info::event_profiling::command_start>();
   unsigned long last_evt_end =
       last_evt.get_profiling_info<sycl::info::event_profiling::command_end>();
   return (last_evt_end - first_evt_submit);

--- a/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/board_test/src/host_speed.hpp
+++ b/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/board_test/src/host_speed.hpp
@@ -71,7 +71,7 @@ struct Speed WriteSpeed(sycl::queue &q, sycl::buffer<char, 1> &device_buffer,
   speed_wr.slowest = 1.0e7f;
 
   for (size_t i = 0; i < num_xfers; i++) {
-    float time_ns = SyclGetQSubExecTimeNs(evt[i]);
+    float time_ns = SyclGetQStExecTimeNs(evt[i]);
     float speed_MBps = ((float)block_bytes / kMB) / ((float)time_ns * 1e-9);
 
     if (speed_MBps > speed_wr.fastest) speed_wr.fastest = speed_MBps;
@@ -149,7 +149,7 @@ struct Speed ReadSpeed(sycl::queue &q, sycl::buffer<char, 1> &device_buffer,
   speed_rd.slowest = 1.0e7f;
 
   for (size_t i = 0; i < num_xfers; i++) {
-    float time_ns = SyclGetQSubExecTimeNs(evt[i]);
+    float time_ns = SyclGetQStExecTimeNs(evt[i]);
     float speed_MBps = ((float)block_bytes / kMB) / ((float)time_ns * 1e-9);
 
     if (speed_MBps > speed_rd.fastest) speed_rd.fastest = speed_MBps;


### PR DESCRIPTION
# Existing Sample Changes
## Description

Updated code sample to use "command_start" kernel event profiling information instead of "command_submit" to handle a [change in SYCL runtime](https://github.com/intel/llvm/commit/097d21c33599972837491378f3b9dd9094c27944). 

## Type of change

Please delete options that are not relevant. Add a 'X' to the one that is applicable. 

- [ X ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Implement fixes for ONSAM Jiras

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ X ] Command Line
- [ ] oneapi-cli
- [ ] Visual Studio
- [ ] Eclipse IDE
- [ ] VSCode
- [ ] When compiling the compliler flag "-Wall -Wformat-security -Werror=format-security" was used