### PR TITLE
FPGA: matrix multiply sample: use template param instead of macro in the code

### DIFF
--- a/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/matmul/src/matmul.hpp
+++ b/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/matmul/src/matmul.hpp
@@ -86,9 +86,9 @@ void MatmulImpl(sycl::queue &q,            // Device queue
   q.memcpy(a, a_matrix.data(), kMatsizeA * num_matrices * sizeof(TT)).wait();
   q.memcpy(b, b_matrix.data(), kMatsizeB * num_matrices * sizeof(TT)).wait();
 
-  using PipeDataA = fpga_tools::NTuple<TT, TILE_A>;
-  using PipeDataB = fpga_tools::NTuple<TT, TILE_B>;
-  using PipeDataC = fpga_tools::NTuple<TT, TILE_A>;
+  using PipeDataA = fpga_tools::NTuple<TT, tile_a>;
+  using PipeDataB = fpga_tools::NTuple<TT, tile_b>;
+  using PipeDataC = fpga_tools::NTuple<TT, tile_a>;
 
   // Pipes to communicate the matrices between kernels
   using PipeA = sycl::ext::intel::pipe<APipe, PipeDataA, 64>;


### PR DESCRIPTION
# Existing Sample Changes
## Description

The matmul.hpp file was using the compiler macros TILE_A and TILE_B in a function instead of the template parameters tile_a and tile_b that are passed into that function. Updating to use the template parameters.

## External Dependencies

List any external dependencies created as a result of this change.

## Type of change

Please delete options that are not relevant. Add a 'X' to the one that is applicable. 

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Implement fixes for ONSAM Jiras

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Command Line
- [ ] oneapi-cli
- [ ] Visual Studio
- [ ] Eclipse IDE
- [ ] VSCode
- [ ] When compiling the compliler flag "-Wall -Wformat-security -Werror=format-security" was used