### PR TITLE
Changed default seed in read_only_cache design

### DIFF
--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/read_only_cache/src/CMakeLists.txt
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/read_only_cache/src/CMakeLists.txt
@@ -20,6 +20,14 @@ if(WIN32)
     set(WIN_FLAG "/EHsc")
 endif()
 
+set(SEED "-Xsseed=2")
+
+if(IGNORE_DEFAULT_SEED)
+    set(SEED "")
+endif()
+
+message(STATUS "SEED=${SEED}")
+
 # A SYCL ahead-of-time (AoT) compile processes the device code in two stages.
 # 1. The "compile" stage compiles the device code to an intermediate representation (SPIR-V).
 # 2. The "link" stage invokes the compiler's FPGA backend before linking.
@@ -28,7 +36,7 @@ set(EMULATOR_COMPILE_FLAGS "-fsycl -fintelfpga -Wall ${WIN_FLAG} -DFPGA_EMULATOR
 set(EMULATOR_LINK_FLAGS "-fsycl -fintelfpga")
 set(SIMULATOR_COMPILE_FLAGS "-fsycl -fintelfpga -Wall ${WIN_FLAG} -Xssimulation -DFPGA_SIMULATOR")
 set(SIMULATOR_LINK_FLAGS "-fsycl -fintelfpga -Xssimulation -Xstarget=${FPGA_DEVICE} ${USER_HARDWARE_FLAGS}")
-set(HARDWARE_COMPILE_FLAGS "-fsycl -fintelfpga -Wall ${WIN_FLAG} -DFPGA_HARDWARE")
+set(HARDWARE_COMPILE_FLAGS "-fsycl -fintelfpga -Wall ${WIN_FLAG} -DFPGA_HARDWARE ${SEED}")
 set(HARDWARE_LINK_FLAGS "-fsycl -fintelfpga -Xshardware -Xstarget=${FPGA_DEVICE} ${USER_HARDWARE_FLAGS}")
 # use cmake -D USER_HARDWARE_FLAGS=<flags> to set extra flags for FPGA backend compilation
 


### PR DESCRIPTION
HSDES: https://hsdes.intel.com/appstore/article/#/14019335652
The default seed suffers from fitter failures in Quartus. Other seeds don't seem to suffer from this issue

Linux build: https://spetc.intel.com/testsummary?trview=0&testRunIds=8228011 
Windows Build: TBD 