### PR TITLE
FPGA: modify matrix multiply sample to use variable latency MM hosts

### DIFF
--- a/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/matmul/src/memory_transfers.hpp
+++ b/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/matmul/src/memory_transfers.hpp
@@ -39,7 +39,7 @@ public:
   mmhost(aspace, // buffer_location or aspace
          28,     // address width
          dwidth, // data width
-         16,     // latency
+         0,      // latency
          1,      // read_write_mode, 0: ReadWrite, 1: Read, 2: Write
          1,      // maxburst
          0,      // align, 0 defaults to alignment of the type
@@ -192,7 +192,7 @@ public:
   mmhost(aspace, // buffer_location or aspace
          28,     // address width
          dwidth, // data width
-         16,     // latency
+         0,      // latency
          1,      // read_write_mode, 0: ReadWrite, 1: Read, 2: Write
          1,      // maxburst
          0,      // align, 0 defaults to alignment of the type
@@ -337,7 +337,7 @@ public:
   mmhost(aspace, // buffer_location or aspace
          28,     // address width
          dwidth, // data width
-         16,     // latency
+         0,      // latency
          2,      // read_write_mode, 0: ReadWrite, 1: Read, 2: Write
          1,      // maxburst
          0,      // align, 0 defaults to alignment of the type


### PR DESCRIPTION
# Existing Sample Changes
## Description

Updates the three DMA kernels to use variable rather than fixed latency MM hosts when compiling in the IP authoring flow.

Fixes Issue# 

## External Dependencies

List any external dependencies created as a result of this change.

## Type of change

Please delete options that are not relevant. Add a 'X' to the one that is applicable. 

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Implement fixes for ONSAM Jiras

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [X] Command Line
- [ ] oneapi-cli
- [ ] Visual Studio
- [ ] Eclipse IDE
- [ ] VSCode
- [ ] When compiling the compliler flag "-Wall -Wformat-security -Werror=format-security" was used