### PR TITLE
Fix and simplify `optimization_targets` for S10 compile

### DIFF
--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/optimization_targets/src/CMakeLists.txt
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/optimization_targets/src/CMakeLists.txt
@@ -20,7 +20,6 @@ set(FPGA_TARGET_MANUAL_REVERT ${TARGET_NAME_MANUAL_REVERT}.fpga)
 # FPGA board selection
 if(NOT DEFINED FPGA_DEVICE)
     set(FPGA_DEVICE "Agilex7")
-    set(DEVICE_FLAG "Agilex7")
     set(MANUAL_REVERT_FLAGS "-Xshyper-optimized-handshaking=on -Xssfc-exit-fifo-type=default")
     message(STATUS "FPGA_DEVICE was not specified.\
                     \nConfiguring the design to the default FPGA family: ${FPGA_DEVICE}\
@@ -28,22 +27,13 @@ if(NOT DEFINED FPGA_DEVICE)
 else()
     string(TOLOWER ${FPGA_DEVICE} FPGA_DEVICE_NAME)
     if(FPGA_DEVICE_NAME MATCHES ".*a10*" OR FPGA_DEVICE_NAME MATCHES ".*arria10.*")
-        set(DEVICE_FLAG "A10")
         set(MANUAL_REVERT_FLAGS "-Xssfc-exit-fifo-type=default")
     elseif(FPGA_DEVICE_NAME MATCHES ".*s10*" OR FPGA_DEVICE_NAME MATCHES ".*stratix10.*")
-        set(DEVICE_FLAG "S10")
         set(MANUAL_REVERT_FLAGS "-Xshyper-optimized-handshaking=on -Xssfc-exit-fifo-type=default")
     elseif(FPGA_DEVICE_NAME MATCHES ".*agilex*")
-        set(DEVICE_FLAG "Agilex7")
         set(MANUAL_REVERT_FLAGS "-Xshyper-optimized-handshaking=on -Xssfc-exit-fifo-type=default")
     endif()
     message(STATUS "Configuring the design with the following target: ${FPGA_DEVICE}")
-endif()
-
-if(NOT DEFINED DEVICE_FLAG)
-    message(FATAL_ERROR "An unrecognized or custom board was passed, but DEVICE_FLAG was not specified. \
-                         Please make sure you have set -DDEVICE_FLAG=A10, -DDEVICE_FLAG=S10 or \
-                         -DDEVICE_FLAG=Agilex7.")
 endif()
 
 # This is a Windows-specific flag that enables exception handling in host code
@@ -55,12 +45,12 @@ endif()
 # 1. The "compile" stage compiles the device code to an intermediate representation (SPIR-V).
 # 2. The "link" stage invokes the compiler's FPGA backend before linking.
 #    For this reason, FPGA backend flags must be passed as link flags in CMake.
-set(EMULATOR_COMPILE_FLAGS "-Wall ${WIN_FLAG} -fsycl -fintelfpga -DFPGA_EMULATOR -D${DEVICE_FLAG}")
+set(EMULATOR_COMPILE_FLAGS "-Wall ${WIN_FLAG} -fsycl -fintelfpga -DFPGA_EMULATOR")
 set(EMULATOR_LINK_FLAGS "-fsycl -fintelfpga")
-set(SIMULATOR_COMPILE_FLAGS "-Wall ${WIN_FLAG} -fsycl -fintelfpga -DFPGA_SIMULATOR -D${DEVICE_FLAG}")
-set(SIMULATOR_LINK_FLAGS "-fsycl -fintelfpga -Xssimulation -Xstarget=${FPGA_DEVICE} -D${DEVICE_FLAG} ${USER_HARDWARE_FLAGS}")
-set(HARDWARE_COMPILE_FLAGS "-Wall ${WIN_FLAG} -fsycl -fintelfpga -DFPGA_HARDWARE -D${DEVICE_FLAG}")
-set(HARDWARE_LINK_FLAGS "-fsycl -fintelfpga -Xshardware -Xstarget=${FPGA_DEVICE} -D${DEVICE_FLAG} ${USER_HARDWARE_FLAGS}")
+set(SIMULATOR_COMPILE_FLAGS "-Wall ${WIN_FLAG} -fsycl -fintelfpga -DFPGA_SIMULATOR")
+set(SIMULATOR_LINK_FLAGS "-fsycl -fintelfpga -Xssimulation -Xstarget=${FPGA_DEVICE} ${USER_HARDWARE_FLAGS}")
+set(HARDWARE_COMPILE_FLAGS "-Wall ${WIN_FLAG} -fsycl -fintelfpga -DFPGA_HARDWARE")
+set(HARDWARE_LINK_FLAGS "-fsycl -fintelfpga -Xshardware -Xstarget=${FPGA_DEVICE} ${USER_HARDWARE_FLAGS}")
 # use cmake -D USER_HARDWARE_FLAGS=<flags> to set extra flags for FPGA backend compilation
 
 ###############################################################################
@@ -83,7 +73,7 @@ add_custom_target(fpga_emu DEPENDS ${EMULATOR_TARGET_NO_CONTROL})
 # To compile manually:
 #   icpx -fsycl -fintelfpga -Xshardware -Xstarget=<FPGA_DEVICE> -fsycl-link=early optimization_targets.cpp -o no_control.a
 #   icpx -fsycl -fintelfpga -Xshardware -Xstarget=<FPGA_DEVICE> -fsycl-link=early optimization_targets.cpp -Xsoptimize=latency -o minimum_latency.a
-#   icpx -fsycl -fintelfpga -Xshardware -Xstarget=<FPGA_DEVICE> -fsycl-link=early optimization_targets.cpp -Xsoptimize=latency -DMANUAL_REVERT -Xshyper-optimized-handshaking=on -Xssfc-exit-fifo-type=default -o manual_revert.a
+#   icpx -fsycl -fintelfpga -Xshardware -Xstarget=<FPGA_DEVICE> -fsycl-link=early optimization_targets.cpp -Xsoptimize=latency -Xshyper-optimized-handshaking=on -Xssfc-exit-fifo-type=default -o manual_revert.a
 # The compile output is not an executable, but an intermediate compilation result unique to SYCL.
 add_executable(${FPGA_EARLY_IMAGE_NO_CONTROL} ${SOURCE_FILE})
 target_include_directories(${FPGA_EARLY_IMAGE_NO_CONTROL} PRIVATE ../../../../include)
@@ -96,7 +86,7 @@ set_target_properties(${FPGA_EARLY_IMAGE_NO_CONTROL} PROPERTIES COMPILE_FLAGS "$
 set_target_properties(${FPGA_EARLY_IMAGE_NO_CONTROL} PROPERTIES LINK_FLAGS "${HARDWARE_LINK_FLAGS} -fsycl-link=early")
 set_target_properties(${FPGA_EARLY_IMAGE_MINIMUM_LATENCY} PROPERTIES COMPILE_FLAGS "${HARDWARE_COMPILE_FLAGS}")
 set_target_properties(${FPGA_EARLY_IMAGE_MINIMUM_LATENCY} PROPERTIES LINK_FLAGS "${HARDWARE_LINK_FLAGS} -fsycl-link=early -Xsoptimize=latency")
-set_target_properties(${FPGA_EARLY_IMAGE_MANUAL_REVERT} PROPERTIES COMPILE_FLAGS "${HARDWARE_COMPILE_FLAGS} -DMANUAL_REVERT")
+set_target_properties(${FPGA_EARLY_IMAGE_MANUAL_REVERT} PROPERTIES COMPILE_FLAGS "${HARDWARE_COMPILE_FLAGS}")
 set_target_properties(${FPGA_EARLY_IMAGE_MANUAL_REVERT} PROPERTIES LINK_FLAGS "${HARDWARE_LINK_FLAGS} -fsycl-link=early -Xsoptimize=latency ${MANUAL_REVERT_FLAGS}")
 # fsycl-link=early stops the compiler after RTL generation, before invoking Quartus®
 
@@ -106,13 +96,13 @@ set_target_properties(${FPGA_EARLY_IMAGE_MANUAL_REVERT} PROPERTIES LINK_FLAGS "$
 # To compile in a single command:
 #    icpx -fsycl -fintelfpga -Xssimulation -Xstarget=<FPGA_DEVICE> -DFPGA_SIMULATOR optimization_targets.cpp -o no_control.fpga_sim
 #    icpx -fsycl -fintelfpga -Xssimulation -Xstarget=<FPGA_DEVICE> -DFPGA_SIMULATOR optimization_targets.cpp -Xsoptimize=latency -o minimum_latency.fpga_sim
-#    icpx -fsycl -fintelfpga -Xssimulation -Xstarget=<FPGA_DEVICE> -DFPGA_SIMULATOR optimization_targets.cpp -Xsoptimize=latency -DMANUAL_REVERT -Xshyper-optimized-handshaking=on -Xssfc-exit-fifo-type=default -o manual_revert.fpga_sim
+#    icpx -fsycl -fintelfpga -Xssimulation -Xstarget=<FPGA_DEVICE> -DFPGA_SIMULATOR optimization_targets.cpp -Xsoptimize=latency -Xshyper-optimized-handshaking=on -Xssfc-exit-fifo-type=default -o manual_revert.fpga_sim
 # CMake executes:
 #    [compile] icpx -fsycl -fintelfpga -DFPGA_SIMULATOR -o no_control.cpp.o -c optimization_targets.cpp
 #    [link]    icpx -fsycl -fintelfpga -Xssimulation -Xstarget=<FPGA_DEVICE> no_control.cpp.o -o no_control.fpga_sim
 #    [compile] icpx -fsycl -fintelfpga -DFPGA_SIMULATOR -o optimization_targets.cpp.o -c optimization_targets.cpp
 #    [link]    icpx -fsycl -fintelfpga -Xssimulation -Xstarget=<FPGA_DEVICE> optimization_targets.cpp.o -Xsoptimize=latency -o minimum_latency.fpga_sim
-#    [compile] icpx -fsycl -fintelfpga -DFPGA_SIMULATOR -o manual_revert.cpp.o -c optimization_targets.cpp -DMANUAL_REVERT
+#    [compile] icpx -fsycl -fintelfpga -DFPGA_SIMULATOR -o manual_revert.cpp.o -c optimization_targets.cpp
 #    [link]    icpx -fsycl -fintelfpga -Xssimulation -Xstarget=<FPGA_DEVICE> manual_revert.cpp.o -Xsoptimize=latency -Xshyper-optimized-handshaking=on -Xssfc-exit-fifo-type=default -o manual_revert.fpga_sim
 add_executable(${SIMULATOR_TARGET_NO_CONTROL} ${SOURCE_FILE})
 target_include_directories(${SIMULATOR_TARGET_NO_CONTROL} PRIVATE ../../../../include)
@@ -125,7 +115,7 @@ set_target_properties(${SIMULATOR_TARGET_NO_CONTROL} PROPERTIES COMPILE_FLAGS "$
 set_target_properties(${SIMULATOR_TARGET_NO_CONTROL} PROPERTIES LINK_FLAGS "${SIMULATOR_LINK_FLAGS}")
 set_target_properties(${SIMULATOR_TARGET_MINIMUM_LATENCY} PROPERTIES COMPILE_FLAGS "${SIMULATOR_COMPILE_FLAGS}")
 set_target_properties(${SIMULATOR_TARGET_MINIMUM_LATENCY} PROPERTIES LINK_FLAGS "${SIMULATOR_LINK_FLAGS} -Xsoptimize=latency")
-set_target_properties(${SIMULATOR_TARGET_MANUAL_REVERT} PROPERTIES COMPILE_FLAGS "${SIMULATOR_COMPILE_FLAGS} -DMANUAL_REVERT")
+set_target_properties(${SIMULATOR_TARGET_MANUAL_REVERT} PROPERTIES COMPILE_FLAGS "${SIMULATOR_COMPILE_FLAGS}")
 set_target_properties(${SIMULATOR_TARGET_MANUAL_REVERT} PROPERTIES LINK_FLAGS "${SIMULATOR_LINK_FLAGS} -Xsoptimize=latency ${MANUAL_REVERT_FLAGS}")
 
 ###############################################################################
@@ -134,13 +124,13 @@ set_target_properties(${SIMULATOR_TARGET_MANUAL_REVERT} PROPERTIES LINK_FLAGS "$
 # To compile in a single command:
 #   icpx -fsycl -fintelfpga -Xshardware -Xstarget=<FPGA_DEVICE> optimization_targets.cpp -o no_control.fpga
 #   icpx -fsycl -fintelfpga -Xshardware -Xstarget=<FPGA_DEVICE> optimization_targets.cpp -Xsoptimize=latency -o minimum_latency.fpga
-#   icpx -fsycl -fintelfpga -Xshardware -Xstarget=<FPGA_DEVICE> optimization_targets.cpp -Xsoptimize=latency -DMANUAL_REVERT -Xshyper-optimized-handshaking=on -Xssfc-exit-fifo-type=default -o manual_revert.fpga
+#   icpx -fsycl -fintelfpga -Xshardware -Xstarget=<FPGA_DEVICE> optimization_targets.cpp -Xsoptimize=latency -Xshyper-optimized-handshaking=on -Xssfc-exit-fifo-type=default -o manual_revert.fpga
 # CMake executes:
 #   [compile] icpx -fsycl -fintelfpga -o no_control.cpp.o -c optimization_targets.cpp
 #   [link]    icpx -fsycl -fintelfpga -Xshardware -Xstarget=<FPGA_DEVICE> no_control.cpp.o -o no_control.fpga
 #   [compile] icpx -fsycl -fintelfpga -o optimization_targets.cpp.o -c optimization_targets.cpp
 #   [link]    icpx -fsycl -fintelfpga -Xshardware -Xstarget=<FPGA_DEVICE> optimization_targets.cpp.o -Xsoptimize=latency -o minimum_latency.fpga
-#   [compile] icpx -fsycl -fintelfpga -o manual_revert.cpp.o -c optimization_targets.cpp -DMANUAL_REVERT
+#   [compile] icpx -fsycl -fintelfpga -o manual_revert.cpp.o -c optimization_targets.cpp
 #   [link]    icpx -fsycl -fintelfpga -Xshardware -Xstarget=<FPGA_DEVICE> manual_revert.cpp.o -Xsoptimize=latency -Xshyper-optimized-handshaking=on -Xssfc-exit-fifo-type=default -o manual_revert.fpga
 add_executable(${FPGA_TARGET_NO_CONTROL} EXCLUDE_FROM_ALL ${SOURCE_FILE})
 target_include_directories(${FPGA_TARGET_NO_CONTROL} PRIVATE ../../../../include)
@@ -153,7 +143,7 @@ set_target_properties(${FPGA_TARGET_NO_CONTROL} PROPERTIES COMPILE_FLAGS "${HARD
 set_target_properties(${FPGA_TARGET_NO_CONTROL} PROPERTIES LINK_FLAGS "${HARDWARE_LINK_FLAGS} -reuse-exe=${CMAKE_BINARY_DIR}/${FPGA_TARGET_NO_CONTROL}")
 set_target_properties(${FPGA_TARGET_MINIMUM_LATENCY} PROPERTIES COMPILE_FLAGS "${HARDWARE_COMPILE_FLAGS}")
 set_target_properties(${FPGA_TARGET_MINIMUM_LATENCY} PROPERTIES LINK_FLAGS "${HARDWARE_LINK_FLAGS} -reuse-exe=${CMAKE_BINARY_DIR}/${FPGA_TARGET_MINIMUM_LATENCY} -Xsoptimize=latency")
-set_target_properties(${FPGA_TARGET_MANUAL_REVERT} PROPERTIES COMPILE_FLAGS "${HARDWARE_COMPILE_FLAGS} -DMANUAL_REVERT")
+set_target_properties(${FPGA_TARGET_MANUAL_REVERT} PROPERTIES COMPILE_FLAGS "${HARDWARE_COMPILE_FLAGS}")
 set_target_properties(${FPGA_TARGET_MANUAL_REVERT} PROPERTIES LINK_FLAGS "${HARDWARE_LINK_FLAGS} -reuse-exe=${CMAKE_BINARY_DIR}/${FPGA_TARGET_MANUAL_REVERT} -Xsoptimize=latency ${MANUAL_REVERT_FLAGS}")
 # The -reuse-exe flag enables rapid recompilation of host-only code changes.
 # See C++SYCL_FPGA/GettingStarted/fast_recompile for details.

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/optimization_targets/src/optimization_targets.cpp
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/optimization_targets/src/optimization_targets.cpp
@@ -74,11 +74,6 @@ void RunKernel(const RGBVec &r, const RGBVec &g, const RGBVec &b,
       // Using kernel_args_restrict tells the compiler that the input
       // and output buffers won't alias.
       h.single_task<Kernel>([=]() [[intel::kernel_args_restrict]] {
-#if defined(MANUAL_REVERT)
-#if defined(S10)
-        [[intel::speculated_iterations(4)]]
-#endif
-#endif
         for (size_t i = 0; i < kInputSize; i++) {
           out_acc[i] = Compute(r_acc[i], g_acc[i], b_acc[i]);
         }


### PR DESCRIPTION
## Description

- The `MANUAL_REVERT` compile tries to manually revert the minimum latency flow settings to match the `NO_CONTROL` compile. However, `[[intel::speculated_iterations(4)]]` becomes unnecessary in `MANUAL_REVERT` because the speculated iteration is 0 in the corresponding `NO_CONTROL` compile now.
- Also remove two unused -D macros in CMakeLists.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] Command Line
- [x] Regtest
  - IPA: https://spetc.intel.com/testsummary?trview=0&testRunIds=8501121
  - Full system: https://spetc.intel.com/testsummary?trview=0&testRunIds=8496942