### PR TITLE
[FPGA] Update the default seed in lsu_control tutorial

### DIFF
--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/lsu_control/src/CMakeLists.txt
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/lsu_control/src/CMakeLists.txt
@@ -19,6 +19,14 @@ if(WIN32)
     set(WIN_FLAG "/EHsc")
 endif()
 
+set(SEED "-Xsseed=2")
+
+if(IGNORE_DEFAULT_SEED)
+    set(SEED "")
+endif()
+
+message(STATUS "SEED=${SEED}")
+
 # A SYCL ahead-of-time (AoT) compile processes the device code in two stages.
 # 1. The "compile" stage compiles the device code to an intermediate representation (SPIR-V).
 # 2. The "link" stage invokes the compiler's FPGA backend before linking.
@@ -27,7 +35,7 @@ set(EMULATOR_COMPILE_FLAGS "-fsycl -fintelfpga -Wall ${WIN_FLAG} -DFPGA_EMULATOR
 set(EMULATOR_LINK_FLAGS "-fsycl -fintelfpga")
 set(SIMULATOR_COMPILE_FLAGS "-fsycl -fintelfpga -Wall ${WIN_FLAG} -Xssimulation -DFPGA_SIMULATOR")
 # use cmake -D USER_HARDWARE_FLAGS=<flags> to set extra flags for FPGA simulator compilation
-set(HARDWARE_COMPILE_FLAGS "-fsycl -fintelfpga -Wall ${WIN_FLAG} -DFPGA_HARDWARE")
+set(HARDWARE_COMPILE_FLAGS "-fsycl -fintelfpga -Wall ${WIN_FLAG} -DFPGA_HARDWARE ${SEED}")
 if(FPGA_DEVICE STREQUAL "intel_a10gx_pac:pac_a10")
     # hyper-optimized-handshaking does not apply to Intel Arria 10® FPGAs
     set(SIMULATOR_LINK_FLAGS "-fsycl -fintelfpga -Xssimulation -Xstarget=${FPGA_DEVICE} ${USER_HARDWARE_FLAGS}")


### PR DESCRIPTION
## Description

This PR addresses an issue where the default seed fails consistently with fitter failures in Quartus. Other seeds do not suffer from this issue. Running 10 other seeds show that the default seed is failing, but all others are passing: https://spetc.intel.com/testsummary?trview=0&testRunIds=8264656

A similar fix was required for the read_only_cache tutorial: https://github.com/oneapi-src/oneAPI-samples/pull/1741 

## External Dependencies

* N/A

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [X] Command Line
- [ ] oneapi-cli
- [ ] Visual Studio
- [ ] Eclipse IDE
- [ ] VSCode
- [ ] When compiling the compliler flag "-Wall -Wformat-security -Werror=format-security" was used
