### PR TITLE
Adapt to the `get_pointer` return type change from upstream intel/llvm

### DIFF
--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/experimental/latency_control/src/latency_control.cpp
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/experimental/latency_control/src/latency_control.cpp
@@ -46,9 +46,9 @@ void KernelRun(const std::vector<int> &in_data, std::vector<int> &out_data,
 
       h.single_task<LatencyControl>([=]() [[intel::kernel_args_restrict]] {
         auto in_ptr =
-            in_accessor.template get_multi_ptr<access::decorated::no>();
+            in_accessor.template get_multi_ptr<sycl::access::decorated::no>();
         auto out_ptr =
-            out_accessor.template get_multi_ptr<access::decorated::no>();
+            out_accessor.template get_multi_ptr<sycl::access::decorated::no>();
 
         for (size_t i = 0; i < size; i++) {
           // The following load has a label 0.

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/experimental/latency_control/src/latency_control.cpp
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/experimental/latency_control/src/latency_control.cpp
@@ -45,8 +45,10 @@ void KernelRun(const std::vector<int> &in_data, std::vector<int> &out_data,
                                   sycl::no_init);
 
       h.single_task<LatencyControl>([=]() [[intel::kernel_args_restrict]] {
-        auto in_ptr = in_accessor.get_pointer();
-        auto out_ptr = out_accessor.get_pointer();
+        auto in_ptr =
+            in_accessor.template get_multi_ptr<access::decorated::no>();
+        auto out_ptr =
+            out_accessor.template get_multi_ptr<access::decorated::no>();
 
         for (size_t i = 0; i < size; i++) {
           // The following load has a label 0.

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/lsu_control/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/lsu_control/README.md
@@ -10,7 +10,7 @@ This sample is an FPGA tutorial that demonstrates how to configure the load-stor
 
 ## Purpose
 
-The compiler creates load-store units (LSU) to access off-chip data. The compiler has many options to choose from when configuring each LSU. The SYCL*-compliant LSU controls extension allows you to override the compiler's internal heuristics and control the architecture of each LSU. An introduction to the extension in this tutorial will explain the available options, extension defaults, appropriate use cases, and area trade-offs.
+The compiler creates load-store units (LSU) to access memories, both on-chip and off-chip. The compiler has many options to choose from when configuring each LSU. The SYCL*-compliant LSU controls extension allows you to override the compiler's internal heuristics and control the architecture of individual LSUs that are used to access variable-latency off-chip memory. An introduction to the extension in this tutorial will explain the available options, extension defaults, appropriate use cases, and area trade-offs.
 
 ## Prerequisites
 
@@ -63,7 +63,7 @@ The sample illustrates the following important concepts.
 
 ### LSUs and LSU Styles
 
-An LSU is a block that handles loading and storing data to and from memory. Off-chip memory can have variable latency. To mitigate this, different LSU implementations, referred to as styles, are available.
+An LSU is a block that handles loading and storing data to and from memory. Off-chip memory can have variable latency. To mitigate this, different LSU styles are available.
 
 The two LSU styles used in this tutorial are listed below:
 
@@ -77,11 +77,15 @@ The best LSU style depends on the memory access pattern in your design. There ar
 
 In addition to these two styles, there are also LSU modifiers. LSU modifiers are add-ons that can be combined with LSU styles, such as caching, which can be combined with the burst-coalesced LSU style.
 
-For more details on LSU modifiers and LSU styles, refer to the Memory Accesses section in the [FPGA Optimization Guide for Intel® oneAPI Toolkits Developer Guide](https://software.intel.com/content/www/us/en/develop/documentation/oneapi-fpga-optimization-guide).
+For more details on LSU modifiers and LSU styles, refer to the *Memory Accesses* section in the [FPGA Optimization Guide for Intel® oneAPI Toolkits Developer Guide](https://www.intel.com/content/www/us/en/docs/oneapi-fpga-add-on/optimization-guide/current/memory-accesses.html).
 
 ### Introduction to the LSU Control Extension
 
-The class: ```ext::intel::lsu``` enables you to control the architecture of the LSU. The class has two member functions, `load()` and `store()`, which allow loading from and storing to a global pointer.
+The class: ```ext::intel::lsu``` enables you to control the architecture of the LSU. The class has two member functions, `load()` and `store()`, which allow loading from and storing to a global pointer (via `sycl::multi_ptr` rather than raw pointer).
+
+There are two steps to use the LSU control extension to optimize LSU behaviour:
+1. Get a `sycl::multi_ptr` representation of the memory you wish to access using the `get_multi_ptr<>()` function.
+2. Access this `sycl::multi_ptr` using one of the LSU control functions.
 
 The table below summarizes the LSU control extension parameters. The parameters will be respected to the extent possible.
 
@@ -97,17 +101,17 @@ If the default options are used, a pipelined LSU is implemented.
 #### Example: Controlling the `prefetch` and `statically_coalesce` Parameters
 
 ```c++
-//Creating typedefs using the LSU controls class
-//for each combination of LSU options desired.
+// Creating typedefs using the LSU controls class
+// for each combination of LSU options desired.
 using PrefetchingLSU = ext::intel::lsu<ext::intel::prefetch<true>,
-                                  ext::intel::statically_coalesce<false>>;
+                                       ext::intel::statically_coalesce<false>>;
 // ...
 q.submit([&](handler &h) {
   h.single_task<Kernel>([=] {
-    //Pointer to external memory
+    // Pointer to external memory
     auto input_ptr = input_accessor.template get_multi_ptr<access::decorated::no>();
 
-    //Compiler will use a Prefetch LSU for this load
+    // Compiler will use a Prefetch LSU for this load
     int in_data = PrefetchingLSU::load(input_ptr);
 
     //...
@@ -116,7 +120,7 @@ q.submit([&](handler &h) {
 ```
 
 Currently, not every combination of parameters is valid in the compiler.
-For more details on the descriptions of LSU controls, styles, and modifiers refer to the *FPGA LSU Controls* section in the [FPGA Optimization Guide for Intel® oneAPI Toolkits Developer Guide](https://software.intel.com/content/www/us/en/develop/documentation/oneapi-fpga-optimization-guide).
+For more details on the descriptions of LSU controls, styles, and modifiers refer to the *Load-Store Unit Controls* section in the [FPGA Optimization Guide for Intel® oneAPI Toolkits Developer Guide](https://www.intel.com/content/www/us/en/docs/oneapi-fpga-add-on/optimization-guide/current/load-store-unit-controls.html).
 
 ### Tutorial Overview
 

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/lsu_control/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/lsu_control/README.md
@@ -105,7 +105,7 @@ using PrefetchingLSU = ext::intel::lsu<ext::intel::prefetch<true>,
 q.submit([&](handler &h) {
   h.single_task<Kernel>([=] {
     //Pointer to external memory
-    auto input_ptr = input_accessor.get_pointer();
+    auto input_ptr = input_accessor.template get_multi_ptr<access::decorated::no>();
 
     //Compiler will use a Prefetch LSU for this load
     int in_data = PrefetchingLSU::load(input_ptr);

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/lsu_control/src/lsu_control.cpp
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/lsu_control/src/lsu_control.cpp
@@ -79,7 +79,8 @@ void KernelRun(const std::vector<int> &input_data, const size_t &input_size,
 
       // Kernel that uses the prefetch LSU
       h.single_task<KernelPrefetch>([=]() [[intel::kernel_args_restrict]] {
-        auto input_ptr = input_a.get_pointer();
+        auto input_ptr =
+            input_a.template get_multi_ptr<access::decorated::no>();
         auto output_ptr = output_a.get_pointer();
 
         int total = 0;
@@ -96,7 +97,8 @@ void KernelRun(const std::vector<int> &input_data, const size_t &input_size,
       
       // Kernel that uses the burst-coalesced LSU
       h.single_task<KernelBurst>([=]() [[intel::kernel_args_restrict]] {
-        auto input_ptr = input_a.get_pointer();
+        auto input_ptr =
+            input_a.template get_multi_ptr<access::decorated::no>();
         auto output_ptr = output_a.get_pointer();
 
         int total = 0;


### PR DESCRIPTION
## Description

The upstream commit https://github.com/intel/llvm/pull/8874 changed the return type of `accessor::get_pointer` from a `multi_ptr` to a raw pointer, which affects all uses of `lsu::load` and `lsu::store` who expect a `multi_ptr` as their first function argument.

This commit updates the two affected code samples (lsu_control, latency_control) to avoid the compile failure caused by pointer type mismatch between `accessor::get_pointer` and `lsu::load`/`lsu::store`.

Fixes Issue https://jira.devtools.intel.com/browse/HLD-2916.

Case tracker for improving LSU control API in the future: https://hsdes.intel.com/appstore/article/#/14020028781.

## Type of change

- [X] Implement fixes for ONSAM Jiras

## How Has This Been Tested?

- [x] Command Line
- [x] Regtests: https://spetc.intel.com/testanalysis?trview=0&testRunIds=8472382,8472387&tapgsize=1500&tasort=testCasePath&tasortdir=asc