### PR TITLE
Add -fsycl to some designs with the -fsycl missing in comments in the icpx command

### DIFF
--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/experimental/hostpipes/src/CMakeLists.txt
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/experimental/hostpipes/src/CMakeLists.txt
@@ -46,10 +46,10 @@ set(HARDWARE_LINK_FLAGS "-fsycl -fintelfpga -Xshardware -Xstarget=${FPGA_DEVICE}
 ### FPGA Emulator
 ###############################################################################
 # To compile in a single command:
-#    icpx -fintelfpga -DFPGA_EMULATOR hostpipes.cpp -o hostpipes.fpga_emu
+#    icpx -fsycl -fintelfpga -DFPGA_EMULATOR hostpipes.cpp -o hostpipes.fpga_emu
 # CMake executes:
-#    [compile] icpx -fintelfpga -DFPGA_EMULATOR -o hostpipes.cpp.o -c hostpipes.cpp
-#    [link]    icpx -fintelfpga hostpipes.cpp.o -o hostpipes.fpga_emu
+#    [compile] icpx -fsycl -fintelfpga -DFPGA_EMULATOR -o hostpipes.cpp.o -c hostpipes.cpp
+#    [link]    icpx -fsycl -fintelfpga hostpipes.cpp.o -o hostpipes.fpga_emu
 add_executable(${EMULATOR_TARGET} ${SOURCE_FILE})
 target_include_directories(${EMULATOR_TARGET} PRIVATE ../../../../../include)
 set_target_properties(${EMULATOR_TARGET} PROPERTIES COMPILE_FLAGS "${EMULATOR_COMPILE_FLAGS}")
@@ -77,7 +77,7 @@ set_target_properties(${SIMULATOR_TARGET} PROPERTIES LINK_FLAGS "${SIMULATOR_LIN
 ### Generate Report
 ###############################################################################
 # To compile manually:
-#   icpx -fintelfpga -Xshardware -Xstarget=<FPGA_DEVICE> -fsycl-link=early hostpipes.cpp -o hostpipes_report.a
+#   icpx -fsycl -fintelfpga -Xshardware -Xstarget=<FPGA_DEVICE> -fsycl-link=early hostpipes.cpp -o hostpipes_report.a
 set(FPGA_EARLY_IMAGE ${TARGET_NAME}_report.a)
 # The compile output is not an executable, but an intermediate compilation result unique to SYCL.
 add_executable(${FPGA_EARLY_IMAGE} ${SOURCE_FILE})
@@ -91,10 +91,10 @@ set_target_properties(${FPGA_EARLY_IMAGE} PROPERTIES LINK_FLAGS "${HARDWARE_LINK
 ### FPGA Hardware
 ###############################################################################
 # To compile in a single command:
-#   icpx -fintelfpga -Xshardware -Xstarget=<FPGA_BOARD> hostpipes.cpp -o hostpipes.fpga
+#   icpx -fsycl -fintelfpga -Xshardware -Xstarget=<FPGA_BOARD> hostpipes.cpp -o hostpipes.fpga
 # CMake executes:
-#   [compile] icpx -fintelfpga -o hostpipes.cpp.o -c hostpipes.cpp
-#   [link]    icpx -fintelfpga -Xshardware -Xstarget=<FPGA_DEVICE> hostpipes.cpp.o -o hostpipes.fpga
+#   [compile] icpx -fsycl -fintelfpga -o hostpipes.cpp.o -c hostpipes.cpp
+#   [link]    icpx -fsycl -fintelfpga -Xshardware -Xstarget=<FPGA_DEVICE> hostpipes.cpp.o -o hostpipes.fpga
 add_executable(${FPGA_TARGET} EXCLUDE_FROM_ALL ${SOURCE_FILE})
 target_include_directories(${FPGA_TARGET} PRIVATE ../../../../../include)
 add_custom_target(fpga DEPENDS ${FPGA_TARGET})

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/loop_ivdep/src/CMakeLists.txt
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/loop_ivdep/src/CMakeLists.txt
@@ -49,7 +49,7 @@ add_custom_target(fpga_emu DEPENDS ${EMULATOR_TARGET})
 ### FPGA Simulator
 ###############################################################################
 # To compile in a single command:
-#    icpx -fintelfpga -Xssimulation -Xsghdl -Xstarget=<FPGA_DEVICE> -DFPGA_SIMULATOR loop_ivdep.cpp -o loop_ivdep.fpga_sim
+#    icpx -fsycl -fintelfpga -Xssimulation -Xsghdl -Xstarget=<FPGA_DEVICE> -DFPGA_SIMULATOR loop_ivdep.cpp -o loop_ivdep.fpga_sim
 # CMake executes:
 #    [compile] icpx -fsycl -fintelfpga -Xssimulation -DFPGA_SIMULATOR -o loop_ivdep.cpp.o -c loop_ivdep.cpp
 #    [link]    icpx -fsycl -fintelfpga -Xssimulation -Xsghdl -Xstarget=<FPGA_DEVICE> loop_ivdep.cpp.o -o loop_ivdep.fpga_sim

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/loop_ivdep/src/CMakeLists.txt
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/loop_ivdep/src/CMakeLists.txt
@@ -51,8 +51,8 @@ add_custom_target(fpga_emu DEPENDS ${EMULATOR_TARGET})
 # To compile in a single command:
 #    icpx -fintelfpga -Xssimulation -Xsghdl -Xstarget=<FPGA_DEVICE> -DFPGA_SIMULATOR loop_ivdep.cpp -o loop_ivdep.fpga_sim
 # CMake executes:
-#    [compile] icpx -fintelfpga -Xssimulation -DFPGA_SIMULATOR -o loop_ivdep.cpp.o -c loop_ivdep.cpp
-#    [link]    icpx -fintelfpga -Xssimulation -Xsghdl -Xstarget=<FPGA_DEVICE> loop_ivdep.cpp.o -o loop_ivdep.fpga_sim
+#    [compile] icpx -fsycl -fintelfpga -Xssimulation -DFPGA_SIMULATOR -o loop_ivdep.cpp.o -c loop_ivdep.cpp
+#    [link]    icpx -fsycl -fintelfpga -Xssimulation -Xsghdl -Xstarget=<FPGA_DEVICE> loop_ivdep.cpp.o -o loop_ivdep.fpga_sim
 add_executable(${SIMULATOR_TARGET} ${SOURCE_FILE})
 target_include_directories(${SIMULATOR_TARGET} PRIVATE ../../../../include)
 set_target_properties(${SIMULATOR_TARGET} PROPERTIES COMPILE_FLAGS "${SIMULATOR_COMPILE_FLAGS}")

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/loop_unroll/src/CMakeLists.txt
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/loop_unroll/src/CMakeLists.txt
@@ -49,10 +49,10 @@ add_custom_target(fpga_emu DEPENDS ${EMULATOR_TARGET})
 ### FPGA Simulator
 ###############################################################################
 # To compile in a single command:
-#    icpx -fintelfpga -Xssimulation -Xsghdl -Xstarget=<FPGA_DEVICE> -DFPGA_SIMULATOR loop_unroll.cpp -o loop_unroll.fpga_sim
+#    icpx -fsycl -fintelfpga -Xssimulation -Xsghdl -Xstarget=<FPGA_DEVICE> -DFPGA_SIMULATOR loop_unroll.cpp -o loop_unroll.fpga_sim
 # CMake executes:
-#    [compile] icpx -fintelfpga -Xssimulation -DFPGA_SIMULATOR -o loop_unroll.cpp.o -c loop_unroll.cpp
-#    [link]    icpx -fintelfpga -Xssimulation -Xsghdl -Xstarget=<FPGA_DEVICE> loop_unroll.cpp.o -o loop_unroll.fpga_sim
+#    [compile] icpx -fsycl -fintelfpga -Xssimulation -DFPGA_SIMULATOR -o loop_unroll.cpp.o -c loop_unroll.cpp
+#    [link]    icpx -fsycl -fintelfpga -Xssimulation -Xsghdl -Xstarget=<FPGA_DEVICE> loop_unroll.cpp.o -o loop_unroll.fpga_sim
 add_executable(${SIMULATOR_TARGET} ${SOURCE_FILE})
 target_include_directories(${SIMULATOR_TARGET} PRIVATE ../../../../include)
 set_target_properties(${SIMULATOR_TARGET} PROPERTIES COMPILE_FLAGS "${SIMULATOR_COMPILE_FLAGS}")

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/max_interleaving/src/CMakeLists.txt
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/max_interleaving/src/CMakeLists.txt
@@ -50,10 +50,10 @@ add_custom_target(fpga_emu DEPENDS ${EMULATOR_TARGET})
 ### FPGA Simulator
 ###############################################################################
 # To compile in a single command:
-#    icpx -fintelfpga -Xssimulation -Xsghdl -Xstarget=<FPGA_DEVICE> -DFPGA_SIMULATOR max_interleaving.cpp -o max_interleaving.fpga_sim
+#    icpx -fsycl -fintelfpga -Xssimulation -Xsghdl -Xstarget=<FPGA_DEVICE> -DFPGA_SIMULATOR max_interleaving.cpp -o max_interleaving.fpga_sim
 # CMake executes:
-#    [compile] icpx -fintelfpga -Xssimulation -DFPGA_SIMULATOR -o max_interleaving.cpp.o -c max_interleaving.cpp
-#    [link]    icpx -fintelfpga -Xssimulation -Xsghdl -Xstarget=<FPGA_DEVICE> max_interleaving.cpp.o -o max_interleaving.fpga_sim
+#    [compile] icpx -fsycl -fintelfpga -Xssimulation -DFPGA_SIMULATOR -o max_interleaving.cpp.o -c max_interleaving.cpp
+#    [link]    icpx -fsycl -fintelfpga -Xssimulation -Xsghdl -Xstarget=<FPGA_DEVICE> max_interleaving.cpp.o -o max_interleaving.fpga_sim
 add_executable(${SIMULATOR_TARGET} ${SOURCE_FILE})
 target_include_directories(${SIMULATOR_TARGET} PRIVATE ../../../../include)
 set_target_properties(${SIMULATOR_TARGET} PROPERTIES COMPILE_FLAGS "${SIMULATOR_COMPILE_FLAGS}")


### PR DESCRIPTION
# Existing Sample Changes

## Description

Add -fsycl to some designs with the -fsycl missing in comments in the icpx command

-fsycl is required for compiling to FPGA

Fixes Issue# no issue code

## External Dependencies

n/a

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

No testing required since this is a change only to comments 