### PR TITLE
Make the design smaller to prevent timing violations

### DIFF
--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Tools/system_profiling/src/double_buffering.cpp
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Tools/system_profiling/src/double_buffering.cpp
@@ -29,7 +29,7 @@ constexpr int kTimes = 3;
 constexpr int kSize = 4096;
 #else
 constexpr int kTimes = 3;  // originally 100
-constexpr int kSize = 2621440;
+constexpr int kSize = 262144;
 #endif
 
 // Kernel executes a power function (base^kPow). Must be


### PR DESCRIPTION
# Existing Sample Changes
## Description

This test is periodically hits timing violations in S10 compiles, and this change makes the design smaller to make it more likely to fit without timing violations.

Fixes Issue#14019796464  

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Tested using a regtest to confirm timing violations no longer come up in S10: https://spetc.intel.com/testsummary?trview=0&testRunIds=8426203
Ran the executable with the openCL Intercept Layer and confirmed the difference between where double buffering is and isn't applied is still visible.
(see image below - I used an older version of the intercept layer so it doesn't look the same as in the readme, but the difference in gaps between kernel executions is still visible)
![image](https://github.com/oneapi-src/oneAPI-samples/assets/52976762/d8acfd25-e4f4-4809-ad3d-6e0f253a2c06)

