### PR TITLE
FPGA: adjust the number of private copies in the covariance matrix kernel

### DIFF
--- a/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/pca/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/pca/README.md
@@ -68,7 +68,7 @@ Performance results are based on testing as of June 1st, 2023.
 | Device                                            | Throughput
 |:---                                               |:---
 | Intel® PAC with Intel® Arria® 10 GX FPGA          | 7.7k matrices/s for matrices of size 8 features * 4176 samples
-
+| Terasic DE10-Agilex Development Board             | 16k matrices/s for matrices of size 8 features * 4176 samples
 
 ## Key Implementation Details
 
@@ -458,22 +458,31 @@ Additionally, the `cmake` build system can be configured using the following par
 Example Output when running on **Intel® PAC with Intel® Arria® 10 GX FPGA**.
 
 ```
-
 Running on device: pac_a10 : Intel PAC Platform (pac_f300000)
 Reading the input data from file.
 Features count: 8
 Samples count: 4176
-Software iterations 25
 Running Principal Component analysis of 1 matrix 4096 times
 Using device allocations
    Total duration:   0.531844 s
 Throughput: 7.70151k matrices/s
 Verifying results...
 All the tests passed.
-Estimated throughput: 7483 matrices/s at 250 MHz
-Estimated throughput: 8979 matrices/s at 300 MHz
-Estimated throughput: 10476 matrices/s at 350 MHz
-Estimated throughput: 17959 matrices/s at 600 MHz
+```
+
+Example Output when running on the **Terasic DE10-Agilex Development Board**.
+
+```
+Running on device: de10_agilex : Agilex Reference Platform (aclde10_agilex0)
+Reading the input data from file.
+Features count: 8
+Samples count: 4176
+Running Principal Component analysis of 1 matrix 4096 times
+Using device allocations
+   Total duration:   0.250902 s
+Throughput: 16.3251k matrices/s
+Verifying results...
+All the tests passed.
 ```
 
 ## License

--- a/DirectProgramming/C++SYCL_FPGA/include/streaming_covariance_matrix.hpp
+++ b/DirectProgramming/C++SYCL_FPGA/include/streaming_covariance_matrix.hpp
@@ -60,7 +60,7 @@ struct StreamingCovarianceMatrix {
     T means[columns];
     // Array to keep the T matrix
     [[intel::max_replicates(1)]]    // NO-FORMAT: Attribute
-    [[intel::private_copies(128)]]  // NO-FORMAT: Attribute
+    [[intel::private_copies(4)]]  // NO-FORMAT: Attribute
     T t_matrix[columns * columns];
 
     // We keep count of the current block number
@@ -72,7 +72,7 @@ struct StreamingCovarianceMatrix {
       [[intel::numbanks(kNumBanksNextPow2)]]  // NO-FORMAT: Attribute
       [[intel::bankwidth(kBankwidth)]]        // NO-FORMAT: Attribute
       [[intel::max_replicates(1)]]            // NO-FORMAT: Attribute
-      [[intel::private_copies(128)]]          // NO-FORMAT: Attribute
+      [[intel::private_copies(2)]]          // NO-FORMAT: Attribute
       row_tuple a_load[columns];
 
       [[intel::initiation_interval(1)]]  // NO-FORMAT: Attribute
@@ -109,7 +109,7 @@ struct StreamingCovarianceMatrix {
 
       // Arrays to keep all the data of the current block being computed
       [[intel::max_replicates(1)]]    // NO-FORMAT: Attribute
-      [[intel::private_copies(128)]]  // NO-FORMAT: Attribute
+      [[intel::private_copies(2)]]  // NO-FORMAT: Attribute
       T t_matrix_compute[columns * columns];
       T t_matrix_diagonal_replicate_partial[columns];
       T means_partial[columns];
@@ -182,7 +182,7 @@ struct StreamingCovarianceMatrix {
 
       // For the computation of COV
       [[intel::max_replicates(1)]]    // NO-FORMAT: Attribute
-      [[intel::private_copies(128)]]  // NO-FORMAT: Attribute
+      [[intel::private_copies(2)]]  // NO-FORMAT: Attribute
       T t_matrix_consume[columns][columns];
 
       // Update the global T matrix with the partial results and copy the result
@@ -203,7 +203,7 @@ struct StreamingCovarianceMatrix {
       [[intel::numbanks(kNumBanksNextPow2)]]  // NO-FORMAT: Attribute
       [[intel::bankwidth(kBankwidth)]]        // NO-FORMAT: Attribute
       [[intel::max_replicates(1)]]            // NO-FORMAT: Attribute
-      [[intel::private_copies(128)]]          // NO-FORMAT: Attribute
+      [[intel::private_copies(2)]]          // NO-FORMAT: Attribute
       T cov_matrix[columns][columns];
 
       {


### PR DESCRIPTION
The number of private copies for different arrays was set to 128, a large number that was optimized away by the compiler.
This change adjusts this number to a more sensible value.