### PR TITLE
Updated sample.json for guided_matrix_mul_OpenMP

### DIFF
--- a/DirectProgramming/Fortran/guided_matrix_mul_OpenMP/sample.json
+++ b/DirectProgramming/Fortran/guided_matrix_mul_OpenMP/sample.json
@@ -6,6 +6,7 @@
   "toolchain": [ "ifort", "ifx" ],
   "languages": [ { "fortran": {} } ],
   "targetDevice": [ "CPU", "GPU" ],
+  "gpuRequired": ["pvc"],
   "os": [ "linux", "windows" ],
   "builder": [ "make" ],
   "ciTests": {


### PR DESCRIPTION
# Existing Sample Changes
## Description

Updated sample.json for guided_matrix_mul_OpenMP to use double floating point precision for CI testing.

Fixes Issue# ONSAM-1618

## Type of change

Please delete options that are not relevant. Add a 'X' to the one that is applicable. 

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Implement fixes for ONSAM Jiras

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Command Line
- [ ] oneapi-cli
- [ ] Visual Studio
- [ ] Eclipse IDE
- [ ] VSCode
- [ ] When compiling the compliler flag "-Wall -Wformat-security -Werror=format-security" was used