### PR TITLE
Updated sample.json files for binomial and dpc_reduce

### DIFF
--- a/DirectProgramming/C++SYCL/ParallelPatterns/dpc_reduce/sample.json
+++ b/DirectProgramming/C++SYCL/ParallelPatterns/dpc_reduce/sample.json
@@ -6,21 +6,21 @@
   "toolchain": ["dpcpp"],
   "languages": [{
     "cpp": {}
-   }],
-   "targetDevice": ["CPU", "GPU"],
-   "gpuRequired": ["gen9"],
-   "os": ["linux"],
-   "builder": ["cmake"],
-   "ciTests": {
-     "linux": [{
-       "id": "dpc_reduce",
-       "steps": [
-         "export I_MPI_CXX=icpx",
- 	 "mkdir build",
- 	 "cd build",
- 	 "cmake ..",
- 	 "make", 
-         "CL_CONFIG_CPU_FORCE_PRIVATE_MEM_SIZE=16MB  ./dpc_reduce"
+  }],
+  "targetDevice": ["CPU", "GPU"],
+  "gpuRequired": ["gen9"],
+  "os": ["linux"],
+  "builder": ["cmake"],
+  "ciTests": {
+    "linux": [{
+      "id": "dpc_reduce",
+      "steps": [
+        "export I_MPI_CXX=icpx",
+ 	      "mkdir build",
+ 	      "cd build",
+ 	      "cmake ..",
+ 	      "make", 
+        "CL_CONFIG_CPU_FORCE_PRIVATE_MEM_SIZE=16MB  ./dpc_reduce"
         ]
       }
     ]

--- a/DirectProgramming/C++SYCL/ParallelPatterns/dpc_reduce/sample.json
+++ b/DirectProgramming/C++SYCL/ParallelPatterns/dpc_reduce/sample.json
@@ -16,10 +16,10 @@
       "id": "dpc_reduce",
       "steps": [
         "export I_MPI_CXX=icpx",
- 	      "mkdir build",
- 	      "cd build",
- 	      "cmake ..",
- 	      "make", 
+        "mkdir build",
+        "cd build",
+        "cmake ..",
+        "make", 
         "CL_CONFIG_CPU_FORCE_PRIVATE_MEM_SIZE=16MB  ./dpc_reduce"
         ]
       }

--- a/DirectProgramming/C++SYCL/ParallelPatterns/dpc_reduce/sample.json
+++ b/DirectProgramming/C++SYCL/ParallelPatterns/dpc_reduce/sample.json
@@ -1,31 +1,29 @@
- {
- 	"guid": "ECF6C8EB-753B-4107-AF64-60662CE41726",
- 	"name": "DPC Reduce",
- 	"categories": ["Toolkit/oneAPI Direct Programming/C++SYCL/Parallel Patterns"],
- 	"description": "This sample models transform Reduce in different ways showing capability of Intel® oneAPI",
- 	"toolchain": ["dpcpp"],
- 	"languages": [{
- 		"cpp": {}
- 	}],
- 	"targetDevice": ["CPU", "GPU"],
- 	"os": ["linux"],
- 	"builder": ["cmake"],
-    "ciTests": {
-       "linux": [
-         {
-           "id": "dpc_reduce",
-           "steps": [
-	       "export I_MPI_CXX=icpx",
- 	       "mkdir build",
- 			   "cd build",
- 			   "cmake ..",
- 			   "make", 
-               "CL_CONFIG_CPU_FORCE_PRIVATE_MEM_SIZE=16MB  ./dpc_reduce"
-              ]
-            }
-      ]
+{
+  "guid": "ECF6C8EB-753B-4107-AF64-60662CE41726",
+  "name": "DPC Reduce",
+  "categories": ["Toolkit/oneAPI Direct Programming/C++SYCL/Parallel Patterns"],
+  "description": "This sample models transform Reduce in different ways showing capability of Intel® oneAPI",
+  "toolchain": ["dpcpp"],
+  "languages": [{
+    "cpp": {}
+   }],
+   "targetDevice": ["CPU", "GPU"],
+   "gpuRequired": ["gen9"],
+   "os": ["linux"],
+   "builder": ["cmake"],
+   "ciTests": {
+     "linux": [{
+       "id": "dpc_reduce",
+       "steps": [
+         "export I_MPI_CXX=icpx",
+ 	 "mkdir build",
+ 	 "cd build",
+ 	 "cmake ..",
+ 	 "make", 
+         "CL_CONFIG_CPU_FORCE_PRIVATE_MEM_SIZE=16MB  ./dpc_reduce"
+        ]
+      }
+    ]
   },
   "expertise": "Concepts and Functionality"
 }
-
-

--- a/Libraries/oneMKL/binomial/sample.json
+++ b/Libraries/oneMKL/binomial/sample.json
@@ -7,6 +7,7 @@
   "dependencies": [ "mkl" ],
   "languages": [ { "cpp": { "properties": { "projectOptions": [ { "projectType": "makefile" } ] } } } ],
   "targetDevice": [ "CPU", "GPU" ],
+  "gpuRequired": ["gen9"],
   "os": [ "linux", "windows" ],
   "builder": [ "make" ],
   "ciTests": {


### PR DESCRIPTION
# Existing Sample Changes
## Description

Updated sample.json files to indicate that binomial and dpc_reduce samples use double fp precision.

Fixes Issue# ONSAM-1618


## Type of change

Please delete options that are not relevant. Add a 'X' to the one that is applicable. 

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Implement fixes for ONSAM Jiras

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Command Line
- [ ] oneapi-cli
- [ ] Visual Studio
- [ ] Eclipse IDE
- [ ] VSCode
- [ ] When compiling the compliler flag "-Wall -Wformat-security -Werror=format-security" was used
