### PR TITLE
FPGA: Matrix multiply sample: add wait() call to feeders

### DIFF
--- a/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/matmul/src/matmul.hpp
+++ b/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/matmul/src/matmul.hpp
@@ -103,7 +103,7 @@ void MatmulImpl(sycl::queue &q,            // Device queue
                                PipeDone>{a, repetitions});
 
   // Producer kernel for matrix B
-  q.single_task<FeederB>(
+  auto feeder_b_event = q.single_task<FeederB>(
       MatrixReadFromDDRToPipeB<TT, kBL2, rows_a, common, cols_b, tile_a, tile_b,
                                kElemsPerDDRAccess, num_matrices, PipeB>{
           b, repetitions});
@@ -119,6 +119,8 @@ void MatmulImpl(sycl::queue &q,            // Device queue
                           kElemsPerDDRAccess, num_matrices, PipeC>{
           c, repetitions});
 
+  feeder_a_event.wait();
+  feeder_b_event.wait();
   drain_event.wait();
 
   // Compute the total time the execution lasted


### PR DESCRIPTION
# Existing Sample Changes
## Description

Adds a call to wait() on the feeders to guarantee that all kernels which access USM have finished before the memory is freed.

## External Dependencies

List any external dependencies created as a result of this change.

## Type of change

Please delete options that are not relevant. Add a 'X' to the one that is applicable. 

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Implement fixes for ONSAM Jiras

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Command Line
- [ ] oneapi-cli
- [ ] Visual Studio
- [ ] Eclipse IDE
- [ ] VSCode
- [ ] When compiling the compliler flag "-Wall -Wformat-security -Werror=format-security" was used