### PR TITLE
Updated oneMKL matrix_mul_mkl sample

### DIFF
--- a/Libraries/oneMKL/matrix_mul_mkl/GNUmakefile
+++ b/Libraries/oneMKL/matrix_mul_mkl/GNUmakefile
@@ -1,21 +1,25 @@
 # Makefile for GNU Make
 
-default: run
+default: all
 
-all: run
+all: sgemm.mkl dgemm.mkl
 
-run: matrix_mul_mkl
-	./matrix_mul_mkl
+run: sgemm.mkl dgemm.mkl
+	./sgemm.mkl
+	./dgemm.mkl
 
-MKL_COPTS = -DMKL_ILP64  -I"${MKLROOT}/include"
-MKL_LIBS = -L${MKLROOT}/lib/intel64 -lmkl_sycl -lmkl_intel_ilp64 -lmkl_sequential -lmkl_core -lsycl -lOpenCL -lpthread -lm -ldl
+MKL_COPTS = 
+MKL_LIBS = -qmkl
 
-DPCPP_OPTS = $(MKL_COPTS) -fsycl-device-code-split=per_kernel $(MKL_LIBS)
+DPCPP_OPTS = -O3 $(MKL_COPTS) $(MKL_LIBS)
 
-matrix_mul_mkl: matrix_mul_mkl.cpp
-	icpx $< -fsycl -o $@ $(DPCPP_OPTS)
+sgemm.mkl: matrix_mul_mkl.cpp
+	icpx -fsycl $< -o $@ $(DPCPP_OPTS)
+
+dgemm.mkl: matrix_mul_mkl.cpp
+	icpx -fsycl $< -o $@ $(DPCPP_OPTS) -DUSE_DOUBLE
 
 clean:
-	-rm -f matrix_mul_mkl
+	-rm -f sgemm.mkl dgemm.mkl
 
 .PHONY: clean run all

--- a/Libraries/oneMKL/matrix_mul_mkl/README.md
+++ b/Libraries/oneMKL/matrix_mul_mkl/README.md
@@ -71,12 +71,12 @@ Run `nmake` to build and run the sample. `nmake clean` removes temporary files.
 If everything is working correctly, the program will generate two input matrices and call oneMKL to multiply them. It will also compute the product matrix itself to verify the results from oneMKL.
 
 ```
-./matrix_mul_mkl
-Device: Intel(R) Gen9 HD Graphics NEO
-Problem size:  A (600x1200) * B (1200x2400)  -->  C (600x2400)
+./dgemm.mkl
+Problem size:  A (8192x8192) * B (8192x8192)  -->  C (8192x8192)
+Benchmark interations: 100
+Device: Intel(R) Data Center GPU Max 1100
 Launching oneMKL GEMM calculation...
-Performing reference calculation...
-Results are accurate.
+DGEMM performance : 14979.3 GFLOPS
 ```
 
 ### Troubleshooting

--- a/Libraries/oneMKL/matrix_mul_mkl/makefile
+++ b/Libraries/oneMKL/matrix_mul_mkl/makefile
@@ -1,18 +1,22 @@
 # Makefile for NMAKE
 
-default: run
+default: all
 
-all: run
+all: sgemm.exe dgemm.exe
 
-run: matrix_mul_mkl.exe
-	.\matrix_mul_mkl.exe
+run: sgemm.exe dgemm.exe
+	.\sgemm.exe
+	.\dgemm.exe
 
 DPCPP_OPTS=/I"$(MKLROOT)\include" /Qmkl /EHsc -fsycl-device-code-split=per_kernel OpenCL.lib
 
-matrix_mul_mkl.exe: matrix_mul_mkl.cpp
-	icx-cl -fsycl matrix_mul_mkl.cpp /Fematrix_mul_mkl.exe $(DPCPP_OPTS)
+sgemm.exe: matrix_mul_mkl.cpp
+	icx-cl -fsycl matrix_mul_mkl.cpp /Fesgemm.exe $(DPCPP_OPTS)
+
+dgemm.exe: matrix_mul_mkl.cpp
+	icx-cl -fsycl matrix_mul_mkl.cpp /Fedgemm.exe $(DPCPP_OPTS) -DUSE_DOUBLE
 
 clean:
-	del /q matrix_mul_mkl.exe matrix_mul_mkl.exp matrix_mul_mkl.lib
+	del /q sgemm.exe sgemm.exp sgemm.lib dgemm.exe dgemm.exp dgemm.lib
 
 pseudo: clean run all


### PR DESCRIPTION
# Existing Sample Changes
## Description

Updated the matrix_mul_mkl sample to support both single and double floating point precision, a fixed matrix size (8192), and a fixed loop size (100). Tested on PVC.

## Type of change

Please delete options that are not relevant. Add a 'X' to the one that is applicable. 

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Implement fixes for ONSAM Jiras

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [X] Command Line
- [ ] oneapi-cli
- [ ] Visual Studio
- [ ] Eclipse IDE
- [ ] VSCode
- [ ] When compiling the compliler flag "-Wall -Wformat-security -Werror=format-security" was used