### PR TITLE
Updated makefile for MergesortOMP sample to use icpc for macOS

### DIFF
--- a/DirectProgramming/C++/GraphTraversal/MergesortOMP/Makefile
+++ b/DirectProgramming/C++/GraphTraversal/MergesortOMP/Makefile
@@ -1,9 +1,9 @@
-CXX := icpx
+CXX := icpc
 SRCDIR := src
 BUILDDIR := release
-CFLAGS := -O3 -flto -qopenmp -std=c++11
+CFLAGS := -O3 -ipo -qopenmp -std=c++11
 EXTRA_CFLAGS :=
-LIBFLAGS := -flto -qopenmp
+LIBFLAGS := -qopenmp
 
 ifdef perf_num
 	EXTRA_CFLAGS += -D PERF_NUM


### PR DESCRIPTION
# Existing Sample Changes
## Description

Updated makefile for MergesortOMP sample to use icpc for macOS. icpx does not exist on macOS.

Fixes Issue# ONSAM-1616

## Type of change

Please delete options that are not relevant. Add a 'X' to the one that is applicable. 

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Implement fixes for ONSAM Jiras

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Command Line
- [ ] oneapi-cli
- [ ] Visual Studio
- [ ] Eclipse IDE
- [ ] VSCode
- [ ] When compiling the compliler flag "-Wall -Wformat-security -Werror=format-security" was used