### PR TITLE
Revisited MonteCarloMultiGPU SYCL Migration  with 01_dpct_output folder modification

### DIFF
--- a/DirectProgramming/C++SYCL/MapReduce/guided_MonteCarloMultiGPU_SYCLMigration/01_dpct_output/CMakeLists.txt
+++ b/DirectProgramming/C++SYCL/MapReduce/guided_MonteCarloMultiGPU_SYCLMigration/01_dpct_output/CMakeLists.txt
@@ -1,0 +1,13 @@
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fsycl")
+set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS}")
+SET(CMAKE_EXE_LINKER_FLAGS  "-pthread ${CMAKE_EXE_LINKER_FLAGS}")
+SET(CMAKE_EXE_LINKER_FLAGS  "-qmkl ${CMAKE_EXE_LINKER_FLAGS}")
+include_directories(${CMAKE_SOURCE_DIR}/01_dpct_output/Common/)
+include_directories(${CMAKE_SOURCE_DIR}/01_dpct_output/include/)
+
+add_executable (01_dpct_output Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarloMultiGPU.cpp.dp.cpp Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_gold.cpp.dp.cpp Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_kernel.dp.cpp Samples/5_Domain_Specific/MonteCarloMultiGPU/multithreading.cpp)
+target_link_libraries(01_dpct_output sycl)
+
+add_custom_target (run_cpu cd ${CMAKE_SOURCE_DIR}/01_dpct_output/ && SYCL_DEVICE_FILTER=cpu ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/01_dpct_output)
+add_custom_target (run_gpu cd ${CMAKE_SOURCE_DIR}/01_dpct_output/ && SYCL_DEVICE_FILTER=level_zero:gpu ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/01_dpct_output)
+add_custom_target (run_gpu_opencl cd ${CMAKE_SOURCE_DIR}/01_dpct_output/ && SYCL_DEVICE_FILTER=opencl:gpu ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/01_dpct_output)

--- a/DirectProgramming/C++SYCL/MapReduce/guided_MonteCarloMultiGPU_SYCLMigration/01_dpct_output/Common/helper_cuda.h
+++ b/DirectProgramming/C++SYCL/MapReduce/guided_MonteCarloMultiGPU_SYCLMigration/01_dpct_output/Common/helper_cuda.h
@@ -54,7 +54,7 @@
 #ifdef __DPCT_HPP__
 static const char *_cudaGetErrorEnum(dpct::err0 error) {
   /*
-  DPCT1009:5: SYCL uses exceptions to report errors and does not use the error
+  DPCT1009:4: SYCL uses exceptions to report errors and does not use the error
   codes. The original code was commented out and a warning string was inserted.
   You need to rewrite this code.
   */
@@ -602,7 +602,7 @@ void check(T result, char const *const func, const char *const file,
 inline void __getLastCudaError(const char *errorMessage, const char *file,
                                const int line) {
   /*
-  DPCT1010:6: SYCL uses exceptions to report errors and does not use the error
+  DPCT1010:5: SYCL uses exceptions to report errors and does not use the error
   codes. The call was replaced with 0. You need to rewrite this code.
   */
   dpct::err0 err = 0;
@@ -615,7 +615,7 @@ inline void __getLastCudaError(const char *errorMessage, const char *file,
 inline void __printLastCudaError(const char *errorMessage, const char *file,
                                  const int line) {
   /*
-  DPCT1010:8: SYCL uses exceptions to report errors and does not use the error
+  DPCT1010:7: SYCL uses exceptions to report errors and does not use the error
   codes. The call was replaced with 0. You need to rewrite this code.
   */
   dpct::err0 err = 0;
@@ -636,7 +636,7 @@ inline int ftoi(float value) {
 inline int _ConvertSMVer2Cores(int major, int minor) {
   // Defines for GPU Architecture types (using the SM version to determine
   // the # of cores per SM
-  typedef struct dpct_type_148198 {
+  typedef struct dpct_type_146989 {
     int SM;  // 0xMm (hexidecimal notation), M = SM Major version,
     // and m = SM minor version
     int Cores;
@@ -685,7 +685,7 @@ inline int _ConvertSMVer2Cores(int major, int minor) {
 inline const char* _ConvertSMVer2ArchName(int major, int minor) {
   // Defines for GPU Architecture types (using the SM version to determine
   // the GPU Arch name)
-  typedef struct dpct_type_135042 {
+  typedef struct dpct_type_101439 {
     int SM;  // 0xMm (hexidecimal notation), M = SM Major version,
     // and m = SM minor version
     const char* name;
@@ -737,7 +737,7 @@ inline const char* _ConvertSMVer2ArchName(int major, int minor) {
 inline int gpuDeviceInit(int devID) {
   int device_count;
   /*
-  DPCT1003:10: Migrated API does not return error code. (*, 0) is inserted. You
+  DPCT1003:9: Migrated API does not return error code. (*, 0) is inserted. You
   may need to rewrite this code.
   */
   checkCudaErrors((device_count = dpct::dev_mgr::instance().device_count(), 0));
@@ -767,7 +767,7 @@ inline int gpuDeviceInit(int devID) {
 
   int computeMode = -1, major = 0, minor = 0;
   /*
-  DPCT1035:11: All SYCL devices can be used by the host to submit tasks. You may
+  DPCT1035:10: All SYCL devices can be used by the host to submit tasks. You may
   need to adjust this code.
   */
   checkCudaErrors((computeMode = 1, 0));
@@ -778,7 +778,7 @@ inline int gpuDeviceInit(int devID) {
       (minor = dpct::dev_mgr::instance().get_device(devID).get_minor_version(),
        0));
   /*
-  DPCT1035:12: All SYCL devices can be used by the host to submit tasks. You may
+  DPCT1035:11: All SYCL devices can be used by the host to submit tasks. You may
   need to adjust this code.
   */
   if (computeMode == 0) {
@@ -794,11 +794,11 @@ inline int gpuDeviceInit(int devID) {
   }
 
   /*
-  DPCT1093:13: The "devID" device may be not the one intended for use. Adjust
+  DPCT1093:12: The "devID" device may be not the one intended for use. Adjust
   the selected device if needed.
   */
   /*
-  DPCT1003:14: Migrated API does not return error code. (*, 0) is inserted. You
+  DPCT1003:13: Migrated API does not return error code. (*, 0) is inserted. You
   may need to rewrite this code.
   */
   checkCudaErrors((dpct::select_device(devID), 0));
@@ -816,7 +816,7 @@ inline int gpuGetMaxGflopsDeviceId() try {
 
   uint64_t max_compute_perf = 0;
   /*
-  DPCT1003:15: Migrated API does not return error code. (*, 0) is inserted. You
+  DPCT1003:14: Migrated API does not return error code. (*, 0) is inserted. You
   may need to rewrite this code.
   */
   checkCudaErrors((device_count = dpct::dev_mgr::instance().device_count(), 0));
@@ -834,7 +834,7 @@ inline int gpuGetMaxGflopsDeviceId() try {
   while (current_device < device_count) {
     int computeMode = -1, major = 0, minor = 0;
     /*
-    DPCT1035:16: All SYCL devices can be used by the host to submit tasks. You
+    DPCT1035:15: All SYCL devices can be used by the host to submit tasks. You
     may need to adjust this code.
     */
     checkCudaErrors((computeMode = 1, 0));
@@ -850,7 +850,7 @@ inline int gpuGetMaxGflopsDeviceId() try {
     // If this GPU is not running on Compute Mode prohibited,
     // then we can add it to the list
     /*
-    DPCT1035:17: All SYCL devices can be used by the host to submit tasks. You
+    DPCT1035:16: All SYCL devices can be used by the host to submit tasks. You
     may need to adjust this code.
     */
     if (computeMode != 0) {
@@ -921,11 +921,11 @@ inline int findCudaDevice(int argc, const char **argv) {
     // Otherwise pick the device with highest Gflops/s
     devID = gpuGetMaxGflopsDeviceId();
     /*
-    DPCT1093:18: The "devID" device may be not the one intended for use. Adjust
+    DPCT1093:17: The "devID" device may be not the one intended for use. Adjust
     the selected device if needed.
     */
     /*
-    DPCT1003:19: Migrated API does not return error code. (*, 0) is inserted.
+    DPCT1003:18: Migrated API does not return error code. (*, 0) is inserted.
     You may need to rewrite this code.
     */
     checkCudaErrors((dpct::select_device(devID), 0));
@@ -950,7 +950,7 @@ inline int findIntegratedGPU() {
   int devices_prohibited = 0;
 
   /*
-  DPCT1003:20: Migrated API does not return error code. (*, 0) is inserted. You
+  DPCT1003:19: Migrated API does not return error code. (*, 0) is inserted. You
   may need to rewrite this code.
   */
   checkCudaErrors((device_count = dpct::dev_mgr::instance().device_count(), 0));
@@ -964,7 +964,7 @@ inline int findIntegratedGPU() {
   while (current_device < device_count) {
     int computeMode = -1, integrated = -1;
     /*
-    DPCT1035:21: All SYCL devices can be used by the host to submit tasks. You
+    DPCT1035:20: All SYCL devices can be used by the host to submit tasks. You
     may need to adjust this code.
     */
     checkCudaErrors((computeMode = 1, 0));
@@ -975,16 +975,16 @@ inline int findIntegratedGPU() {
     // If GPU is integrated and is not running on Compute Mode prohibited,
     // then cuda can map to GLES resource
     /*
-    DPCT1035:22: All SYCL devices can be used by the host to submit tasks. You
+    DPCT1035:21: All SYCL devices can be used by the host to submit tasks. You
     may need to adjust this code.
     */
     if (integrated && (computeMode != 0)) {
       /*
-      DPCT1093:23: The "current_device" device may be not the one intended for
+      DPCT1093:22: The "current_device" device may be not the one intended for
       use. Adjust the selected device if needed.
       */
       /*
-      DPCT1003:24: Migrated API does not return error code. (*, 0) is inserted.
+      DPCT1003:23: Migrated API does not return error code. (*, 0) is inserted.
       You may need to rewrite this code.
       */
       checkCudaErrors((dpct::select_device(current_device), 0));

--- a/DirectProgramming/C++SYCL/MapReduce/guided_MonteCarloMultiGPU_SYCLMigration/01_dpct_output/Common/helper_cuda.h.yaml
+++ b/DirectProgramming/C++SYCL/MapReduce/guided_MonteCarloMultiGPU_SYCLMigration/01_dpct_output/Common/helper_cuda.h.yaml
@@ -1,7 +1,7 @@
 ---
-MainSourceFile:  '/home/tcs2/Manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/dpct_output/Common/helper_cuda.h'
+MainSourceFile:  '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/dpct_output/Common/helper_cuda.h'
 Replacements:
-  - FilePath:        '/home/tcs2/Manju/cuda-samples/Common/helper_cuda.h'
+  - FilePath:        '/home/tcs/Manjula_workspace/manju/cuda-samples/Common/helper_cuda.h'
     Offset:          1793
     Length:          0
     ReplacementText: "#include <sycl/sycl.hpp>\n#include <dpct/dpct.hpp>\n"
@@ -10,7 +10,7 @@ Replacements:
     InitStr:         ''
     NewHostVarName:  ''
     BlockLevelFormatFlag: false
-  - FilePath:        '/home/tcs2/Manju/cuda-samples/Common/helper_cuda.h'
+  - FilePath:        '/home/tcs/Manjula_workspace/manju/cuda-samples/Common/helper_cuda.h'
     Offset:          2210
     Length:          18
     ReplacementText: __DPCT_HPP__
@@ -19,7 +19,7 @@ Replacements:
     InitStr:         ''
     NewHostVarName:  ''
     BlockLevelFormatFlag: false
-  - FilePath:        '/home/tcs2/Manju/cuda-samples/Common/helper_cuda.h'
+  - FilePath:        '/home/tcs/Manjula_workspace/manju/cuda-samples/Common/helper_cuda.h'
     Offset:          2266
     Length:          11
     ReplacementText: 'dpct::err0'
@@ -28,16 +28,16 @@ Replacements:
     InitStr:         ''
     NewHostVarName:  ''
     BlockLevelFormatFlag: false
-  - FilePath:        '/home/tcs2/Manju/cuda-samples/Common/helper_cuda.h'
+  - FilePath:        '/home/tcs/Manjula_workspace/manju/cuda-samples/Common/helper_cuda.h'
     Offset:          2287
     Length:          0
-    ReplacementText: "  /*\n  DPCT1009:5: SYCL uses exceptions to report errors and does not use the error codes. The original code was commented out and a warning string was inserted. You need to rewrite this code.\n  */\n"
+    ReplacementText: "  /*\n  DPCT1009:4: SYCL uses exceptions to report errors and does not use the error codes. The original code was commented out and a warning string was inserted. You need to rewrite this code.\n  */\n"
     ConstantFlag:    ''
     ConstantOffset:  0
     InitStr:         ''
     NewHostVarName:  ''
     BlockLevelFormatFlag: false
-  - FilePath:        '/home/tcs2/Manju/cuda-samples/Common/helper_cuda.h'
+  - FilePath:        '/home/tcs/Manjula_workspace/manju/cuda-samples/Common/helper_cuda.h'
     Offset:          2296
     Length:          23
     ReplacementText: '"cudaGetErrorName is not supported"/*cudaGetErrorName(error)*/'
@@ -46,7 +46,7 @@ Replacements:
     InitStr:         ''
     NewHostVarName:  ''
     BlockLevelFormatFlag: false
-  - FilePath:        '/home/tcs2/Manju/cuda-samples/Common/helper_cuda.h'
+  - FilePath:        '/home/tcs/Manjula_workspace/manju/cuda-samples/Common/helper_cuda.h'
     Offset:          7109
     Length:          14
     ReplacementText: int
@@ -55,7 +55,7 @@ Replacements:
     InitStr:         ''
     NewHostVarName:  ''
     BlockLevelFormatFlag: false
-  - FilePath:        '/home/tcs2/Manju/cuda-samples/Common/helper_cuda.h'
+  - FilePath:        '/home/tcs/Manjula_workspace/manju/cuda-samples/Common/helper_cuda.h'
     Offset:          7161
     Length:          21
     ReplacementText: '0'
@@ -64,7 +64,7 @@ Replacements:
     InitStr:         ''
     NewHostVarName:  ''
     BlockLevelFormatFlag: false
-  - FilePath:        '/home/tcs2/Manju/cuda-samples/Common/helper_cuda.h'
+  - FilePath:        '/home/tcs/Manjula_workspace/manju/cuda-samples/Common/helper_cuda.h'
     Offset:          7232
     Length:          30
     ReplacementText: '100'
@@ -73,7 +73,7 @@ Replacements:
     InitStr:         ''
     NewHostVarName:  ''
     BlockLevelFormatFlag: false
-  - FilePath:        '/home/tcs2/Manju/cuda-samples/Common/helper_cuda.h'
+  - FilePath:        '/home/tcs/Manjula_workspace/manju/cuda-samples/Common/helper_cuda.h'
     Offset:          7321
     Length:          29
     ReplacementText: '101'
@@ -82,7 +82,7 @@ Replacements:
     InitStr:         ''
     NewHostVarName:  ''
     BlockLevelFormatFlag: false
-  - FilePath:        '/home/tcs2/Manju/cuda-samples/Common/helper_cuda.h'
+  - FilePath:        '/home/tcs/Manjula_workspace/manju/cuda-samples/Common/helper_cuda.h'
     Offset:          7408
     Length:          31
     ReplacementText: '102'
@@ -91,7 +91,7 @@ Replacements:
     InitStr:         ''
     NewHostVarName:  ''
     BlockLevelFormatFlag: false
-  - FilePath:        '/home/tcs2/Manju/cuda-samples/Common/helper_cuda.h'
+  - FilePath:        '/home/tcs/Manjula_workspace/manju/cuda-samples/Common/helper_cuda.h'
     Offset:          7499
     Length:          24
     ReplacementText: '103'
@@ -100,7 +100,7 @@ Replacements:
     InitStr:         ''
     NewHostVarName:  ''
     BlockLevelFormatFlag: false
-  - FilePath:        '/home/tcs2/Manju/cuda-samples/Common/helper_cuda.h'
+  - FilePath:        '/home/tcs/Manjula_workspace/manju/cuda-samples/Common/helper_cuda.h'
     Offset:          7576
     Length:          26
     ReplacementText: '104'
@@ -109,7 +109,7 @@ Replacements:
     InitStr:         ''
     NewHostVarName:  ''
     BlockLevelFormatFlag: false
-  - FilePath:        '/home/tcs2/Manju/cuda-samples/Common/helper_cuda.h'
+  - FilePath:        '/home/tcs/Manjula_workspace/manju/cuda-samples/Common/helper_cuda.h'
     Offset:          7657
     Length:          33
     ReplacementText: '105'
@@ -118,7 +118,7 @@ Replacements:
     InitStr:         ''
     NewHostVarName:  ''
     BlockLevelFormatFlag: false
-  - FilePath:        '/home/tcs2/Manju/cuda-samples/Common/helper_cuda.h'
+  - FilePath:        '/home/tcs/Manjula_workspace/manju/cuda-samples/Common/helper_cuda.h'
     Offset:          7752
     Length:          39
     ReplacementText: '106'
@@ -127,7 +127,7 @@ Replacements:
     InitStr:         ''
     NewHostVarName:  ''
     BlockLevelFormatFlag: false
-  - FilePath:        '/home/tcs2/Manju/cuda-samples/Common/helper_cuda.h'
+  - FilePath:        '/home/tcs/Manjula_workspace/manju/cuda-samples/Common/helper_cuda.h'
     Offset:          7859
     Length:          28
     ReplacementText: '201'
@@ -136,7 +136,7 @@ Replacements:
     InitStr:         ''
     NewHostVarName:  ''
     BlockLevelFormatFlag: false
-  - FilePath:        '/home/tcs2/Manju/cuda-samples/Common/helper_cuda.h'
+  - FilePath:        '/home/tcs/Manjula_workspace/manju/cuda-samples/Common/helper_cuda.h'
     Offset:          7944
     Length:          33
     ReplacementText: '202'
@@ -145,7 +145,7 @@ Replacements:
     InitStr:         ''
     NewHostVarName:  ''
     BlockLevelFormatFlag: false
-  - FilePath:        '/home/tcs2/Manju/cuda-samples/Common/helper_cuda.h'
+  - FilePath:        '/home/tcs/Manjula_workspace/manju/cuda-samples/Common/helper_cuda.h'
     Offset:          8039
     Length:          35
     ReplacementText: '203'
@@ -154,7 +154,7 @@ Replacements:
     InitStr:         ''
     NewHostVarName:  ''
     BlockLevelFormatFlag: false
-  - FilePath:        '/home/tcs2/Manju/cuda-samples/Common/helper_cuda.h'
+  - FilePath:        '/home/tcs/Manjula_workspace/manju/cuda-samples/Common/helper_cuda.h'
     Offset:          8138
     Length:          27
     ReplacementText: '204'
@@ -163,7 +163,7 @@ Replacements:
     InitStr:         ''
     NewHostVarName:  ''
     BlockLevelFormatFlag: false
-  - FilePath:        '/home/tcs2/Manju/cuda-samples/Common/helper_cuda.h'
+  - FilePath:        '/home/tcs/Manjula_workspace/manju/cuda-samples/Common/helper_cuda.h'
     Offset:          8221
     Length:          28
     ReplacementText: '999'
@@ -172,7 +172,7 @@ Replacements:
     InitStr:         ''
     NewHostVarName:  ''
     BlockLevelFormatFlag: false
-  - FilePath:        '/home/tcs2/Manju/cuda-samples/Common/helper_cuda.h'
+  - FilePath:        '/home/tcs/Manjula_workspace/manju/cuda-samples/Common/helper_cuda.h'
     Offset:          15785
     Length:          199
     ReplacementText: ''
@@ -181,7 +181,7 @@ Replacements:
     InitStr:         ''
     NewHostVarName:  ''
     BlockLevelFormatFlag: false
-  - FilePath:        '/home/tcs2/Manju/cuda-samples/Common/helper_cuda.h'
+  - FilePath:        '/home/tcs/Manjula_workspace/manju/cuda-samples/Common/helper_cuda.h'
     Offset:          15995
     Length:          18
     ReplacementText: __DPCT_HPP__
@@ -190,16 +190,16 @@ Replacements:
     InitStr:         ''
     NewHostVarName:  ''
     BlockLevelFormatFlag: false
-  - FilePath:        '/home/tcs2/Manju/cuda-samples/Common/helper_cuda.h'
+  - FilePath:        '/home/tcs/Manjula_workspace/manju/cuda-samples/Common/helper_cuda.h'
     Offset:          16461
     Length:          0
-    ReplacementText: "  /*\n  DPCT1010:6: SYCL uses exceptions to report errors and does not use the error codes. The call was replaced with 0. You need to rewrite this code.\n  */\n"
+    ReplacementText: "  /*\n  DPCT1010:5: SYCL uses exceptions to report errors and does not use the error codes. The call was replaced with 0. You need to rewrite this code.\n  */\n"
     ConstantFlag:    ''
     ConstantOffset:  0
     InitStr:         ''
     NewHostVarName:  ''
     BlockLevelFormatFlag: false
-  - FilePath:        '/home/tcs2/Manju/cuda-samples/Common/helper_cuda.h'
+  - FilePath:        '/home/tcs/Manjula_workspace/manju/cuda-samples/Common/helper_cuda.h'
     Offset:          16463
     Length:          11
     ReplacementText: 'dpct::err0'
@@ -208,7 +208,7 @@ Replacements:
     InitStr:         ''
     NewHostVarName:  ''
     BlockLevelFormatFlag: false
-  - FilePath:        '/home/tcs2/Manju/cuda-samples/Common/helper_cuda.h'
+  - FilePath:        '/home/tcs/Manjula_workspace/manju/cuda-samples/Common/helper_cuda.h'
     Offset:          16481
     Length:          18
     ReplacementText: '0'
@@ -217,7 +217,7 @@ Replacements:
     InitStr:         ''
     NewHostVarName:  ''
     BlockLevelFormatFlag: false
-  - FilePath:        '/home/tcs2/Manju/cuda-samples/Common/helper_cuda.h'
+  - FilePath:        '/home/tcs/Manjula_workspace/manju/cuda-samples/Common/helper_cuda.h'
     Offset:          16504
     Length:          259
     ReplacementText: ''
@@ -226,16 +226,16 @@ Replacements:
     InitStr:         ''
     NewHostVarName:  ''
     BlockLevelFormatFlag: false
-  - FilePath:        '/home/tcs2/Manju/cuda-samples/Common/helper_cuda.h'
+  - FilePath:        '/home/tcs/Manjula_workspace/manju/cuda-samples/Common/helper_cuda.h'
     Offset:          17099
     Length:          0
-    ReplacementText: "  /*\n  DPCT1010:8: SYCL uses exceptions to report errors and does not use the error codes. The call was replaced with 0. You need to rewrite this code.\n  */\n"
+    ReplacementText: "  /*\n  DPCT1010:7: SYCL uses exceptions to report errors and does not use the error codes. The call was replaced with 0. You need to rewrite this code.\n  */\n"
     ConstantFlag:    ''
     ConstantOffset:  0
     InitStr:         ''
     NewHostVarName:  ''
     BlockLevelFormatFlag: false
-  - FilePath:        '/home/tcs2/Manju/cuda-samples/Common/helper_cuda.h'
+  - FilePath:        '/home/tcs/Manjula_workspace/manju/cuda-samples/Common/helper_cuda.h'
     Offset:          17101
     Length:          11
     ReplacementText: 'dpct::err0'
@@ -244,7 +244,7 @@ Replacements:
     InitStr:         ''
     NewHostVarName:  ''
     BlockLevelFormatFlag: false
-  - FilePath:        '/home/tcs2/Manju/cuda-samples/Common/helper_cuda.h'
+  - FilePath:        '/home/tcs/Manjula_workspace/manju/cuda-samples/Common/helper_cuda.h'
     Offset:          17119
     Length:          18
     ReplacementText: '0'
@@ -253,7 +253,7 @@ Replacements:
     InitStr:         ''
     NewHostVarName:  ''
     BlockLevelFormatFlag: false
-  - FilePath:        '/home/tcs2/Manju/cuda-samples/Common/helper_cuda.h'
+  - FilePath:        '/home/tcs/Manjula_workspace/manju/cuda-samples/Common/helper_cuda.h'
     Offset:          17142
     Length:          235
     ReplacementText: ''
@@ -262,25 +262,25 @@ Replacements:
     InitStr:         ''
     NewHostVarName:  ''
     BlockLevelFormatFlag: false
-  - FilePath:        '/home/tcs2/Manju/cuda-samples/Common/helper_cuda.h'
+  - FilePath:        '/home/tcs/Manjula_workspace/manju/cuda-samples/Common/helper_cuda.h'
     Offset:          17829
     Length:          0
-    ReplacementText: ' dpct_type_148198'
+    ReplacementText: ' dpct_type_146989'
     ConstantFlag:    ''
     ConstantOffset:  0
     InitStr:         ''
     NewHostVarName:  ''
     BlockLevelFormatFlag: false
-  - FilePath:        '/home/tcs2/Manju/cuda-samples/Common/helper_cuda.h'
+  - FilePath:        '/home/tcs/Manjula_workspace/manju/cuda-samples/Common/helper_cuda.h'
     Offset:          19036
     Length:          0
-    ReplacementText: ' dpct_type_135042'
+    ReplacementText: ' dpct_type_101439'
     ConstantFlag:    ''
     ConstantOffset:  0
     InitStr:         ''
     NewHostVarName:  ''
     BlockLevelFormatFlag: false
-  - FilePath:        '/home/tcs2/Manju/cuda-samples/Common/helper_cuda.h'
+  - FilePath:        '/home/tcs/Manjula_workspace/manju/cuda-samples/Common/helper_cuda.h'
     Offset:          20194
     Length:          18
     ReplacementText: __DPCT_HPP__
@@ -289,16 +289,16 @@ Replacements:
     InitStr:         ''
     NewHostVarName:  ''
     BlockLevelFormatFlag: false
-  - FilePath:        '/home/tcs2/Manju/cuda-samples/Common/helper_cuda.h'
+  - FilePath:        '/home/tcs/Manjula_workspace/manju/cuda-samples/Common/helper_cuda.h'
     Offset:          20313
     Length:          0
-    ReplacementText: "  /*\n  DPCT1003:10: Migrated API does not return error code. (*, 0) is inserted. You may need to rewrite this code.\n  */\n"
+    ReplacementText: "  /*\n  DPCT1003:9: Migrated API does not return error code. (*, 0) is inserted. You may need to rewrite this code.\n  */\n"
     ConstantFlag:    ''
     ConstantOffset:  0
     InitStr:         ''
     NewHostVarName:  ''
     BlockLevelFormatFlag: false
-  - FilePath:        '/home/tcs2/Manju/cuda-samples/Common/helper_cuda.h'
+  - FilePath:        '/home/tcs/Manjula_workspace/manju/cuda-samples/Common/helper_cuda.h'
     Offset:          20331
     Length:          33
     ReplacementText: '(device_count = dpct::dev_mgr::instance().device_count(), 0)'
@@ -307,16 +307,16 @@ Replacements:
     InitStr:         ''
     NewHostVarName:  ''
     BlockLevelFormatFlag: false
-  - FilePath:        '/home/tcs2/Manju/cuda-samples/Common/helper_cuda.h'
+  - FilePath:        '/home/tcs/Manjula_workspace/manju/cuda-samples/Common/helper_cuda.h'
     Offset:          20960
     Length:          0
-    ReplacementText: "  /*\n  DPCT1035:11: All SYCL devices can be used by the host to submit tasks. You may need to adjust this code.\n  */\n"
+    ReplacementText: "  /*\n  DPCT1035:10: All SYCL devices can be used by the host to submit tasks. You may need to adjust this code.\n  */\n"
     ConstantFlag:    ''
     ConstantOffset:  0
     InitStr:         ''
     NewHostVarName:  ''
     BlockLevelFormatFlag: false
-  - FilePath:        '/home/tcs2/Manju/cuda-samples/Common/helper_cuda.h'
+  - FilePath:        '/home/tcs/Manjula_workspace/manju/cuda-samples/Common/helper_cuda.h'
     Offset:          20978
     Length:          67
     ReplacementText: '(computeMode = 1, 0)'
@@ -325,7 +325,7 @@ Replacements:
     InitStr:         ''
     NewHostVarName:  ''
     BlockLevelFormatFlag: false
-  - FilePath:        '/home/tcs2/Manju/cuda-samples/Common/helper_cuda.h'
+  - FilePath:        '/home/tcs/Manjula_workspace/manju/cuda-samples/Common/helper_cuda.h'
     Offset:          21066
     Length:          72
     ReplacementText: '(major = dpct::dev_mgr::instance().get_device(devID).get_major_version(), 0)'
@@ -334,7 +334,7 @@ Replacements:
     InitStr:         ''
     NewHostVarName:  ''
     BlockLevelFormatFlag: false
-  - FilePath:        '/home/tcs2/Manju/cuda-samples/Common/helper_cuda.h'
+  - FilePath:        '/home/tcs/Manjula_workspace/manju/cuda-samples/Common/helper_cuda.h'
     Offset:          21159
     Length:          72
     ReplacementText: '(minor = dpct::dev_mgr::instance().get_device(devID).get_minor_version(), 0)'
@@ -343,16 +343,16 @@ Replacements:
     InitStr:         ''
     NewHostVarName:  ''
     BlockLevelFormatFlag: false
-  - FilePath:        '/home/tcs2/Manju/cuda-samples/Common/helper_cuda.h'
+  - FilePath:        '/home/tcs/Manjula_workspace/manju/cuda-samples/Common/helper_cuda.h'
     Offset:          21234
     Length:          0
-    ReplacementText: "  /*\n  DPCT1035:12: All SYCL devices can be used by the host to submit tasks. You may need to adjust this code.\n  */\n"
+    ReplacementText: "  /*\n  DPCT1035:11: All SYCL devices can be used by the host to submit tasks. You may need to adjust this code.\n  */\n"
     ConstantFlag:    ''
     ConstantOffset:  0
     InitStr:         ''
     NewHostVarName:  ''
     BlockLevelFormatFlag: false
-  - FilePath:        '/home/tcs2/Manju/cuda-samples/Common/helper_cuda.h'
+  - FilePath:        '/home/tcs/Manjula_workspace/manju/cuda-samples/Common/helper_cuda.h'
     Offset:          21255
     Length:          25
     ReplacementText: '0'
@@ -361,16 +361,16 @@ Replacements:
     InitStr:         ''
     NewHostVarName:  ''
     BlockLevelFormatFlag: false
-  - FilePath:        '/home/tcs2/Manju/cuda-samples/Common/helper_cuda.h'
+  - FilePath:        '/home/tcs/Manjula_workspace/manju/cuda-samples/Common/helper_cuda.h'
     Offset:          21573
     Length:          0
-    ReplacementText: "  /*\n  DPCT1093:13: The \"devID\" device may be not the one intended for use. Adjust the selected device if needed.\n  */\n  /*\n  DPCT1003:14: Migrated API does not return error code. (*, 0) is inserted. You may need to rewrite this code.\n  */\n"
+    ReplacementText: "  /*\n  DPCT1093:12: The \"devID\" device may be not the one intended for use. Adjust the selected device if needed.\n  */\n  /*\n  DPCT1003:13: Migrated API does not return error code. (*, 0) is inserted. You may need to rewrite this code.\n  */\n"
     ConstantFlag:    ''
     ConstantOffset:  0
     InitStr:         ''
     NewHostVarName:  ''
     BlockLevelFormatFlag: false
-  - FilePath:        '/home/tcs2/Manju/cuda-samples/Common/helper_cuda.h'
+  - FilePath:        '/home/tcs/Manjula_workspace/manju/cuda-samples/Common/helper_cuda.h'
     Offset:          21591
     Length:          13
     ReplacementText: '(dpct::select_device'
@@ -379,7 +379,7 @@ Replacements:
     InitStr:         ''
     NewHostVarName:  ''
     BlockLevelFormatFlag: false
-  - FilePath:        '/home/tcs2/Manju/cuda-samples/Common/helper_cuda.h'
+  - FilePath:        '/home/tcs/Manjula_workspace/manju/cuda-samples/Common/helper_cuda.h'
     Offset:          21611
     Length:          0
     ReplacementText: ', 0)'
@@ -388,7 +388,7 @@ Replacements:
     InitStr:         ''
     NewHostVarName:  ''
     BlockLevelFormatFlag: false
-  - FilePath:        '/home/tcs2/Manju/cuda-samples/Common/helper_cuda.h'
+  - FilePath:        '/home/tcs/Manjula_workspace/manju/cuda-samples/Common/helper_cuda.h'
     Offset:          21830
     Length:          0
     ReplacementText: ' try '
@@ -397,16 +397,16 @@ Replacements:
     InitStr:         ''
     NewHostVarName:  ''
     BlockLevelFormatFlag: false
-  - FilePath:        '/home/tcs2/Manju/cuda-samples/Common/helper_cuda.h'
+  - FilePath:        '/home/tcs/Manjula_workspace/manju/cuda-samples/Common/helper_cuda.h'
     Offset:          21995
     Length:          0
-    ReplacementText: "  /*\n  DPCT1003:15: Migrated API does not return error code. (*, 0) is inserted. You may need to rewrite this code.\n  */\n"
+    ReplacementText: "  /*\n  DPCT1003:14: Migrated API does not return error code. (*, 0) is inserted. You may need to rewrite this code.\n  */\n"
     ConstantFlag:    ''
     ConstantOffset:  0
     InitStr:         ''
     NewHostVarName:  ''
     BlockLevelFormatFlag: false
-  - FilePath:        '/home/tcs2/Manju/cuda-samples/Common/helper_cuda.h'
+  - FilePath:        '/home/tcs/Manjula_workspace/manju/cuda-samples/Common/helper_cuda.h'
     Offset:          22013
     Length:          33
     ReplacementText: '(device_count = dpct::dev_mgr::instance().device_count(), 0)'
@@ -415,16 +415,16 @@ Replacements:
     InitStr:         ''
     NewHostVarName:  ''
     BlockLevelFormatFlag: false
-  - FilePath:        '/home/tcs2/Manju/cuda-samples/Common/helper_cuda.h'
+  - FilePath:        '/home/tcs/Manjula_workspace/manju/cuda-samples/Common/helper_cuda.h'
     Offset:          22381
     Length:          0
-    ReplacementText: "    /*\n    DPCT1035:16: All SYCL devices can be used by the host to submit tasks. You may need to adjust this code.\n    */\n"
+    ReplacementText: "    /*\n    DPCT1035:15: All SYCL devices can be used by the host to submit tasks. You may need to adjust this code.\n    */\n"
     ConstantFlag:    ''
     ConstantOffset:  0
     InitStr:         ''
     NewHostVarName:  ''
     BlockLevelFormatFlag: false
-  - FilePath:        '/home/tcs2/Manju/cuda-samples/Common/helper_cuda.h'
+  - FilePath:        '/home/tcs/Manjula_workspace/manju/cuda-samples/Common/helper_cuda.h'
     Offset:          22401
     Length:          76
     ReplacementText: '(computeMode = 1, 0)'
@@ -433,7 +433,7 @@ Replacements:
     InitStr:         ''
     NewHostVarName:  ''
     BlockLevelFormatFlag: false
-  - FilePath:        '/home/tcs2/Manju/cuda-samples/Common/helper_cuda.h'
+  - FilePath:        '/home/tcs/Manjula_workspace/manju/cuda-samples/Common/helper_cuda.h'
     Offset:          22500
     Length:          81
     ReplacementText: '(major = dpct::dev_mgr::instance().get_device(current_device).get_major_version(), 0)'
@@ -442,7 +442,7 @@ Replacements:
     InitStr:         ''
     NewHostVarName:  ''
     BlockLevelFormatFlag: false
-  - FilePath:        '/home/tcs2/Manju/cuda-samples/Common/helper_cuda.h'
+  - FilePath:        '/home/tcs/Manjula_workspace/manju/cuda-samples/Common/helper_cuda.h'
     Offset:          22604
     Length:          81
     ReplacementText: '(minor = dpct::dev_mgr::instance().get_device(current_device).get_minor_version(), 0)'
@@ -451,16 +451,16 @@ Replacements:
     InitStr:         ''
     NewHostVarName:  ''
     BlockLevelFormatFlag: false
-  - FilePath:        '/home/tcs2/Manju/cuda-samples/Common/helper_cuda.h'
+  - FilePath:        '/home/tcs/Manjula_workspace/manju/cuda-samples/Common/helper_cuda.h'
     Offset:          22789
     Length:          0
-    ReplacementText: "    /*\n    DPCT1035:17: All SYCL devices can be used by the host to submit tasks. You may need to adjust this code.\n    */\n"
+    ReplacementText: "    /*\n    DPCT1035:16: All SYCL devices can be used by the host to submit tasks. You may need to adjust this code.\n    */\n"
     ConstantFlag:    ''
     ConstantOffset:  0
     InitStr:         ''
     NewHostVarName:  ''
     BlockLevelFormatFlag: false
-  - FilePath:        '/home/tcs2/Manju/cuda-samples/Common/helper_cuda.h'
+  - FilePath:        '/home/tcs/Manjula_workspace/manju/cuda-samples/Common/helper_cuda.h'
     Offset:          22812
     Length:          25
     ReplacementText: '0'
@@ -469,7 +469,7 @@ Replacements:
     InitStr:         ''
     NewHostVarName:  ''
     BlockLevelFormatFlag: false
-  - FilePath:        '/home/tcs2/Manju/cuda-samples/Common/helper_cuda.h'
+  - FilePath:        '/home/tcs/Manjula_workspace/manju/cuda-samples/Common/helper_cuda.h'
     Offset:          23085
     Length:          92
     ReplacementText: '(multiProcessorCount = dpct::dev_mgr::instance().get_device(current_device).get_max_compute_units(), 0)'
@@ -478,7 +478,7 @@ Replacements:
     InitStr:         ''
     NewHostVarName:  ''
     BlockLevelFormatFlag: false
-  - FilePath:        '/home/tcs2/Manju/cuda-samples/Common/helper_cuda.h'
+  - FilePath:        '/home/tcs/Manjula_workspace/manju/cuda-samples/Common/helper_cuda.h'
     Offset:          23186
     Length:          11
     ReplacementText: 'dpct::err0'
@@ -487,7 +487,7 @@ Replacements:
     InitStr:         ''
     NewHostVarName:  ''
     BlockLevelFormatFlag: false
-  - FilePath:        '/home/tcs2/Manju/cuda-samples/Common/helper_cuda.h'
+  - FilePath:        '/home/tcs/Manjula_workspace/manju/cuda-samples/Common/helper_cuda.h'
     Offset:          23207
     Length:          72
     ReplacementText: '(clockRate = dpct::dev_mgr::instance().get_device(current_device).get_max_clock_frequency(), 0)'
@@ -496,7 +496,7 @@ Replacements:
     InitStr:         ''
     NewHostVarName:  ''
     BlockLevelFormatFlag: false
-  - FilePath:        '/home/tcs2/Manju/cuda-samples/Common/helper_cuda.h'
+  - FilePath:        '/home/tcs/Manjula_workspace/manju/cuda-samples/Common/helper_cuda.h'
     Offset:          23287
     Length:          473
     ReplacementText: ''
@@ -505,7 +505,7 @@ Replacements:
     InitStr:         ''
     NewHostVarName:  ''
     BlockLevelFormatFlag: false
-  - FilePath:        '/home/tcs2/Manju/cuda-samples/Common/helper_cuda.h'
+  - FilePath:        '/home/tcs/Manjula_workspace/manju/cuda-samples/Common/helper_cuda.h'
     Offset:          24298
     Length:          0
     ReplacementText: "\ncatch (sycl::exception const &exc) {\n  std::cerr << exc.what() << \"Exception caught at file:\" << __FILE__ << \", line:\" << __LINE__ << std::endl;\n  std::exit(1);\n}"
@@ -514,16 +514,16 @@ Replacements:
     InitStr:         ''
     NewHostVarName:  ''
     BlockLevelFormatFlag: false
-  - FilePath:        '/home/tcs2/Manju/cuda-samples/Common/helper_cuda.h'
+  - FilePath:        '/home/tcs/Manjula_workspace/manju/cuda-samples/Common/helper_cuda.h'
     Offset:          24947
     Length:          0
-    ReplacementText: "    /*\n    DPCT1093:18: The \"devID\" device may be not the one intended for use. Adjust the selected device if needed.\n    */\n    /*\n    DPCT1003:19: Migrated API does not return error code. (*, 0) is inserted. You may need to rewrite this code.\n    */\n"
+    ReplacementText: "    /*\n    DPCT1093:17: The \"devID\" device may be not the one intended for use. Adjust the selected device if needed.\n    */\n    /*\n    DPCT1003:18: Migrated API does not return error code. (*, 0) is inserted. You may need to rewrite this code.\n    */\n"
     ConstantFlag:    ''
     ConstantOffset:  0
     InitStr:         ''
     NewHostVarName:  ''
     BlockLevelFormatFlag: false
-  - FilePath:        '/home/tcs2/Manju/cuda-samples/Common/helper_cuda.h'
+  - FilePath:        '/home/tcs/Manjula_workspace/manju/cuda-samples/Common/helper_cuda.h'
     Offset:          24967
     Length:          13
     ReplacementText: '(dpct::select_device'
@@ -532,7 +532,7 @@ Replacements:
     InitStr:         ''
     NewHostVarName:  ''
     BlockLevelFormatFlag: false
-  - FilePath:        '/home/tcs2/Manju/cuda-samples/Common/helper_cuda.h'
+  - FilePath:        '/home/tcs/Manjula_workspace/manju/cuda-samples/Common/helper_cuda.h'
     Offset:          24987
     Length:          0
     ReplacementText: ', 0)'
@@ -541,7 +541,7 @@ Replacements:
     InitStr:         ''
     NewHostVarName:  ''
     BlockLevelFormatFlag: false
-  - FilePath:        '/home/tcs2/Manju/cuda-samples/Common/helper_cuda.h'
+  - FilePath:        '/home/tcs/Manjula_workspace/manju/cuda-samples/Common/helper_cuda.h'
     Offset:          25040
     Length:          72
     ReplacementText: '(major = dpct::dev_mgr::instance().get_device(devID).get_major_version(), 0)'
@@ -550,7 +550,7 @@ Replacements:
     InitStr:         ''
     NewHostVarName:  ''
     BlockLevelFormatFlag: false
-  - FilePath:        '/home/tcs2/Manju/cuda-samples/Common/helper_cuda.h'
+  - FilePath:        '/home/tcs/Manjula_workspace/manju/cuda-samples/Common/helper_cuda.h'
     Offset:          25135
     Length:          72
     ReplacementText: '(minor = dpct::dev_mgr::instance().get_device(devID).get_minor_version(), 0)'
@@ -559,16 +559,16 @@ Replacements:
     InitStr:         ''
     NewHostVarName:  ''
     BlockLevelFormatFlag: false
-  - FilePath:        '/home/tcs2/Manju/cuda-samples/Common/helper_cuda.h'
+  - FilePath:        '/home/tcs/Manjula_workspace/manju/cuda-samples/Common/helper_cuda.h'
     Offset:          25490
     Length:          0
-    ReplacementText: "  /*\n  DPCT1003:20: Migrated API does not return error code. (*, 0) is inserted. You may need to rewrite this code.\n  */\n"
+    ReplacementText: "  /*\n  DPCT1003:19: Migrated API does not return error code. (*, 0) is inserted. You may need to rewrite this code.\n  */\n"
     ConstantFlag:    ''
     ConstantOffset:  0
     InitStr:         ''
     NewHostVarName:  ''
     BlockLevelFormatFlag: false
-  - FilePath:        '/home/tcs2/Manju/cuda-samples/Common/helper_cuda.h'
+  - FilePath:        '/home/tcs/Manjula_workspace/manju/cuda-samples/Common/helper_cuda.h'
     Offset:          25508
     Length:          33
     ReplacementText: '(device_count = dpct::dev_mgr::instance().device_count(), 0)'
@@ -577,16 +577,16 @@ Replacements:
     InitStr:         ''
     NewHostVarName:  ''
     BlockLevelFormatFlag: false
-  - FilePath:        '/home/tcs2/Manju/cuda-samples/Common/helper_cuda.h'
+  - FilePath:        '/home/tcs/Manjula_workspace/manju/cuda-samples/Common/helper_cuda.h'
     Offset:          25806
     Length:          0
-    ReplacementText: "    /*\n    DPCT1035:21: All SYCL devices can be used by the host to submit tasks. You may need to adjust this code.\n    */\n"
+    ReplacementText: "    /*\n    DPCT1035:20: All SYCL devices can be used by the host to submit tasks. You may need to adjust this code.\n    */\n"
     ConstantFlag:    ''
     ConstantOffset:  0
     InitStr:         ''
     NewHostVarName:  ''
     BlockLevelFormatFlag: false
-  - FilePath:        '/home/tcs2/Manju/cuda-samples/Common/helper_cuda.h'
+  - FilePath:        '/home/tcs/Manjula_workspace/manju/cuda-samples/Common/helper_cuda.h'
     Offset:          25826
     Length:          76
     ReplacementText: '(computeMode = 1, 0)'
@@ -595,7 +595,7 @@ Replacements:
     InitStr:         ''
     NewHostVarName:  ''
     BlockLevelFormatFlag: false
-  - FilePath:        '/home/tcs2/Manju/cuda-samples/Common/helper_cuda.h'
+  - FilePath:        '/home/tcs/Manjula_workspace/manju/cuda-samples/Common/helper_cuda.h'
     Offset:          25925
     Length:          74
     ReplacementText: '(integrated = dpct::dev_mgr::instance().get_device(current_device).get_integrated(), 0)'
@@ -604,16 +604,16 @@ Replacements:
     InitStr:         ''
     NewHostVarName:  ''
     BlockLevelFormatFlag: false
-  - FilePath:        '/home/tcs2/Manju/cuda-samples/Common/helper_cuda.h'
+  - FilePath:        '/home/tcs/Manjula_workspace/manju/cuda-samples/Common/helper_cuda.h'
     Offset:          26119
     Length:          0
-    ReplacementText: "    /*\n    DPCT1035:22: All SYCL devices can be used by the host to submit tasks. You may need to adjust this code.\n    */\n"
+    ReplacementText: "    /*\n    DPCT1035:21: All SYCL devices can be used by the host to submit tasks. You may need to adjust this code.\n    */\n"
     ConstantFlag:    ''
     ConstantOffset:  0
     InitStr:         ''
     NewHostVarName:  ''
     BlockLevelFormatFlag: false
-  - FilePath:        '/home/tcs2/Manju/cuda-samples/Common/helper_cuda.h'
+  - FilePath:        '/home/tcs/Manjula_workspace/manju/cuda-samples/Common/helper_cuda.h'
     Offset:          26157
     Length:          25
     ReplacementText: '0'
@@ -622,16 +622,16 @@ Replacements:
     InitStr:         ''
     NewHostVarName:  ''
     BlockLevelFormatFlag: false
-  - FilePath:        '/home/tcs2/Manju/cuda-samples/Common/helper_cuda.h'
+  - FilePath:        '/home/tcs/Manjula_workspace/manju/cuda-samples/Common/helper_cuda.h'
     Offset:          26187
     Length:          0
-    ReplacementText: "      /*\n      DPCT1093:23: The \"current_device\" device may be not the one intended for use. Adjust the selected device if needed.\n      */\n      /*\n      DPCT1003:24: Migrated API does not return error code. (*, 0) is inserted. You may need to rewrite this code.\n      */\n"
+    ReplacementText: "      /*\n      DPCT1093:22: The \"current_device\" device may be not the one intended for use. Adjust the selected device if needed.\n      */\n      /*\n      DPCT1003:23: Migrated API does not return error code. (*, 0) is inserted. You may need to rewrite this code.\n      */\n"
     ConstantFlag:    ''
     ConstantOffset:  0
     InitStr:         ''
     NewHostVarName:  ''
     BlockLevelFormatFlag: false
-  - FilePath:        '/home/tcs2/Manju/cuda-samples/Common/helper_cuda.h'
+  - FilePath:        '/home/tcs/Manjula_workspace/manju/cuda-samples/Common/helper_cuda.h'
     Offset:          26209
     Length:          13
     ReplacementText: '(dpct::select_device'
@@ -640,7 +640,7 @@ Replacements:
     InitStr:         ''
     NewHostVarName:  ''
     BlockLevelFormatFlag: false
-  - FilePath:        '/home/tcs2/Manju/cuda-samples/Common/helper_cuda.h'
+  - FilePath:        '/home/tcs/Manjula_workspace/manju/cuda-samples/Common/helper_cuda.h'
     Offset:          26238
     Length:          0
     ReplacementText: ', 0)'
@@ -649,7 +649,7 @@ Replacements:
     InitStr:         ''
     NewHostVarName:  ''
     BlockLevelFormatFlag: false
-  - FilePath:        '/home/tcs2/Manju/cuda-samples/Common/helper_cuda.h'
+  - FilePath:        '/home/tcs/Manjula_workspace/manju/cuda-samples/Common/helper_cuda.h'
     Offset:          26296
     Length:          81
     ReplacementText: '(major = dpct::dev_mgr::instance().get_device(current_device).get_major_version(), 0)'
@@ -658,7 +658,7 @@ Replacements:
     InitStr:         ''
     NewHostVarName:  ''
     BlockLevelFormatFlag: false
-  - FilePath:        '/home/tcs2/Manju/cuda-samples/Common/helper_cuda.h'
+  - FilePath:        '/home/tcs/Manjula_workspace/manju/cuda-samples/Common/helper_cuda.h'
     Offset:          26402
     Length:          81
     ReplacementText: '(minor = dpct::dev_mgr::instance().get_device(current_device).get_minor_version(), 0)'
@@ -667,7 +667,7 @@ Replacements:
     InitStr:         ''
     NewHostVarName:  ''
     BlockLevelFormatFlag: false
-  - FilePath:        '/home/tcs2/Manju/cuda-samples/Common/helper_cuda.h'
+  - FilePath:        '/home/tcs/Manjula_workspace/manju/cuda-samples/Common/helper_cuda.h'
     Offset:          27117
     Length:          19
     ReplacementText: 'dev = dpct::dev_mgr::instance().current_device_id()'
@@ -676,7 +676,7 @@ Replacements:
     InitStr:         ''
     NewHostVarName:  ''
     BlockLevelFormatFlag: false
-  - FilePath:        '/home/tcs2/Manju/cuda-samples/Common/helper_cuda.h'
+  - FilePath:        '/home/tcs/Manjula_workspace/manju/cuda-samples/Common/helper_cuda.h'
     Offset:          27157
     Length:          70
     ReplacementText: '(major = dpct::dev_mgr::instance().get_device(dev).get_major_version(), 0)'
@@ -685,7 +685,7 @@ Replacements:
     InitStr:         ''
     NewHostVarName:  ''
     BlockLevelFormatFlag: false
-  - FilePath:        '/home/tcs2/Manju/cuda-samples/Common/helper_cuda.h'
+  - FilePath:        '/home/tcs/Manjula_workspace/manju/cuda-samples/Common/helper_cuda.h'
     Offset:          27248
     Length:          70
     ReplacementText: '(minor = dpct::dev_mgr::instance().get_device(dev).get_minor_version(), 0)'
@@ -695,9 +695,9 @@ Replacements:
     NewHostVarName:  ''
     BlockLevelFormatFlag: false
 MainSourceFilesDigest:
-  - MainSourceFile:  '/home/tcs2/Manju/cuda-samples/Common/helper_cuda.h'
+  - MainSourceFile:  '/home/tcs/Manjula_workspace/manju/cuda-samples/Common/helper_cuda.h'
     Digest:          b335aa967b6d80921de9d6528e1564a5
-DpctVersion:     17.0.0
+DpctVersion:     2023.1.0
 MainHelperFileName: dpct
 USMLevel:        ''
 FeatureMap:
@@ -705,166 +705,228 @@ FeatureMap:
     destroy_event:
       IsCalled:        true
       CallerSrcFiles:
-        - '/home/tcs2/Manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarloMultiGPU.cpp'
+        - '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarloMultiGPU.cpp'
+      FeatureName:     destroy_event
       SubFeatureMap:   {}
     dev_mgr:
       IsCalled:        false
+      FeatureName:     ''
       SubFeatureMap:
         dev_mgr_current_device_id:
           IsCalled:        true
           CallerSrcFiles:
-            - '/home/tcs2/Manju/cuda-samples/Common/helper_cuda.h'
+            - '/home/tcs/Manjula_workspace/manju/cuda-samples/Common/helper_cuda.h'
+          FeatureName:     'dev_mgr::current_device_id'
           SubFeatureMap:   {}
         dev_mgr_device_count:
           IsCalled:        true
           CallerSrcFiles:
-            - '/home/tcs2/Manju/cuda-samples/Common/helper_cuda.h'
-            - '/home/tcs2/Manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarloMultiGPU.cpp'
+            - '/home/tcs/Manjula_workspace/manju/cuda-samples/Common/helper_cuda.h'
+            - '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarloMultiGPU.cpp'
+          FeatureName:     'dev_mgr::device_count'
           SubFeatureMap:   {}
         dev_mgr_get_device:
           IsCalled:        true
           CallerSrcFiles:
-            - '/home/tcs2/Manju/cuda-samples/Common/helper_cuda.h'
-            - '/home/tcs2/Manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarloMultiGPU.cpp'
+            - '/home/tcs/Manjula_workspace/manju/cuda-samples/Common/helper_cuda.h'
+            - '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarloMultiGPU.cpp'
+          FeatureName:     'dev_mgr::get_device'
           SubFeatureMap:   {}
     device_ext:
       IsCalled:        false
+      FeatureName:     ''
       SubFeatureMap:
         device_ext_create_queue:
           IsCalled:        true
           CallerSrcFiles:
-            - '/home/tcs2/Manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarloMultiGPU.cpp'
+            - '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarloMultiGPU.cpp'
+          FeatureName:     'device_ext::create_queue'
           SubFeatureMap:   {}
         device_ext_destroy_queue:
           IsCalled:        true
           CallerSrcFiles:
-            - '/home/tcs2/Manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarloMultiGPU.cpp'
+            - '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarloMultiGPU.cpp'
+          FeatureName:     'device_ext::destroy_queue'
           SubFeatureMap:   {}
         device_ext_get_device_info_return_info:
           IsCalled:        true
           CallerSrcFiles:
-            - '/home/tcs2/Manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarloMultiGPU.cpp'
+            - '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarloMultiGPU.cpp'
+          FeatureName:     'device_ext::get_device_info'
           SubFeatureMap:   {}
         device_ext_get_integrated:
           IsCalled:        true
           CallerSrcFiles:
-            - '/home/tcs2/Manju/cuda-samples/Common/helper_cuda.h'
+            - '/home/tcs/Manjula_workspace/manju/cuda-samples/Common/helper_cuda.h'
+          FeatureName:     'device_ext::get_integrated'
           SubFeatureMap:   {}
         device_ext_get_major_version:
           IsCalled:        true
           CallerSrcFiles:
-            - '/home/tcs2/Manju/cuda-samples/Common/helper_cuda.h'
+            - '/home/tcs/Manjula_workspace/manju/cuda-samples/Common/helper_cuda.h'
+          FeatureName:     'device_ext::get_major_version'
           SubFeatureMap:   {}
         device_ext_get_max_clock_frequency:
           IsCalled:        true
           CallerSrcFiles:
-            - '/home/tcs2/Manju/cuda-samples/Common/helper_cuda.h'
+            - '/home/tcs/Manjula_workspace/manju/cuda-samples/Common/helper_cuda.h'
+          FeatureName:     'device_ext::get_max_clock_frequency'
           SubFeatureMap:   {}
         device_ext_get_max_compute_units:
           IsCalled:        true
           CallerSrcFiles:
-            - '/home/tcs2/Manju/cuda-samples/Common/helper_cuda.h'
+            - '/home/tcs/Manjula_workspace/manju/cuda-samples/Common/helper_cuda.h'
+          FeatureName:     'device_ext::get_max_compute_units'
           SubFeatureMap:   {}
         device_ext_get_minor_version:
           IsCalled:        true
           CallerSrcFiles:
-            - '/home/tcs2/Manju/cuda-samples/Common/helper_cuda.h'
+            - '/home/tcs/Manjula_workspace/manju/cuda-samples/Common/helper_cuda.h'
+          FeatureName:     'device_ext::get_minor_version'
           SubFeatureMap:   {}
         device_ext_queues_wait_and_throw:
           IsCalled:        true
           CallerSrcFiles:
-            - '/home/tcs2/Manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarloMultiGPU.cpp'
+            - '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarloMultiGPU.cpp'
+          FeatureName:     'device_ext::queues_wait_and_throw'
           SubFeatureMap:   {}
     device_info:
       IsCalled:        true
       CallerSrcFiles:
-        - '/home/tcs2/Manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarloMultiGPU.cpp'
+        - '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarloMultiGPU.cpp'
+      FeatureName:     device_info
       SubFeatureMap:
         device_info_get_major_version:
           IsCalled:        true
           CallerSrcFiles:
-            - '/home/tcs2/Manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarloMultiGPU.cpp'
+            - '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarloMultiGPU.cpp'
+          FeatureName:     'device_info::get_major_version'
           SubFeatureMap:   {}
         device_info_get_max_compute_units:
           IsCalled:        true
           CallerSrcFiles:
-            - '/home/tcs2/Manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarloMultiGPU.cpp'
+            - '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarloMultiGPU.cpp'
+          FeatureName:     'device_info::get_max_compute_units'
           SubFeatureMap:   {}
         device_info_get_minor_version:
           IsCalled:        true
           CallerSrcFiles:
-            - '/home/tcs2/Manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarloMultiGPU.cpp'
+            - '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarloMultiGPU.cpp'
+          FeatureName:     'device_info::get_minor_version'
           SubFeatureMap:   {}
         device_info_get_name:
           IsCalled:        true
           CallerSrcFiles:
-            - '/home/tcs2/Manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarloMultiGPU.cpp'
+            - '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarloMultiGPU.cpp'
+          FeatureName:     'device_info::get_name'
           SubFeatureMap:   {}
+    get_current_device:
+      IsCalled:        true
+      CallerSrcFiles:
+        - '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarloMultiGPU.cpp'
+      FeatureName:     get_current_device
+      SubFeatureMap:   {}
+    get_default_queue:
+      IsCalled:        true
+      CallerSrcFiles:
+        - '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarloMultiGPU.cpp'
+        - '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_kernel.cu'
+      FeatureName:     get_default_queue
+      SubFeatureMap:   {}
     select_device:
       IsCalled:        true
       CallerSrcFiles:
-        - '/home/tcs2/Manju/cuda-samples/Common/helper_cuda.h'
-        - '/home/tcs2/Manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarloMultiGPU.cpp'
+        - '/home/tcs/Manjula_workspace/manju/cuda-samples/Common/helper_cuda.h'
+        - '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarloMultiGPU.cpp'
+      FeatureName:     select_device
       SubFeatureMap:   {}
     typedef_event_ptr:
       IsCalled:        true
       CallerSrcFiles:
-        - '/home/tcs2/Manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarloMultiGPU.cpp'
+        - '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarloMultiGPU.cpp'
+      FeatureName:     typedef_event_ptr
       SubFeatureMap:   {}
     typedef_queue_ptr:
       IsCalled:        true
       CallerSrcFiles:
-        - '/home/tcs2/Manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarloMultiGPU.cpp'
-        - '/home/tcs2/Manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_common.h'
-        - '/home/tcs2/Manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_kernel.cu'
+        - '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarloMultiGPU.cpp'
+        - '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_common.h'
+        - '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_kernel.cu'
+      FeatureName:     queue_ptr
       SubFeatureMap:   {}
   memory.hpp:
+    async_dpct_memcpy:
+      IsCalled:        true
+      CallerSrcFiles:
+        - '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_kernel.cu'
+      FeatureName:     async_dpct_memcpy
+      SubFeatureMap:   {}
+    async_dpct_memcpy_2d:
+      IsCalled:        true
+      CallerSrcFiles:
+        - '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_kernel.cu'
+      FeatureName:     async_dpct_memcpy
+      SubFeatureMap:   {}
+    async_dpct_memcpy_3d:
+      IsCalled:        true
+      CallerSrcFiles:
+        - '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_kernel.cu'
+      FeatureName:     async_dpct_memcpy
+      SubFeatureMap:   {}
     dpct_memset:
       IsCalled:        true
       CallerSrcFiles:
-        - '/home/tcs2/Manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_kernel.cu'
+        - '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_kernel.cu'
+      FeatureName:     dpct_memset
       SubFeatureMap:   {}
     dpct_memset_2d:
       IsCalled:        true
       CallerSrcFiles:
-        - '/home/tcs2/Manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_kernel.cu'
+        - '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_kernel.cu'
+      FeatureName:     dpct_memset
       SubFeatureMap:   {}
     dpct_memset_3d:
       IsCalled:        true
       CallerSrcFiles:
-        - '/home/tcs2/Manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_kernel.cu'
+        - '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_kernel.cu'
+      FeatureName:     dpct_memset
       SubFeatureMap:   {}
     memcpy_direction:
       IsCalled:        true
       CallerSrcFiles:
-        - '/home/tcs2/Manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_kernel.cu'
+        - '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_kernel.cu'
+      FeatureName:     memcpy_direction
       SubFeatureMap:   {}
   rng_utils.hpp:
     create_host_rng:
       IsCalled:        true
       CallerSrcFiles:
-        - '/home/tcs2/Manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_gold.cpp'
+        - '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_gold.cpp'
+      FeatureName:     create_host_rng
       SubFeatureMap:   {}
     rng_generator_generate:
       IsCalled:        true
       CallerSrcFiles:
-        - '/home/tcs2/Manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_kernel.cu'
+        - '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_kernel.cu'
+      FeatureName:     'rng_generator::generate'
       SubFeatureMap:   {}
     typedef_host_rng_ptr:
       IsCalled:        true
       CallerSrcFiles:
-        - '/home/tcs2/Manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_gold.cpp'
+        - '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_gold.cpp'
+      FeatureName:     typedef_host_rng_ptr
       SubFeatureMap:   {}
   util.hpp:
     err_types:
       IsCalled:        true
       CallerSrcFiles:
-        - '/home/tcs2/Manju/cuda-samples/Common/helper_cuda.h'
+        - '/home/tcs/Manjula_workspace/manju/cuda-samples/Common/helper_cuda.h'
+      FeatureName:     err_types
       SubFeatureMap:   {}
 CompileTargets:  {}
 OptionMap:
   AnalysisScopePath:
-    Value:           '/home/tcs2/Manju/cuda-samples'
+    Value:           '/home/tcs/Manjula_workspace/manju/cuda-samples'
     Specified:       false
   AsyncHandler:
     Value:           'false'
@@ -873,7 +935,7 @@ OptionMap:
     Value:           'false'
     Specified:       false
   CompilationsDir:
-    Value:           '/home/tcs2/Manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU'
+    Value:           '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU'
     Specified:       true
   CtadEnabled:
     Value:           'false'

--- a/DirectProgramming/C++SYCL/MapReduce/guided_MonteCarloMultiGPU_SYCLMigration/01_dpct_output/MainSourceFiles.yaml
+++ b/DirectProgramming/C++SYCL/MapReduce/guided_MonteCarloMultiGPU_SYCLMigration/01_dpct_output/MainSourceFiles.yaml
@@ -1,7 +1,7 @@
 ---
 MainSourceFile:  MainSrcFiles_placehold
 Replacements:
-  - FilePath:        '/home/tcs2/Manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarloMultiGPU.cpp'
+  - FilePath:        '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarloMultiGPU.cpp'
     Offset:          1729
     Length:          0
     ReplacementText: "#include <sycl/sycl.hpp>\n#include <dpct/dpct.hpp>\n"
@@ -10,7 +10,7 @@ Replacements:
     InitStr:         ''
     NewHostVarName:  ''
     BlockLevelFormatFlag: false
-  - FilePath:        '/home/tcs2/Manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarloMultiGPU.cpp'
+  - FilePath:        '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarloMultiGPU.cpp'
     Offset:          1806
     Length:          26
     ReplacementText: ''
@@ -19,7 +19,7 @@ Replacements:
     InitStr:         ''
     NewHostVarName:  ''
     BlockLevelFormatFlag: false
-  - FilePath:        '/home/tcs2/Manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarloMultiGPU.cpp'
+  - FilePath:        '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarloMultiGPU.cpp'
     Offset:          2080
     Length:          0
     ReplacementText: "\n#include <chrono>\n"
@@ -28,7 +28,7 @@ Replacements:
     InitStr:         ''
     NewHostVarName:  ''
     BlockLevelFormatFlag: false
-  - FilePath:        '/home/tcs2/Manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarloMultiGPU.cpp'
+  - FilePath:        '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarloMultiGPU.cpp'
     Offset:          2697
     Length:          14
     ReplacementText: 'dpct::device_info'
@@ -37,16 +37,16 @@ Replacements:
     InitStr:         ''
     NewHostVarName:  ''
     BlockLevelFormatFlag: false
-  - FilePath:        '/home/tcs2/Manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarloMultiGPU.cpp'
+  - FilePath:        '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarloMultiGPU.cpp'
     Offset:          2724
     Length:          0
-    ReplacementText: "    /*\n    DPCT1003:49: Migrated API does not return error code. (*, 0) is inserted. You may need to rewrite this code.\n    */\n"
+    ReplacementText: "    /*\n    DPCT1003:47: Migrated API does not return error code. (*, 0) is inserted. You may need to rewrite this code.\n    */\n"
     ConstantFlag:    ''
     ConstantOffset:  0
     InitStr:         ''
     NewHostVarName:  ''
     BlockLevelFormatFlag: false
-  - FilePath:        '/home/tcs2/Manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarloMultiGPU.cpp'
+  - FilePath:        '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarloMultiGPU.cpp'
     Offset:          2744
     Length:          23
     ReplacementText: '(dpct::dev_mgr::instance().get_device'
@@ -55,7 +55,7 @@ Replacements:
     InitStr:         ''
     NewHostVarName:  ''
     BlockLevelFormatFlag: false
-  - FilePath:        '/home/tcs2/Manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarloMultiGPU.cpp'
+  - FilePath:        '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarloMultiGPU.cpp'
     Offset:          2768
     Length:          13
     ReplacementText: ''
@@ -64,7 +64,7 @@ Replacements:
     InitStr:         ''
     NewHostVarName:  ''
     BlockLevelFormatFlag: false
-  - FilePath:        '/home/tcs2/Manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarloMultiGPU.cpp'
+  - FilePath:        '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarloMultiGPU.cpp'
     Offset:          2783
     Length:          0
     ReplacementText: '.get_device_info(deviceProp), 0)'
@@ -73,16 +73,16 @@ Replacements:
     InitStr:         ''
     NewHostVarName:  ''
     BlockLevelFormatFlag: false
-  - FilePath:        '/home/tcs2/Manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarloMultiGPU.cpp'
+  - FilePath:        '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarloMultiGPU.cpp'
     Offset:          2786
     Length:          0
-    ReplacementText: "    /*\n    DPCT1005:50: The SYCL device version is different from CUDA Compute Compatibility. You may need to rewrite this code.\n    */\n"
+    ReplacementText: "    /*\n    DPCT1005:48: The SYCL device version is different from CUDA Compute Compatibility. You may need to rewrite this code.\n    */\n"
     ConstantFlag:    ''
     ConstantOffset:  0
     InitStr:         ''
     NewHostVarName:  ''
     BlockLevelFormatFlag: false
-  - FilePath:        '/home/tcs2/Manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarloMultiGPU.cpp'
+  - FilePath:        '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarloMultiGPU.cpp'
     Offset:          2837
     Length:          5
     ReplacementText: 'get_major_version()'
@@ -91,7 +91,7 @@ Replacements:
     InitStr:         ''
     NewHostVarName:  ''
     BlockLevelFormatFlag: false
-  - FilePath:        '/home/tcs2/Manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarloMultiGPU.cpp'
+  - FilePath:        '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarloMultiGPU.cpp'
     Offset:          2855
     Length:          5
     ReplacementText: 'get_minor_version()'
@@ -100,7 +100,7 @@ Replacements:
     InitStr:         ''
     NewHostVarName:  ''
     BlockLevelFormatFlag: false
-  - FilePath:        '/home/tcs2/Manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarloMultiGPU.cpp'
+  - FilePath:        '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarloMultiGPU.cpp'
     Offset:          2895
     Length:          19
     ReplacementText: 'get_max_compute_units()'
@@ -109,7 +109,7 @@ Replacements:
     InitStr:         ''
     NewHostVarName:  ''
     BlockLevelFormatFlag: false
-  - FilePath:        '/home/tcs2/Manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarloMultiGPU.cpp'
+  - FilePath:        '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarloMultiGPU.cpp'
     Offset:          3107
     Length:          14
     ReplacementText: 'dpct::device_info'
@@ -118,16 +118,16 @@ Replacements:
     InitStr:         ''
     NewHostVarName:  ''
     BlockLevelFormatFlag: false
-  - FilePath:        '/home/tcs2/Manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarloMultiGPU.cpp'
+  - FilePath:        '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarloMultiGPU.cpp'
     Offset:          3134
     Length:          0
-    ReplacementText: "  /*\n  DPCT1003:51: Migrated API does not return error code. (*, 0) is inserted. You may need to rewrite this code.\n  */\n"
+    ReplacementText: "  /*\n  DPCT1003:49: Migrated API does not return error code. (*, 0) is inserted. You may need to rewrite this code.\n  */\n"
     ConstantFlag:    ''
     ConstantOffset:  0
     InitStr:         ''
     NewHostVarName:  ''
     BlockLevelFormatFlag: false
-  - FilePath:        '/home/tcs2/Manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarloMultiGPU.cpp'
+  - FilePath:        '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarloMultiGPU.cpp'
     Offset:          3152
     Length:          23
     ReplacementText: '(dpct::dev_mgr::instance().get_device'
@@ -136,7 +136,7 @@ Replacements:
     InitStr:         ''
     NewHostVarName:  ''
     BlockLevelFormatFlag: false
-  - FilePath:        '/home/tcs2/Manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarloMultiGPU.cpp'
+  - FilePath:        '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarloMultiGPU.cpp'
     Offset:          3176
     Length:          13
     ReplacementText: ''
@@ -145,7 +145,7 @@ Replacements:
     InitStr:         ''
     NewHostVarName:  ''
     BlockLevelFormatFlag: false
-  - FilePath:        '/home/tcs2/Manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarloMultiGPU.cpp'
+  - FilePath:        '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarloMultiGPU.cpp'
     Offset:          3198
     Length:          0
     ReplacementText: '.get_device_info(deviceProp), 0)'
@@ -154,7 +154,7 @@ Replacements:
     InitStr:         ''
     NewHostVarName:  ''
     BlockLevelFormatFlag: false
-  - FilePath:        '/home/tcs2/Manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarloMultiGPU.cpp'
+  - FilePath:        '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarloMultiGPU.cpp'
     Offset:          3232
     Length:          19
     ReplacementText: 'get_max_compute_units()'
@@ -163,16 +163,16 @@ Replacements:
     InitStr:         ''
     NewHostVarName:  ''
     BlockLevelFormatFlag: false
-  - FilePath:        '/home/tcs2/Manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarloMultiGPU.cpp'
+  - FilePath:        '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarloMultiGPU.cpp'
     Offset:          4088
     Length:          0
-    ReplacementText: "  /*\n  DPCT1093:52: The \"plan->device\" device may be not the one intended for use. Adjust the selected device if needed.\n  */\n  /*\n  DPCT1003:53: Migrated API does not return error code. (*, 0) is inserted. You may need to rewrite this code.\n  */\n"
+    ReplacementText: "  /*\n  DPCT1093:50: The \"plan->device\" device may be not the one intended for use. Adjust the selected device if needed.\n  */\n  /*\n  DPCT1003:51: Migrated API does not return error code. (*, 0) is inserted. You may need to rewrite this code.\n  */\n"
     ConstantFlag:    ''
     ConstantOffset:  0
     InitStr:         ''
     NewHostVarName:  ''
     BlockLevelFormatFlag: false
-  - FilePath:        '/home/tcs2/Manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarloMultiGPU.cpp'
+  - FilePath:        '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarloMultiGPU.cpp'
     Offset:          4106
     Length:          13
     ReplacementText: '(dpct::select_device'
@@ -181,7 +181,7 @@ Replacements:
     InitStr:         ''
     NewHostVarName:  ''
     BlockLevelFormatFlag: false
-  - FilePath:        '/home/tcs2/Manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarloMultiGPU.cpp'
+  - FilePath:        '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarloMultiGPU.cpp'
     Offset:          4133
     Length:          0
     ReplacementText: ', 0)'
@@ -190,7 +190,7 @@ Replacements:
     InitStr:         ''
     NewHostVarName:  ''
     BlockLevelFormatFlag: false
-  - FilePath:        '/home/tcs2/Manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarloMultiGPU.cpp'
+  - FilePath:        '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarloMultiGPU.cpp'
     Offset:          4139
     Length:          14
     ReplacementText: 'dpct::device_info'
@@ -199,16 +199,16 @@ Replacements:
     InitStr:         ''
     NewHostVarName:  ''
     BlockLevelFormatFlag: false
-  - FilePath:        '/home/tcs2/Manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarloMultiGPU.cpp'
+  - FilePath:        '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarloMultiGPU.cpp'
     Offset:          4166
     Length:          0
-    ReplacementText: "  /*\n  DPCT1003:54: Migrated API does not return error code. (*, 0) is inserted. You may need to rewrite this code.\n  */\n"
+    ReplacementText: "  /*\n  DPCT1003:52: Migrated API does not return error code. (*, 0) is inserted. You may need to rewrite this code.\n  */\n"
     ConstantFlag:    ''
     ConstantOffset:  0
     InitStr:         ''
     NewHostVarName:  ''
     BlockLevelFormatFlag: false
-  - FilePath:        '/home/tcs2/Manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarloMultiGPU.cpp'
+  - FilePath:        '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarloMultiGPU.cpp'
     Offset:          4184
     Length:          23
     ReplacementText: '(dpct::dev_mgr::instance().get_device'
@@ -217,7 +217,7 @@ Replacements:
     InitStr:         ''
     NewHostVarName:  ''
     BlockLevelFormatFlag: false
-  - FilePath:        '/home/tcs2/Manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarloMultiGPU.cpp'
+  - FilePath:        '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarloMultiGPU.cpp'
     Offset:          4208
     Length:          13
     ReplacementText: ''
@@ -226,7 +226,7 @@ Replacements:
     InitStr:         ''
     NewHostVarName:  ''
     BlockLevelFormatFlag: false
-  - FilePath:        '/home/tcs2/Manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarloMultiGPU.cpp'
+  - FilePath:        '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarloMultiGPU.cpp'
     Offset:          4234
     Length:          0
     ReplacementText: '.get_device_info(deviceProp), 0)'
@@ -235,16 +235,16 @@ Replacements:
     InitStr:         ''
     NewHostVarName:  ''
     BlockLevelFormatFlag: false
-  - FilePath:        '/home/tcs2/Manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarloMultiGPU.cpp'
+  - FilePath:        '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarloMultiGPU.cpp'
     Offset:          4457
     Length:          0
-    ReplacementText: "  /*\n  DPCT1003:55: Migrated API does not return error code. (*, 0) is inserted. You may need to rewrite this code.\n  */\n"
+    ReplacementText: "  /*\n  DPCT1003:53: Migrated API does not return error code. (*, 0) is inserted. You may need to rewrite this code.\n  */\n"
     ConstantFlag:    ''
     ConstantOffset:  0
     InitStr:         ''
     NewHostVarName:  ''
     BlockLevelFormatFlag: false
-  - FilePath:        '/home/tcs2/Manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarloMultiGPU.cpp'
+  - FilePath:        '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarloMultiGPU.cpp'
     Offset:          4475
     Length:          23
     ReplacementText: '(dpct::get_current_device().queues_wait_and_throw(), 0)'
@@ -253,7 +253,7 @@ Replacements:
     InitStr:         ''
     NewHostVarName:  ''
     BlockLevelFormatFlag: false
-  - FilePath:        '/home/tcs2/Manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarloMultiGPU.cpp'
+  - FilePath:        '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarloMultiGPU.cpp'
     Offset:          4617
     Length:          24
     ReplacementText: 'dpct::get_default_queue().wait()'
@@ -262,7 +262,7 @@ Replacements:
     InitStr:         ''
     NewHostVarName:  ''
     BlockLevelFormatFlag: false
-  - FilePath:        '/home/tcs2/Manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarloMultiGPU.cpp'
+  - FilePath:        '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarloMultiGPU.cpp'
     Offset:          4736
     Length:          4
     ReplacementText: 'get_name()'
@@ -271,7 +271,7 @@ Replacements:
     InitStr:         ''
     NewHostVarName:  ''
     BlockLevelFormatFlag: false
-  - FilePath:        '/home/tcs2/Manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarloMultiGPU.cpp'
+  - FilePath:        '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarloMultiGPU.cpp'
     Offset:          4879
     Length:          12
     ReplacementText: 'dpct::queue_ptr'
@@ -280,7 +280,7 @@ Replacements:
     InitStr:         ''
     NewHostVarName:  ''
     BlockLevelFormatFlag: false
-  - FilePath:        '/home/tcs2/Manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarloMultiGPU.cpp'
+  - FilePath:        '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarloMultiGPU.cpp'
     Offset:          4904
     Length:          12
     ReplacementText: 'dpct::queue_ptr'
@@ -289,7 +289,7 @@ Replacements:
     InitStr:         ''
     NewHostVarName:  ''
     BlockLevelFormatFlag: false
-  - FilePath:        '/home/tcs2/Manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarloMultiGPU.cpp'
+  - FilePath:        '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarloMultiGPU.cpp'
     Offset:          4942
     Length:          12
     ReplacementText: 'dpct::queue_ptr'
@@ -298,7 +298,7 @@ Replacements:
     InitStr:         ''
     NewHostVarName:  ''
     BlockLevelFormatFlag: false
-  - FilePath:        '/home/tcs2/Manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarloMultiGPU.cpp'
+  - FilePath:        '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarloMultiGPU.cpp'
     Offset:          4960
     Length:          11
     ReplacementText: 'dpct::event_ptr'
@@ -307,7 +307,7 @@ Replacements:
     InitStr:         ''
     NewHostVarName:  ''
     BlockLevelFormatFlag: false
-  - FilePath:        '/home/tcs2/Manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarloMultiGPU.cpp'
+  - FilePath:        '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarloMultiGPU.cpp'
     Offset:          4983
     Length:          11
     ReplacementText: 'dpct::event_ptr'
@@ -316,7 +316,7 @@ Replacements:
     InitStr:         ''
     NewHostVarName:  ''
     BlockLevelFormatFlag: false
-  - FilePath:        '/home/tcs2/Manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarloMultiGPU.cpp'
+  - FilePath:        '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarloMultiGPU.cpp'
     Offset:          5020
     Length:          11
     ReplacementText: 'dpct::event_ptr'
@@ -325,7 +325,7 @@ Replacements:
     InitStr:         ''
     NewHostVarName:  ''
     BlockLevelFormatFlag: false
-  - FilePath:        '/home/tcs2/Manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarloMultiGPU.cpp'
+  - FilePath:        '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarloMultiGPU.cpp'
     Offset:          5034
     Length:          0
     ReplacementText: "\n  std::chrono::time_point<std::chrono::steady_clock> events_ct1_i;"
@@ -334,16 +334,16 @@ Replacements:
     InitStr:         ''
     NewHostVarName:  ''
     BlockLevelFormatFlag: false
-  - FilePath:        '/home/tcs2/Manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarloMultiGPU.cpp'
+  - FilePath:        '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarloMultiGPU.cpp'
     Offset:          5073
     Length:          0
-    ReplacementText: "    /*\n    DPCT1093:56: The \"plan[i].device\" device may be not the one intended for use. Adjust the selected device if needed.\n    */\n    /*\n    DPCT1003:57: Migrated API does not return error code. (*, 0) is inserted. You may need to rewrite this code.\n    */\n"
+    ReplacementText: "    /*\n    DPCT1093:54: The \"plan[i].device\" device may be not the one intended for use. Adjust the selected device if needed.\n    */\n    /*\n    DPCT1003:55: Migrated API does not return error code. (*, 0) is inserted. You may need to rewrite this code.\n    */\n"
     ConstantFlag:    ''
     ConstantOffset:  0
     InitStr:         ''
     NewHostVarName:  ''
     BlockLevelFormatFlag: false
-  - FilePath:        '/home/tcs2/Manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarloMultiGPU.cpp'
+  - FilePath:        '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarloMultiGPU.cpp'
     Offset:          5093
     Length:          13
     ReplacementText: '(dpct::select_device'
@@ -352,7 +352,7 @@ Replacements:
     InitStr:         ''
     NewHostVarName:  ''
     BlockLevelFormatFlag: false
-  - FilePath:        '/home/tcs2/Manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarloMultiGPU.cpp'
+  - FilePath:        '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarloMultiGPU.cpp'
     Offset:          5122
     Length:          0
     ReplacementText: ', 0)'
@@ -361,16 +361,16 @@ Replacements:
     InitStr:         ''
     NewHostVarName:  ''
     BlockLevelFormatFlag: false
-  - FilePath:        '/home/tcs2/Manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarloMultiGPU.cpp'
+  - FilePath:        '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarloMultiGPU.cpp'
     Offset:          5125
     Length:          0
-    ReplacementText: "    /*\n    DPCT1003:58: Migrated API does not return error code. (*, 0) is inserted. You may need to rewrite this code.\n    */\n"
+    ReplacementText: "    /*\n    DPCT1003:56: Migrated API does not return error code. (*, 0) is inserted. You may need to rewrite this code.\n    */\n"
     ConstantFlag:    ''
     ConstantOffset:  0
     InitStr:         ''
     NewHostVarName:  ''
     BlockLevelFormatFlag: false
-  - FilePath:        '/home/tcs2/Manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarloMultiGPU.cpp'
+  - FilePath:        '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarloMultiGPU.cpp'
     Offset:          5145
     Length:          31
     ReplacementText: '((streams[i]) = dpct::get_current_device().create_queue(), 0)'
@@ -379,16 +379,16 @@ Replacements:
     InitStr:         ''
     NewHostVarName:  ''
     BlockLevelFormatFlag: false
-  - FilePath:        '/home/tcs2/Manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarloMultiGPU.cpp'
+  - FilePath:        '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarloMultiGPU.cpp'
     Offset:          5179
     Length:          0
-    ReplacementText: "    /*\n    DPCT1003:59: Migrated API does not return error code. (*, 0) is inserted. You may need to rewrite this code.\n    */\n"
+    ReplacementText: "    /*\n    DPCT1003:57: Migrated API does not return error code. (*, 0) is inserted. You may need to rewrite this code.\n    */\n"
     ConstantFlag:    ''
     ConstantOffset:  0
     InitStr:         ''
     NewHostVarName:  ''
     BlockLevelFormatFlag: false
-  - FilePath:        '/home/tcs2/Manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarloMultiGPU.cpp'
+  - FilePath:        '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarloMultiGPU.cpp'
     Offset:          5199
     Length:          29
     ReplacementText: '(events[i] = new sycl::event(), 0)'
@@ -397,16 +397,16 @@ Replacements:
     InitStr:         ''
     NewHostVarName:  ''
     BlockLevelFormatFlag: false
-  - FilePath:        '/home/tcs2/Manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarloMultiGPU.cpp'
+  - FilePath:        '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarloMultiGPU.cpp'
     Offset:          5504
     Length:          0
-    ReplacementText: "    /*\n    DPCT1093:60: The \"plan[i].device\" device may be not the one intended for use. Adjust the selected device if needed.\n    */\n    /*\n    DPCT1003:61: Migrated API does not return error code. (*, 0) is inserted. You may need to rewrite this code.\n    */\n"
+    ReplacementText: "    /*\n    DPCT1093:58: The \"plan[i].device\" device may be not the one intended for use. Adjust the selected device if needed.\n    */\n    /*\n    DPCT1003:59: Migrated API does not return error code. (*, 0) is inserted. You may need to rewrite this code.\n    */\n"
     ConstantFlag:    ''
     ConstantOffset:  0
     InitStr:         ''
     NewHostVarName:  ''
     BlockLevelFormatFlag: false
-  - FilePath:        '/home/tcs2/Manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarloMultiGPU.cpp'
+  - FilePath:        '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarloMultiGPU.cpp'
     Offset:          5524
     Length:          13
     ReplacementText: '(dpct::select_device'
@@ -415,7 +415,7 @@ Replacements:
     InitStr:         ''
     NewHostVarName:  ''
     BlockLevelFormatFlag: false
-  - FilePath:        '/home/tcs2/Manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarloMultiGPU.cpp'
+  - FilePath:        '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarloMultiGPU.cpp'
     Offset:          5553
     Length:          0
     ReplacementText: ', 0)'
@@ -424,7 +424,7 @@ Replacements:
     InitStr:         ''
     NewHostVarName:  ''
     BlockLevelFormatFlag: false
-  - FilePath:        '/home/tcs2/Manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarloMultiGPU.cpp'
+  - FilePath:        '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarloMultiGPU.cpp'
     Offset:          5561
     Length:          14
     ReplacementText: 'dpct::device_info'
@@ -433,16 +433,16 @@ Replacements:
     InitStr:         ''
     NewHostVarName:  ''
     BlockLevelFormatFlag: false
-  - FilePath:        '/home/tcs2/Manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarloMultiGPU.cpp'
+  - FilePath:        '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarloMultiGPU.cpp'
     Offset:          5588
     Length:          0
-    ReplacementText: "    /*\n    DPCT1003:62: Migrated API does not return error code. (*, 0) is inserted. You may need to rewrite this code.\n    */\n"
+    ReplacementText: "    /*\n    DPCT1003:60: Migrated API does not return error code. (*, 0) is inserted. You may need to rewrite this code.\n    */\n"
     ConstantFlag:    ''
     ConstantOffset:  0
     InitStr:         ''
     NewHostVarName:  ''
     BlockLevelFormatFlag: false
-  - FilePath:        '/home/tcs2/Manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarloMultiGPU.cpp'
+  - FilePath:        '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarloMultiGPU.cpp'
     Offset:          5608
     Length:          23
     ReplacementText: '(dpct::dev_mgr::instance().get_device'
@@ -451,7 +451,7 @@ Replacements:
     InitStr:         ''
     NewHostVarName:  ''
     BlockLevelFormatFlag: false
-  - FilePath:        '/home/tcs2/Manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarloMultiGPU.cpp'
+  - FilePath:        '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarloMultiGPU.cpp'
     Offset:          5632
     Length:          13
     ReplacementText: ''
@@ -460,7 +460,7 @@ Replacements:
     InitStr:         ''
     NewHostVarName:  ''
     BlockLevelFormatFlag: false
-  - FilePath:        '/home/tcs2/Manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarloMultiGPU.cpp'
+  - FilePath:        '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarloMultiGPU.cpp'
     Offset:          5660
     Length:          0
     ReplacementText: '.get_device_info(deviceProp), 0)'
@@ -469,16 +469,16 @@ Replacements:
     InitStr:         ''
     NewHostVarName:  ''
     BlockLevelFormatFlag: false
-  - FilePath:        '/home/tcs2/Manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarloMultiGPU.cpp'
+  - FilePath:        '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarloMultiGPU.cpp'
     Offset:          5825
     Length:          0
-    ReplacementText: "    /*\n    DPCT1093:63: The \"plan[i].device\" device may be not the one intended for use. Adjust the selected device if needed.\n    */\n    /*\n    DPCT1003:64: Migrated API does not return error code. (*, 0) is inserted. You may need to rewrite this code.\n    */\n"
+    ReplacementText: "    /*\n    DPCT1093:61: The \"plan[i].device\" device may be not the one intended for use. Adjust the selected device if needed.\n    */\n    /*\n    DPCT1003:62: Migrated API does not return error code. (*, 0) is inserted. You may need to rewrite this code.\n    */\n"
     ConstantFlag:    ''
     ConstantOffset:  0
     InitStr:         ''
     NewHostVarName:  ''
     BlockLevelFormatFlag: false
-  - FilePath:        '/home/tcs2/Manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarloMultiGPU.cpp'
+  - FilePath:        '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarloMultiGPU.cpp'
     Offset:          5845
     Length:          13
     ReplacementText: '(dpct::select_device'
@@ -487,7 +487,7 @@ Replacements:
     InitStr:         ''
     NewHostVarName:  ''
     BlockLevelFormatFlag: false
-  - FilePath:        '/home/tcs2/Manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarloMultiGPU.cpp'
+  - FilePath:        '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarloMultiGPU.cpp'
     Offset:          5874
     Length:          0
     ReplacementText: ', 0)'
@@ -496,16 +496,16 @@ Replacements:
     InitStr:         ''
     NewHostVarName:  ''
     BlockLevelFormatFlag: false
-  - FilePath:        '/home/tcs2/Manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarloMultiGPU.cpp'
+  - FilePath:        '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarloMultiGPU.cpp'
     Offset:          5877
     Length:          0
-    ReplacementText: "    /*\n    DPCT1003:65: Migrated API does not return error code. (*, 0) is inserted. You may need to rewrite this code.\n    */\n"
+    ReplacementText: "    /*\n    DPCT1003:63: Migrated API does not return error code. (*, 0) is inserted. You may need to rewrite this code.\n    */\n"
     ConstantFlag:    ''
     ConstantOffset:  0
     InitStr:         ''
     NewHostVarName:  ''
     BlockLevelFormatFlag: false
-  - FilePath:        '/home/tcs2/Manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarloMultiGPU.cpp'
+  - FilePath:        '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarloMultiGPU.cpp'
     Offset:          5897
     Length:          23
     ReplacementText: '(dpct::get_current_device().queues_wait_and_throw(), 0)'
@@ -514,16 +514,16 @@ Replacements:
     InitStr:         ''
     NewHostVarName:  ''
     BlockLevelFormatFlag: false
-  - FilePath:        '/home/tcs2/Manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarloMultiGPU.cpp'
+  - FilePath:        '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarloMultiGPU.cpp'
     Offset:          6045
     Length:          0
-    ReplacementText: "    /*\n    DPCT1093:66: The \"plan[i].device\" device may be not the one intended for use. Adjust the selected device if needed.\n    */\n    /*\n    DPCT1003:67: Migrated API does not return error code. (*, 0) is inserted. You may need to rewrite this code.\n    */\n"
+    ReplacementText: "    /*\n    DPCT1093:64: The \"plan[i].device\" device may be not the one intended for use. Adjust the selected device if needed.\n    */\n    /*\n    DPCT1003:65: Migrated API does not return error code. (*, 0) is inserted. You may need to rewrite this code.\n    */\n"
     ConstantFlag:    ''
     ConstantOffset:  0
     InitStr:         ''
     NewHostVarName:  ''
     BlockLevelFormatFlag: false
-  - FilePath:        '/home/tcs2/Manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarloMultiGPU.cpp'
+  - FilePath:        '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarloMultiGPU.cpp'
     Offset:          6065
     Length:          13
     ReplacementText: '(dpct::select_device'
@@ -532,7 +532,7 @@ Replacements:
     InitStr:         ''
     NewHostVarName:  ''
     BlockLevelFormatFlag: false
-  - FilePath:        '/home/tcs2/Manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarloMultiGPU.cpp'
+  - FilePath:        '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarloMultiGPU.cpp'
     Offset:          6094
     Length:          0
     ReplacementText: ', 0)'
@@ -541,16 +541,16 @@ Replacements:
     InitStr:         ''
     NewHostVarName:  ''
     BlockLevelFormatFlag: false
-  - FilePath:        '/home/tcs2/Manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarloMultiGPU.cpp'
+  - FilePath:        '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarloMultiGPU.cpp'
     Offset:          6165
     Length:          0
-    ReplacementText: "    /*\n    DPCT1012:68: Detected kernel execution time measurement pattern and generated an initial code for time measurements in SYCL. You can change the way time is measured depending on your goals.\n    */\n    /*\n    DPCT1024:69: The original code returned the error code that was further consumed by the program logic. This original code was replaced with 0. You may need to rewrite the program logic consuming the error code.\n    */\n"
+    ReplacementText: "    /*\n    DPCT1012:66: Detected kernel execution time measurement pattern and generated an initial code for time measurements in SYCL. You can change the way time is measured depending on your goals.\n    */\n    /*\n    DPCT1024:67: The original code returned the error code that was further consumed by the program logic. This original code was replaced with 0. You may need to rewrite the program logic consuming the error code.\n    */\n"
     ConstantFlag:    ''
     ConstantOffset:  0
     InitStr:         ''
     NewHostVarName:  ''
     BlockLevelFormatFlag: false
-  - FilePath:        '/home/tcs2/Manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarloMultiGPU.cpp'
+  - FilePath:        '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarloMultiGPU.cpp'
     Offset:          6169
     Length:          0
     ReplacementText: "events_ct1_i = std::chrono::steady_clock::now(); \n    "
@@ -559,7 +559,7 @@ Replacements:
     InitStr:         ''
     NewHostVarName:  ''
     BlockLevelFormatFlag: false
-  - FilePath:        '/home/tcs2/Manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarloMultiGPU.cpp'
+  - FilePath:        '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarloMultiGPU.cpp'
     Offset:          6185
     Length:          38
     ReplacementText: '(*events[i] = streams[i]->ext_oneapi_submit_barrier(), 0)'
@@ -568,16 +568,16 @@ Replacements:
     InitStr:         ''
     NewHostVarName:  ''
     BlockLevelFormatFlag: false
-  - FilePath:        '/home/tcs2/Manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarloMultiGPU.cpp'
+  - FilePath:        '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarloMultiGPU.cpp'
     Offset:          6268
     Length:          0
-    ReplacementText: "    /*\n    DPCT1093:70: The \"plan[i].device\" device may be not the one intended for use. Adjust the selected device if needed.\n    */\n    /*\n    DPCT1003:71: Migrated API does not return error code. (*, 0) is inserted. You may need to rewrite this code.\n    */\n"
+    ReplacementText: "    /*\n    DPCT1093:68: The \"plan[i].device\" device may be not the one intended for use. Adjust the selected device if needed.\n    */\n    /*\n    DPCT1003:69: Migrated API does not return error code. (*, 0) is inserted. You may need to rewrite this code.\n    */\n"
     ConstantFlag:    ''
     ConstantOffset:  0
     InitStr:         ''
     NewHostVarName:  ''
     BlockLevelFormatFlag: false
-  - FilePath:        '/home/tcs2/Manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarloMultiGPU.cpp'
+  - FilePath:        '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarloMultiGPU.cpp'
     Offset:          6288
     Length:          13
     ReplacementText: '(dpct::select_device'
@@ -586,7 +586,7 @@ Replacements:
     InitStr:         ''
     NewHostVarName:  ''
     BlockLevelFormatFlag: false
-  - FilePath:        '/home/tcs2/Manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarloMultiGPU.cpp'
+  - FilePath:        '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarloMultiGPU.cpp'
     Offset:          6317
     Length:          0
     ReplacementText: ', 0)'
@@ -595,7 +595,7 @@ Replacements:
     InitStr:         ''
     NewHostVarName:  ''
     BlockLevelFormatFlag: false
-  - FilePath:        '/home/tcs2/Manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarloMultiGPU.cpp'
+  - FilePath:        '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarloMultiGPU.cpp'
     Offset:          6324
     Length:          31
     ReplacementText: 'events[i]->wait_and_throw()'
@@ -604,16 +604,16 @@ Replacements:
     InitStr:         ''
     NewHostVarName:  ''
     BlockLevelFormatFlag: false
-  - FilePath:        '/home/tcs2/Manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarloMultiGPU.cpp'
+  - FilePath:        '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarloMultiGPU.cpp'
     Offset:          6448
     Length:          0
-    ReplacementText: "    /*\n    DPCT1093:72: The \"plan[i].device\" device may be not the one intended for use. Adjust the selected device if needed.\n    */\n    /*\n    DPCT1003:73: Migrated API does not return error code. (*, 0) is inserted. You may need to rewrite this code.\n    */\n"
+    ReplacementText: "    /*\n    DPCT1093:70: The \"plan[i].device\" device may be not the one intended for use. Adjust the selected device if needed.\n    */\n    /*\n    DPCT1003:71: Migrated API does not return error code. (*, 0) is inserted. You may need to rewrite this code.\n    */\n"
     ConstantFlag:    ''
     ConstantOffset:  0
     InitStr:         ''
     NewHostVarName:  ''
     BlockLevelFormatFlag: false
-  - FilePath:        '/home/tcs2/Manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarloMultiGPU.cpp'
+  - FilePath:        '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarloMultiGPU.cpp'
     Offset:          6468
     Length:          13
     ReplacementText: '(dpct::select_device'
@@ -622,7 +622,7 @@ Replacements:
     InitStr:         ''
     NewHostVarName:  ''
     BlockLevelFormatFlag: false
-  - FilePath:        '/home/tcs2/Manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarloMultiGPU.cpp'
+  - FilePath:        '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarloMultiGPU.cpp'
     Offset:          6497
     Length:          0
     ReplacementText: ', 0)'
@@ -631,16 +631,16 @@ Replacements:
     InitStr:         ''
     NewHostVarName:  ''
     BlockLevelFormatFlag: false
-  - FilePath:        '/home/tcs2/Manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarloMultiGPU.cpp'
+  - FilePath:        '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarloMultiGPU.cpp'
     Offset:          6534
     Length:          0
-    ReplacementText: "    /*\n    DPCT1003:74: Migrated API does not return error code. (*, 0) is inserted. You may need to rewrite this code.\n    */\n"
+    ReplacementText: "    /*\n    DPCT1003:72: Migrated API does not return error code. (*, 0) is inserted. You may need to rewrite this code.\n    */\n"
     ConstantFlag:    ''
     ConstantOffset:  0
     InitStr:         ''
     NewHostVarName:  ''
     BlockLevelFormatFlag: false
-  - FilePath:        '/home/tcs2/Manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarloMultiGPU.cpp'
+  - FilePath:        '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarloMultiGPU.cpp'
     Offset:          6554
     Length:          29
     ReplacementText: '(dpct::get_current_device().destroy_queue(streams[i]), 0)'
@@ -649,16 +649,16 @@ Replacements:
     InitStr:         ''
     NewHostVarName:  ''
     BlockLevelFormatFlag: false
-  - FilePath:        '/home/tcs2/Manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarloMultiGPU.cpp'
+  - FilePath:        '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarloMultiGPU.cpp'
     Offset:          6586
     Length:          0
-    ReplacementText: "    /*\n    DPCT1003:75: Migrated API does not return error code. (*, 0) is inserted. You may need to rewrite this code.\n    */\n"
+    ReplacementText: "    /*\n    DPCT1003:73: Migrated API does not return error code. (*, 0) is inserted. You may need to rewrite this code.\n    */\n"
     ConstantFlag:    ''
     ConstantOffset:  0
     InitStr:         ''
     NewHostVarName:  ''
     BlockLevelFormatFlag: false
-  - FilePath:        '/home/tcs2/Manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarloMultiGPU.cpp'
+  - FilePath:        '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarloMultiGPU.cpp'
     Offset:          6606
     Length:          27
     ReplacementText: '(dpct::destroy_event(events[i]), 0)'
@@ -667,16 +667,16 @@ Replacements:
     InitStr:         ''
     NewHostVarName:  ''
     BlockLevelFormatFlag: false
-  - FilePath:        '/home/tcs2/Manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarloMultiGPU.cpp'
+  - FilePath:        '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarloMultiGPU.cpp'
     Offset:          8601
     Length:          0
-    ReplacementText: "  /*\n  DPCT1003:76: Migrated API does not return error code. (*, 0) is inserted. You may need to rewrite this code.\n  */\n"
+    ReplacementText: "  /*\n  DPCT1003:74: Migrated API does not return error code. (*, 0) is inserted. You may need to rewrite this code.\n  */\n"
     ConstantFlag:    ''
     ConstantOffset:  0
     InitStr:         ''
     NewHostVarName:  ''
     BlockLevelFormatFlag: false
-  - FilePath:        '/home/tcs2/Manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarloMultiGPU.cpp'
+  - FilePath:        '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarloMultiGPU.cpp'
     Offset:          8619
     Length:          26
     ReplacementText: '(GPU_N = dpct::dev_mgr::instance().device_count(), 0)'
@@ -685,7 +685,7 @@ Replacements:
     InitStr:         ''
     NewHostVarName:  ''
     BlockLevelFormatFlag: false
-  - FilePath:        '/home/tcs2/Manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarloMultiGPU.cpp'
+  - FilePath:        '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarloMultiGPU.cpp'
     Offset:          11474
     Length:          14
     ReplacementText: 'dpct::device_info'
@@ -694,16 +694,16 @@ Replacements:
     InitStr:         ''
     NewHostVarName:  ''
     BlockLevelFormatFlag: false
-  - FilePath:        '/home/tcs2/Manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarloMultiGPU.cpp'
+  - FilePath:        '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarloMultiGPU.cpp'
     Offset:          11501
     Length:          0
-    ReplacementText: "      /*\n      DPCT1003:77: Migrated API does not return error code. (*, 0) is inserted. You may need to rewrite this code.\n      */\n"
+    ReplacementText: "      /*\n      DPCT1003:75: Migrated API does not return error code. (*, 0) is inserted. You may need to rewrite this code.\n      */\n"
     ConstantFlag:    ''
     ConstantOffset:  0
     InitStr:         ''
     NewHostVarName:  ''
     BlockLevelFormatFlag: false
-  - FilePath:        '/home/tcs2/Manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarloMultiGPU.cpp'
+  - FilePath:        '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarloMultiGPU.cpp'
     Offset:          11534
     Length:          23
     ReplacementText: '(dpct::dev_mgr::instance().get_device'
@@ -712,7 +712,7 @@ Replacements:
     InitStr:         ''
     NewHostVarName:  ''
     BlockLevelFormatFlag: false
-  - FilePath:        '/home/tcs2/Manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarloMultiGPU.cpp'
+  - FilePath:        '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarloMultiGPU.cpp'
     Offset:          11558
     Length:          13
     ReplacementText: ''
@@ -721,7 +721,7 @@ Replacements:
     InitStr:         ''
     NewHostVarName:  ''
     BlockLevelFormatFlag: false
-  - FilePath:        '/home/tcs2/Manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarloMultiGPU.cpp'
+  - FilePath:        '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarloMultiGPU.cpp'
     Offset:          11594
     Length:          0
     ReplacementText: '.get_device_info(deviceProp), 0)'
@@ -730,7 +730,7 @@ Replacements:
     InitStr:         ''
     NewHostVarName:  ''
     BlockLevelFormatFlag: false
-  - FilePath:        '/home/tcs2/Manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarloMultiGPU.cpp'
+  - FilePath:        '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarloMultiGPU.cpp'
     Offset:          11669
     Length:          4
     ReplacementText: 'get_name()'
@@ -739,7 +739,7 @@ Replacements:
     InitStr:         ''
     NewHostVarName:  ''
     BlockLevelFormatFlag: false
-  - FilePath:        '/home/tcs2/Manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarloMultiGPU.cpp'
+  - FilePath:        '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarloMultiGPU.cpp'
     Offset:          12713
     Length:          14
     ReplacementText: 'dpct::device_info'
@@ -748,16 +748,16 @@ Replacements:
     InitStr:         ''
     NewHostVarName:  ''
     BlockLevelFormatFlag: false
-  - FilePath:        '/home/tcs2/Manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarloMultiGPU.cpp'
+  - FilePath:        '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarloMultiGPU.cpp'
     Offset:          12740
     Length:          0
-    ReplacementText: "      /*\n      DPCT1003:78: Migrated API does not return error code. (*, 0) is inserted. You may need to rewrite this code.\n      */\n"
+    ReplacementText: "      /*\n      DPCT1003:76: Migrated API does not return error code. (*, 0) is inserted. You may need to rewrite this code.\n      */\n"
     ConstantFlag:    ''
     ConstantOffset:  0
     InitStr:         ''
     NewHostVarName:  ''
     BlockLevelFormatFlag: false
-  - FilePath:        '/home/tcs2/Manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarloMultiGPU.cpp'
+  - FilePath:        '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarloMultiGPU.cpp'
     Offset:          12773
     Length:          23
     ReplacementText: '(dpct::dev_mgr::instance().get_device'
@@ -766,7 +766,7 @@ Replacements:
     InitStr:         ''
     NewHostVarName:  ''
     BlockLevelFormatFlag: false
-  - FilePath:        '/home/tcs2/Manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarloMultiGPU.cpp'
+  - FilePath:        '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarloMultiGPU.cpp'
     Offset:          12797
     Length:          13
     ReplacementText: ''
@@ -775,7 +775,7 @@ Replacements:
     InitStr:         ''
     NewHostVarName:  ''
     BlockLevelFormatFlag: false
-  - FilePath:        '/home/tcs2/Manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarloMultiGPU.cpp'
+  - FilePath:        '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarloMultiGPU.cpp'
     Offset:          12833
     Length:          0
     ReplacementText: '.get_device_info(deviceProp), 0)'
@@ -784,7 +784,7 @@ Replacements:
     InitStr:         ''
     NewHostVarName:  ''
     BlockLevelFormatFlag: false
-  - FilePath:        '/home/tcs2/Manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarloMultiGPU.cpp'
+  - FilePath:        '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarloMultiGPU.cpp'
     Offset:          12908
     Length:          4
     ReplacementText: 'get_name()'
@@ -793,16 +793,16 @@ Replacements:
     InitStr:         ''
     NewHostVarName:  ''
     BlockLevelFormatFlag: false
-  - FilePath:        '/home/tcs2/Manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarloMultiGPU.cpp'
+  - FilePath:        '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarloMultiGPU.cpp'
     Offset:          14552
     Length:          0
-    ReplacementText: "    /*\n    DPCT1093:79: The \"i\" device may be not the one intended for use. Adjust the selected device if needed.\n    */\n    /*\n    DPCT1003:80: Migrated API does not return error code. (*, 0) is inserted. You may need to rewrite this code.\n    */\n"
+    ReplacementText: "    /*\n    DPCT1093:77: The \"i\" device may be not the one intended for use. Adjust the selected device if needed.\n    */\n    /*\n    DPCT1003:78: Migrated API does not return error code. (*, 0) is inserted. You may need to rewrite this code.\n    */\n"
     ConstantFlag:    ''
     ConstantOffset:  0
     InitStr:         ''
     NewHostVarName:  ''
     BlockLevelFormatFlag: false
-  - FilePath:        '/home/tcs2/Manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarloMultiGPU.cpp'
+  - FilePath:        '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarloMultiGPU.cpp'
     Offset:          14572
     Length:          13
     ReplacementText: '(dpct::select_device'
@@ -811,7 +811,7 @@ Replacements:
     InitStr:         ''
     NewHostVarName:  ''
     BlockLevelFormatFlag: false
-  - FilePath:        '/home/tcs2/Manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarloMultiGPU.cpp'
+  - FilePath:        '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarloMultiGPU.cpp'
     Offset:          14588
     Length:          0
     ReplacementText: ', 0)'
@@ -820,7 +820,7 @@ Replacements:
     InitStr:         ''
     NewHostVarName:  ''
     BlockLevelFormatFlag: false
-  - FilePath:        '/home/tcs2/Manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_gold.cpp'
+  - FilePath:        '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_gold.cpp'
     Offset:          1563
     Length:          0
     ReplacementText: "#include <sycl/sycl.hpp>\n#include <dpct/dpct.hpp>\n"
@@ -829,7 +829,7 @@ Replacements:
     InitStr:         ''
     NewHostVarName:  ''
     BlockLevelFormatFlag: false
-  - FilePath:        '/home/tcs2/Manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_gold.cpp'
+  - FilePath:        '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_gold.cpp'
     Offset:          1619
     Length:          0
     ReplacementText: "\n#include <oneapi/mkl.hpp>\n\n#include <oneapi/mkl/rng/device.hpp>\n"
@@ -838,7 +838,7 @@ Replacements:
     InitStr:         ''
     NewHostVarName:  ''
     BlockLevelFormatFlag: false
-  - FilePath:        '/home/tcs2/Manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_gold.cpp'
+  - FilePath:        '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_gold.cpp'
     Offset:          1621
     Length:          20
     ReplacementText: ''
@@ -847,7 +847,7 @@ Replacements:
     InitStr:         ''
     NewHostVarName:  ''
     BlockLevelFormatFlag: false
-  - FilePath:        '/home/tcs2/Manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_gold.cpp'
+  - FilePath:        '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_gold.cpp'
     Offset:          3933
     Length:          17
     ReplacementText: 'dpct::rng::host_rng_ptr'
@@ -856,25 +856,25 @@ Replacements:
     InitStr:         ''
     NewHostVarName:  ''
     BlockLevelFormatFlag: false
-  - FilePath:        '/home/tcs2/Manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_gold.cpp'
+  - FilePath:        '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_gold.cpp'
     Offset:          3957
     Length:          0
-    ReplacementText: "  /*\n  DPCT1003:45: Migrated API does not return error code. (*, 0) is inserted. You may need to rewrite this code.\n  */\n"
+    ReplacementText: "  /*\n  DPCT1003:25: Migrated API does not return error code. (*, 0) is inserted. You may need to rewrite this code.\n  */\n"
     ConstantFlag:    ''
     ConstantOffset:  0
     InitStr:         ''
     NewHostVarName:  ''
     BlockLevelFormatFlag: false
-  - FilePath:        '/home/tcs2/Manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_gold.cpp'
+  - FilePath:        '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_gold.cpp'
     Offset:          3975
     Length:          58
-    ReplacementText: '(gen = dpct::rng::create_host_rng(dpct::rng::random_engine_type::mcg59)'
+    ReplacementText: '(gen = dpct::rng::create_host_rng(dpct::rng::random_engine_type::philox4x32x10)'
     ConstantFlag:    ''
     ConstantOffset:  0
     InitStr:         ''
     NewHostVarName:  ''
     BlockLevelFormatFlag: false
-  - FilePath:        '/home/tcs2/Manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_gold.cpp'
+  - FilePath:        '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_gold.cpp'
     Offset:          4033
     Length:          0
     ReplacementText: ', 0)'
@@ -883,16 +883,16 @@ Replacements:
     InitStr:         ''
     NewHostVarName:  ''
     BlockLevelFormatFlag: false
-  - FilePath:        '/home/tcs2/Manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_gold.cpp'
+  - FilePath:        '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_gold.cpp'
     Offset:          4073
     Length:          0
-    ReplacementText: "  /*\n  DPCT1003:46: Migrated API does not return error code. (*, 0) is inserted. You may need to rewrite this code.\n  */\n"
+    ReplacementText: "  /*\n  DPCT1003:26: Migrated API does not return error code. (*, 0) is inserted. You may need to rewrite this code.\n  */\n"
     ConstantFlag:    ''
     ConstantOffset:  0
     InitStr:         ''
     NewHostVarName:  ''
     BlockLevelFormatFlag: false
-  - FilePath:        '/home/tcs2/Manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_gold.cpp'
+  - FilePath:        '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_gold.cpp'
     Offset:          4091
     Length:          45
     ReplacementText: '(gen->set_seed(seed)'
@@ -901,7 +901,7 @@ Replacements:
     InitStr:         ''
     NewHostVarName:  ''
     BlockLevelFormatFlag: false
-  - FilePath:        '/home/tcs2/Manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_gold.cpp'
+  - FilePath:        '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_gold.cpp'
     Offset:          4136
     Length:          0
     ReplacementText: ', 0)'
@@ -910,16 +910,16 @@ Replacements:
     InitStr:         ''
     NewHostVarName:  ''
     BlockLevelFormatFlag: false
-  - FilePath:        '/home/tcs2/Manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_gold.cpp'
+  - FilePath:        '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_gold.cpp'
     Offset:          4257
     Length:          0
-    ReplacementText: "    /*\n    DPCT1003:47: Migrated API does not return error code. (*, 0) is inserted. You may need to rewrite this code.\n    */\n"
+    ReplacementText: "    /*\n    DPCT1003:27: Migrated API does not return error code. (*, 0) is inserted. You may need to rewrite this code.\n    */\n"
     ConstantFlag:    ''
     ConstantOffset:  0
     InitStr:         ''
     NewHostVarName:  ''
     BlockLevelFormatFlag: false
-  - FilePath:        '/home/tcs2/Manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_gold.cpp'
+  - FilePath:        '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_gold.cpp'
     Offset:          4277
     Length:          51
     ReplacementText: '(gen->generate_gaussian(samples, pathN, 0.0, 1.0)'
@@ -928,7 +928,7 @@ Replacements:
     InitStr:         ''
     NewHostVarName:  ''
     BlockLevelFormatFlag: false
-  - FilePath:        '/home/tcs2/Manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_gold.cpp'
+  - FilePath:        '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_gold.cpp'
     Offset:          4328
     Length:          0
     ReplacementText: ', 0)'
@@ -937,16 +937,16 @@ Replacements:
     InitStr:         ''
     NewHostVarName:  ''
     BlockLevelFormatFlag: false
-  - FilePath:        '/home/tcs2/Manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_gold.cpp'
+  - FilePath:        '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_gold.cpp'
     Offset:          4683
     Length:          0
-    ReplacementText: "  /*\n  DPCT1003:48: Migrated API does not return error code. (*, 0) is inserted. You may need to rewrite this code.\n  */\n"
+    ReplacementText: "  /*\n  DPCT1003:28: Migrated API does not return error code. (*, 0) is inserted. You may need to rewrite this code.\n  */\n"
     ConstantFlag:    ''
     ConstantOffset:  0
     InitStr:         ''
     NewHostVarName:  ''
     BlockLevelFormatFlag: false
-  - FilePath:        '/home/tcs2/Manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_gold.cpp'
+  - FilePath:        '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_gold.cpp'
     Offset:          4701
     Length:          27
     ReplacementText: '(gen.reset()'
@@ -955,7 +955,7 @@ Replacements:
     InitStr:         ''
     NewHostVarName:  ''
     BlockLevelFormatFlag: false
-  - FilePath:        '/home/tcs2/Manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_gold.cpp'
+  - FilePath:        '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_gold.cpp'
     Offset:          4728
     Length:          0
     ReplacementText: ', 0)'
@@ -964,7 +964,7 @@ Replacements:
     InitStr:         ''
     NewHostVarName:  ''
     BlockLevelFormatFlag: false
-  - FilePath:        '/home/tcs2/Manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_kernel.cu'
+  - FilePath:        '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_kernel.cu'
     Offset:          1741
     Length:          0
     ReplacementText: "#include <sycl/sycl.hpp>\n#include <dpct/dpct.hpp>\n"
@@ -973,16 +973,7 @@ Replacements:
     InitStr:         ''
     NewHostVarName:  ''
     BlockLevelFormatFlag: false
-  - FilePath:        '/home/tcs2/Manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_kernel.cu'
-    Offset:          1780
-    Length:          32
-    ReplacementText: ''
-    ConstantFlag:    ''
-    ConstantOffset:  0
-    InitStr:         ''
-    NewHostVarName:  ''
-    BlockLevelFormatFlag: false
-  - FilePath:        '/home/tcs2/Manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_kernel.cu'
+  - FilePath:        '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_kernel.cu'
     Offset:          1813
     Length:          34
     ReplacementText: ''
@@ -991,7 +982,7 @@ Replacements:
     InitStr:         ''
     NewHostVarName:  ''
     BlockLevelFormatFlag: false
-  - FilePath:        '/home/tcs2/Manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_kernel.cu'
+  - FilePath:        '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_kernel.cu'
     Offset:          1872
     Length:          0
     ReplacementText: "\n#include <oneapi/mkl.hpp>\n\n#include <oneapi/mkl/rng/device.hpp>\n"
@@ -1000,7 +991,7 @@ Replacements:
     InitStr:         ''
     NewHostVarName:  ''
     BlockLevelFormatFlag: false
-  - FilePath:        '/home/tcs2/Manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_kernel.cu'
+  - FilePath:        '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_kernel.cu'
     Offset:          1873
     Length:          27
     ReplacementText: ''
@@ -1009,7 +1000,7 @@ Replacements:
     InitStr:         ''
     NewHostVarName:  ''
     BlockLevelFormatFlag: false
-  - FilePath:        '/home/tcs2/Manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_kernel.cu'
+  - FilePath:        '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_kernel.cu'
     Offset:          2186
     Length:          35
     ReplacementText: '#include "MonteCarlo_reduction.dp.hpp"'
@@ -1018,7 +1009,7 @@ Replacements:
     InitStr:         ''
     NewHostVarName:  ''
     BlockLevelFormatFlag: false
-  - FilePath:        '/home/tcs2/Manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_kernel.cu'
+  - FilePath:        '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_kernel.cu'
     Offset:          2221
     Length:          0
     ReplacementText: "\n#include <cmath>\n"
@@ -1027,16 +1018,16 @@ Replacements:
     InitStr:         ''
     NewHostVarName:  ''
     BlockLevelFormatFlag: false
-  - FilePath:        '/home/tcs2/Manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_kernel.cu'
+  - FilePath:        '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_kernel.cu'
     Offset:          2505
     Length:          0
-    ReplacementText: ' dpct_type_177251'
+    ReplacementText: ' dpct_type_127056'
     ConstantFlag:    ''
     ConstantOffset:  0
     InitStr:         ''
     NewHostVarName:  ''
     BlockLevelFormatFlag: false
-  - FilePath:        '/home/tcs2/Manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_kernel.cu'
+  - FilePath:        '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_kernel.cu'
     Offset:          2809
     Length:          11
     ReplacementText: ''
@@ -1045,7 +1036,7 @@ Replacements:
     InitStr:         ''
     NewHostVarName:  ''
     BlockLevelFormatFlag: false
-  - FilePath:        '/home/tcs2/Manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_kernel.cu'
+  - FilePath:        '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_kernel.cu'
     Offset:          2965
     Length:          28
     ReplacementText: 'sycl::exp(MuByT + VBySqrtT * r)'
@@ -1054,7 +1045,7 @@ Replacements:
     InitStr:         ''
     NewHostVarName:  ''
     BlockLevelFormatFlag: false
-  - FilePath:        '/home/tcs2/Manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_kernel.cu'
+  - FilePath:        '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_kernel.cu'
     Offset:          3050
     Length:          11
     ReplacementText: ''
@@ -1063,7 +1054,7 @@ Replacements:
     InitStr:         ''
     NewHostVarName:  ''
     BlockLevelFormatFlag: false
-  - FilePath:        '/home/tcs2/Manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_kernel.cu'
+  - FilePath:        '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_kernel.cu'
     Offset:          3214
     Length:          25
     ReplacementText: 'sycl::exp(MuByT + VBySqrtT * r)'
@@ -1072,16 +1063,7 @@ Replacements:
     InitStr:         ''
     NewHostVarName:  ''
     BlockLevelFormatFlag: false
-  - FilePath:        '/home/tcs2/Manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_kernel.cu'
-    Offset:          3685
-    Length:          0
-    ReplacementText: "/*\nDPCT1110:3: The total declared local variable size in device function \"MonteCarloOneBlockPerOption\" exceeds 128 bytes and may cause high register pressure. Consult with your hardware vendor to find the total register size available and adjust the code, or use smaller sub-group size to avoid high register pressure.\n*/\n"
-    ConstantFlag:    ''
-    ConstantOffset:  0
-    InitStr:         ''
-    NewHostVarName:  ''
-    BlockLevelFormatFlag: false
-  - FilePath:        '/home/tcs2/Manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_kernel.cu'
+  - FilePath:        '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_kernel.cu'
     Offset:          3692
     Length:          11
     ReplacementText: ''
@@ -1090,25 +1072,25 @@ Replacements:
     InitStr:         ''
     NewHostVarName:  ''
     BlockLevelFormatFlag: false
-  - FilePath:        '/home/tcs2/Manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_kernel.cu'
+  - FilePath:        '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_kernel.cu'
     Offset:          3737
     Length:          0
-    ReplacementText: "    /*\n    DPCT1032:26: A different random number generator is used. You may need to adjust the code.\n    */\n"
+    ReplacementText: "    /*\n    DPCT1032:29: A different random number generator is used. You may need to adjust the code.\n    */\n"
     ConstantFlag:    ''
     ConstantOffset:  0
     InitStr:         ''
     NewHostVarName:  ''
     BlockLevelFormatFlag: false
-  - FilePath:        '/home/tcs2/Manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_kernel.cu'
+  - FilePath:        '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_kernel.cu'
     Offset:          3741
     Length:          11
-    ReplacementText: 'dpct::rng::device::rng_generator<oneapi::mkl::rng::device::mcg59<1>>'
+    ReplacementText: 'dpct::rng::device::rng_generator<oneapi::mkl::rng::device::philox4x32x10<1>>'
     ConstantFlag:    ''
     ConstantOffset:  0
     InitStr:         ''
     NewHostVarName:  ''
     BlockLevelFormatFlag: false
-  - FilePath:        '/home/tcs2/Manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_kernel.cu'
+  - FilePath:        '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_kernel.cu'
     Offset:          3892
     Length:          0
     ReplacementText: ",\n    const sycl::nd_item<3> &item_ct1, real *s_SumCall, real *s_Sum2Call"
@@ -1117,7 +1099,7 @@ Replacements:
     InitStr:         ''
     NewHostVarName:  ''
     BlockLevelFormatFlag: false
-  - FilePath:        '/home/tcs2/Manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_kernel.cu'
+  - FilePath:        '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_kernel.cu'
     Offset:          3932
     Length:          16
     ReplacementText: auto
@@ -1126,7 +1108,7 @@ Replacements:
     InitStr:         ''
     NewHostVarName:  ''
     BlockLevelFormatFlag: false
-  - FilePath:        '/home/tcs2/Manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_kernel.cu'
+  - FilePath:        '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_kernel.cu'
     Offset:          3955
     Length:          23
     ReplacementText: 'item_ct1.get_group()'
@@ -1135,7 +1117,7 @@ Replacements:
     InitStr:         ''
     NewHostVarName:  ''
     BlockLevelFormatFlag: false
-  - FilePath:        '/home/tcs2/Manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_kernel.cu'
+  - FilePath:        '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_kernel.cu'
     Offset:          3982
     Length:          25
     ReplacementText: 'sycl::sub_group'
@@ -1144,7 +1126,7 @@ Replacements:
     InitStr:         ''
     NewHostVarName:  ''
     BlockLevelFormatFlag: false
-  - FilePath:        '/home/tcs2/Manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_kernel.cu'
+  - FilePath:        '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_kernel.cu'
     Offset:          4017
     Length:          28
     ReplacementText: 'item_ct1.get_sub_group()'
@@ -1153,7 +1135,7 @@ Replacements:
     InitStr:         ''
     NewHostVarName:  ''
     BlockLevelFormatFlag: false
-  - FilePath:        '/home/tcs2/Manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_kernel.cu'
+  - FilePath:        '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_kernel.cu'
     Offset:          4080
     Length:          33
     ReplacementText: ''
@@ -1162,7 +1144,7 @@ Replacements:
     InitStr:         ''
     NewHostVarName:  ''
     BlockLevelFormatFlag: false
-  - FilePath:        '/home/tcs2/Manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_kernel.cu'
+  - FilePath:        '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_kernel.cu'
     Offset:          4116
     Length:          34
     ReplacementText: ''
@@ -1171,7 +1153,7 @@ Replacements:
     InitStr:         ''
     NewHostVarName:  ''
     BlockLevelFormatFlag: false
-  - FilePath:        '/home/tcs2/Manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_kernel.cu'
+  - FilePath:        '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_kernel.cu'
     Offset:          4196
     Length:          11
     ReplacementText: 'item_ct1.get_local_id(2)'
@@ -1180,7 +1162,7 @@ Replacements:
     InitStr:         ''
     NewHostVarName:  ''
     BlockLevelFormatFlag: false
-  - FilePath:        '/home/tcs2/Manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_kernel.cu'
+  - FilePath:        '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_kernel.cu'
     Offset:          4210
     Length:          10
     ReplacementText: 'item_ct1.get_group(2)'
@@ -1189,7 +1171,7 @@ Replacements:
     InitStr:         ''
     NewHostVarName:  ''
     BlockLevelFormatFlag: false
-  - FilePath:        '/home/tcs2/Manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_kernel.cu'
+  - FilePath:        '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_kernel.cu'
     Offset:          4223
     Length:          10
     ReplacementText: 'item_ct1.get_local_range(2)'
@@ -1198,25 +1180,25 @@ Replacements:
     InitStr:         ''
     NewHostVarName:  ''
     BlockLevelFormatFlag: false
-  - FilePath:        '/home/tcs2/Manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_kernel.cu'
+  - FilePath:        '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_kernel.cu'
     Offset:          4297
     Length:          0
-    ReplacementText: "  /*\n  DPCT1032:27: A different random number generator is used. You may need to adjust the code.\n  */\n"
+    ReplacementText: "  /*\n  DPCT1032:30: A different random number generator is used. You may need to adjust the code.\n  */\n"
     ConstantFlag:    ''
     ConstantOffset:  0
     InitStr:         ''
     NewHostVarName:  ''
     BlockLevelFormatFlag: false
-  - FilePath:        '/home/tcs2/Manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_kernel.cu'
+  - FilePath:        '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_kernel.cu'
     Offset:          4299
     Length:          11
-    ReplacementText: 'dpct::rng::device::rng_generator<oneapi::mkl::rng::device::mcg59<1>>'
+    ReplacementText: 'dpct::rng::device::rng_generator<oneapi::mkl::rng::device::philox4x32x10<1>>'
     ConstantFlag:    ''
     ConstantOffset:  0
     InitStr:         ''
     NewHostVarName:  ''
     BlockLevelFormatFlag: false
-  - FilePath:        '/home/tcs2/Manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_kernel.cu'
+  - FilePath:        '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_kernel.cu'
     Offset:          4365
     Length:          10
     ReplacementText: 'item_ct1.get_group(2)'
@@ -1225,7 +1207,7 @@ Replacements:
     InitStr:         ''
     NewHostVarName:  ''
     BlockLevelFormatFlag: false
-  - FilePath:        '/home/tcs2/Manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_kernel.cu'
+  - FilePath:        '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_kernel.cu'
     Offset:          4422
     Length:          9
     ReplacementText: 'item_ct1.get_group_range(2)'
@@ -1234,7 +1216,7 @@ Replacements:
     InitStr:         ''
     NewHostVarName:  ''
     BlockLevelFormatFlag: false
-  - FilePath:        '/home/tcs2/Manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_kernel.cu'
+  - FilePath:        '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_kernel.cu'
     Offset:          4836
     Length:          11
     ReplacementText: 'item_ct1.get_local_id(2)'
@@ -1243,7 +1225,7 @@ Replacements:
     InitStr:         ''
     NewHostVarName:  ''
     BlockLevelFormatFlag: false
-  - FilePath:        '/home/tcs2/Manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_kernel.cu'
+  - FilePath:        '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_kernel.cu'
     Offset:          4871
     Length:          10
     ReplacementText: 'item_ct1.get_local_range(2)'
@@ -1252,7 +1234,7 @@ Replacements:
     InitStr:         ''
     NewHostVarName:  ''
     BlockLevelFormatFlag: false
-  - FilePath:        '/home/tcs2/Manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_kernel.cu'
+  - FilePath:        '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_kernel.cu'
     Offset:          5009
     Length:          26
     ReplacementText: 'localState.generate<oneapi::mkl::rng::device::gaussian<float>, 1>()'
@@ -1261,16 +1243,16 @@ Replacements:
     InitStr:         ''
     NewHostVarName:  ''
     BlockLevelFormatFlag: false
-  - FilePath:        '/home/tcs2/Manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_kernel.cu'
+  - FilePath:        '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_kernel.cu'
     Offset:          5385
     Length:          0
-    ReplacementText: "    /*\n    DPCT1065:4: Consider replacing sycl::nd_item::barrier() with sycl::nd_item::barrier(sycl::access::fence_space::local_space) for better performance if there is no access to global memory.\n    */\n"
+    ReplacementText: "    /*\n    DPCT1065:3: Consider replacing sycl::nd_item::barrier() with sycl::nd_item::barrier(sycl::access::fence_space::local_space) for better performance if there is no access to global memory.\n    */\n"
     ConstantFlag:    ''
     ConstantOffset:  0
     InitStr:         ''
     NewHostVarName:  ''
     BlockLevelFormatFlag: false
-  - FilePath:        '/home/tcs2/Manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_kernel.cu'
+  - FilePath:        '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_kernel.cu'
     Offset:          5389
     Length:          13
     ReplacementText: 'item_ct1.barrier()'
@@ -1279,7 +1261,7 @@ Replacements:
     InitStr:         ''
     NewHostVarName:  ''
     BlockLevelFormatFlag: false
-  - FilePath:        '/home/tcs2/Manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_kernel.cu'
+  - FilePath:        '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_kernel.cu'
     Offset:          5539
     Length:          0
     ReplacementText: ', item_ct1'
@@ -1288,16 +1270,16 @@ Replacements:
     InitStr:         ''
     NewHostVarName:  ''
     BlockLevelFormatFlag: false
-  - FilePath:        '/home/tcs2/Manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_kernel.cu'
+  - FilePath:        '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_kernel.cu'
     Offset:          5549
     Length:          0
-    ReplacementText: "/*\nDPCT1032:28: A different random number generator is used. You may need to adjust the code.\n*/\n"
+    ReplacementText: "/*\nDPCT1032:31: A different random number generator is used. You may need to adjust the code.\n*/\n"
     ConstantFlag:    ''
     ConstantOffset:  0
     InitStr:         ''
     NewHostVarName:  ''
     BlockLevelFormatFlag: false
-  - FilePath:        '/home/tcs2/Manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_kernel.cu'
+  - FilePath:        '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_kernel.cu'
     Offset:          5556
     Length:          11
     ReplacementText: ''
@@ -1306,16 +1288,16 @@ Replacements:
     InitStr:         ''
     NewHostVarName:  ''
     BlockLevelFormatFlag: false
-  - FilePath:        '/home/tcs2/Manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_kernel.cu'
+  - FilePath:        '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_kernel.cu'
     Offset:          5587
     Length:          11
-    ReplacementText: 'dpct::rng::device::rng_generator<oneapi::mkl::rng::device::mcg59<1>>'
+    ReplacementText: 'dpct::rng::device::rng_generator<oneapi::mkl::rng::device::philox4x32x10<1>>'
     ConstantFlag:    ''
     ConstantOffset:  0
     InitStr:         ''
     NewHostVarName:  ''
     BlockLevelFormatFlag: false
-  - FilePath:        '/home/tcs2/Manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_kernel.cu'
+  - FilePath:        '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_kernel.cu'
     Offset:          5623
     Length:          0
     ReplacementText: ",\n                           const sycl::nd_item<3> &item_ct1"
@@ -1324,7 +1306,7 @@ Replacements:
     InitStr:         ''
     NewHostVarName:  ''
     BlockLevelFormatFlag: false
-  - FilePath:        '/home/tcs2/Manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_kernel.cu'
+  - FilePath:        '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_kernel.cu'
     Offset:          5671
     Length:          11
     ReplacementText: 'item_ct1.get_local_id(2)'
@@ -1333,7 +1315,7 @@ Replacements:
     InitStr:         ''
     NewHostVarName:  ''
     BlockLevelFormatFlag: false
-  - FilePath:        '/home/tcs2/Manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_kernel.cu'
+  - FilePath:        '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_kernel.cu'
     Offset:          5685
     Length:          10
     ReplacementText: 'item_ct1.get_group(2)'
@@ -1342,7 +1324,7 @@ Replacements:
     InitStr:         ''
     NewHostVarName:  ''
     BlockLevelFormatFlag: false
-  - FilePath:        '/home/tcs2/Manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_kernel.cu'
+  - FilePath:        '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_kernel.cu'
     Offset:          5698
     Length:          10
     ReplacementText: 'item_ct1.get_local_range(2)'
@@ -1351,34 +1333,25 @@ Replacements:
     InitStr:         ''
     NewHostVarName:  ''
     BlockLevelFormatFlag: false
-  - FilePath:        '/home/tcs2/Manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_kernel.cu'
-    Offset:          5818
-    Length:          0
-    ReplacementText: "  /*\n  DPCT1105:29: The mcg59 random number generator is used. The subsequence argument \"item_ct1.get_local_id(2)\" is ignored. You need to verify the migration.\n  */\n"
-    ConstantFlag:    ''
-    ConstantOffset:  0
-    InitStr:         ''
-    NewHostVarName:  ''
-    BlockLevelFormatFlag: false
-  - FilePath:        '/home/tcs2/Manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_kernel.cu'
+  - FilePath:        '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_kernel.cu'
     Offset:          5820
     Length:          93
-    ReplacementText: 'rngState[tid] = dpct::rng::device::rng_generator<oneapi::mkl::rng::device::mcg59<1>>(item_ct1.get_group(2) + item_ct1.get_group_range(2) * device_id, 0)'
+    ReplacementText: 'rngState[tid] = dpct::rng::device::rng_generator<oneapi::mkl::rng::device::philox4x32x10<1>>(item_ct1.get_group(2) + item_ct1.get_group_range(2) * device_id, {0, static_cast<std::uint64_t>((item_ct1.get_local_id(2)) * 8)})'
     ConstantFlag:    ''
     ConstantOffset:  0
     InitStr:         ''
     NewHostVarName:  ''
     BlockLevelFormatFlag: false
-  - FilePath:        '/home/tcs2/Manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_kernel.cu'
+  - FilePath:        '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_kernel.cu'
     Offset:          6178
     Length:          0
-    ReplacementText: "  /*\n  DPCT1003:30: Migrated API does not return error code. (*, 0) is inserted. You may need to rewrite this code.\n  */\n"
+    ReplacementText: "  /*\n  DPCT1003:32: Migrated API does not return error code. (*, 0) is inserted. You may need to rewrite this code.\n  */\n"
     ConstantFlag:    ''
     ConstantOffset:  0
     InitStr:         ''
     NewHostVarName:  ''
     BlockLevelFormatFlag: false
-  - FilePath:        '/home/tcs2/Manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_kernel.cu'
+  - FilePath:        '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_kernel.cu'
     Offset:          6196
     Length:          105
     ReplacementText: '(plan->d_OptionData = (void *)sycl::malloc_device(sizeof(__TOptionData) * (plan->optionCount), dpct::get_default_queue()), 0)'
@@ -1387,16 +1360,16 @@ Replacements:
     InitStr:         ''
     NewHostVarName:  ''
     BlockLevelFormatFlag: false
-  - FilePath:        '/home/tcs2/Manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_kernel.cu'
+  - FilePath:        '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_kernel.cu'
     Offset:          6304
     Length:          0
-    ReplacementText: "  /*\n  DPCT1003:31: Migrated API does not return error code. (*, 0) is inserted. You may need to rewrite this code.\n  */\n"
+    ReplacementText: "  /*\n  DPCT1003:33: Migrated API does not return error code. (*, 0) is inserted. You may need to rewrite this code.\n  */\n"
     ConstantFlag:    ''
     ConstantOffset:  0
     InitStr:         ''
     NewHostVarName:  ''
     BlockLevelFormatFlag: false
-  - FilePath:        '/home/tcs2/Manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_kernel.cu'
+  - FilePath:        '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_kernel.cu'
     Offset:          6322
     Length:          105
     ReplacementText: '(plan->d_CallValue = (void *)sycl::malloc_device(sizeof(__TOptionValue) * (plan->optionCount), dpct::get_default_queue()), 0)'
@@ -1405,16 +1378,16 @@ Replacements:
     InitStr:         ''
     NewHostVarName:  ''
     BlockLevelFormatFlag: false
-  - FilePath:        '/home/tcs2/Manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_kernel.cu'
+  - FilePath:        '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_kernel.cu'
     Offset:          6430
     Length:          0
-    ReplacementText: "  /*\n  DPCT1003:32: Migrated API does not return error code. (*, 0) is inserted. You may need to rewrite this code.\n  */\n"
+    ReplacementText: "  /*\n  DPCT1003:34: Migrated API does not return error code. (*, 0) is inserted. You may need to rewrite this code.\n  */\n"
     ConstantFlag:    ''
     ConstantOffset:  0
     InitStr:         ''
     NewHostVarName:  ''
     BlockLevelFormatFlag: false
-  - FilePath:        '/home/tcs2/Manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_kernel.cu'
+  - FilePath:        '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_kernel.cu'
     Offset:          6448
     Length:          113
     ReplacementText: '(plan->h_OptionData = (void *)sycl::malloc_host(sizeof(__TOptionData) * (plan->optionCount), dpct::get_default_queue()), 0)'
@@ -1423,16 +1396,16 @@ Replacements:
     InitStr:         ''
     NewHostVarName:  ''
     BlockLevelFormatFlag: false
-  - FilePath:        '/home/tcs2/Manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_kernel.cu'
+  - FilePath:        '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_kernel.cu'
     Offset:          6601
     Length:          0
-    ReplacementText: "  /*\n  DPCT1003:33: Migrated API does not return error code. (*, 0) is inserted. You may need to rewrite this code.\n  */\n"
+    ReplacementText: "  /*\n  DPCT1003:35: Migrated API does not return error code. (*, 0) is inserted. You may need to rewrite this code.\n  */\n"
     ConstantFlag:    ''
     ConstantOffset:  0
     InitStr:         ''
     NewHostVarName:  ''
     BlockLevelFormatFlag: false
-  - FilePath:        '/home/tcs2/Manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_kernel.cu'
+  - FilePath:        '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_kernel.cu'
     Offset:          6619
     Length:          113
     ReplacementText: '(plan->h_CallValue = sycl::malloc_host<__TOptionValue>((plan->optionCount), dpct::get_default_queue()), 0)'
@@ -1441,26 +1414,8 @@ Replacements:
     InitStr:         ''
     NewHostVarName:  ''
     BlockLevelFormatFlag: false
-  - FilePath:        '/home/tcs2/Manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_kernel.cu'
+  - FilePath:        '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_kernel.cu'
     Offset:          6792
-    Length:          0
-    ReplacementText: "  /*\n  DPCT1003:34: Migrated API does not return error code. (*, 0) is inserted. You may need to rewrite this code.\n  */\n"
-    ConstantFlag:    ''
-    ConstantOffset:  0
-    InitStr:         ''
-    NewHostVarName:  ''
-    BlockLevelFormatFlag: false
-  - FilePath:        '/home/tcs2/Manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_kernel.cu'
-    Offset:          6810
-    Length:          115
-    ReplacementText: '(plan->rngStates = sycl::malloc_device<dpct::rng::device::rng_generator<oneapi::mkl::rng::device::mcg59<1>>>(plan->gridSize * THREAD_N, dpct::get_default_queue()), 0)'
-    ConstantFlag:    ''
-    ConstantOffset:  0
-    InitStr:         ''
-    NewHostVarName:  ''
-    BlockLevelFormatFlag: false
-  - FilePath:        '/home/tcs2/Manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_kernel.cu'
-    Offset:          6928
     Length:          0
     ReplacementText: "  /*\n  DPCT1003:36: Migrated API does not return error code. (*, 0) is inserted. You may need to rewrite this code.\n  */\n"
     ConstantFlag:    ''
@@ -1468,7 +1423,25 @@ Replacements:
     InitStr:         ''
     NewHostVarName:  ''
     BlockLevelFormatFlag: false
-  - FilePath:        '/home/tcs2/Manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_kernel.cu'
+  - FilePath:        '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_kernel.cu'
+    Offset:          6810
+    Length:          115
+    ReplacementText: '(plan->rngStates = sycl::malloc_device<dpct::rng::device::rng_generator<oneapi::mkl::rng::device::philox4x32x10<1>>>(plan->gridSize * THREAD_N, dpct::get_default_queue()), 0)'
+    ConstantFlag:    ''
+    ConstantOffset:  0
+    InitStr:         ''
+    NewHostVarName:  ''
+    BlockLevelFormatFlag: false
+  - FilePath:        '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_kernel.cu'
+    Offset:          6928
+    Length:          0
+    ReplacementText: "  /*\n  DPCT1003:38: Migrated API does not return error code. (*, 0) is inserted. You may need to rewrite this code.\n  */\n"
+    ConstantFlag:    ''
+    ConstantOffset:  0
+    InitStr:         ''
+    NewHostVarName:  ''
+    BlockLevelFormatFlag: false
+  - FilePath:        '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_kernel.cu'
     Offset:          6946
     Length:          10
     ReplacementText: '(dpct::get_default_queue().memset'
@@ -1477,25 +1450,25 @@ Replacements:
     InitStr:         ''
     NewHostVarName:  ''
     BlockLevelFormatFlag: false
-  - FilePath:        '/home/tcs2/Manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_kernel.cu'
+  - FilePath:        '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_kernel.cu'
     Offset:          6977
     Length:          0
-    ReplacementText: "                             /*\n                             DPCT1032:37: A different random number generator is used. You may need to adjust the code.\n                             */\n"
+    ReplacementText: "                             /*\n                             DPCT1032:39: A different random number generator is used. You may need to adjust the code.\n                             */\n"
     ConstantFlag:    ''
     ConstantOffset:  0
     InitStr:         ''
     NewHostVarName:  ''
     BlockLevelFormatFlag: false
-  - FilePath:        '/home/tcs2/Manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_kernel.cu'
+  - FilePath:        '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_kernel.cu'
     Offset:          7041
     Length:          11
-    ReplacementText: 'dpct::rng::device::rng_generator<oneapi::mkl::rng::device::mcg59<1>>'
+    ReplacementText: 'dpct::rng::device::rng_generator<oneapi::mkl::rng::device::philox4x32x10<1>>'
     ConstantFlag:    ''
     ConstantOffset:  0
     InitStr:         ''
     NewHostVarName:  ''
     BlockLevelFormatFlag: false
-  - FilePath:        '/home/tcs2/Manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_kernel.cu'
+  - FilePath:        '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_kernel.cu'
     Offset:          7054
     Length:          0
     ReplacementText: '.wait(), 0)'
@@ -1504,7 +1477,7 @@ Replacements:
     InitStr:         ''
     NewHostVarName:  ''
     BlockLevelFormatFlag: false
-  - FilePath:        '/home/tcs2/Manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_kernel.cu'
+  - FilePath:        '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_kernel.cu'
     Offset:          7140
     Length:          75
     ReplacementText: "dpct::get_default_queue().submit(\n    [&](sycl::handler &cgh) {\n      auto plan_rngStates_ct0 = plan->rngStates;\n      auto plan_device_ct1 = plan->device;\n\n      cgh.parallel_for(\n        sycl::nd_range<3>(sycl::range<3>(1, 1, plan->gridSize) * sycl::range<3>(1, 1, THREAD_N), sycl::range<3>(1, 1, THREAD_N)), \n        [=](sycl::nd_item<3> item_ct1) {\n          rngSetupStates(plan_rngStates_ct0, plan_device_ct1, item_ct1);\n        });\n    });"
@@ -1513,7 +1486,7 @@ Replacements:
     InitStr:         ''
     NewHostVarName:  ''
     BlockLevelFormatFlag: true
-  - FilePath:        '/home/tcs2/Manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_kernel.cu'
+  - FilePath:        '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_kernel.cu'
     Offset:          7215
     Length:          1
     ReplacementText: ''
@@ -1522,16 +1495,16 @@ Replacements:
     InitStr:         ''
     NewHostVarName:  ''
     BlockLevelFormatFlag: false
-  - FilePath:        '/home/tcs2/Manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_kernel.cu'
+  - FilePath:        '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_kernel.cu'
     Offset:          8093
     Length:          0
-    ReplacementText: "  /*\n  DPCT1003:38: Migrated API does not return error code. (*, 0) is inserted. You may need to rewrite this code.\n  */\n"
+    ReplacementText: "  /*\n  DPCT1003:40: Migrated API does not return error code. (*, 0) is inserted. You may need to rewrite this code.\n  */\n"
     ConstantFlag:    ''
     ConstantOffset:  0
     InitStr:         ''
     NewHostVarName:  ''
     BlockLevelFormatFlag: false
-  - FilePath:        '/home/tcs2/Manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_kernel.cu'
+  - FilePath:        '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_kernel.cu'
     Offset:          8111
     Length:          25
     ReplacementText: '(sycl::free(plan->rngStates, dpct::get_default_queue())'
@@ -1540,7 +1513,7 @@ Replacements:
     InitStr:         ''
     NewHostVarName:  ''
     BlockLevelFormatFlag: false
-  - FilePath:        '/home/tcs2/Manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_kernel.cu'
+  - FilePath:        '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_kernel.cu'
     Offset:          8136
     Length:          0
     ReplacementText: ', 0)'
@@ -1549,16 +1522,16 @@ Replacements:
     InitStr:         ''
     NewHostVarName:  ''
     BlockLevelFormatFlag: false
-  - FilePath:        '/home/tcs2/Manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_kernel.cu'
+  - FilePath:        '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_kernel.cu'
     Offset:          8139
     Length:          0
-    ReplacementText: "  /*\n  DPCT1003:39: Migrated API does not return error code. (*, 0) is inserted. You may need to rewrite this code.\n  */\n"
+    ReplacementText: "  /*\n  DPCT1003:41: Migrated API does not return error code. (*, 0) is inserted. You may need to rewrite this code.\n  */\n"
     ConstantFlag:    ''
     ConstantOffset:  0
     InitStr:         ''
     NewHostVarName:  ''
     BlockLevelFormatFlag: false
-  - FilePath:        '/home/tcs2/Manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_kernel.cu'
+  - FilePath:        '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_kernel.cu'
     Offset:          8157
     Length:          31
     ReplacementText: '(sycl::free(plan->h_CallValue, dpct::get_default_queue())'
@@ -1567,7 +1540,7 @@ Replacements:
     InitStr:         ''
     NewHostVarName:  ''
     BlockLevelFormatFlag: false
-  - FilePath:        '/home/tcs2/Manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_kernel.cu'
+  - FilePath:        '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_kernel.cu'
     Offset:          8188
     Length:          0
     ReplacementText: ', 0)'
@@ -1576,16 +1549,16 @@ Replacements:
     InitStr:         ''
     NewHostVarName:  ''
     BlockLevelFormatFlag: false
-  - FilePath:        '/home/tcs2/Manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_kernel.cu'
+  - FilePath:        '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_kernel.cu'
     Offset:          8191
     Length:          0
-    ReplacementText: "  /*\n  DPCT1003:40: Migrated API does not return error code. (*, 0) is inserted. You may need to rewrite this code.\n  */\n"
+    ReplacementText: "  /*\n  DPCT1003:42: Migrated API does not return error code. (*, 0) is inserted. You may need to rewrite this code.\n  */\n"
     ConstantFlag:    ''
     ConstantOffset:  0
     InitStr:         ''
     NewHostVarName:  ''
     BlockLevelFormatFlag: false
-  - FilePath:        '/home/tcs2/Manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_kernel.cu'
+  - FilePath:        '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_kernel.cu'
     Offset:          8209
     Length:          32
     ReplacementText: '(sycl::free(plan->h_OptionData, dpct::get_default_queue())'
@@ -1594,7 +1567,7 @@ Replacements:
     InitStr:         ''
     NewHostVarName:  ''
     BlockLevelFormatFlag: false
-  - FilePath:        '/home/tcs2/Manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_kernel.cu'
+  - FilePath:        '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_kernel.cu'
     Offset:          8241
     Length:          0
     ReplacementText: ', 0)'
@@ -1603,16 +1576,16 @@ Replacements:
     InitStr:         ''
     NewHostVarName:  ''
     BlockLevelFormatFlag: false
-  - FilePath:        '/home/tcs2/Manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_kernel.cu'
+  - FilePath:        '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_kernel.cu'
     Offset:          8244
     Length:          0
-    ReplacementText: "  /*\n  DPCT1003:41: Migrated API does not return error code. (*, 0) is inserted. You may need to rewrite this code.\n  */\n"
+    ReplacementText: "  /*\n  DPCT1003:43: Migrated API does not return error code. (*, 0) is inserted. You may need to rewrite this code.\n  */\n"
     ConstantFlag:    ''
     ConstantOffset:  0
     InitStr:         ''
     NewHostVarName:  ''
     BlockLevelFormatFlag: false
-  - FilePath:        '/home/tcs2/Manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_kernel.cu'
+  - FilePath:        '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_kernel.cu'
     Offset:          8262
     Length:          27
     ReplacementText: '(sycl::free(plan->d_CallValue, dpct::get_default_queue())'
@@ -1621,7 +1594,7 @@ Replacements:
     InitStr:         ''
     NewHostVarName:  ''
     BlockLevelFormatFlag: false
-  - FilePath:        '/home/tcs2/Manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_kernel.cu'
+  - FilePath:        '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_kernel.cu'
     Offset:          8289
     Length:          0
     ReplacementText: ', 0)'
@@ -1630,16 +1603,16 @@ Replacements:
     InitStr:         ''
     NewHostVarName:  ''
     BlockLevelFormatFlag: false
-  - FilePath:        '/home/tcs2/Manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_kernel.cu'
+  - FilePath:        '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_kernel.cu'
     Offset:          8292
     Length:          0
-    ReplacementText: "  /*\n  DPCT1003:42: Migrated API does not return error code. (*, 0) is inserted. You may need to rewrite this code.\n  */\n"
+    ReplacementText: "  /*\n  DPCT1003:44: Migrated API does not return error code. (*, 0) is inserted. You may need to rewrite this code.\n  */\n"
     ConstantFlag:    ''
     ConstantOffset:  0
     InitStr:         ''
     NewHostVarName:  ''
     BlockLevelFormatFlag: false
-  - FilePath:        '/home/tcs2/Manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_kernel.cu'
+  - FilePath:        '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_kernel.cu'
     Offset:          8310
     Length:          28
     ReplacementText: '(sycl::free(plan->d_OptionData, dpct::get_default_queue())'
@@ -1648,7 +1621,7 @@ Replacements:
     InitStr:         ''
     NewHostVarName:  ''
     BlockLevelFormatFlag: false
-  - FilePath:        '/home/tcs2/Manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_kernel.cu'
+  - FilePath:        '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_kernel.cu'
     Offset:          8338
     Length:          0
     ReplacementText: ', 0)'
@@ -1657,7 +1630,7 @@ Replacements:
     InitStr:         ''
     NewHostVarName:  ''
     BlockLevelFormatFlag: false
-  - FilePath:        '/home/tcs2/Manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_kernel.cu'
+  - FilePath:        '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_kernel.cu'
     Offset:          8414
     Length:          12
     ReplacementText: 'dpct::queue_ptr'
@@ -1666,16 +1639,16 @@ Replacements:
     InitStr:         ''
     NewHostVarName:  ''
     BlockLevelFormatFlag: false
-  - FilePath:        '/home/tcs2/Manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_kernel.cu'
+  - FilePath:        '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_kernel.cu'
     Offset:          9163
     Length:          0
-    ReplacementText: "  /*\n  DPCT1003:43: Migrated API does not return error code. (*, 0) is inserted. You may need to rewrite this code.\n  */\n"
+    ReplacementText: "  /*\n  DPCT1003:45: Migrated API does not return error code. (*, 0) is inserted. You may need to rewrite this code.\n  */\n"
     ConstantFlag:    ''
     ConstantOffset:  0
     InitStr:         ''
     NewHostVarName:  ''
     BlockLevelFormatFlag: false
-  - FilePath:        '/home/tcs2/Manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_kernel.cu'
+  - FilePath:        '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_kernel.cu'
     Offset:          9181
     Length:          15
     ReplacementText: '(stream->memcpy'
@@ -1684,7 +1657,7 @@ Replacements:
     InitStr:         ''
     NewHostVarName:  ''
     BlockLevelFormatFlag: false
-  - FilePath:        '/home/tcs2/Manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_kernel.cu'
+  - FilePath:        '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_kernel.cu'
     Offset:          9306
     Length:          58
     ReplacementText: ''
@@ -1693,7 +1666,7 @@ Replacements:
     InitStr:         ''
     NewHostVarName:  ''
     BlockLevelFormatFlag: false
-  - FilePath:        '/home/tcs2/Manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_kernel.cu'
+  - FilePath:        '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_kernel.cu'
     Offset:          9364
     Length:          8
     ReplacementText: ''
@@ -1702,7 +1675,7 @@ Replacements:
     InitStr:         ''
     NewHostVarName:  ''
     BlockLevelFormatFlag: false
-  - FilePath:        '/home/tcs2/Manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_kernel.cu'
+  - FilePath:        '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_kernel.cu'
     Offset:          9373
     Length:          0
     ReplacementText: ', 0)'
@@ -1711,16 +1684,16 @@ Replacements:
     InitStr:         ''
     NewHostVarName:  ''
     BlockLevelFormatFlag: false
-  - FilePath:        '/home/tcs2/Manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_kernel.cu'
+  - FilePath:        '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_kernel.cu'
     Offset:          9379
     Length:          208
-    ReplacementText: "stream->submit(\n    [&](sycl::handler &cgh) {\n      /*\n      DPCT1101:81: 'SUM_N' expression was replaced with a value. Modify the code to use the original expression, provided in comments, if it is correct.\n      */\n      sycl::local_accessor<real, 1> s_SumCall_acc_ct1(sycl::range<1>(256/*SUM_N*/), cgh);\n      /*\n      DPCT1101:82: 'SUM_N' expression was replaced with a value. Modify the code to use the original expression, provided in comments, if it is correct.\n      */\n      sycl::local_accessor<real, 1> s_Sum2Call_acc_ct1(sycl::range<1>(256/*SUM_N*/), cgh);\n\n      auto plan_rngStates_ct0 = plan->rngStates;\n      auto plan_d_OptionData_ct1 = (__TOptionData *)(plan->d_OptionData);\n      auto plan_d_CallValue_ct2 = (__TOptionValue *)(plan->d_CallValue);\n      auto plan_pathN_ct3 = plan->pathN;\n      auto plan_optionCount_ct4 = plan->optionCount;\n\n      cgh.parallel_for(\n        sycl::nd_range<3>(sycl::range<3>(1, 1, plan->gridSize) * sycl::range<3>(1, 1, THREAD_N), sycl::range<3>(1, 1, THREAD_N)), \n        [=](sycl::nd_item<3> item_ct1) [[intel::reqd_sub_group_size(32)]] {\n          MonteCarloOneBlockPerOption(plan_rngStates_ct0, plan_d_OptionData_ct1, plan_d_CallValue_ct2, plan_pathN_ct3, plan_optionCount_ct4, item_ct1, s_SumCall_acc_ct1.get_pointer(), s_Sum2Call_acc_ct1.get_pointer());\n        });\n    });"
+    ReplacementText: "stream->submit(\n    [&](sycl::handler &cgh) {\n      /*\n      DPCT1101:79: 'SUM_N' expression was replaced with a value. Modify the code to use the original expression, provided in comments, if it is correct.\n      */\n      sycl::local_accessor<real, 1> s_SumCall_acc_ct1(sycl::range<1>(256/*SUM_N*/), cgh);\n      /*\n      DPCT1101:80: 'SUM_N' expression was replaced with a value. Modify the code to use the original expression, provided in comments, if it is correct.\n      */\n      sycl::local_accessor<real, 1> s_Sum2Call_acc_ct1(sycl::range<1>(256/*SUM_N*/), cgh);\n\n      auto plan_rngStates_ct0 = plan->rngStates;\n      auto plan_d_OptionData_ct1 = (__TOptionData *)(plan->d_OptionData);\n      auto plan_d_CallValue_ct2 = (__TOptionValue *)(plan->d_CallValue);\n      auto plan_pathN_ct3 = plan->pathN;\n      auto plan_optionCount_ct4 = plan->optionCount;\n\n      cgh.parallel_for(\n        sycl::nd_range<3>(sycl::range<3>(1, 1, plan->gridSize) * sycl::range<3>(1, 1, THREAD_N), sycl::range<3>(1, 1, THREAD_N)), \n        [=](sycl::nd_item<3> item_ct1) [[intel::reqd_sub_group_size(32)]] {\n          MonteCarloOneBlockPerOption(plan_rngStates_ct0, plan_d_OptionData_ct1, plan_d_CallValue_ct2, plan_pathN_ct3, plan_optionCount_ct4, item_ct1, s_SumCall_acc_ct1.get_pointer(), s_Sum2Call_acc_ct1.get_pointer());\n        });\n    });"
     ConstantFlag:    ''
     ConstantOffset:  0
     InitStr:         ''
     NewHostVarName:  ''
     BlockLevelFormatFlag: true
-  - FilePath:        '/home/tcs2/Manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_kernel.cu'
+  - FilePath:        '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_kernel.cu'
     Offset:          9587
     Length:          1
     ReplacementText: ''
@@ -1729,16 +1702,16 @@ Replacements:
     InitStr:         ''
     NewHostVarName:  ''
     BlockLevelFormatFlag: false
-  - FilePath:        '/home/tcs2/Manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_kernel.cu'
+  - FilePath:        '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_kernel.cu'
     Offset:          9662
     Length:          0
-    ReplacementText: "  /*\n  DPCT1003:44: Migrated API does not return error code. (*, 0) is inserted. You may need to rewrite this code.\n  */\n"
+    ReplacementText: "  /*\n  DPCT1003:46: Migrated API does not return error code. (*, 0) is inserted. You may need to rewrite this code.\n  */\n"
     ConstantFlag:    ''
     ConstantOffset:  0
     InitStr:         ''
     NewHostVarName:  ''
     BlockLevelFormatFlag: false
-  - FilePath:        '/home/tcs2/Manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_kernel.cu'
+  - FilePath:        '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_kernel.cu'
     Offset:          9680
     Length:          15
     ReplacementText: '(stream->memcpy'
@@ -1747,7 +1720,7 @@ Replacements:
     InitStr:         ''
     NewHostVarName:  ''
     BlockLevelFormatFlag: false
-  - FilePath:        '/home/tcs2/Manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_kernel.cu'
+  - FilePath:        '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_kernel.cu'
     Offset:          9804
     Length:          58
     ReplacementText: ''
@@ -1756,7 +1729,7 @@ Replacements:
     InitStr:         ''
     NewHostVarName:  ''
     BlockLevelFormatFlag: false
-  - FilePath:        '/home/tcs2/Manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_kernel.cu'
+  - FilePath:        '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_kernel.cu'
     Offset:          9862
     Length:          8
     ReplacementText: ''
@@ -1765,7 +1738,7 @@ Replacements:
     InitStr:         ''
     NewHostVarName:  ''
     BlockLevelFormatFlag: false
-  - FilePath:        '/home/tcs2/Manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_kernel.cu'
+  - FilePath:        '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_kernel.cu'
     Offset:          9871
     Length:          0
     ReplacementText: ', 0)'
@@ -1775,13 +1748,13 @@ Replacements:
     NewHostVarName:  ''
     BlockLevelFormatFlag: false
 MainSourceFilesDigest:
-  - MainSourceFile:  '/home/tcs2/Manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarloMultiGPU.cpp'
+  - MainSourceFile:  '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarloMultiGPU.cpp'
     Digest:          9b6751ce6ca8975f456d2a766b2b31e9
-  - MainSourceFile:  '/home/tcs2/Manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_gold.cpp'
+  - MainSourceFile:  '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_gold.cpp'
     Digest:          159520f3d2870e5dd7ce9e3a94b71419
-  - MainSourceFile:  '/home/tcs2/Manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_kernel.cu'
+  - MainSourceFile:  '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_kernel.cu'
     Digest:          a980a50dca71a0a0651d3dc4f5a45f22
-DpctVersion:     17.0.0
+DpctVersion:     2023.1.0
 MainHelperFileName: dpct
 USMLevel:        ''
 FeatureMap:
@@ -1789,491 +1762,648 @@ FeatureMap:
     destroy_event:
       IsCalled:        true
       CallerSrcFiles:
-        - '/home/tcs2/Manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarloMultiGPU.cpp'
+        - '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarloMultiGPU.cpp'
+      FeatureName:     destroy_event
       SubFeatureMap:   {}
     dev_mgr:
       IsCalled:        true
       CallerSrcFiles:
-        - '/home/tcs2/Manju/cuda-samples/Common/helper_cuda.h'
-        - '/home/tcs2/Manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarloMultiGPU.cpp'
-        - '/home/tcs2/Manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_kernel.cu'
+        - '/home/tcs/Manjula_workspace/manju/cuda-samples/Common/helper_cuda.h'
+        - '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarloMultiGPU.cpp'
+        - '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_kernel.cu'
+      FeatureName:     dev_mgr
       SubFeatureMap:
         dev_mgr_1:
           IsCalled:        true
           CallerSrcFiles:
-            - '/home/tcs2/Manju/cuda-samples/Common/helper_cuda.h'
-            - '/home/tcs2/Manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarloMultiGPU.cpp'
-            - '/home/tcs2/Manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_kernel.cu'
+            - '/home/tcs/Manjula_workspace/manju/cuda-samples/Common/helper_cuda.h'
+            - '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarloMultiGPU.cpp'
+            - '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_gold.cpp'
+            - '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_kernel.cu'
+          FeatureName:     dev_mgr
           SubFeatureMap:   {}
         dev_mgr_2:
           IsCalled:        true
           CallerSrcFiles:
-            - '/home/tcs2/Manju/cuda-samples/Common/helper_cuda.h'
-            - '/home/tcs2/Manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarloMultiGPU.cpp'
+            - '/home/tcs/Manjula_workspace/manju/cuda-samples/Common/helper_cuda.h'
+            - '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarloMultiGPU.cpp'
+            - '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_kernel.cu'
+          FeatureName:     dev_mgr
           SubFeatureMap:   {}
         dev_mgr_3:
           IsCalled:        true
           CallerSrcFiles:
-            - '/home/tcs2/Manju/cuda-samples/Common/helper_cuda.h'
-            - '/home/tcs2/Manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarloMultiGPU.cpp'
+            - '/home/tcs/Manjula_workspace/manju/cuda-samples/Common/helper_cuda.h'
+            - '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarloMultiGPU.cpp'
+            - '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_kernel.cu'
+          FeatureName:     dev_mgr
           SubFeatureMap:   {}
         dev_mgr_4:
           IsCalled:        true
           CallerSrcFiles:
-            - '/home/tcs2/Manju/cuda-samples/Common/helper_cuda.h'
-            - '/home/tcs2/Manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarloMultiGPU.cpp'
+            - '/home/tcs/Manjula_workspace/manju/cuda-samples/Common/helper_cuda.h'
+            - '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarloMultiGPU.cpp'
+            - '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_kernel.cu'
+          FeatureName:     dev_mgr
           SubFeatureMap:   {}
         dev_mgr_check_id:
           IsCalled:        true
           CallerSrcFiles:
-            - '/home/tcs2/Manju/cuda-samples/Common/helper_cuda.h'
-            - '/home/tcs2/Manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarloMultiGPU.cpp'
-            - '/home/tcs2/Manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_kernel.cu'
+            - '/home/tcs/Manjula_workspace/manju/cuda-samples/Common/helper_cuda.h'
+            - '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarloMultiGPU.cpp'
+            - '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_gold.cpp'
+            - '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_kernel.cu'
+          FeatureName:     'dev_mgr::check_id'
           SubFeatureMap:   {}
         dev_mgr_current_device:
           IsCalled:        true
           CallerSrcFiles:
-            - '/home/tcs2/Manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_gold.cpp'
-            - '/home/tcs2/Manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_kernel.cu'
+            - '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarloMultiGPU.cpp'
+            - '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_gold.cpp'
+            - '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_kernel.cu'
+          FeatureName:     'dev_mgr::current_device'
           SubFeatureMap:   {}
         dev_mgr_current_device_id:
           IsCalled:        true
           CallerSrcFiles:
-            - '/home/tcs2/Manju/cuda-samples/Common/helper_cuda.h'
-            - '/home/tcs2/Manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_kernel.cu'
+            - '/home/tcs/Manjula_workspace/manju/cuda-samples/Common/helper_cuda.h'
+            - '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarloMultiGPU.cpp'
+            - '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_gold.cpp'
+            - '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_kernel.cu'
+          FeatureName:     'dev_mgr::current_device_id'
           SubFeatureMap:   {}
         dev_mgr_device_count:
           IsCalled:        true
           CallerSrcFiles:
-            - '/home/tcs2/Manju/cuda-samples/Common/helper_cuda.h'
-            - '/home/tcs2/Manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarloMultiGPU.cpp'
+            - '/home/tcs/Manjula_workspace/manju/cuda-samples/Common/helper_cuda.h'
+            - '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarloMultiGPU.cpp'
+          FeatureName:     'dev_mgr::device_count'
           SubFeatureMap:   {}
         dev_mgr_get_device:
           IsCalled:        true
           CallerSrcFiles:
-            - '/home/tcs2/Manju/cuda-samples/Common/helper_cuda.h'
-            - '/home/tcs2/Manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarloMultiGPU.cpp'
+            - '/home/tcs/Manjula_workspace/manju/cuda-samples/Common/helper_cuda.h'
+            - '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarloMultiGPU.cpp'
+          FeatureName:     'dev_mgr::get_device'
           SubFeatureMap:   {}
         dev_mgr_select_device:
           IsCalled:        true
           CallerSrcFiles:
-            - '/home/tcs2/Manju/cuda-samples/Common/helper_cuda.h'
-            - '/home/tcs2/Manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarloMultiGPU.cpp'
+            - '/home/tcs/Manjula_workspace/manju/cuda-samples/Common/helper_cuda.h'
+            - '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarloMultiGPU.cpp'
+          FeatureName:     'dev_mgr::select_device'
           SubFeatureMap:   {}
     device_ext:
       IsCalled:        true
       CallerSrcFiles:
-        - '/home/tcs2/Manju/cuda-samples/Common/helper_cuda.h'
-        - '/home/tcs2/Manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarloMultiGPU.cpp'
-        - '/home/tcs2/Manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_kernel.cu'
+        - '/home/tcs/Manjula_workspace/manju/cuda-samples/Common/helper_cuda.h'
+        - '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarloMultiGPU.cpp'
+        - '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_gold.cpp'
+        - '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_kernel.cu'
+      FeatureName:     device_ext
       SubFeatureMap:
         device_ext_1:
           IsCalled:        true
           CallerSrcFiles:
-            - '/home/tcs2/Manju/cuda-samples/Common/helper_cuda.h'
-            - '/home/tcs2/Manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarloMultiGPU.cpp'
+            - '/home/tcs/Manjula_workspace/manju/cuda-samples/Common/helper_cuda.h'
+            - '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarloMultiGPU.cpp'
+            - '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_kernel.cu'
+          FeatureName:     device_ext
           SubFeatureMap:   {}
         device_ext_2:
           IsCalled:        true
           CallerSrcFiles:
-            - '/home/tcs2/Manju/cuda-samples/Common/helper_cuda.h'
-            - '/home/tcs2/Manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarloMultiGPU.cpp'
-          SubFeatureMap:   {}
-        device_ext_create_inorder_queue:
-          IsCalled:        true
-          CallerSrcFiles:
-            - '/home/tcs2/Manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarloMultiGPU.cpp'
+            - '/home/tcs/Manjula_workspace/manju/cuda-samples/Common/helper_cuda.h'
+            - '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarloMultiGPU.cpp'
+            - '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_kernel.cu'
+          FeatureName:     device_ext
           SubFeatureMap:   {}
         device_ext_create_queue:
           IsCalled:        true
           CallerSrcFiles:
-            - '/home/tcs2/Manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarloMultiGPU.cpp'
+            - '/home/tcs/Manjula_workspace/manju/cuda-samples/Common/helper_cuda.h'
+            - '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarloMultiGPU.cpp'
+            - '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_kernel.cu'
+          FeatureName:     'device_ext::create_queue'
           SubFeatureMap:   {}
         device_ext_default_queue:
           IsCalled:        true
           CallerSrcFiles:
-            - '/home/tcs2/Manju/cuda-samples/Common/helper_cuda.h'
-            - '/home/tcs2/Manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarloMultiGPU.cpp'
-            - '/home/tcs2/Manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_gold.cpp'
-            - '/home/tcs2/Manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_kernel.cu'
+            - '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarloMultiGPU.cpp'
+            - '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_gold.cpp'
+            - '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_kernel.cu'
+          FeatureName:     'device_ext::default_queue'
           SubFeatureMap:   {}
         device_ext_destroy_queue:
           IsCalled:        true
           CallerSrcFiles:
-            - '/home/tcs2/Manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarloMultiGPU.cpp'
+            - '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarloMultiGPU.cpp'
+          FeatureName:     'device_ext::destroy_queue'
+          SubFeatureMap:   {}
+        device_ext_get_default_property_list_for_queue:
+          IsCalled:        true
+          CallerSrcFiles:
+            - '/home/tcs/Manjula_workspace/manju/cuda-samples/Common/helper_cuda.h'
+            - '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarloMultiGPU.cpp'
+            - '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_kernel.cu'
+          FeatureName:     device_ext_get_default_property_list_for_queue
           SubFeatureMap:   {}
         device_ext_get_device_info_return_info:
           IsCalled:        true
           CallerSrcFiles:
-            - '/home/tcs2/Manju/cuda-samples/Common/helper_cuda.h'
-            - '/home/tcs2/Manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarloMultiGPU.cpp'
+            - '/home/tcs/Manjula_workspace/manju/cuda-samples/Common/helper_cuda.h'
+            - '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarloMultiGPU.cpp'
+          FeatureName:     'device_ext::get_device_info'
           SubFeatureMap:   {}
         device_ext_get_device_info_return_void:
           IsCalled:        true
           CallerSrcFiles:
-            - '/home/tcs2/Manju/cuda-samples/Common/helper_cuda.h'
-            - '/home/tcs2/Manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarloMultiGPU.cpp'
+            - '/home/tcs/Manjula_workspace/manju/cuda-samples/Common/helper_cuda.h'
+            - '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarloMultiGPU.cpp'
+          FeatureName:     'device_ext::get_device_info'
           SubFeatureMap:   {}
         device_ext_get_integrated:
           IsCalled:        true
           CallerSrcFiles:
-            - '/home/tcs2/Manju/cuda-samples/Common/helper_cuda.h'
+            - '/home/tcs/Manjula_workspace/manju/cuda-samples/Common/helper_cuda.h'
+          FeatureName:     'device_ext::get_integrated'
           SubFeatureMap:   {}
         device_ext_get_major_version:
           IsCalled:        true
           CallerSrcFiles:
-            - '/home/tcs2/Manju/cuda-samples/Common/helper_cuda.h'
+            - '/home/tcs/Manjula_workspace/manju/cuda-samples/Common/helper_cuda.h'
+          FeatureName:     'device_ext::get_major_version'
           SubFeatureMap:   {}
         device_ext_get_max_clock_frequency:
           IsCalled:        true
           CallerSrcFiles:
-            - '/home/tcs2/Manju/cuda-samples/Common/helper_cuda.h'
+            - '/home/tcs/Manjula_workspace/manju/cuda-samples/Common/helper_cuda.h'
+          FeatureName:     'device_ext::get_max_clock_frequency'
           SubFeatureMap:   {}
         device_ext_get_max_compute_units:
           IsCalled:        true
           CallerSrcFiles:
-            - '/home/tcs2/Manju/cuda-samples/Common/helper_cuda.h'
+            - '/home/tcs/Manjula_workspace/manju/cuda-samples/Common/helper_cuda.h'
+          FeatureName:     'device_ext::get_max_compute_units'
           SubFeatureMap:   {}
         device_ext_get_minor_version:
           IsCalled:        true
           CallerSrcFiles:
-            - '/home/tcs2/Manju/cuda-samples/Common/helper_cuda.h'
+            - '/home/tcs/Manjula_workspace/manju/cuda-samples/Common/helper_cuda.h'
+          FeatureName:     'device_ext::get_minor_version'
           SubFeatureMap:   {}
         device_ext_get_version:
           IsCalled:        true
           CallerSrcFiles:
-            - '/home/tcs2/Manju/cuda-samples/Common/helper_cuda.h'
-            - '/home/tcs2/Manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarloMultiGPU.cpp'
-          SubFeatureMap:   {}
-        device_ext_inorder_queue:
-          IsCalled:        true
-          CallerSrcFiles:
-            - '/home/tcs2/Manju/cuda-samples/Common/helper_cuda.h'
-            - '/home/tcs2/Manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarloMultiGPU.cpp'
-            - '/home/tcs2/Manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_kernel.cu'
+            - '/home/tcs/Manjula_workspace/manju/cuda-samples/Common/helper_cuda.h'
+            - '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarloMultiGPU.cpp'
+          FeatureName:     'device_ext::get_version'
           SubFeatureMap:   {}
         device_ext_queues_wait_and_throw:
           IsCalled:        true
           CallerSrcFiles:
-            - '/home/tcs2/Manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarloMultiGPU.cpp'
+            - '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarloMultiGPU.cpp'
+          FeatureName:     'device_ext::queues_wait_and_throw'
           SubFeatureMap:   {}
     device_info:
       IsCalled:        true
       CallerSrcFiles:
-        - '/home/tcs2/Manju/cuda-samples/Common/helper_cuda.h'
-        - '/home/tcs2/Manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarloMultiGPU.cpp'
+        - '/home/tcs/Manjula_workspace/manju/cuda-samples/Common/helper_cuda.h'
+        - '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarloMultiGPU.cpp'
+      FeatureName:     device_info
       SubFeatureMap:
         device_info_1:
           IsCalled:        true
           CallerSrcFiles:
-            - '/home/tcs2/Manju/cuda-samples/Common/helper_cuda.h'
-            - '/home/tcs2/Manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarloMultiGPU.cpp'
+            - '/home/tcs/Manjula_workspace/manju/cuda-samples/Common/helper_cuda.h'
+            - '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarloMultiGPU.cpp'
+          FeatureName:     device_info
           SubFeatureMap:   {}
         device_info_get_integrated:
           IsCalled:        true
           CallerSrcFiles:
-            - '/home/tcs2/Manju/cuda-samples/Common/helper_cuda.h'
+            - '/home/tcs/Manjula_workspace/manju/cuda-samples/Common/helper_cuda.h'
+          FeatureName:     'device_info::get_integrated'
           SubFeatureMap:   {}
         device_info_get_major_version:
           IsCalled:        true
           CallerSrcFiles:
-            - '/home/tcs2/Manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarloMultiGPU.cpp'
+            - '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarloMultiGPU.cpp'
+          FeatureName:     'device_info::get_major_version'
           SubFeatureMap:   {}
         device_info_get_max_clock_frequency:
           IsCalled:        true
           CallerSrcFiles:
-            - '/home/tcs2/Manju/cuda-samples/Common/helper_cuda.h'
+            - '/home/tcs/Manjula_workspace/manju/cuda-samples/Common/helper_cuda.h'
+          FeatureName:     'device_info::get_max_clock_frequency'
           SubFeatureMap:   {}
         device_info_get_max_compute_units:
           IsCalled:        true
           CallerSrcFiles:
-            - '/home/tcs2/Manju/cuda-samples/Common/helper_cuda.h'
-            - '/home/tcs2/Manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarloMultiGPU.cpp'
+            - '/home/tcs/Manjula_workspace/manju/cuda-samples/Common/helper_cuda.h'
+            - '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarloMultiGPU.cpp'
+          FeatureName:     'device_info::get_max_compute_units'
           SubFeatureMap:   {}
         device_info_get_minor_version:
           IsCalled:        true
           CallerSrcFiles:
-            - '/home/tcs2/Manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarloMultiGPU.cpp'
+            - '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarloMultiGPU.cpp'
+          FeatureName:     'device_info::get_minor_version'
           SubFeatureMap:   {}
         device_info_get_name:
           IsCalled:        true
           CallerSrcFiles:
-            - '/home/tcs2/Manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarloMultiGPU.cpp'
-          SubFeatureMap:   {}
-        device_info_set_device_id:
-          IsCalled:        true
-          CallerSrcFiles:
-            - '/home/tcs2/Manju/cuda-samples/Common/helper_cuda.h'
-            - '/home/tcs2/Manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarloMultiGPU.cpp'
+            - '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarloMultiGPU.cpp'
+          FeatureName:     'device_info::get_name'
           SubFeatureMap:   {}
         device_info_set_global_mem_size:
           IsCalled:        true
           CallerSrcFiles:
-            - '/home/tcs2/Manju/cuda-samples/Common/helper_cuda.h'
-            - '/home/tcs2/Manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarloMultiGPU.cpp'
+            - '/home/tcs/Manjula_workspace/manju/cuda-samples/Common/helper_cuda.h'
+            - '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarloMultiGPU.cpp'
+          FeatureName:     'device_info::set_global_mem_size'
           SubFeatureMap:   {}
         device_info_set_host_unified_memory:
           IsCalled:        true
           CallerSrcFiles:
-            - '/home/tcs2/Manju/cuda-samples/Common/helper_cuda.h'
-            - '/home/tcs2/Manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarloMultiGPU.cpp'
+            - '/home/tcs/Manjula_workspace/manju/cuda-samples/Common/helper_cuda.h'
+            - '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarloMultiGPU.cpp'
+          FeatureName:     'device_info::set_host_unified_memory'
           SubFeatureMap:   {}
         device_info_set_local_mem_size:
           IsCalled:        true
           CallerSrcFiles:
-            - '/home/tcs2/Manju/cuda-samples/Common/helper_cuda.h'
-            - '/home/tcs2/Manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarloMultiGPU.cpp'
+            - '/home/tcs/Manjula_workspace/manju/cuda-samples/Common/helper_cuda.h'
+            - '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarloMultiGPU.cpp'
+          FeatureName:     'device_info::set_local_mem_size'
           SubFeatureMap:   {}
         device_info_set_major_version:
           IsCalled:        true
           CallerSrcFiles:
-            - '/home/tcs2/Manju/cuda-samples/Common/helper_cuda.h'
-            - '/home/tcs2/Manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarloMultiGPU.cpp'
+            - '/home/tcs/Manjula_workspace/manju/cuda-samples/Common/helper_cuda.h'
+            - '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarloMultiGPU.cpp'
+          FeatureName:     'device_info::set_major_version'
           SubFeatureMap:   {}
         device_info_set_max_clock_frequency:
           IsCalled:        true
           CallerSrcFiles:
-            - '/home/tcs2/Manju/cuda-samples/Common/helper_cuda.h'
-            - '/home/tcs2/Manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarloMultiGPU.cpp'
+            - '/home/tcs/Manjula_workspace/manju/cuda-samples/Common/helper_cuda.h'
+            - '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarloMultiGPU.cpp'
+          FeatureName:     'device_info::set_max_clock_frequency'
           SubFeatureMap:   {}
         device_info_set_max_compute_units:
           IsCalled:        true
           CallerSrcFiles:
-            - '/home/tcs2/Manju/cuda-samples/Common/helper_cuda.h'
-            - '/home/tcs2/Manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarloMultiGPU.cpp'
+            - '/home/tcs/Manjula_workspace/manju/cuda-samples/Common/helper_cuda.h'
+            - '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarloMultiGPU.cpp'
+          FeatureName:     'device_info::set_max_compute_units'
           SubFeatureMap:   {}
         device_info_set_max_nd_range_size:
           IsCalled:        true
           CallerSrcFiles:
-            - '/home/tcs2/Manju/cuda-samples/Common/helper_cuda.h'
-            - '/home/tcs2/Manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarloMultiGPU.cpp'
+            - '/home/tcs/Manjula_workspace/manju/cuda-samples/Common/helper_cuda.h'
+            - '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarloMultiGPU.cpp'
+          FeatureName:     'device_info::set_max_nd_range_size'
           SubFeatureMap:   {}
         device_info_set_max_register_size_per_work_group:
           IsCalled:        true
           CallerSrcFiles:
-            - '/home/tcs2/Manju/cuda-samples/Common/helper_cuda.h'
-            - '/home/tcs2/Manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarloMultiGPU.cpp'
+            - '/home/tcs/Manjula_workspace/manju/cuda-samples/Common/helper_cuda.h'
+            - '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarloMultiGPU.cpp'
+          FeatureName:     device_info_set_max_register_size_per_work_group
           SubFeatureMap:   {}
         device_info_set_max_sub_group_size:
           IsCalled:        true
           CallerSrcFiles:
-            - '/home/tcs2/Manju/cuda-samples/Common/helper_cuda.h'
-            - '/home/tcs2/Manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarloMultiGPU.cpp'
+            - '/home/tcs/Manjula_workspace/manju/cuda-samples/Common/helper_cuda.h'
+            - '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarloMultiGPU.cpp'
+          FeatureName:     'device_info::set_max_sub_group_size'
           SubFeatureMap:   {}
         device_info_set_max_work_group_size:
           IsCalled:        true
           CallerSrcFiles:
-            - '/home/tcs2/Manju/cuda-samples/Common/helper_cuda.h'
-            - '/home/tcs2/Manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarloMultiGPU.cpp'
+            - '/home/tcs/Manjula_workspace/manju/cuda-samples/Common/helper_cuda.h'
+            - '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarloMultiGPU.cpp'
+          FeatureName:     'device_info::set_max_work_group_size'
           SubFeatureMap:   {}
         device_info_set_max_work_item_sizes:
           IsCalled:        true
           CallerSrcFiles:
-            - '/home/tcs2/Manju/cuda-samples/Common/helper_cuda.h'
-            - '/home/tcs2/Manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarloMultiGPU.cpp'
+            - '/home/tcs/Manjula_workspace/manju/cuda-samples/Common/helper_cuda.h'
+            - '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarloMultiGPU.cpp'
+          FeatureName:     'device_info::set_max_work_item_sizes'
           SubFeatureMap:   {}
         device_info_set_max_work_items_per_compute_unit:
           IsCalled:        true
           CallerSrcFiles:
-            - '/home/tcs2/Manju/cuda-samples/Common/helper_cuda.h'
-            - '/home/tcs2/Manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarloMultiGPU.cpp'
+            - '/home/tcs/Manjula_workspace/manju/cuda-samples/Common/helper_cuda.h'
+            - '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarloMultiGPU.cpp'
+          FeatureName:     'device_info::set_max_work_items_per_compute_unit'
           SubFeatureMap:   {}
         device_info_set_minor_version:
           IsCalled:        true
           CallerSrcFiles:
-            - '/home/tcs2/Manju/cuda-samples/Common/helper_cuda.h'
-            - '/home/tcs2/Manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarloMultiGPU.cpp'
+            - '/home/tcs/Manjula_workspace/manju/cuda-samples/Common/helper_cuda.h'
+            - '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarloMultiGPU.cpp'
+          FeatureName:     'device_info::set_minor_version'
           SubFeatureMap:   {}
         device_info_set_name:
           IsCalled:        true
           CallerSrcFiles:
-            - '/home/tcs2/Manju/cuda-samples/Common/helper_cuda.h'
-            - '/home/tcs2/Manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarloMultiGPU.cpp'
-          SubFeatureMap:   {}
-        device_info_set_uuid:
-          IsCalled:        true
-          CallerSrcFiles:
-            - '/home/tcs2/Manju/cuda-samples/Common/helper_cuda.h'
-            - '/home/tcs2/Manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarloMultiGPU.cpp'
+            - '/home/tcs/Manjula_workspace/manju/cuda-samples/Common/helper_cuda.h'
+            - '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarloMultiGPU.cpp'
+          FeatureName:     'device_info::set_name'
           SubFeatureMap:   {}
     device_info_set_memory_bus_width:
       IsCalled:        true
       CallerSrcFiles:
-        - '/home/tcs2/Manju/cuda-samples/Common/helper_cuda.h'
-        - '/home/tcs2/Manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarloMultiGPU.cpp'
+        - '/home/tcs/Manjula_workspace/manju/cuda-samples/Common/helper_cuda.h'
+        - '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarloMultiGPU.cpp'
+      FeatureName:     device_info_set_memory_bus_width
       SubFeatureMap:   {}
     device_info_set_memory_clock_rate:
       IsCalled:        true
       CallerSrcFiles:
-        - '/home/tcs2/Manju/cuda-samples/Common/helper_cuda.h'
-        - '/home/tcs2/Manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarloMultiGPU.cpp'
+        - '/home/tcs/Manjula_workspace/manju/cuda-samples/Common/helper_cuda.h'
+        - '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarloMultiGPU.cpp'
+      FeatureName:     device_info_set_memory_clock_rate
       SubFeatureMap:   {}
     exception_handler:
       IsCalled:        true
       CallerSrcFiles:
-        - '/home/tcs2/Manju/cuda-samples/Common/helper_cuda.h'
-        - '/home/tcs2/Manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarloMultiGPU.cpp'
+        - '/home/tcs/Manjula_workspace/manju/cuda-samples/Common/helper_cuda.h'
+        - '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarloMultiGPU.cpp'
+        - '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_kernel.cu'
+      FeatureName:     exception_handler
+      SubFeatureMap:   {}
+    get_current_device:
+      IsCalled:        true
+      CallerSrcFiles:
+        - '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarloMultiGPU.cpp'
+      FeatureName:     get_current_device
       SubFeatureMap:   {}
     get_default_queue:
       IsCalled:        true
       CallerSrcFiles:
-        - '/home/tcs2/Manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_gold.cpp'
-        - '/home/tcs2/Manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_kernel.cu'
+        - '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarloMultiGPU.cpp'
+        - '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_gold.cpp'
+        - '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_kernel.cu'
+      FeatureName:     get_default_queue
       SubFeatureMap:   {}
     get_tid:
       IsCalled:        true
       CallerSrcFiles:
-        - '/home/tcs2/Manju/cuda-samples/Common/helper_cuda.h'
-        - '/home/tcs2/Manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarloMultiGPU.cpp'
-        - '/home/tcs2/Manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_kernel.cu'
+        - '/home/tcs/Manjula_workspace/manju/cuda-samples/Common/helper_cuda.h'
+        - '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarloMultiGPU.cpp'
+        - '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_kernel.cu'
+      FeatureName:     get_tid
       SubFeatureMap:   {}
     select_device:
       IsCalled:        true
       CallerSrcFiles:
-        - '/home/tcs2/Manju/cuda-samples/Common/helper_cuda.h'
-        - '/home/tcs2/Manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarloMultiGPU.cpp'
+        - '/home/tcs/Manjula_workspace/manju/cuda-samples/Common/helper_cuda.h'
+        - '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarloMultiGPU.cpp'
+      FeatureName:     select_device
       SubFeatureMap:   {}
     typedef_event_ptr:
       IsCalled:        true
       CallerSrcFiles:
-        - '/home/tcs2/Manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarloMultiGPU.cpp'
+        - '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarloMultiGPU.cpp'
+      FeatureName:     typedef_event_ptr
       SubFeatureMap:   {}
     typedef_queue_ptr:
       IsCalled:        true
       CallerSrcFiles:
-        - '/home/tcs2/Manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarloMultiGPU.cpp'
-        - '/home/tcs2/Manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_common.h'
-        - '/home/tcs2/Manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_kernel.cu'
+        - '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarloMultiGPU.cpp'
+        - '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_common.h'
+        - '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_kernel.cu'
+      FeatureName:     queue_ptr
       SubFeatureMap:   {}
   dpct.hpp:
     non_local_include_dependency:
       IsCalled:        true
       CallerSrcFiles:
         - ''
+      FeatureName:     ''
       SubFeatureMap:   {}
   lib_common_utils.hpp:
     get_memory:
       IsCalled:        true
       CallerSrcFiles:
-        - '/home/tcs2/Manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_gold.cpp'
+        - '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_gold.cpp'
+      FeatureName:     get_memory
       SubFeatureMap:   {}
   memory.hpp:
+    async_dpct_memcpy:
+      IsCalled:        true
+      CallerSrcFiles:
+        - '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_kernel.cu'
+      FeatureName:     async_dpct_memcpy
+      SubFeatureMap:   {}
+    async_dpct_memcpy_2d:
+      IsCalled:        true
+      CallerSrcFiles:
+        - '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_kernel.cu'
+      FeatureName:     async_dpct_memcpy
+      SubFeatureMap:   {}
+    async_dpct_memcpy_3d:
+      IsCalled:        true
+      CallerSrcFiles:
+        - '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_kernel.cu'
+      FeatureName:     async_dpct_memcpy
+      SubFeatureMap:   {}
+    dpct_get_copy_range_detail:
+      IsCalled:        true
+      CallerSrcFiles:
+        - '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_kernel.cu'
+      FeatureName:     dpct_get_copy_range_detail
+      SubFeatureMap:   {}
+    dpct_get_offset_detail:
+      IsCalled:        true
+      CallerSrcFiles:
+        - '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_kernel.cu'
+      FeatureName:     dpct_get_offset_detail
+      SubFeatureMap:   {}
+    dpct_memcpy_2d_3d_pitch_detail:
+      IsCalled:        true
+      CallerSrcFiles:
+        - '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_kernel.cu'
+      FeatureName:     dpct_memcpy
+      SubFeatureMap:   {}
+    dpct_memcpy_2d_pitch_detail:
+      IsCalled:        true
+      CallerSrcFiles:
+        - '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_kernel.cu'
+      FeatureName:     dpct_memcpy
+      SubFeatureMap:   {}
+    dpct_memcpy_3d_detail:
+      IsCalled:        true
+      CallerSrcFiles:
+        - '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_kernel.cu'
+      FeatureName:     dpct_memcpy
+      SubFeatureMap:   {}
+    dpct_memcpy_detail:
+      IsCalled:        true
+      CallerSrcFiles:
+        - '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_kernel.cu'
+      FeatureName:     dpct_memcpy
+      SubFeatureMap:   {}
     dpct_memset:
       IsCalled:        true
       CallerSrcFiles:
-        - '/home/tcs2/Manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_kernel.cu'
+        - '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_kernel.cu'
+      FeatureName:     dpct_memset
       SubFeatureMap:   {}
     dpct_memset_2d:
       IsCalled:        true
       CallerSrcFiles:
-        - '/home/tcs2/Manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_kernel.cu'
+        - '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_kernel.cu'
+      FeatureName:     dpct_memset
       SubFeatureMap:   {}
     dpct_memset_2d_detail:
       IsCalled:        true
       CallerSrcFiles:
-        - '/home/tcs2/Manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_kernel.cu'
+        - '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_kernel.cu'
+      FeatureName:     dpct_memset
       SubFeatureMap:   {}
     dpct_memset_3d:
       IsCalled:        true
       CallerSrcFiles:
-        - '/home/tcs2/Manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_kernel.cu'
+        - '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_kernel.cu'
+      FeatureName:     dpct_memset
       SubFeatureMap:   {}
     dpct_memset_3d_detail:
       IsCalled:        true
       CallerSrcFiles:
-        - '/home/tcs2/Manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_kernel.cu'
+        - '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_kernel.cu'
+      FeatureName:     dpct_memset
       SubFeatureMap:   {}
     dpct_memset_detail:
       IsCalled:        true
       CallerSrcFiles:
-        - '/home/tcs2/Manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_kernel.cu'
+        - '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_kernel.cu'
+      FeatureName:     dpct_memset
+      SubFeatureMap:   {}
+    get_memcpy_direction:
+      IsCalled:        true
+      CallerSrcFiles:
+        - '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_kernel.cu'
+      FeatureName:     get_memcpy_direction
+      SubFeatureMap:   {}
+    get_pointer_attribute:
+      IsCalled:        true
+      CallerSrcFiles:
+        - '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_kernel.cu'
+      FeatureName:     get_pointer_attribute
       SubFeatureMap:   {}
     memcpy_direction:
       IsCalled:        true
       CallerSrcFiles:
-        - '/home/tcs2/Manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_kernel.cu'
+        - '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_kernel.cu'
+      FeatureName:     memcpy_direction
       SubFeatureMap:   {}
     pitched_data:
       IsCalled:        true
       CallerSrcFiles:
-        - '/home/tcs2/Manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_kernel.cu'
+        - '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_kernel.cu'
+      FeatureName:     pitched_data
       SubFeatureMap:
         pitched_data_get_data_ptr:
           IsCalled:        true
           CallerSrcFiles:
-            - '/home/tcs2/Manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_kernel.cu'
+            - '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_kernel.cu'
+          FeatureName:     'pitched_data::get_data_ptr'
           SubFeatureMap:   {}
         pitched_data_get_pitch:
           IsCalled:        true
           CallerSrcFiles:
-            - '/home/tcs2/Manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_kernel.cu'
+            - '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_kernel.cu'
+          FeatureName:     'pitched_data::get_pitch'
           SubFeatureMap:   {}
         pitched_data_get_y:
           IsCalled:        true
           CallerSrcFiles:
-            - '/home/tcs2/Manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_kernel.cu'
+            - '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_kernel.cu'
+          FeatureName:     'pitched_data::get_y'
           SubFeatureMap:   {}
     pitched_data_1:
       IsCalled:        true
       CallerSrcFiles:
-        - '/home/tcs2/Manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_kernel.cu'
+        - '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_kernel.cu'
+      FeatureName:     pitched_data
+      SubFeatureMap:   {}
+    pointer_access_attribute:
+      IsCalled:        true
+      CallerSrcFiles:
+        - '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_kernel.cu'
+      FeatureName:     pointer_access_attribute
       SubFeatureMap:   {}
   rng_utils.hpp:
     create_host_rng:
       IsCalled:        true
       CallerSrcFiles:
-        - '/home/tcs2/Manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_gold.cpp'
+        - '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_gold.cpp'
+      FeatureName:     create_host_rng
       SubFeatureMap:   {}
     random_engine_type:
       IsCalled:        true
       CallerSrcFiles:
-        - '/home/tcs2/Manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_gold.cpp'
+        - '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_gold.cpp'
+      FeatureName:     random_engine_type
       SubFeatureMap:   {}
     rng_generator:
       IsCalled:        true
       CallerSrcFiles:
-        - '/home/tcs2/Manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_kernel.cu'
+        - '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_kernel.cu'
+      FeatureName:     rng_generator
       SubFeatureMap:   {}
     rng_generator_1:
       IsCalled:        true
       CallerSrcFiles:
-        - '/home/tcs2/Manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_kernel.cu'
+        - '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_kernel.cu'
+      FeatureName:     rng_generator
       SubFeatureMap:   {}
     rng_generator_base:
       IsCalled:        true
       CallerSrcFiles:
-        - '/home/tcs2/Manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_gold.cpp'
+        - '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_gold.cpp'
+      FeatureName:     rng_generator_base
       SubFeatureMap:   {}
     rng_generator_generate:
       IsCalled:        true
       CallerSrcFiles:
-        - '/home/tcs2/Manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_kernel.cu'
+        - '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_kernel.cu'
+      FeatureName:     'rng_generator::generate'
       SubFeatureMap:   {}
     rng_generator_generate_vec:
       IsCalled:        true
       CallerSrcFiles:
-        - '/home/tcs2/Manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_kernel.cu'
+        - '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_kernel.cu'
+      FeatureName:     'rng_generator::generate_vec'
       SubFeatureMap:   {}
     rng_generator_host:
       IsCalled:        true
       CallerSrcFiles:
-        - '/home/tcs2/Manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_gold.cpp'
+        - '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_gold.cpp'
+      FeatureName:     rng_generator_host
       SubFeatureMap:   {}
     typedef_host_rng_ptr:
       IsCalled:        true
       CallerSrcFiles:
-        - '/home/tcs2/Manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_gold.cpp'
+        - '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_gold.cpp'
+      FeatureName:     typedef_host_rng_ptr
       SubFeatureMap:   {}
   util.hpp:
     err_types:
       IsCalled:        true
       CallerSrcFiles:
-        - '/home/tcs2/Manju/cuda-samples/Common/helper_cuda.h'
+        - '/home/tcs/Manjula_workspace/manju/cuda-samples/Common/helper_cuda.h'
+      FeatureName:     err_types
       SubFeatureMap:   {}
 CompileTargets:  {}
 OptionMap:
   AnalysisScopePath:
-    Value:           '/home/tcs2/Manju/cuda-samples'
+    Value:           '/home/tcs/Manjula_workspace/manju/cuda-samples'
     Specified:       false
   AsyncHandler:
     Value:           'false'
@@ -2282,7 +2412,7 @@ OptionMap:
     Value:           'false'
     Specified:       false
   CompilationsDir:
-    Value:           '/home/tcs2/Manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU'
+    Value:           '/home/tcs/Manjula_workspace/manju/cuda-samples/Samples/5_Domain_Specific/MonteCarloMultiGPU'
     Specified:       true
   CtadEnabled:
     Value:           'false'

--- a/DirectProgramming/C++SYCL/MapReduce/guided_MonteCarloMultiGPU_SYCLMigration/01_dpct_output/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarloMultiGPU.cpp.dp.cpp
+++ b/DirectProgramming/C++SYCL/MapReduce/guided_MonteCarloMultiGPU_SYCLMigration/01_dpct_output/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarloMultiGPU.cpp.dp.cpp
@@ -69,14 +69,14 @@ int adjustProblemSize(int GPU_N, int default_nOptions) {
   for (int i = 0; i < GPU_N; i++) {
     dpct::device_info deviceProp;
     /*
-    DPCT1003:49: Migrated API does not return error code. (*, 0) is inserted.
+    DPCT1003:47: Migrated API does not return error code. (*, 0) is inserted.
     You may need to rewrite this code.
     */
     checkCudaErrors(
         (dpct::dev_mgr::instance().get_device(i).get_device_info(deviceProp),
          0));
     /*
-    DPCT1005:50: The SYCL device version is different from CUDA Compute
+    DPCT1005:48: The SYCL device version is different from CUDA Compute
     Compatibility. You may need to rewrite this code.
     */
     int cudaCores = _ConvertSMVer2Cores(deviceProp.get_major_version(),
@@ -94,7 +94,7 @@ int adjustProblemSize(int GPU_N, int default_nOptions) {
 int adjustGridSize(int GPUIndex, int defaultGridSize) {
   dpct::device_info deviceProp;
   /*
-  DPCT1003:51: Migrated API does not return error code. (*, 0) is inserted. You
+  DPCT1003:49: Migrated API does not return error code. (*, 0) is inserted. You
   may need to rewrite this code.
   */
   checkCudaErrors(
@@ -123,18 +123,18 @@ StopWatchInterface **hTimer = NULL;
 static CUT_THREADPROC solverThread(TOptionPlan *plan) {
   // Init GPU
   /*
-  DPCT1093:52: The "plan->device" device may be not the one intended for use.
+  DPCT1093:50: The "plan->device" device may be not the one intended for use.
   Adjust the selected device if needed.
   */
   /*
-  DPCT1003:53: Migrated API does not return error code. (*, 0) is inserted. You
+  DPCT1003:51: Migrated API does not return error code. (*, 0) is inserted. You
   may need to rewrite this code.
   */
   checkCudaErrors((dpct::select_device(plan->device), 0));
 
   dpct::device_info deviceProp;
   /*
-  DPCT1003:54: Migrated API does not return error code. (*, 0) is inserted. You
+  DPCT1003:52: Migrated API does not return error code. (*, 0) is inserted. You
   may need to rewrite this code.
   */
   checkCudaErrors((dpct::dev_mgr::instance()
@@ -153,7 +153,7 @@ static CUT_THREADPROC solverThread(TOptionPlan *plan) {
   MonteCarloGPU(plan);
 
   /*
-  DPCT1003:55: Migrated API does not return error code. (*, 0) is inserted. You
+  DPCT1003:53: Migrated API does not return error code. (*, 0) is inserted. You
   may need to rewrite this code.
   */
   checkCudaErrors((dpct::get_current_device().queues_wait_and_throw(), 0));
@@ -182,22 +182,22 @@ static void multiSolver(TOptionPlan *plan, int nPlans) {
 
   for (int i = 0; i < nPlans; i++) {
     /*
-    DPCT1093:56: The "plan[i].device" device may be not the one intended for
+    DPCT1093:54: The "plan[i].device" device may be not the one intended for
     use. Adjust the selected device if needed.
     */
     /*
-    DPCT1003:57: Migrated API does not return error code. (*, 0) is inserted.
+    DPCT1003:55: Migrated API does not return error code. (*, 0) is inserted.
     You may need to rewrite this code.
     */
     checkCudaErrors((dpct::select_device(plan[i].device), 0));
     /*
-    DPCT1003:58: Migrated API does not return error code. (*, 0) is inserted.
+    DPCT1003:56: Migrated API does not return error code. (*, 0) is inserted.
     You may need to rewrite this code.
     */
     checkCudaErrors(
         ((streams[i]) = dpct::get_current_device().create_queue(), 0));
     /*
-    DPCT1003:59: Migrated API does not return error code. (*, 0) is inserted.
+    DPCT1003:57: Migrated API does not return error code. (*, 0) is inserted.
     You may need to rewrite this code.
     */
     checkCudaErrors((events[i] = new sycl::event(), 0));
@@ -210,18 +210,18 @@ static void multiSolver(TOptionPlan *plan, int nPlans) {
   for (int i = 0; i < nPlans; i++) {
     // set the target device to perform initialization on
     /*
-    DPCT1093:60: The "plan[i].device" device may be not the one intended for
+    DPCT1093:58: The "plan[i].device" device may be not the one intended for
     use. Adjust the selected device if needed.
     */
     /*
-    DPCT1003:61: Migrated API does not return error code. (*, 0) is inserted.
+    DPCT1003:59: Migrated API does not return error code. (*, 0) is inserted.
     You may need to rewrite this code.
     */
     checkCudaErrors((dpct::select_device(plan[i].device), 0));
 
     dpct::device_info deviceProp;
     /*
-    DPCT1003:62: Migrated API does not return error code. (*, 0) is inserted.
+    DPCT1003:60: Migrated API does not return error code. (*, 0) is inserted.
     You may need to rewrite this code.
     */
     checkCudaErrors((dpct::dev_mgr::instance()
@@ -236,16 +236,16 @@ static void multiSolver(TOptionPlan *plan, int nPlans) {
 
   for (int i = 0; i < nPlans; i++) {
     /*
-    DPCT1093:63: The "plan[i].device" device may be not the one intended for
+    DPCT1093:61: The "plan[i].device" device may be not the one intended for
     use. Adjust the selected device if needed.
     */
     /*
-    DPCT1003:64: Migrated API does not return error code. (*, 0) is inserted.
+    DPCT1003:62: Migrated API does not return error code. (*, 0) is inserted.
     You may need to rewrite this code.
     */
     checkCudaErrors((dpct::select_device(plan[i].device), 0));
     /*
-    DPCT1003:65: Migrated API does not return error code. (*, 0) is inserted.
+    DPCT1003:63: Migrated API does not return error code. (*, 0) is inserted.
     You may need to rewrite this code.
     */
     checkCudaErrors((dpct::get_current_device().queues_wait_and_throw(), 0));
@@ -257,11 +257,11 @@ static void multiSolver(TOptionPlan *plan, int nPlans) {
 
   for (int i = 0; i < nPlans; i++) {
     /*
-    DPCT1093:66: The "plan[i].device" device may be not the one intended for
+    DPCT1093:64: The "plan[i].device" device may be not the one intended for
     use. Adjust the selected device if needed.
     */
     /*
-    DPCT1003:67: Migrated API does not return error code. (*, 0) is inserted.
+    DPCT1003:65: Migrated API does not return error code. (*, 0) is inserted.
     You may need to rewrite this code.
     */
     checkCudaErrors((dpct::select_device(plan[i].device), 0));
@@ -270,12 +270,12 @@ static void multiSolver(TOptionPlan *plan, int nPlans) {
     MonteCarloGPU(&plan[i], streams[i]);
 
     /*
-    DPCT1012:68: Detected kernel execution time measurement pattern and
+    DPCT1012:66: Detected kernel execution time measurement pattern and
     generated an initial code for time measurements in SYCL. You can change the
     way time is measured depending on your goals.
     */
     /*
-    DPCT1024:69: The original code returned the error code that was further
+    DPCT1024:67: The original code returned the error code that was further
     consumed by the program logic. This original code was replaced with 0. You
     may need to rewrite the program logic consuming the error code.
     */
@@ -285,11 +285,11 @@ static void multiSolver(TOptionPlan *plan, int nPlans) {
 
   for (int i = 0; i < nPlans; i++) {
     /*
-    DPCT1093:70: The "plan[i].device" device may be not the one intended for
+    DPCT1093:68: The "plan[i].device" device may be not the one intended for
     use. Adjust the selected device if needed.
     */
     /*
-    DPCT1003:71: Migrated API does not return error code. (*, 0) is inserted.
+    DPCT1003:69: Migrated API does not return error code. (*, 0) is inserted.
     You may need to rewrite this code.
     */
     checkCudaErrors((dpct::select_device(plan[i].device), 0));
@@ -301,22 +301,22 @@ static void multiSolver(TOptionPlan *plan, int nPlans) {
 
   for (int i = 0; i < nPlans; i++) {
     /*
-    DPCT1093:72: The "plan[i].device" device may be not the one intended for
+    DPCT1093:70: The "plan[i].device" device may be not the one intended for
     use. Adjust the selected device if needed.
     */
     /*
-    DPCT1003:73: Migrated API does not return error code. (*, 0) is inserted.
+    DPCT1003:71: Migrated API does not return error code. (*, 0) is inserted.
     You may need to rewrite this code.
     */
     checkCudaErrors((dpct::select_device(plan[i].device), 0));
     closeMonteCarloGPU(&plan[i]);
     /*
-    DPCT1003:74: Migrated API does not return error code. (*, 0) is inserted.
+    DPCT1003:72: Migrated API does not return error code. (*, 0) is inserted.
     You may need to rewrite this code.
     */
     checkCudaErrors((dpct::get_current_device().destroy_queue(streams[i]), 0));
     /*
-    DPCT1003:75: Migrated API does not return error code. (*, 0) is inserted.
+    DPCT1003:73: Migrated API does not return error code. (*, 0) is inserted.
     You may need to rewrite this code.
     */
     checkCudaErrors((dpct::destroy_event(events[i]), 0));
@@ -398,7 +398,7 @@ int main(int argc, char **argv) {
   // GPU number present in the system
   int GPU_N;
   /*
-  DPCT1003:76: Migrated API does not return error code. (*, 0) is inserted. You
+  DPCT1003:74: Migrated API does not return error code. (*, 0) is inserted. You
   may need to rewrite this code.
   */
   checkCudaErrors((GPU_N = dpct::dev_mgr::instance().device_count(), 0));
@@ -499,7 +499,7 @@ int main(int argc, char **argv) {
     for (i = 0; i < GPU_N; i++) {
       dpct::device_info deviceProp;
       /*
-      DPCT1003:77: Migrated API does not return error code. (*, 0) is inserted.
+      DPCT1003:75: Migrated API does not return error code. (*, 0) is inserted.
       You may need to rewrite this code.
       */
       checkCudaErrors((dpct::dev_mgr::instance()
@@ -547,7 +547,7 @@ int main(int argc, char **argv) {
     for (i = 0; i < GPU_N; i++) {
       dpct::device_info deviceProp;
       /*
-      DPCT1003:78: Migrated API does not return error code. (*, 0) is inserted.
+      DPCT1003:76: Migrated API does not return error code. (*, 0) is inserted.
       You may need to rewrite this code.
       */
       checkCudaErrors((dpct::dev_mgr::instance()
@@ -614,11 +614,11 @@ int main(int argc, char **argv) {
   for (int i = 0; i < GPU_N; i++) {
     sdkStartTimer(&hTimer[i]);
     /*
-    DPCT1093:79: The "i" device may be not the one intended for use. Adjust the
+    DPCT1093:77: The "i" device may be not the one intended for use. Adjust the
     selected device if needed.
     */
     /*
-    DPCT1003:80: Migrated API does not return error code. (*, 0) is inserted.
+    DPCT1003:78: Migrated API does not return error code. (*, 0) is inserted.
     You may need to rewrite this code.
     */
     checkCudaErrors((dpct::select_device(i), 0));

--- a/DirectProgramming/C++SYCL/MapReduce/guided_MonteCarloMultiGPU_SYCLMigration/01_dpct_output/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_common.h
+++ b/DirectProgramming/C++SYCL/MapReduce/guided_MonteCarloMultiGPU_SYCLMigration/01_dpct_output/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_common.h
@@ -37,7 +37,7 @@
 ////////////////////////////////////////////////////////////////////////////////
 // Global types
 ////////////////////////////////////////////////////////////////////////////////
-typedef struct dpct_type_623103 {
+typedef struct dpct_type_136915 {
   float S;
   float X;
   float T;
@@ -48,19 +48,19 @@ typedef struct dpct_type_623103 {
 typedef struct
     // #ifdef __CUDACC__
     //__align__(8)
-    // #endif dpct_type_143893
+    // #endif dpct_type_392709
     {
   float Expected;
   float Confidence;
 } TOptionValue;
 
 // GPU outputs before CPU postprocessing
-typedef struct dpct_type_790570 {
+typedef struct dpct_type_108828 {
   real Expected;
   real Confidence;
 } __TOptionValue;
 
-typedef struct dpct_type_137502 {
+typedef struct dpct_type_723642 {
   // Device ID for multi-GPU version
   int device;
   // Option count for this plan
@@ -85,10 +85,10 @@ typedef struct dpct_type_137502 {
 
   // random number generator states
   /*
-  DPCT1032:25: A different random number generator is used. You may need to
+  DPCT1032:24: A different random number generator is used. You may need to
   adjust the code.
   */
-  dpct::rng::device::rng_generator<oneapi::mkl::rng::device::mcg59<1>>
+  dpct::rng::device::rng_generator<oneapi::mkl::rng::device::philox4x32x10<1>>
       *rngStates;
 
   // Pseudorandom samples count

--- a/DirectProgramming/C++SYCL/MapReduce/guided_MonteCarloMultiGPU_SYCLMigration/01_dpct_output/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_gold.cpp.dp.cpp
+++ b/DirectProgramming/C++SYCL/MapReduce/guided_MonteCarloMultiGPU_SYCLMigration/01_dpct_output/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_gold.cpp.dp.cpp
@@ -106,15 +106,15 @@ extern "C" void MonteCarloCPU(TOptionValue &callValue, TOptionData optionData,
   dpct::rng::host_rng_ptr gen;
 
   /*
-  DPCT1003:45: Migrated API does not return error code. (*, 0) is inserted. You
+  DPCT1003:25: Migrated API does not return error code. (*, 0) is inserted. You
   may need to rewrite this code.
   */
-  checkCudaErrors(
-      (gen = dpct::rng::create_host_rng(dpct::rng::random_engine_type::mcg59),
-       0));
+  checkCudaErrors((gen = dpct::rng::create_host_rng(
+                       dpct::rng::random_engine_type::philox4x32x10),
+                   0));
   unsigned long long seed = 1234ULL;
   /*
-  DPCT1003:46: Migrated API does not return error code. (*, 0) is inserted. You
+  DPCT1003:26: Migrated API does not return error code. (*, 0) is inserted. You
   may need to rewrite this code.
   */
   checkCudaErrors((gen->set_seed(seed), 0));
@@ -124,7 +124,7 @@ extern "C" void MonteCarloCPU(TOptionValue &callValue, TOptionData optionData,
   } else {
     samples = (float *)malloc(pathN * sizeof(float));
     /*
-    DPCT1003:47: Migrated API does not return error code. (*, 0) is inserted.
+    DPCT1003:27: Migrated API does not return error code. (*, 0) is inserted.
     You may need to rewrite this code.
     */
     checkCudaErrors((gen->generate_gaussian(samples, pathN, 0.0, 1.0), 0));
@@ -144,7 +144,7 @@ extern "C" void MonteCarloCPU(TOptionValue &callValue, TOptionData optionData,
   if (h_Samples == NULL) free(samples);
 
   /*
-  DPCT1003:48: Migrated API does not return error code. (*, 0) is inserted. You
+  DPCT1003:28: Migrated API does not return error code. (*, 0) is inserted. You
   may need to rewrite this code.
   */
   checkCudaErrors((gen.reset(), 0));

--- a/DirectProgramming/C++SYCL/MapReduce/guided_MonteCarloMultiGPU_SYCLMigration/01_dpct_output/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_reduction.dp.hpp
+++ b/DirectProgramming/C++SYCL/MapReduce/guided_MonteCarloMultiGPU_SYCLMigration/01_dpct_output/Samples/5_Domain_Specific/MonteCarloMultiGPU/MonteCarlo_reduction.dp.hpp
@@ -30,6 +30,7 @@
 
 #include <sycl/sycl.hpp>
 #include <dpct/dpct.hpp>
+//#include <cooperative_groups.h>
 
 ////////////////////////////////////////////////////////////////////////////////
 // This function calculates total sum for each of the two input arrays.

--- a/DirectProgramming/C++SYCL/MapReduce/guided_MonteCarloMultiGPU_SYCLMigration/01_dpct_output/include/dpct/device.hpp
+++ b/DirectProgramming/C++SYCL/MapReduce/guided_MonteCarloMultiGPU_SYCLMigration/01_dpct_output/include/dpct/device.hpp
@@ -11,7 +11,6 @@
 
 #include <sycl/sycl.hpp>
 #include <algorithm>
-#include <array>
 #include <cstring>
 #include <iostream>
 #include <mutex>
@@ -33,7 +32,7 @@
 namespace dpct {
 
 /// SYCL default exception handler
-inline auto exception_handler = [](sycl::exception_list exceptions) {
+auto exception_handler = [](sycl::exception_list exceptions) {
   for (std::exception_ptr const &e : exceptions) {
     try {
       std::rethrow_exception(e);
@@ -144,14 +143,6 @@ public:
     _max_register_size_per_work_group = max_register_size_per_work_group;
   }
 
-  void set_device_id(uint32_t device_id) {
-    _device_id = device_id;
-  }
-
-  void set_uuid(std::array<unsigned char, 16> uuid) {
-    _uuid = std::move(uuid);
-  }
-
 private:
   char _name[256];
   sycl::id<3> _max_work_item_sizes;
@@ -174,23 +165,24 @@ private:
   size_t _local_mem_size;
   size_t _max_nd_range_size[3];
   int _max_nd_range_size_i[3];
-  uint32_t _device_id;
-  std::array<unsigned char, 16> _uuid;
 };
 
 /// dpct device extension
 class device_ext : public sycl::device {
-  typedef std::mutex mutex_type;
-
 public:
   device_ext() : sycl::device(), _ctx(*this) {}
   ~device_ext() {
-    std::lock_guard<mutex_type> lock(m_mutex);
-    clear_queues();
+    std::lock_guard<std::recursive_mutex> lock(m_mutex);
+    for (auto &task : _tasks) {
+      if (task.joinable())
+        task.join();
+    }
+    _tasks.clear();
+    _queues.clear();
   }
-  device_ext(const sycl::device &base) : sycl::device(base), _ctx(*this) {
-    std::lock_guard<mutex_type> lock(m_mutex);
-    init_queues();
+  device_ext(const sycl::device &base)
+      : sycl::device(base), _ctx(*this) {
+    _saved_queue = _default_queue = create_queue(true);
   }
 
   int get_major_version() const {
@@ -209,7 +201,6 @@ public:
     return get_device_info().get_max_compute_units();
   }
 
-  /// Return the maximum clock frequency of this device in KHz.
   int get_max_clock_frequency() const {
     return get_device_info().get_max_clock_frequency();
   }
@@ -237,7 +228,7 @@ public:
         this->has(sycl::aspect::usm_host_allocations));
 
     prop.set_max_clock_frequency(
-        get_info<sycl::info::device::max_clock_frequency>() * 1000);
+        get_info<sycl::info::device::max_clock_frequency>());
 
     prop.set_max_compute_units(
         get_info<sycl::info::device::max_compute_units>());
@@ -257,14 +248,6 @@ public:
     if (this->has(sycl::aspect::ext_intel_memory_bus_width)) {
       prop.set_memory_bus_width(
           this->get_info<sycl::ext::intel::info::device::memory_bus_width>());
-    }
-    if (this->has(sycl::aspect::ext_intel_device_id)) {
-      prop.set_device_id(
-          this->get_info<sycl::ext::intel::info::device::device_id>());
-    }
-    if (this->has(sycl::aspect::ext_intel_device_info_uuid)) {
-      prop.set_uuid(
-          this->get_info<sycl::ext::intel::info::device::uuid>());
     }
 #elif defined(_MSC_VER) && !defined(__clang__)
 #pragma message("get_device_info: querying memory_clock_rate and \
@@ -307,14 +290,10 @@ Use 64 bits as memory_bus_width default value."
     return prop;
   }
 
-  sycl::queue &in_order_queue() { return *_q_in_order; }
-
-  sycl::queue &default_queue() {
-    return in_order_queue();
-  }
+  sycl::queue &default_queue() { return *_default_queue; }
 
   void queues_wait_and_throw() {
-    std::unique_lock<mutex_type> lock(m_mutex);
+    std::unique_lock<std::recursive_mutex> lock(m_mutex);
     std::vector<std::shared_ptr<sycl::queue>> current_queues(
         _queues);
     lock.unlock();
@@ -326,17 +305,20 @@ Use 64 bits as memory_bus_width default value."
   }
 
   sycl::queue *create_queue(bool enable_exception_handler = false) {
-    return create_in_order_queue(enable_exception_handler);
-  }
+    std::lock_guard<std::recursive_mutex> lock(m_mutex);
+    sycl::async_handler eh = {};
+    if (enable_exception_handler) {
+      eh = exception_handler;
+    }
+    auto property = get_default_property_list_for_queue();
+    _queues.push_back(std::make_shared<sycl::queue>(
+        _ctx, *this, eh, property));
 
-  sycl::queue *create_in_order_queue(bool enable_exception_handler = false) {
-    std::lock_guard<mutex_type> lock(m_mutex);
-    return create_queue_impl(enable_exception_handler,
-                             sycl::property::queue::in_order());
+    return _queues.back().get();
   }
 
   void destroy_queue(sycl::queue *&queue) {
-    std::lock_guard<mutex_type> lock(m_mutex);
+    std::lock_guard<std::recursive_mutex> lock(m_mutex);
     _queues.erase(std::remove_if(_queues.begin(), _queues.end(),
                                   [=](const std::shared_ptr<sycl::queue> &q) -> bool {
                                     return q.get() == queue;
@@ -346,34 +328,17 @@ Use 64 bits as memory_bus_width default value."
   }
 
 private:
-  void clear_queues() {
-    _queues.clear();
-    _q_in_order = _q_out_of_order = _saved_queue = nullptr;
-  }
 
-  void init_queues() {
-    _q_in_order = create_queue_impl(true, sycl::property::queue::in_order());
-    _q_out_of_order = create_queue_impl(true);
-    _saved_queue = &default_queue();
-  }
-
-  /// Caller should acquire resource \p m_mutex before calling this function.
-  template <class... Properties>
-  sycl::queue *create_queue_impl(bool enable_exception_handler,
-                                 Properties... properties) {
-    sycl::async_handler eh = {};
-    if (enable_exception_handler) {
-      eh = exception_handler;
-    }
-    _queues.push_back(std::make_shared<sycl::queue>(
-        _ctx, *this, eh,
-        sycl::property_list(
+  sycl::property_list get_default_property_list_for_queue() const {
 #ifdef DPCT_PROFILING_ENABLED
-            sycl::property::queue::enable_profiling(),
+    auto property =
+        sycl::property_list{sycl::property::queue::enable_profiling(),
+                            sycl::property::queue::in_order()};
+#else
+    auto property =
+        sycl::property_list{sycl::property::queue::in_order()};
 #endif
-            properties...)));
-
-    return _queues.back().get();
+    return property;
   }
 
   void get_version(int &major, int &minor) const {
@@ -398,11 +363,12 @@ private:
     minor = std::stoi(&(ver[i]));
   }
 
-  sycl::queue *_q_in_order, *_q_out_of_order;
+  sycl::queue *_default_queue;
   sycl::queue *_saved_queue;
   sycl::context _ctx;
   std::vector<std::shared_ptr<sycl::queue>> _queues;
-  mutable mutex_type m_mutex;
+  mutable std::recursive_mutex m_mutex;
+  std::vector<std::thread> _tasks;
 };
 
 static inline unsigned int get_tid() {
@@ -497,11 +463,15 @@ private:
   int _cpu_device = -1;
 };
 
-/// Util function to get the default queue of current selected device depends on
-/// the USM config. Return the default out-of-ordered queue when USM-none is
-/// enabled, otherwise return the default in-ordered queue.
+/// Util function to get the default queue of current device in
+/// dpct device manager.
 static inline sycl::queue &get_default_queue() {
   return dev_mgr::instance().current_device().default_queue();
+}
+
+/// Util function to get the current device.
+static inline device_ext &get_current_device() {
+  return dev_mgr::instance().current_device();
 }
 
 static inline unsigned int select_device(unsigned int id) {

--- a/DirectProgramming/C++SYCL/MapReduce/guided_MonteCarloMultiGPU_SYCLMigration/01_dpct_output/include/dpct/memory.hpp
+++ b/DirectProgramming/C++SYCL/MapReduce/guided_MonteCarloMultiGPU_SYCLMigration/01_dpct_output/include/dpct/memory.hpp
@@ -106,7 +106,292 @@ dpct_memset(sycl::queue &q, void *ptr, size_t pitch, int val, size_t x,
                      sycl::range<3>(x, y, 1));
 }
 
+enum class pointer_access_attribute {
+  host_only = 0,
+  device_only,
+  host_device,
+  end
+};
+
+static pointer_access_attribute get_pointer_attribute(sycl::queue &q,
+                                                      const void *ptr) {
+  switch (sycl::get_pointer_type(ptr, q.get_context())) {
+  case sycl::usm::alloc::unknown:
+    return pointer_access_attribute::host_only;
+  case sycl::usm::alloc::device:
+    return pointer_access_attribute::device_only;
+  case sycl::usm::alloc::shared:
+  case sycl::usm::alloc::host:
+    return pointer_access_attribute::host_device;
+  }
+}
+
+static memcpy_direction deduce_memcpy_direction(sycl::queue &q, void *to_ptr,
+                                             const void *from_ptr,
+                                             memcpy_direction dir) {
+  switch (dir) {
+  case memcpy_direction::host_to_host:
+  case memcpy_direction::host_to_device:
+  case memcpy_direction::device_to_host:
+  case memcpy_direction::device_to_device:
+    return dir;
+  case memcpy_direction::automatic: {
+    // table[to_attribute][from_attribute]
+    static const memcpy_direction
+        direction_table[static_cast<unsigned>(pointer_access_attribute::end)]
+                       [static_cast<unsigned>(pointer_access_attribute::end)] =
+                           {{memcpy_direction::host_to_host,
+                             memcpy_direction::device_to_host,
+                             memcpy_direction::host_to_host},
+                            {memcpy_direction::host_to_device,
+                             memcpy_direction::device_to_device,
+                             memcpy_direction::device_to_device},
+                            {memcpy_direction::host_to_host,
+                             memcpy_direction::device_to_device,
+                             memcpy_direction::device_to_device}};
+    return direction_table[static_cast<unsigned>(get_pointer_attribute(
+        q, to_ptr))][static_cast<unsigned>(get_pointer_attribute(q, from_ptr))];
+  }
+  default:
+    throw std::runtime_error("dpct_memcpy: invalid direction value");
+  }
+}
+
+static sycl::event
+dpct_memcpy(sycl::queue &q, void *to_ptr, const void *from_ptr, size_t size,
+            memcpy_direction direction,
+            const std::vector<sycl::event> &dep_events = {}) {
+  if (!size)
+    return sycl::event{};
+  return q.memcpy(to_ptr, from_ptr, size, dep_events);
+}
+
+// Get actual copy range and make sure it will not exceed range.
+static inline size_t get_copy_range(sycl::range<3> size, size_t slice,
+                                    size_t pitch) {
+  return slice * (size.get(2) - 1) + pitch * (size.get(1) - 1) + size.get(0);
+}
+
+static inline size_t get_offset(sycl::id<3> id, size_t slice,
+                                    size_t pitch) {
+  return slice * id.get(2) + pitch * id.get(1) + id.get(0);
+}
+
+/// copy 3D matrix specified by \p size from 3D matrix specified by \p from_ptr
+/// and \p from_range to another specified by \p to_ptr and \p to_range.
+static inline std::vector<sycl::event>
+dpct_memcpy(sycl::queue &q, void *to_ptr, const void *from_ptr,
+            sycl::range<3> to_range, sycl::range<3> from_range,
+            sycl::id<3> to_id, sycl::id<3> from_id,
+            sycl::range<3> size, memcpy_direction direction,
+            const std::vector<sycl::event> &dep_events = {}) {
+  // RAII for host pointer
+  class host_buffer {
+    void *_buf;
+    size_t _size;
+    sycl::queue &_q;
+    const std::vector<sycl::event> &_deps; // free operation depends
+
+  public:
+    host_buffer(size_t size, sycl::queue &q,
+                const std::vector<sycl::event> &deps)
+        : _buf(std::malloc(size)), _size(size), _q(q), _deps(deps) {}
+    void *get_ptr() const { return _buf; }
+    size_t get_size() const { return _size; }
+    ~host_buffer() {
+      if (_buf) {
+        _q.submit([&](sycl::handler &cgh) {
+          cgh.depends_on(_deps);
+          cgh.host_task([buf = _buf] { std::free(buf); });
+        });
+      }
+    }
+  };
+  std::vector<sycl::event> event_list;
+
+  size_t to_slice = to_range.get(1) * to_range.get(0),
+         from_slice = from_range.get(1) * from_range.get(0);
+  unsigned char *to_surface =
+      (unsigned char *)to_ptr + get_offset(to_id, to_slice, to_range.get(0));
+  const unsigned char *from_surface =
+      (const unsigned char *)from_ptr +
+      get_offset(from_id, from_slice, from_range.get(0));
+
+  if (to_slice == from_slice && to_slice == size.get(1) * size.get(0)) {
+    return {dpct_memcpy(q, to_surface, from_surface, to_slice * size.get(2),
+                        direction, dep_events)};
+  }
+  direction = deduce_memcpy_direction(q, to_ptr, from_ptr, direction);
+  size_t size_slice = size.get(1) * size.get(0);
+  switch (direction) {
+  case host_to_host:
+    for (size_t z = 0; z < size.get(2); ++z) {
+      unsigned char *to_ptr = to_surface;
+      const unsigned char *from_ptr = from_surface;
+      if (to_range.get(0) == from_range.get(0) &&
+          to_range.get(0) == size.get(0)) {
+        event_list.push_back(dpct_memcpy(q, to_ptr, from_ptr, size_slice,
+                                         direction, dep_events));
+      } else {
+        for (size_t y = 0; y < size.get(1); ++y) {
+          event_list.push_back(dpct_memcpy(q, to_ptr, from_ptr, size.get(0),
+                                           direction, dep_events));
+          to_ptr += to_range.get(0);
+          from_ptr += from_range.get(0);
+        }
+      }
+      to_surface += to_slice;
+      from_surface += from_slice;
+    }
+    break;
+  case host_to_device: {
+    host_buffer buf(get_copy_range(size, to_slice, to_range.get(0)), q,
+                    event_list);
+    std::vector<sycl::event> host_events;
+    if (to_slice == size_slice) {
+      // Copy host data to a temp host buffer with the shape of target.
+      host_events =
+          dpct_memcpy(q, buf.get_ptr(), from_surface, to_range, from_range,
+                      sycl::id<3>(0, 0, 0), sycl::id<3>(0, 0, 0), size,
+                      host_to_host, dep_events);
+    } else {
+      // Copy host data to a temp host buffer with the shape of target.
+      host_events = dpct_memcpy(
+          q, buf.get_ptr(), from_surface, to_range, from_range,
+          sycl::id<3>(0, 0, 0), sycl::id<3>(0, 0, 0), size, host_to_host,
+          // If has padding data, not sure whether it is useless. So fill temp
+          // buffer with it.
+          std::vector<sycl::event>{
+              dpct_memcpy(q, buf.get_ptr(), to_surface, buf.get_size(),
+                          device_to_host, dep_events)});
+    }
+    // Copy from temp host buffer to device with only one submit.
+    event_list.push_back(dpct_memcpy(q, to_surface, buf.get_ptr(),
+                                     buf.get_size(), host_to_device,
+                                     host_events));
+    break;
+  }
+  case device_to_host: {
+    host_buffer buf(get_copy_range(size, from_slice, from_range.get(0)), q,
+                    event_list);
+    // Copy from host temp buffer to host target with reshaping.
+    event_list = dpct_memcpy(
+        q, to_surface, buf.get_ptr(), to_range, from_range, sycl::id<3>(0, 0, 0),
+        sycl::id<3>(0, 0, 0), size, host_to_host,
+        // Copy from device to temp host buffer with only one submit.
+        std::vector<sycl::event>{dpct_memcpy(q, buf.get_ptr(), from_surface,
+                                                 buf.get_size(),
+                                                 device_to_host, dep_events)});
+    break;
+  }
+  case device_to_device:
+    event_list.push_back(q.submit([&](sycl::handler &cgh) {
+      cgh.depends_on(dep_events);
+      cgh.parallel_for<class dpct_memcpy_3d_detail>(
+          size,
+          [=](sycl::id<3> id) {
+            to_surface[get_offset(id, to_slice, to_range.get(0))] =
+                from_surface[get_offset(id, from_slice, from_range.get(0))];
+          });
+    }));
+  break;
+  default:
+    throw std::runtime_error("dpct_memcpy: invalid direction value");
+  }
+  return event_list;
+}
+
+/// memcpy 2D/3D matrix specified by pitched_data.
+static inline std::vector<sycl::event>
+dpct_memcpy(sycl::queue &q, pitched_data to, sycl::id<3> to_id,
+            pitched_data from, sycl::id<3> from_id, sycl::range<3> size,
+            memcpy_direction direction = automatic) {
+  return dpct_memcpy(q, to.get_data_ptr(), from.get_data_ptr(),
+                     sycl::range<3>(to.get_pitch(), to.get_y(), 1),
+                     sycl::range<3>(from.get_pitch(), from.get_y(), 1), to_id, from_id,
+                     size, direction);
+}
+
+/// memcpy 2D matrix with pitch.
+static inline std::vector<sycl::event>
+dpct_memcpy(sycl::queue &q, void *to_ptr, const void *from_ptr,
+            size_t to_pitch, size_t from_pitch, size_t x, size_t y,
+            memcpy_direction direction = automatic) {
+  return dpct_memcpy(q, to_ptr, from_ptr, sycl::range<3>(to_pitch, y, 1),
+                     sycl::range<3>(from_pitch, y, 1),
+                     sycl::id<3>(0, 0, 0), sycl::id<3>(0, 0, 0),
+                     sycl::range<3>(x, y, 1), direction);
+}
+
 } // namespace detail
+
+/// Asynchronously copies \p size bytes from the address specified by \p
+/// from_ptr to the address specified by \p to_ptr. The value of \p direction is
+/// used to set the copy direction, it can be \a host_to_host, \a
+/// host_to_device, \a device_to_host, \a device_to_device or \a automatic. The
+/// return of the function does NOT guarantee the copy is completed.
+///
+/// \param to_ptr Pointer to destination memory address.
+/// \param from_ptr Pointer to source memory address.
+/// \param size Number of bytes to be copied.
+/// \param direction Direction of the copy.
+/// \param q Queue to execute the copy task.
+/// \returns no return value.
+static void async_dpct_memcpy(void *to_ptr, const void *from_ptr, size_t size,
+                              memcpy_direction direction = automatic,
+                              sycl::queue &q = dpct::get_default_queue()) {
+  detail::dpct_memcpy(q, to_ptr, from_ptr, size, direction);
+}
+
+/// Asynchronously copies 2D matrix specified by \p x and \p y from the address
+/// specified by \p from_ptr to the address specified by \p to_ptr, while \p
+/// \p from_pitch and \p to_pitch are the range of dim x in bytes of the matrix
+/// specified by \p from_ptr and \p to_ptr. The value of \p direction is used to
+/// set the copy direction, it can be \a host_to_host, \a host_to_device, \a
+/// device_to_host, \a device_to_device or \a automatic. The return of the
+/// function does NOT guarantee the copy is completed.
+///
+/// \param to_ptr Pointer to destination memory address.
+/// \param to_pitch Range of dim x in bytes of destination matrix.
+/// \param from_ptr Pointer to source memory address.
+/// \param from_pitch Range of dim x in bytes of source matrix.
+/// \param x Range of dim x of matrix to be copied.
+/// \param y Range of dim y of matrix to be copied.
+/// \param direction Direction of the copy.
+/// \param q Queue to execute the copy task.
+/// \returns no return value.
+static inline void
+async_dpct_memcpy(void *to_ptr, size_t to_pitch, const void *from_ptr,
+                  size_t from_pitch, size_t x, size_t y,
+                  memcpy_direction direction = automatic,
+                  sycl::queue &q = get_default_queue()) {
+  detail::dpct_memcpy(q, to_ptr, from_ptr, to_pitch, from_pitch, x, y,
+                      direction);
+}
+
+/// Asynchronously copies a subset of a 3D matrix specified by \p to to another
+/// 3D matrix specified by \p from. The from and to position info are specified
+/// by \p from_pos and \p to_pos The copied matrix size is specified by \p size.
+/// The value of \p direction is used to set the copy direction, it can be \a
+/// host_to_host, \a host_to_device, \a device_to_host, \a device_to_device or
+/// \a automatic. The return of the function does NOT guarantee the copy is
+/// completed.
+///
+/// \param to Destination matrix info.
+/// \param to_pos Position of destination.
+/// \param from Source matrix info.
+/// \param from_pos Position of destination.
+/// \param size Range of the submatrix to be copied.
+/// \param direction Direction of the copy.
+/// \param q Queue to execute the copy task.
+/// \returns no return value.
+static inline void
+async_dpct_memcpy(pitched_data to, sycl::id<3> to_pos, pitched_data from,
+                  sycl::id<3> from_pos, sycl::range<3> size,
+                  memcpy_direction direction = automatic,
+                  sycl::queue &q = get_default_queue()) {
+  detail::dpct_memcpy(q, to, to_pos, from, from_pos, size, direction);
+}
 
 /// Synchronously sets \p value to the first \p size bytes starting from \p
 /// dev_ptr. The function will return after the memset operation is completed.


### PR DESCRIPTION
# Existing Sample Changes
## Description

A different version of 01_dpct_output folder is uploaded previously and now it is replaced with the proper version.

## Type of change

Please delete options that are not relevant. Add a 'X' to the one that is applicable. 

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Implement fixes for ONSAM Jiras

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [X] Command Line
- [ ] oneapi-cli
- [ ] Visual Studio
- [ ] Eclipse IDE
- [ ] VSCode
- [X] When compiling the compliler flag "-Wall -Wformat-security -Werror=format-security" was used

