### PR TITLE
[oneMKL]Enable support for new Toolkit layout for 2024

### DIFF
--- a/Libraries/oneMKL/binomial/GNUmakefile
+++ b/Libraries/oneMKL/binomial/GNUmakefile
@@ -2,8 +2,8 @@ all: binomial_sycl
 
 init_on_host ?= 0
 
-MKL_COPTS = -DMKL_ILP64  -I"${MKLROOT}/include"
-MKL_LIBS = -L${MKLROOT}/lib/intel64 -lmkl_sycl -lmkl_intel_ilp64 -lmkl_sequential -lmkl_core
+MKL_COPTS = -DMKL_ILP64  -qmkl=sequential
+MKL_LIBS  = -lsycl -lOpenCL -lpthread -lm -ldl
 
 binomial_sycl: src/binomial_sycl.cpp src/binomial_main.cpp src/binomial.hpp
 	icpx -fsycl -O3 -DSMALL_OPT_N=0 -DVERBOSE=1 -DREPORT_COLD=1 -DREPORT_WARM=1 -DINIT_ON_HOST=$(init_on_host)  $(MKL_COPTS) -o $@ src/binomial_main.cpp src/binomial_sycl.cpp $(MKL_LIBS)

--- a/Libraries/oneMKL/black_scholes/GNUmakefile
+++ b/Libraries/oneMKL/black_scholes/GNUmakefile
@@ -8,7 +8,7 @@ all: black_scholes_sycl
 init_on_host ?= 0
 
 MKL_COPTS = -DMKL_ILP64 -I"${MKLROOT}/include"
-MKL_LIBS  = -L${MKLROOT}/lib/intel64 -lmkl_sycl -lmkl_intel_ilp64 -lmkl_sequential -lmkl_core
+MKL_LIBS  = -L${MKLROOT}/lib -lmkl_sycl -lmkl_intel_ilp64 -lmkl_sequential -lmkl_core
 
 black_scholes_sycl: src/black_scholes_sycl.cpp
 	icpx -O3 -g -fsycl $(MKL_COPTS) $(MKL_LIBS) -DVERBOSE=1 -DSMALL_OPT_N=0 -DINIT_ON_HOST=$(init_on_host) -o $@  src/black_scholes_sycl.cpp

--- a/Libraries/oneMKL/black_scholes/GNUmakefile
+++ b/Libraries/oneMKL/black_scholes/GNUmakefile
@@ -7,8 +7,8 @@ all: black_scholes_sycl
 
 init_on_host ?= 0
 
-MKL_COPTS = -DMKL_ILP64 -I"${MKLROOT}/include"
-MKL_LIBS  = -L${MKLROOT}/lib -lmkl_sycl -lmkl_intel_ilp64 -lmkl_sequential -lmkl_core
+MKL_COPTS = -DMKL_ILP64 -qmkl=sequential
+MKL_LIBS  = -lsycl -lOpenCL -lpthread -lm -ldl
 
 black_scholes_sycl: src/black_scholes_sycl.cpp
 	icpx -O3 -g -fsycl $(MKL_COPTS) $(MKL_LIBS) -DVERBOSE=1 -DSMALL_OPT_N=0 -DINIT_ON_HOST=$(init_on_host) -o $@  src/black_scholes_sycl.cpp

--- a/Libraries/oneMKL/block_cholesky_decomposition/GNUmakefile
+++ b/Libraries/oneMKL/block_cholesky_decomposition/GNUmakefile
@@ -5,7 +5,7 @@ all: factor solve
 	./solve
 
 MKL_COPTS = -DMKL_ILP64  -I"${MKLROOT}/include"
-MKL_LIBS = -L${MKLROOT}/lib/intel64 -lmkl_sycl -lmkl_intel_ilp64 -lmkl_sequential -lmkl_core -lsycl -lOpenCL -lpthread -lm -ldl
+MKL_LIBS = -L${MKLROOT}/lib -lmkl_sycl -lmkl_intel_ilp64 -lmkl_sequential -lmkl_core -lsycl -lOpenCL -lpthread -lm -ldl
 
 factor: factor.cpp dpbltrf.cpp auxi.cpp
 	icpx $^ -o $@ -fsycl -fsycl-device-code-split=per_kernel $(MKL_COPTS) $(MKL_LIBS)

--- a/Libraries/oneMKL/block_cholesky_decomposition/GNUmakefile
+++ b/Libraries/oneMKL/block_cholesky_decomposition/GNUmakefile
@@ -4,8 +4,8 @@ all: factor solve
 	./factor
 	./solve
 
-MKL_COPTS = -DMKL_ILP64  -I"${MKLROOT}/include"
-MKL_LIBS = -L${MKLROOT}/lib -lmkl_sycl -lmkl_intel_ilp64 -lmkl_sequential -lmkl_core -lsycl -lOpenCL -lpthread -lm -ldl
+MKL_COPTS = -DMKL_ILP64  -qmkl=sequential
+MKL_LIBS  = -lsycl -lOpenCL -lpthread -lm -ldl
 
 factor: factor.cpp dpbltrf.cpp auxi.cpp
 	icpx $^ -o $@ -fsycl -fsycl-device-code-split=per_kernel $(MKL_COPTS) $(MKL_LIBS)

--- a/Libraries/oneMKL/block_cholesky_decomposition/dpbltrf.cpp
+++ b/Libraries/oneMKL/block_cholesky_decomposition/dpbltrf.cpp
@@ -20,7 +20,7 @@ using namespace oneapi;
 /************************************************************************
 * Definition:
 * ===========
-*   int64_t dpbltrf(cl::sycl::queue queue, int64_t n, int64_t nb, double* d, int64_t ldd, double* b, int64_t ldb) {
+*   int64_t dpbltrf(sycl::queue queue, int64_t n, int64_t nb, double* d, int64_t ldd, double* b, int64_t ldb) {
 *
 * Purpose:
 * ========
@@ -93,7 +93,7 @@ using namespace oneapi;
 *                 completed. This may indicate an error in forming the
 *                 matrix A.
 ***********************************************************************/
-int64_t dpbltrf(cl::sycl::queue queue, int64_t n, int64_t nb, double* d, int64_t ldd, double* b, int64_t ldb) {
+int64_t dpbltrf(sycl::queue queue, int64_t n, int64_t nb, double* d, int64_t ldd, double* b, int64_t ldb) {
 
     // Matrix accessors
     auto D = [=](int64_t i, int64_t j) -> double& { return d[(i) + (j)*ldd]; };
@@ -112,8 +112,8 @@ int64_t dpbltrf(cl::sycl::queue queue, int64_t n, int64_t nb, double* d, int64_t
     if (info)
         return info;
 
-    cl::sycl::context context = queue.get_context();
-    cl::sycl::device device = queue.get_device();
+    sycl::context context = queue.get_context();
+    sycl::device device = queue.get_device();
 
     // Compute Cholesky factorization of the first diagonal block
     try {

--- a/Libraries/oneMKL/block_cholesky_decomposition/dpbltrs.cpp
+++ b/Libraries/oneMKL/block_cholesky_decomposition/dpbltrs.cpp
@@ -21,7 +21,7 @@ using namespace oneapi;
 /************************************************************************
 * Definition:
 * ===========
-*   int64_t dpbltrs(cl::sycl::queue queue, int64_t n, int64_t nrhs, int64_t nb, double* d, int64_t ldd, double* b, int64_t ldb, double* f, int64_t ldf)
+*   int64_t dpbltrs(sycl::queue queue, int64_t n, int64_t nrhs, int64_t nb, double* d, int64_t ldd, double* b, int64_t ldb, double* f, int64_t ldf)
 *
 * Purpose:
 * ========
@@ -89,7 +89,7 @@ using namespace oneapi;
 *     < 0:        if INFO = -i, the i-th argument had an illegal value
 * =====================================================================
 */
-int64_t dpbltrs(cl::sycl::queue queue, int64_t n, int64_t nrhs, int64_t nb, double* d, int64_t ldd, double* b, int64_t ldb, double* f, int64_t ldf) {
+int64_t dpbltrs(sycl::queue queue, int64_t n, int64_t nrhs, int64_t nb, double* d, int64_t ldd, double* b, int64_t ldb, double* f, int64_t ldf) {
 
     auto D = [=](int64_t i, int64_t j) -> double& { return d[i + j*ldd]; };
     auto B = [=](int64_t i, int64_t j) -> double& { return b[i + j*ldb]; };

--- a/Libraries/oneMKL/block_cholesky_decomposition/factor.cpp
+++ b/Libraries/oneMKL/block_cholesky_decomposition/factor.cpp
@@ -44,7 +44,7 @@ int64_t dpbltrf(sycl::queue queue, int64_t n, int64_t nb, double* d, int64_t ldd
 double test_res(int64_t, int64_t, double*, int64_t, double*, int64_t, double*, int64_t, double*, int64_t, double*, int64_t, double*, int64_t);
 
 template<typename T>
-using allocator_t = sycl::usm_allocator<T, cl::sycl::usm::alloc::shared>;
+using allocator_t = sycl::usm_allocator<T, sycl::usm::alloc::shared>;
 
 
 int main() {
@@ -73,7 +73,7 @@ int main() {
         }
     };
 
-    sycl::device device{cl::sycl::default_selector{}};
+    sycl::device device{sycl::default_selector{}};
     sycl::queue queue(device, error_handler);
     sycl::context context = queue.get_context();
 

--- a/Libraries/oneMKL/block_cholesky_decomposition/solve.cpp
+++ b/Libraries/oneMKL/block_cholesky_decomposition/solve.cpp
@@ -42,10 +42,10 @@
 using namespace oneapi;
 
 template<typename T>
-using allocator_t = cl::sycl::usm_allocator<T, cl::sycl::usm::alloc::shared>;
+using allocator_t = sycl::usm_allocator<T, sycl::usm::alloc::shared>;
 
-int64_t dpbltrf(cl::sycl::queue queue, int64_t n, int64_t nb, double* d, int64_t ldd, double* b, int64_t ldb);
-int64_t dpbltrs(cl::sycl::queue queue, int64_t n, int64_t nrhs, int64_t nb, double* d, int64_t ldd, double* b, int64_t ldb, double* f, int64_t ldf);
+int64_t dpbltrf(sycl::queue queue, int64_t n, int64_t nb, double* d, int64_t ldd, double* b, int64_t ldb);
+int64_t dpbltrs(sycl::queue queue, int64_t n, int64_t nrhs, int64_t nb, double* d, int64_t ldd, double* b, int64_t ldb, double* f, int64_t ldf);
 
 double test_res1(int64_t n, int64_t nrhs, int64_t nb, double* d, int64_t ldd, double* b, int64_t ldb, double* f, int64_t ldf, double* x, int64_t ldx );
 
@@ -59,7 +59,7 @@ int main() {
     int64_t info = 0;
 
     // Asynchronous error handler
-    auto error_handler = [&] (cl::sycl::exception_list exceptions) {
+    auto error_handler = [&] (sycl::exception_list exceptions) {
         for (auto const& e : exceptions) {
             try {
                 std::rethrow_exception(e);
@@ -67,7 +67,7 @@ int main() {
                 // Handle LAPACK related exceptions happened during asynchronous call
                 info = e.info();
                 std::cout << "Unexpected exception caught during asynchronous LAPACK operation:\ninfo: " << e.info() << std::endl;
-            } catch(cl::sycl::exception const& e) {
+            } catch(sycl::exception const& e) {
                 // Handle not LAPACK related exceptions happened during asynchronous call
                 std::cout << "Unexpected exception caught during asynchronous operation:\n" << e.what() << std::endl;
                 info = -1;
@@ -75,9 +75,9 @@ int main() {
         }
     };
 
-    cl::sycl::device device{cl::sycl::default_selector{}};
-    cl::sycl::queue queue(device, error_handler);
-    cl::sycl::context context = queue.get_context();
+    sycl::device device{sycl::default_selector{}};
+    sycl::queue queue(device, error_handler);
+    sycl::context context = queue.get_context();
 
     if (device.get_info<sycl::info::device::double_fp_config>().empty()) {
         std::cerr << "The sample uses double precision, which is not supported" << std::endl;
@@ -138,7 +138,7 @@ int main() {
 
     try {
         info = dpbltrf(queue, n, nb, d.data(), nb, b.data(), nb);
-    } catch(cl::sycl::exception const& e) {
+    } catch(sycl::exception const& e) {
         // Handle not LAPACK related exceptions happened during synchronous call
         std::cout << "Unexpected exception caught during synchronous call to SYCL API:\n" << e.what() << std::endl;
         info = -1;

--- a/Libraries/oneMKL/block_lu_decomposition/GNUmakefile
+++ b/Libraries/oneMKL/block_lu_decomposition/GNUmakefile
@@ -14,6 +14,6 @@ solve: solve.cpp dgeblttrf.cpp dgeblttrs.cpp auxi.cpp
 	icpx $^ -o $@ -fsycl -fsycl-device-code-split=per_kernel $(MKL_COPTS) $(MKL_LIBS)
 
 clean:
-	-rm -f factor solve
+	-rm -f factor solve genxir
 
 .PHONY: clean all

--- a/Libraries/oneMKL/block_lu_decomposition/GNUmakefile
+++ b/Libraries/oneMKL/block_lu_decomposition/GNUmakefile
@@ -4,8 +4,8 @@ all: factor solve
 	./factor
 	./solve
 
-MKL_COPTS = -DMKL_ILP64  -I"${MKLROOT}/include"
-MKL_LIBS = -L${MKLROOT}/lib -lmkl_sycl -lmkl_intel_ilp64 -lmkl_sequential -lmkl_core -lsycl -lOpenCL -lpthread -lm -ldl
+MKL_COPTS = -DMKL_ILP64  -qmkl=sequential
+MKL_LIBS  = -lsycl -lOpenCL -lpthread -lm -ldl
 
 factor: factor.cpp dgeblttrf.cpp auxi.cpp
 	icpx $^ -o $@ -fsycl -fsycl-device-code-split=per_kernel $(MKL_COPTS) $(MKL_LIBS)

--- a/Libraries/oneMKL/block_lu_decomposition/GNUmakefile
+++ b/Libraries/oneMKL/block_lu_decomposition/GNUmakefile
@@ -5,7 +5,7 @@ all: factor solve
 	./solve
 
 MKL_COPTS = -DMKL_ILP64  -I"${MKLROOT}/include"
-MKL_LIBS = -L${MKLROOT}/lib/intel64 -lmkl_sycl -lmkl_intel_ilp64 -lmkl_sequential -lmkl_core -lsycl -lOpenCL -lpthread -lm -ldl
+MKL_LIBS = -L${MKLROOT}/lib -lmkl_sycl -lmkl_intel_ilp64 -lmkl_sequential -lmkl_core -lsycl -lOpenCL -lpthread -lm -ldl
 
 factor: factor.cpp dgeblttrf.cpp auxi.cpp
 	icpx $^ -o $@ -fsycl -fsycl-device-code-split=per_kernel $(MKL_COPTS) $(MKL_LIBS)

--- a/Libraries/oneMKL/block_lu_decomposition/factor.cpp
+++ b/Libraries/oneMKL/block_lu_decomposition/factor.cpp
@@ -72,7 +72,7 @@ int main(){
     sycl::queue queue(device, error_handler);
     sycl::context context = queue.get_context();
 
-    if (device.is_gpu() && device.get_platform().get_backend() != sycl::backend::level_zero) {
+    if (device.is_gpu() && device.get_platform().get_backend() != sycl::backend::ext_oneapi_level_zero) {
         std::cerr << "This sample requires Level Zero when running on GPUs." << std::endl;
         std::cerr << "Please check your system configuration." << std::endl;
         return 0;

--- a/Libraries/oneMKL/block_lu_decomposition/solve.cpp
+++ b/Libraries/oneMKL/block_lu_decomposition/solve.cpp
@@ -87,7 +87,7 @@ int main() {
     sycl::queue queue(device, error_handler);
     sycl::context context = queue.get_context();
 
-    if (device.is_gpu() && device.get_platform().get_backend() != sycl::backend::level_zero) {
+    if (device.is_gpu() && device.get_platform().get_backend() != sycl::backend::ext_oneapi_level_zero) {
         std::cerr << "This sample requires Level Zero when running on GPUs." << std::endl;
         std::cerr << "Please check your system configuration." << std::endl;
         return 0;

--- a/Libraries/oneMKL/computed_tomography/GNUmakefile
+++ b/Libraries/oneMKL/computed_tomography/GNUmakefile
@@ -8,7 +8,7 @@ run: computed_tomography
 	./computed_tomography 400 400 input.bmp radon.bmp restored.bmp
 
 MKL_COPTS = -DMKL_ILP64  -I"${MKLROOT}/include"
-MKL_LIBS = -L${MKLROOT}/lib/intel64 -lmkl_sycl -lmkl_intel_ilp64 -lmkl_sequential -lmkl_core -lsycl -lOpenCL -lpthread -lm -ldl
+MKL_LIBS = -L${MKLROOT}/lib -lmkl_sycl -lmkl_intel_ilp64 -lmkl_sequential -lmkl_core -lsycl -lOpenCL -lpthread -lm -ldl
 
 DPCPP_OPTS = $(MKL_COPTS) -fsycl-device-code-split=per_kernel $(MKL_LIBS)
 

--- a/Libraries/oneMKL/computed_tomography/GNUmakefile
+++ b/Libraries/oneMKL/computed_tomography/GNUmakefile
@@ -7,8 +7,8 @@ all: run
 run: computed_tomography
 	./computed_tomography 400 400 input.bmp radon.bmp restored.bmp
 
-MKL_COPTS = -DMKL_ILP64  -I"${MKLROOT}/include"
-MKL_LIBS = -L${MKLROOT}/lib -lmkl_sycl -lmkl_intel_ilp64 -lmkl_sequential -lmkl_core -lsycl -lOpenCL -lpthread -lm -ldl
+MKL_COPTS = -DMKL_ILP64  -qmkl=sequential
+MKL_LIBS  = -lsycl -lOpenCL -lpthread -lm -ldl
 
 DPCPP_OPTS = $(MKL_COPTS) -fsycl-device-code-split=per_kernel $(MKL_LIBS)
 

--- a/Libraries/oneMKL/fourier_correlation/GNUmakefile
+++ b/Libraries/oneMKL/fourier_correlation/GNUmakefile
@@ -9,7 +9,7 @@ run_all: fcorr_1d_buff fcorr_1d_usm fcorr_2d_usm
 	./fcorr_1d_usm 4096
 	./fcorr_2d_usm
 
-DPCPP_OPTS = -DMKL_ILP64 -I${MKLROOT}/include -qmkl=parallel
+DPCPP_OPTS = -DMKL_ILP64 -qmkl=parallel
 
 fcorr_1d_buff: fcorr_1d_buffers.cpp
 	icpx $< -fsycl -o $@ $(DPCPP_OPTS)

--- a/Libraries/oneMKL/matrix_mul_mkl/GNUmakefile
+++ b/Libraries/oneMKL/matrix_mul_mkl/GNUmakefile
@@ -8,16 +8,17 @@ run: sgemm.mkl dgemm.mkl
 	./sgemm.mkl
 	./dgemm.mkl
 
+INCLUDE_COMMON=../../../common
 MKL_COPTS = -DMKL_ILP64  -qmkl=sequential
 MKL_LIBS  = -lsycl -lOpenCL -lpthread -lm -ldl
 
 DPCPP_OPTS = -O3 $(MKL_COPTS) $(MKL_LIBS)
 
 sgemm.mkl: matrix_mul_mkl.cpp
-	icpx -fsycl $< -o $@ $(DPCPP_OPTS)
+	icpx -fsycl -I$(INCLUDE_COMMON) $< -o $@ $(DPCPP_OPTS)
 
 dgemm.mkl: matrix_mul_mkl.cpp
-	icpx -fsycl $< -o $@ $(DPCPP_OPTS) -DUSE_DOUBLE
+	icpx -fsycl -I$(INCLUDE_COMMON) $< -o $@ $(DPCPP_OPTS) -DUSE_DOUBLE
 
 clean:
 	-rm -f sgemm.mkl dgemm.mkl

--- a/Libraries/oneMKL/matrix_mul_mkl/GNUmakefile
+++ b/Libraries/oneMKL/matrix_mul_mkl/GNUmakefile
@@ -8,8 +8,8 @@ run: sgemm.mkl dgemm.mkl
 	./sgemm.mkl
 	./dgemm.mkl
 
-MKL_COPTS = -DMKL_ILP64  -I"${MKLROOT}/include"
-MKL_LIBS = -L${MKLROOT}/lib -lmkl_sycl -lmkl_intel_ilp64 -lmkl_sequential -lmkl_core -lsycl -lOpenCL -lpthread -lm -ldl
+MKL_COPTS = -DMKL_ILP64  -qmkl=sequential
+MKL_LIBS  = -lsycl -lOpenCL -lpthread -lm -ldl
 
 DPCPP_OPTS = -O3 $(MKL_COPTS) $(MKL_LIBS)
 

--- a/Libraries/oneMKL/matrix_mul_mkl/GNUmakefile
+++ b/Libraries/oneMKL/matrix_mul_mkl/GNUmakefile
@@ -8,8 +8,8 @@ run: sgemm.mkl dgemm.mkl
 	./sgemm.mkl
 	./dgemm.mkl
 
-MKL_COPTS = 
-MKL_LIBS = -qmkl
+MKL_COPTS = -DMKL_ILP64  -I"${MKLROOT}/include"
+MKL_LIBS = -L${MKLROOT}/lib -lmkl_sycl -lmkl_intel_ilp64 -lmkl_sequential -lmkl_core -lsycl -lOpenCL -lpthread -lm -ldl
 
 DPCPP_OPTS = -O3 $(MKL_COPTS) $(MKL_LIBS)
 

--- a/Libraries/oneMKL/monte_carlo_european_opt/GNUmakefile
+++ b/Libraries/oneMKL/monte_carlo_european_opt/GNUmakefile
@@ -17,9 +17,8 @@ endif
 
 # setting initial random number generation on host
 init_on_host ?= 0
-
-MKL_COPTS = -DMKL_ILP64 $(GENERATOR) -I"${MKLROOT}/include"
-MKL_LIBS = -L${MKLROOT}/lib/intel64 -lmkl_sycl -lmkl_intel_ilp64 -lmkl_sequential -lmkl_core
+MKL_COPTS = -DMKL_ILP64 $(GENERATOR) -I"${MKLROOT}/include" -Wall -Wformat-security -Werror=format-security
+MKL_LIBS = -L${MKLROOT}/lib -lmkl_sycl -lmkl_intel_ilp64 -lmkl_sequential -lmkl_core -lpthread -lm -ldl
 
 DPCPP_OPTS = $(MKL_COPTS) -fsycl -DINIT_ON_HOST=$(init_on_host) $(MKL_LIBS)
 

--- a/Libraries/oneMKL/monte_carlo_european_opt/GNUmakefile
+++ b/Libraries/oneMKL/monte_carlo_european_opt/GNUmakefile
@@ -17,8 +17,9 @@ endif
 
 # setting initial random number generation on host
 init_on_host ?= 0
-MKL_COPTS = -DMKL_ILP64 $(GENERATOR) -I"${MKLROOT}/include" -Wall -Wformat-security -Werror=format-security
-MKL_LIBS = -L${MKLROOT}/lib -lmkl_sycl -lmkl_intel_ilp64 -lmkl_sequential -lmkl_core -lpthread -lm -ldl
+
+MKL_COPTS = -DMKL_ILP64 $(GENERATOR) -qmkl=sequential -Wall -Wformat-security -Werror=format-security
+MKL_LIBS  = -lpthread -lm -ldl
 
 DPCPP_OPTS = $(MKL_COPTS) -fsycl -DINIT_ON_HOST=$(init_on_host) $(MKL_LIBS)
 

--- a/Libraries/oneMKL/monte_carlo_pi/GNUmakefile
+++ b/Libraries/oneMKL/monte_carlo_pi/GNUmakefile
@@ -10,7 +10,7 @@ run: mc_pi mc_pi_usm mc_pi_device_api
 	./mc_pi_device_api
 
 MKL_COPTS = -DMKL_ILP64  -I"${MKLROOT}/include"
-MKL_LIBS = -L${MKLROOT}/lib/intel64 -lmkl_sycl -lmkl_intel_ilp64 -lmkl_sequential -lmkl_core -lsycl -lOpenCL -lpthread -lm -ldl
+MKL_LIBS = -L${MKLROOT}/lib -lmkl_sycl -lmkl_intel_ilp64 -lmkl_sequential -lmkl_core -lsycl -lOpenCL -lpthread -lm -ldl
 
 DPCPP_OPTS = $(MKL_COPTS) -fsycl-device-code-split=per_kernel -fno-sycl-early-optimizations $(MKL_LIBS)
 

--- a/Libraries/oneMKL/monte_carlo_pi/GNUmakefile
+++ b/Libraries/oneMKL/monte_carlo_pi/GNUmakefile
@@ -9,8 +9,8 @@ run: mc_pi mc_pi_usm mc_pi_device_api
 	./mc_pi_usm
 	./mc_pi_device_api
 
-MKL_COPTS = -DMKL_ILP64  -I"${MKLROOT}/include"
-MKL_LIBS = -L${MKLROOT}/lib -lmkl_sycl -lmkl_intel_ilp64 -lmkl_sequential -lmkl_core -lsycl -lOpenCL -lpthread -lm -ldl
+MKL_COPTS = -DMKL_ILP64  -qmkl=sequential
+MKL_LIBS  = -lsycl -lOpenCL -lpthread -lm -ldl
 
 DPCPP_OPTS = $(MKL_COPTS) -fsycl-device-code-split=per_kernel -fno-sycl-early-optimizations $(MKL_LIBS)
 

--- a/Libraries/oneMKL/monte_carlo_pi/mc_pi_device_api.cpp
+++ b/Libraries/oneMKL/monte_carlo_pi/mc_pi_device_api.cpp
@@ -47,7 +47,7 @@ double estimate_pi(sycl::queue& q, size_t n_points) {
             [=](sycl::item<1> item) {
                 size_t id_global = item.get_id(0);
                 sycl::vec<float, vec_size> r;
-                sycl::ext::oneapi::atomic_ref<size_t, sycl::memory_order::relaxed,
+                sycl::atomic_ref<size_t, sycl::memory_order::relaxed,
                                     sycl::memory_scope::device,
                                     sycl::access::address_space::global_space> atomic_counter { count_acc[0] };
                 size_t count = 0;

--- a/Libraries/oneMKL/random_sampling_without_replacement/GNUmakefile
+++ b/Libraries/oneMKL/random_sampling_without_replacement/GNUmakefile
@@ -9,8 +9,8 @@ run: lottery lottery_usm lottery_device_api
 		./lottery_usm
 		./lottery_device_api
 
-MKL_COPTS = -DMKL_ILP64  -I"${MKLROOT}/include"
-MKL_LIBS = -L${MKLROOT}/lib -lmkl_sycl -lmkl_intel_ilp64 -lmkl_sequential -lmkl_core -lsycl -lOpenCL -lpthread -lm -ldl
+MKL_COPTS = -DMKL_ILP64  -qmkl=sequential
+MKL_LIBS  = -lsycl -lOpenCL -lpthread -lm -ldl
 
 DPCPP_OPTS = $(MKL_COPTS) -fsycl-device-code-split=per_kernel -fno-sycl-early-optimizations $(MKL_LIBS)
 

--- a/Libraries/oneMKL/random_sampling_without_replacement/GNUmakefile
+++ b/Libraries/oneMKL/random_sampling_without_replacement/GNUmakefile
@@ -10,7 +10,7 @@ run: lottery lottery_usm lottery_device_api
 		./lottery_device_api
 
 MKL_COPTS = -DMKL_ILP64  -I"${MKLROOT}/include"
-MKL_LIBS = -L${MKLROOT}/lib/intel64 -lmkl_sycl -lmkl_intel_ilp64 -lmkl_sequential -lmkl_core -lsycl -lOpenCL -lpthread -lm -ldl
+MKL_LIBS = -L${MKLROOT}/lib -lmkl_sycl -lmkl_intel_ilp64 -lmkl_sequential -lmkl_core -lsycl -lOpenCL -lpthread -lm -ldl
 
 DPCPP_OPTS = $(MKL_COPTS) -fsycl-device-code-split=per_kernel -fno-sycl-early-optimizations $(MKL_LIBS)
 

--- a/Libraries/oneMKL/sparse_conjugate_gradient/GNUmakefile
+++ b/Libraries/oneMKL/sparse_conjugate_gradient/GNUmakefile
@@ -16,6 +16,6 @@ sparse_cg: sparse_cg.cpp
 	icpx $< -fsycl -o $@ $(DPCPP_OPTS)
 
 clean:
-	-rm -f sparse_cg
+	-rm -f sparse_cg genxir
 
 .PHONY: clean run all

--- a/Libraries/oneMKL/sparse_conjugate_gradient/GNUmakefile
+++ b/Libraries/oneMKL/sparse_conjugate_gradient/GNUmakefile
@@ -7,8 +7,8 @@ all: run
 run: sparse_cg
 	./sparse_cg
 
-MKL_COPTS = -DMKL_ILP64  -I"${MKLROOT}/include"
-MKL_LIBS = -L${MKLROOT}/lib -lmkl_sycl -lmkl_intel_ilp64 -lmkl_sequential -lmkl_core -lsycl -lOpenCL -lpthread -lm -ldl
+MKL_COPTS = -DMKL_ILP64  -qmkl=sequential
+MKL_LIBS  = -lsycl -lOpenCL -lpthread -lm -ldl
 
 DPCPP_OPTS = $(MKL_COPTS) -fsycl-device-code-split=per_kernel $(MKL_LIBS)
 

--- a/Libraries/oneMKL/sparse_conjugate_gradient/GNUmakefile
+++ b/Libraries/oneMKL/sparse_conjugate_gradient/GNUmakefile
@@ -8,7 +8,7 @@ run: sparse_cg
 	./sparse_cg
 
 MKL_COPTS = -DMKL_ILP64  -I"${MKLROOT}/include"
-MKL_LIBS = -L${MKLROOT}/lib/intel64 -lmkl_sycl -lmkl_intel_ilp64 -lmkl_sequential -lmkl_core -lsycl -lOpenCL -lpthread -lm -ldl
+MKL_LIBS = -L${MKLROOT}/lib -lmkl_sycl -lmkl_intel_ilp64 -lmkl_sequential -lmkl_core -lsycl -lOpenCL -lpthread -lm -ldl
 
 DPCPP_OPTS = $(MKL_COPTS) -fsycl-device-code-split=per_kernel $(MKL_LIBS)
 

--- a/Libraries/oneMKL/student_t_test/GNUmakefile
+++ b/Libraries/oneMKL/student_t_test/GNUmakefile
@@ -9,7 +9,7 @@ run: t_test t_test_usm
 	./t_test_usm
 
 MKL_COPTS = -DMKL_ILP64  -I"${MKLROOT}/include"
-MKL_LIBS = -L${MKLROOT}/lib/intel64 -lmkl_sycl -lmkl_intel_ilp64 -lmkl_sequential -lmkl_core -lsycl -lOpenCL -lpthread -lm -ldl
+MKL_LIBS = -L${MKLROOT}/lib -lmkl_sycl -lmkl_intel_ilp64 -lmkl_sequential -lmkl_core -lsycl -lOpenCL -lpthread -lm -ldl
 
 DPCPP_OPTS = $(MKL_COPTS) -fsycl-device-code-split=per_kernel -fno-sycl-early-optimizations $(MKL_LIBS)
 

--- a/Libraries/oneMKL/student_t_test/GNUmakefile
+++ b/Libraries/oneMKL/student_t_test/GNUmakefile
@@ -8,8 +8,8 @@ run: t_test t_test_usm
 	./t_test
 	./t_test_usm
 
-MKL_COPTS = -DMKL_ILP64  -I"${MKLROOT}/include"
-MKL_LIBS = -L${MKLROOT}/lib -lmkl_sycl -lmkl_intel_ilp64 -lmkl_sequential -lmkl_core -lsycl -lOpenCL -lpthread -lm -ldl
+MKL_COPTS = -DMKL_ILP64  -qmkl=sequential
+MKL_LIBS  = -lsycl -lOpenCL -lpthread -lm -ldl
 
 DPCPP_OPTS = $(MKL_COPTS) -fsycl-device-code-split=per_kernel -fno-sycl-early-optimizations $(MKL_LIBS)
 


### PR DESCRIPTION
# Existing Sample Changes
## Description
oneAPI release for 2024 will introduce new directory layout changes for toolkits. This PR updates oneMKL samples to use the new directory layout.

## Type of change

- [X] Update (Non-breaking change which supports new directory layout, and older layouts before oneAPI 2024.x, provided the corresponding Intel compiler is used. This is required for using `-qmkl` option correctly.)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
- [X] Ran all oneMKL locally.

run.sh:
```bash
#!/bin/bash

clean_mode=
if [[ $1 == "clean" ]]; then
    clean_mode=clean
fi

for s_dir in $(find . -type f -name *GNUmake* -exec echo $(basename {}) \; | sed -e s/GNUmakefile//g);
do
    # Skip samples that were not modified and depend on other components besides oneMKL
    if [[ $s_dir == "./fourier_correlation/" ]]; then
        continue
    fi
    cd $s_dir;
    make -f GNUmakefile ${clean_mode};
    if [[ $? != 0 ]]; then
        echo "$s_dir FAILED"
    fi
    cd -
done

```
```sh
oneMKL$ ./run.sh > onemkl_test.log 2>&1
oneMKL$ cat onemkl_test.log | grep FAILED
./monte_carlo_pi/ FAILED
oneMKL$
```
Failure not related to these changes:
```
icpx mc_pi.cpp -fsycl -o mc_pi -DMKL_ILP64  -qmkl=sequential -fsycl-device-code-split=per_kernel -fno-sycl-early-optimizations -lsycl -lOpenCL -lpthread -lm -ldl
mc_pi.cpp:70:23: error: no matching member function for call to 'load'
   70 |                     r.load(i + item.get_global_linear_id() * count_per_thread, rng_acc.get_pointer());
      |                     ~~^~~~
```

## Explanation of commits
- The first commit replaces `lib/intel64/` with `lib/` to support the new layout.
- The second commit enables the use of the `-qmkl` option so that build recipes become independent of oneMKL directory layout. (Testing in progress.)
