### PR TITLE
Update FPGA host pipes code sample to native implementation

### DIFF
--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/experimental/hostpipes/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/experimental/hostpipes/README.md
@@ -82,11 +82,11 @@ using SecondPipeInstance = cl::sycl::ext::intel::experimental::pipe<
     >;
 ```
 
-In this example, `FirstPipeT` and `SecondPipeT` are unique user-defined types that identify two host pipes. The first host pipe (which has been aliased to `FirstPipeInstance`), carries `int` type data elements and has a capacity of `8`. The second host pipe (`SecondPipeInstance`) carries `float` type data elements, and has a capacity of `4`. The other host pipe parameters beyond these three have been set to default values. For a description of all host pipe parameters, refer to the *[Intel® oneAPI Programming Guide](https://www.intel.com/content/www/us/en/develop/documentation/oneapi-programming-guide/)*. Using aliases allows these pipes to be referred to by a shorter and more descriptive handle, rather than having to repeatedly type out the full namespace and template parameters.
+In this example, `FirstPipeT` and `SecondPipeT` are unique user-defined types that identify two host pipes. The first host pipe (which has been aliased to `FirstPipeInstance`), carries `int` type data elements and has a capacity of `8`. The second host pipe (`SecondPipeInstance`) carries `float` type data elements, and has a capacity of `4`. Using aliases allows these pipes to be referred to by a shorter and more descriptive handle, rather than having to repeatedly type out the full namespace and template parameters.
 
 #### Host pipe properties
 
-Host pipes use an additional template parameter beyond the three described earlier. This template parameter uses the oneAPI properties class to allow users to define additional semantic properties for a host pipe. The use of these properties is beyond the scope of this tutorial. You can find their definitions and usage in the [oneAPI Programming Guide](https://www.intel.com/content/www/us/en/develop/documentation/oneapi-programming-guide/) Omitting the properties parameter (as has been done for the host pipes in this code sample) gives the host pipe the default values for these properties as described in the guide.
+Host pipes use a fourth template parameter beyond the three described earlier. This template parameter uses the oneAPI properties class to allow users to define additional semantic properties for a host pipe. The use of these properties is beyond the scope of this tutorial. You can find their definitions and usage in the [oneAPI Programming Guide](https://www.intel.com/content/www/us/en/develop/documentation/oneapi-programming-guide/) Omitting the properties parameter (as has been done for the host pipes in this code sample) gives the host pipe the default values for these properties as described in the guide.
 
 ### Host Pipe API
 

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/experimental/hostpipes/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/experimental/hostpipes/README.md
@@ -284,12 +284,7 @@ In the latter launch-collect test, the entire contents of the `in` vector are wr
   >  cmake .. -DFPGA_DEVICE=<FPGA device family or FPGA part number>
   >  ``` 
   >
-  > Alternatively, you can target an explicit FPGA board variant and BSP by using the following command: 
-  >  ```
-  >  cmake .. -DFPGA_DEVICE=<board-support-package>:<board-variant> -DIS_BSP=1
-  >  ``` 
-  >
-  > You will only be able to run an executable on the FPGA if you specified a BSP. This BSP must also support host pipes.
+  > This tutorial only uses the IP Authoring flow and does not support targeting an explicit FPGA board variant and BSP. 
 
 2. Compile the design through the generated `Makefile`. The following build targets are provided, matching the recommended development flow:
 
@@ -304,10 +299,6 @@ In the latter launch-collect test, the entire contents of the `in` vector are wr
   * Generate the optimization report:
     ```
     make report
-    ```
-  * Compile for FPGA hardware (longer compile time, targets FPGA device):
-    ```
-    make fpga
     ```
 
 ### On a Windows* System
@@ -347,10 +338,6 @@ In the latter launch-collect test, the entire contents of the `in` vector are wr
     ```
     nmake report
     ```
-  * Compile for FPGA hardware (longer compile time, targets FPGA device):
-    ```
-    nmake fpga
-    ```
 
 >**Tip**: If you encounter issues with long paths when compiling under Windows*, you might have to create your ‘build’ directory in a shorter path, for example `c:\samples\build`.  You can then run `cmake` from that directory, and provide `cmake` with the full path to your sample directory.
 
@@ -362,9 +349,7 @@ Open the **Views** menu and select **System Viewer**.
 
 In the left-hand pane, select **LoopBackKernelID** under the System hierarchy.
 
-In the main **System Viewer** pane, the pipe read and pipe write for the kernel are highlighted. They show that the read is reading from the `cl::sycl::ext::intel::prototype::internal::pipe<detail::HostPipePipeId<H2DPipeID>` host pipe, and that the write is writing to the `cl::sycl::ext::intel::prototype::internal::pipe<detail::HostPipePipeId<D2HPipeID>` host pipe. Clicking on either of these host pipes verifies the width (32-bit corresponding to the `int` type) and depth (8, which is the `kPipeMinCapacity` that each pipe was declared with).
-
-You might notice that there are additional identifiers in the pipe template (notably, `detail::HostPipePipeId`). This additional identifier is an internal implementation detail of this prototype feature. You can confirm the correspondence of these pipes to the ones declared in the source code by the template parameters `H2DPipeID` and `D2HPipeID`, which are the unique types declared in the source file and used in the pipe declarations:
+In the main **System Viewer** pane, the pipe read and pipe write for the kernel are highlighted in the **LoopBackKernelID.B1** block. Selecting **LoopBackKernelID.B1** in the left-hand pane gives an expanded view of this block in the main pane, with the pipe read represented by a 'RD' node, and pipe write as a 'WR' node. Clicking on either of these nodes gives further information for these pipes in the **Details** pane. This pane will show that the read is reading from the `H2DPipeID` host pipe, and that the write is writing to the `D2HPipeID` host pipe, as well as verifying that both pipes have a width of 32 bits (corresponding to the `int` type) and depth of 8 (which is the `kPipeMinCapacity` that each pipe was declared with).
 
 ```c++
 // forward declare kernel and pipe names to reduce name mangling
@@ -372,13 +357,13 @@ You might notice that there are additional identifiers in the pipe template (not
 class H2DPipeID;
 class D2HPipeID;
 ...
-using H2DPipe = cl::sycl::ext::intel::prototype::pipe<
+using H2DPipe = cl::sycl::ext::intel::experimental::pipe<
    // Usual pipe parameters
    H2DPipeID,         // An identified for the pipe
    ...
    >;
-
-using D2HPipe = cl::sycl::ext::intel::prototype::pipe<
+   
+using D2HPipe = cl::sycl::ext::intel::experimental::pipe<
    // Usual pipe parameters
    D2HPipeID,         // An identified for the pipe
    ...
@@ -389,37 +374,18 @@ using D2HPipe = cl::sycl::ext::intel::prototype::pipe<
 
 ### On Linux
 
-1. Run the sample on the FPGA emulator (the kernel executes on the CPU).
-   ```
-   ./hostpipes.fpga_emu
-   ```
-2. Run the sample on the FPGA simulator.
-   ```
-   CL_CONTEXT_MPSIM_DEVICE_INTELFPGA=1 ./hostpipes.fpga_sim <input_file> [-o=<output_file>]
-   ```
-3. Run the sample on the FPGA device (only if you ran `cmake` with `-DFPGA_DEVICE=<board-support-package>:<board-variant>`).
-   ```
-   ./hostpipes.fpga
-   ```
+  * On Linux
+    ```bash
+    CL_CONTEXT_MPSIM_DEVICE_INTELFPGA=1 ./hostpipes.fpga_sim <input_file> [-o=<output_file>]
+    ```
+  * On Windows
+    ```bash
+    set CL_CONTEXT_MPSIM_DEVICE_INTELFPGA=1
+    hostpipes.fpga_sim.exe <input_file> [-o=<output_file>]
+    set CL_CONTEXT_MPSIM_DEVICE_INTELFPGA=
+    ```
 
-### On Windows
-
-1. Run the sample on the FPGA emulator (the kernel executes on the CPU).
-   ```
-   hostpipes.fpga_emu.exe
-   ```
-2. Run the sample on the FPGA simulator.
-   ```
-   set CL_CONTEXT_MPSIM_DEVICE_INTELFPGA=1
-   hostpipes.fpga_sim.exe <input_file> [-o=<output_file>]
-   set CL_CONTEXT_MPSIM_DEVICE_INTELFPGA=
-   ```
-3. Run the sample on the FPGA device (only if you ran `cmake` with `-DFPGA_DEVICE=<board-support-package>:<board-variant>`).
-   ```
-   hostpipes.fpga.exe
-   ```
-
-## Example Output
+### Example of Output
 
 ```
 Running Alternating write-and-read

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/experimental/hostpipes/src/CMakeLists.txt
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/experimental/hostpipes/src/CMakeLists.txt
@@ -15,7 +15,7 @@ else()
     message(STATUS "Configuring the design with the following target: ${FPGA_DEVICE}")
 
     # Check if the target is a BSP
-    if(IS_BSP MATCHES "1" OR FPGA_DEVICE MATCHES ".*a10_hostpipe.*")
+    if(IS_BSP MATCHES "1" OR FPGA_DEVICE MATCHES ".*a10gx_hostpipe.*")
         set(IS_BSP "1")
     else()
         set(IS_BSP "0")

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/experimental/hostpipes/src/CMakeLists.txt
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/experimental/hostpipes/src/CMakeLists.txt
@@ -15,36 +15,18 @@ else()
     message(STATUS "Configuring the design with the following target: ${FPGA_DEVICE}")
 
     # Check if the target is a BSP
-    if(IS_BSP MATCHES "1" OR FPGA_DEVICE MATCHES ".*pac_a10.*|.*pac_s10.*")
+    if(IS_BSP MATCHES "1" OR FPGA_DEVICE MATCHES ".*a10_hostpipe.*")
         set(IS_BSP "1")
     else()
         set(IS_BSP "0")
-        message(STATUS "The selected target ${FPGA_DEVICE} is assumed to be an FPGA part number, so USM will be enabled by default.")
+        message(STATUS "The selected target ${FPGA_DEVICE} is assumed to be an FPGA part number.")
         message(STATUS "If the target is actually a BSP that does not support USM, run cmake with -DIS_BSP=1.")
     endif()
-endif()
-
-# this tutorial requires USM host allocations. Check the BSP name (which should contain the text 'usm')
-# to ensure the BSP has the required support. Allow the user to define USM_HOST_ALLOCATIONS_ENABLED
-# to override this check (e.g., cmake .. -DUSM_HOST_ALLOCATIONS_ENABLED=1)
-if((IS_BSP STREQUAL "1") AND NOT FPGA_DEVICE MATCHES ".usm.*" AND (NOT DEFINED USM_HOST_ALLOCATIONS_ENABLED OR USM_HOST_ALLOCATIONS_ENABLED STREQUAL "0"))
-    message(FATAL_ERROR "ERROR: This tutorial requires a BSP that has USM host allocations enabled.")
-endif()
-
-if (USM_HOST_ALLOCATIONS_ENABLED)
-    message(STATUS "USM_HOST_ALLOCATIONS_ENABLED set manually!")
 endif()
 
 # This is a Windows-specific flag that enables exception handling in host code
 if(WIN32)
     set(WIN_FLAG "/EHsc")
-endif()
-
-# This is for finding the install path to the necessary include files
-if(DEFINED ENV{INTELFPGAOCLSDKROOT})
-   set(SDK_ROOT_PATH $ENV{INTELFPGAOCLSDKROOT})
-else()
-   message(FATAL_ERROR "The INTELFPGAOCLSDKROOT environment variable must be defined for this tutorial to compile.")
 endif()
 
 # A SYCL ahead-of-time (AoT) compile processes the device code in two stages.

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/experimental/hostpipes/src/CMakeLists.txt
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/experimental/hostpipes/src/CMakeLists.txt
@@ -15,12 +15,13 @@ else()
     message(STATUS "Configuring the design with the following target: ${FPGA_DEVICE}")
 
     # Check if the target is a BSP
-    if(IS_BSP MATCHES "1" OR FPGA_DEVICE MATCHES ".*a10gx_hostpipe.*")
+    if(IS_BSP MATCHES "1" OR FPGA_DEVICE MATCHES ".*pac_a10.*|.*pac_s10.*")
         set(IS_BSP "1")
+        message(FATAL_ERROR "ERROR: This tutorial does not support a BSP target as uses IPA flow only.")
     else()
         set(IS_BSP "0")
         message(STATUS "The selected target ${FPGA_DEVICE} is assumed to be an FPGA part number.")
-        message(STATUS "If the target is actually a BSP that does not support USM, run cmake with -DIS_BSP=1.")
+        message(STATUS "This tutorial does not support a BSP target as it uses IPA flow only.")
     endif()
 endif()
 

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/experimental/hostpipes/src/hostpipes.cpp
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/experimental/hostpipes/src/hostpipes.cpp
@@ -1,7 +1,6 @@
 #include <sycl/sycl.hpp>
 #include <sycl/ext/intel/fpga_extensions.hpp>
-// Host pipe support in $INTELFPGAOCLSDKROOT/include/sycl/ext/intel/prototype
-#include <host_pipes.hpp>
+#include <sycl/ext/intel/experimental/pipes.hpp>
 
 #include <algorithm>
 #include <iomanip>
@@ -24,32 +23,18 @@ constexpr size_t kPipeMinCapacity = 8;
 constexpr size_t kReadyLatency = 0;
 constexpr size_t kBitsPerSymbol = 1;
 
-using H2DPipe = sycl::ext::intel::prototype::pipe<
+using H2DPipe = sycl::ext::intel::experimental::pipe<
     // Usual pipe parameters
     H2DPipeID,         // An identifier for the pipe
     ValueT,            // The type of data in the pipe
-    kPipeMinCapacity,  // The capacity of the pipe
-    // Additional host pipe parameters
-    kReadyLatency,   // Latency for ready signal deassert
-    kBitsPerSymbol,  // Symbol size on data bus
-    true,            // Exposes a valid on the pipe interface
-    false,           // First symbol in high order bits
-    sycl::ext::intel::prototype::internal::protocol_name::
-        AVALON_STREAMING  // Protocol
+    kPipeMinCapacity   // The capacity of the pipe
     >;
 
-using D2HPipe = sycl::ext::intel::prototype::pipe<
+using D2HPipe = sycl::ext::intel::experimental::pipe<
     // Usual pipe parameters
     D2HPipeID,         // An identifier for the pipe
     ValueT,            // The type of data in the pipe
-    kPipeMinCapacity,  // The capacity of the pipe
-    // Additional host pipe parameters
-    kReadyLatency,   // Latency for ready signal deassert
-    kBitsPerSymbol,  // Symbol size on data bus
-    true,            // Exposes a valid on the pipe interface
-    false,           // First symbol in high order bits
-    sycl::ext::intel::prototype::internal::protocol_name::
-        AVALON_STREAMING  // Protocol
+    kPipeMinCapacity   // The capacity of the pipe
     >;
 
 // forward declare the test functions
@@ -91,14 +76,7 @@ int main(int argc, char* argv[]) {
     sycl::queue q(selector, fpga_tools::exception_handler,
                   sycl::property::queue::enable_profiling{});
 
-    // make sure the device supports USM device allocations
     auto device = q.get_device();
-    if (!device.has(sycl::aspect::usm_host_allocations)) {
-      std::cerr << "ERROR: The selected device does not support USM host"
-                << " allocations" << std::endl;
-      return 1;
-    }
-
     std::cout << "Running on device: "
               << device.get_info<sycl::info::device::name>().c_str()
               << std::endl;
@@ -198,8 +176,6 @@ void AlternatingTest(sycl::queue& q, ValueT* in, ValueT* out, size_t count,
 void LaunchCollectTest(sycl::queue& q, ValueT* in, ValueT* out, size_t count,
                        size_t repeats) {
   std::cout << "\t Run Loopback Kernel on FPGA" << std::endl;
-  auto e = SubmitLoopBackKernel<LoopBackKernelID, H2DPipe, D2HPipe>(
-      q, count * repeats);
 
   for (size_t r = 0; r < repeats; r++) {
     std::cout << "\t " << r << ": "
@@ -208,7 +184,12 @@ void LaunchCollectTest(sycl::queue& q, ValueT* in, ValueT* out, size_t count,
       // write data in host-to-device hostpipe
       H2DPipe::write(q, in[i]);
     }
+  }
 
+  auto e = SubmitLoopBackKernel<LoopBackKernelID, H2DPipe, D2HPipe>(
+      q, count * repeats);
+
+  for (size_t r = 0; r < repeats; r++) {
     std::cout << "\t " << r << ": "
               << "Doing " << count << " reads" << std::endl;
     for (size_t i = 0; i < count; i++) {

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/experimental/hostpipes/src/hostpipes.cpp
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/experimental/hostpipes/src/hostpipes.cpp
@@ -1,6 +1,7 @@
 #include <sycl/sycl.hpp>
 #include <sycl/ext/intel/fpga_extensions.hpp>
 #include <sycl/ext/intel/experimental/pipes.hpp>
+#include <sycl/ext/intel/ac_types/ac_int.hpp>
 
 #include <algorithm>
 #include <iomanip>
@@ -18,10 +19,8 @@ class H2DPipeID;
 class D2HPipeID;
 
 // the host pipes
-using ValueT = int;
+using ValueT = ac_int<256>;
 constexpr size_t kPipeMinCapacity = 8;
-constexpr size_t kReadyLatency = 0;
-constexpr size_t kBitsPerSymbol = 1;
 
 using H2DPipe = sycl::ext::intel::experimental::pipe<
     // Usual pipe parameters
@@ -42,7 +41,7 @@ void AlternatingTest(sycl::queue&, ValueT*, ValueT*, size_t, size_t);
 void LaunchCollectTest(sycl::queue&, ValueT*, ValueT*, size_t, size_t);
 
 // offloaded computation
-ValueT SomethingComplicated(ValueT val) { return (ValueT)(val * sqrt(val)); }
+ValueT SomethingComplicated(ValueT val) { return (ValueT)(val * (val >> 2)); }
 
 /////////////////////////////////////////
 

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/experimental/hostpipes/src/hostpipes.cpp
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/experimental/hostpipes/src/hostpipes.cpp
@@ -1,7 +1,6 @@
 #include <sycl/sycl.hpp>
 #include <sycl/ext/intel/fpga_extensions.hpp>
 #include <sycl/ext/intel/experimental/pipes.hpp>
-#include <sycl/ext/intel/ac_types/ac_int.hpp>
 
 #include <algorithm>
 #include <iomanip>
@@ -19,7 +18,7 @@ class H2DPipeID;
 class D2HPipeID;
 
 // the host pipes
-using ValueT = ac_int<256>;
+using ValueT = int;
 constexpr size_t kPipeMinCapacity = 8;
 
 using H2DPipe = sycl::ext::intel::experimental::pipe<
@@ -41,7 +40,7 @@ void AlternatingTest(sycl::queue&, ValueT*, ValueT*, size_t, size_t);
 void LaunchCollectTest(sycl::queue&, ValueT*, ValueT*, size_t, size_t);
 
 // offloaded computation
-ValueT SomethingComplicated(ValueT val) { return (ValueT)(val * (val >> 2)); }
+ValueT SomethingComplicated(ValueT val) { return (ValueT)(val * sqrt(val)); }
 
 /////////////////////////////////////////
 


### PR DESCRIPTION
# Existing Sample Changes
## Description

Update host pipe tutorial to use native host pipes instead of prototype host pipes. This involves updating the include file, source declarations of host pipes, and README documentation. Since there are no BSPs that support native host pipes, also limit the tutorial to IP authoring flow only.

## External Dependencies

none

## Type of change

- [ x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Ran locally via command line. Will link farm results for Linux and Windows regtests when completed.