### PR TITLE
IRTK Intro to Ray Tracing val fix (duplication/GPU)

### DIFF
--- a/RenderingToolkit/Tutorial/IntroToRayTracingWithEmbree/sample.json
+++ b/RenderingToolkit/Tutorial/IntroToRayTracingWithEmbree/sample.json
@@ -7,7 +7,7 @@
   "languages": [{"cpp":{}}],
   "dependencies": ["tbb","rkcommon"],
   "os":["linux", "windows", "darwin"],
-  "targetDevice": ["CPU"],
+  "targetDevice": ["CPU","GPU"],
   "ciTests": {
         "linux": [
                 {
@@ -44,9 +44,6 @@
                     "cd Release",
                     ".\\rkRayTracer.exe",
 		    "cd ..\\..",
-		    "cd gpu",
-		    "mkdir build",
-		    "cd build",
 		    "cd gpu",
 		    "mkdir build",
 		    "cd build",


### PR DESCRIPTION
# Existing Sample Changes
## Description

Just an update for the IRTK tutorial Intro to Ray Tracing samples.json which has a duplication issue and had omitted GPU targeting.

Fixes Issue# 
ONSAM-1612
Cited thanks to @alexeyboreiko 

## External Dependencies

List any external dependencies created as a result of this change.

_Set target device in json to include GPU_

## Type of change

Please delete options that are not relevant. Add a 'X' to the one that is applicable. 

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Implement fixes for ONSAM Jiras

## How Has This Been Tested?



_N/A This is fix for validation only_