### PR TITLE
Removed macOS support from samples

### DIFF
--- a/DirectProgramming/C++/CombinationalLogic/MandelbrotOMP/Makefile
+++ b/DirectProgramming/C++/CombinationalLogic/MandelbrotOMP/Makefile
@@ -1,4 +1,4 @@
-CXX := icpc
+CXX := icpx
 SRCDIR := src
 BUILDDIR := release
 CFLAGS := -O3 -ipo -qopenmp -std=c++11

--- a/DirectProgramming/C++/CombinationalLogic/MandelbrotOMP/README.md
+++ b/DirectProgramming/C++/CombinationalLogic/MandelbrotOMP/README.md
@@ -19,7 +19,7 @@ Each point on the complex plane can be calculated independently, which make the 
 
 | Optimized for                     | Description
 |:---                               |:---
-| OS                                | Ubuntu* 18.04 <br> macOS* Catalina or newer
+| OS                                | Ubuntu* 18.04
 | Hardware                          | Skylake with GEN9 or newer
 | Software                          | Intel® oneAPI DPC++/C++ Compiler
 
@@ -45,12 +45,12 @@ When working with the command-line interface (CLI), you should configure the one
 > **Note**: If you have not already done so, set up your CLI
 > environment by sourcing  the `setvars` script in the root of your oneAPI installation.
 >
-> Linux* and macOS*:
+> Linux*:
 > - For system wide installations: `. /opt/intel/oneapi/setvars.sh`
 > - For private installations: ` . ~/intel/oneapi/setvars.sh`
 > - For non-POSIX shells, like csh, use the following command: `bash -c 'source <install-dir>/setvars.sh ; exec csh'`
 >
-> For more information on configuring environment variables, see [Use the setvars Script with Linux* or macOS*](https://www.intel.com/content/www/us/en/develop/documentation/oneapi-programming-guide/top/oneapi-development-environment-setup/use-the-setvars-script-with-linux-or-macos.html).
+> For more information on configuring environment variables, see [Use the setvars Script with Linux*](https://www.intel.com/content/www/us/en/develop/documentation/oneapi-programming-guide/top/oneapi-development-environment-setup/use-the-setvars-script-with-linux-or-macos.html).
 
 ### Use Visual Studio Code* (VS Code) (Optional)
 
@@ -66,7 +66,7 @@ The basic steps to build and run a sample using VS Code include:
 To learn more about the extensions and how to configure the oneAPI environment, see the 
 [Using Visual Studio Code with Intel® oneAPI Toolkits User Guide](https://www.intel.com/content/www/us/en/develop/documentation/using-vs-code-with-intel-oneapi/top.html).
 
-### On Linux* and macOS*
+### On Linux*
 1. Change to the sample directory.
 2. Build the program.
     ```
@@ -98,7 +98,7 @@ You can modify the Mandelbrot parameters near the head of the `main.cpp` source 
 
 In `mandelbrot.cpp`, the schedule(<static/dynamic>, <chunk_size>) pragmas in the OpenMP parallel for sections can be modified to change the parallelization parameters. changing between static and dynamic affects how work items are distributed between threads, and the chunk_size affects each work item's size. In `mandelbrot.cpp`, there is a preprocessor definition `NUM_THREADS` set to **8**. Changing this value affects the number of threads dedicated to each parallel section. The ideal number of threads will vary based on device hardware.
 
-### On Linux and macOS
+### On Linux
 
 1. Run the program.
    ```

--- a/DirectProgramming/C++/CombinationalLogic/MandelbrotOMP/sample.json
+++ b/DirectProgramming/C++/CombinationalLogic/MandelbrotOMP/sample.json
@@ -2,20 +2,16 @@
     "name": "Mandelbrot OMP",
     "categories": ["Toolkit/oneAPI Direct Programming/C++/Combinational Logic", "Toolkit/oneAPI Tools/Advisor"],
     "description": "Calculates the Mandelbrot Set and outputs a BMP image representation using OpenMP* (OMP)",
-    "os": ["darwin", "linux"],
+    "os": ["linux"],
     "builder": ["make"],
     "languages": [{"cpp":{}}],
     "toolchain": ["icc"],
     "guid": "DD113F58-4D91-41BB-B46E-6CF2C0D9F6F9",
     "targetDevice": ["CPU", "GPU"],
     "ciTests": {
-        "darwin": [ 
-            { "id": "standard", "steps": [ "make", "make run", "make clean" ] },
-            { "id": "perf_num", "env": [ "export perf_num=1" ], "steps": [ "make", "make run", "make clean" ] }
-        ],
-	    "linux": [ 
-            { "id": "standard", "steps": [ "make", "make run", "make clean" ] },
-            { "id": "perf_num", "env": [ "export perf_num=1" ], "steps": [ "make", "make run", "make clean" ] }
+	"linux": [ 
+            { "id": "standard", "steps": [ "make", "./release/Mandelbrot 0", "make clean" ] },
+            { "id": "perf_num", "env": [ "export perf_num=1" ], "steps": [ "make", "./release/Mandelbrot 0", "make clean" ] }
         ]
     },
     "expertise": "Getting Started"

--- a/DirectProgramming/C++/CompilerInfrastructure/Intrinsics/Makefile
+++ b/DirectProgramming/C++/CompilerInfrastructure/Intrinsics/Makefile
@@ -1,4 +1,4 @@
-CC = icc
+CC = icx
 EXECS=intrin_dot_sample.exe intrin_double_sample.exe intrin_ftz_sample.exe
 DBG_EXECS=intrin_dot_sample_dbg.exe intrin_double_sample_dbg.exe intrin_ftz_sample_dbg.exe
 
@@ -31,10 +31,10 @@ intrin_ftz_sample_dbg.exe: intrin_ftz_sample_dbg.o
 	$(CC) -O0 -g $^ -o $@
 
 %.o: src/%.cpp
-	$(CC) -O2 -c -o $@  $<
+	$(CC) -O2 -msse3 -c -o $@  $<
 
 %_dbg.o: src/%.cpp
-	$(CC) -O0 -g -c -o $@  $<
+	$(CC) -O0 -msse3 -g -c -o $@  $<
 
 clean:
 	/bin/rm -f core.* *.o *.exe

--- a/DirectProgramming/C++/CompilerInfrastructure/Intrinsics/README.md
+++ b/DirectProgramming/C++/CompilerInfrastructure/Intrinsics/README.md
@@ -20,7 +20,7 @@ You can find detailed information in the *Intrinsics* section of the [Intel® C+
 
 | Optimized for       | Description
 |:---                 |:---
-| OS                  | macOS* Catalina* or newer
+| OS                  | Ubuntu* 18.04
 | Hardware            | Skylake with GEN9 or newer
 | Software            | Intel® C++ Compiler
 
@@ -45,7 +45,7 @@ When working with the command-line interface (CLI), you should configure the one
 > - For private installations: ` . ~/intel/oneapi/setvars.sh`
 > - For non-POSIX shells, like csh, use the following command: `bash -c 'source <install-dir>/setvars.sh ; exec csh'`
 >
-> For more information on configuring environment variables, see [Use the setvars Script with Linux* or macOS*](https://www.intel.com/content/www/us/en/develop/documentation/oneapi-programming-guide/top/oneapi-development-environment-setup/use-the-setvars-script-with-linux-or-macos.html).
+> For more information on configuring environment variables, see [Use the setvars Script with Linux*](https://www.intel.com/content/www/us/en/develop/documentation/oneapi-programming-guide/top/oneapi-development-environment-setup/use-the-setvars-script-with-linux-or-macos.html).
 
 ### Use Visual Studio Code* (VS Code) (Optional)
 
@@ -61,7 +61,7 @@ The basic steps to build and run a sample using VS Code include:
 To learn more about the extensions and how to configure the oneAPI environment, see the 
 [Using Visual Studio Code with Intel® oneAPI Toolkits User Guide](https://www.intel.com/content/www/us/en/develop/documentation/using-vs-code-with-intel-oneapi/top.html).
 
-### On macOS*
+### On Linux*
 
 1. Build the program.
    ```

--- a/DirectProgramming/C++/CompilerInfrastructure/Intrinsics/sample.json
+++ b/DirectProgramming/C++/CompilerInfrastructure/Intrinsics/sample.json
@@ -2,14 +2,14 @@
     "name": "Intrinsics",
     "categories": ["Toolkit/oneAPI Direct Programming/C++/Compiler Infrastructure"],
     "description": "Demonstrates the Intrinsic functions of the Intel® oneAPI C++ Compiler Classic",
-    "os": ["darwin"],
+    "os": ["linux"],
     "builder": ["make"],
     "languages": [{"cpp":{}}],
     "toolchain": ["icc"],
     "guid": "ACD0E89E-67CC-4CB4-87AB-B12B84962EAF",
     "targetDevice": [ "CPU" ],
     "ciTests": {
-        "darwin": [ 
+        "linux": [ 
             { "id": "standard", "steps": [ "make", "make run", "make clean" ] },
             { "id": "debug", "steps": [ "make debug", "make debug_run", "make clean" ] }
         ]

--- a/DirectProgramming/C++/GraphTraversal/MergesortOMP/README.md
+++ b/DirectProgramming/C++/GraphTraversal/MergesortOMP/README.md
@@ -20,7 +20,7 @@ We then merge sublists two at a time to produce a sorted list. This sample could
 
 | Optimized for          | Description
 |:---                    |:---
-| OS                     | macOS* Catalina or newer
+| OS                     | Ubuntu* 18.04
 | Hardware               | Skylake with GEN9 or newer
 | Software               | Intel® oneAPI DPC++ Compiler
 
@@ -47,7 +47,7 @@ Performance number tabulation.
 > - For private installations: ` . ~/intel/oneapi/setvars.sh`
 > - For non-POSIX shells, like csh, use the following command: `bash -c 'source <install-dir>/setvars.sh ; exec csh'`
 >
-> For more information on configuring environment variables, see [Use the setvars Script with Linux* or macOS*](https://www.intel.com/content/www/us/en/develop/documentation/oneapi-programming-guide/top/oneapi-development-environment-setup/use-the-setvars-script-with-linux-or-macos.html).
+> For more information on configuring environment variables, see [Use the setvars Script with Linux* or Linux*](https://www.intel.com/content/www/us/en/develop/documentation/oneapi-programming-guide/top/oneapi-development-environment-setup/use-the-setvars-script-with-linux-or-macos.html).
 
 ### Use Visual Studio Code* (VS Code) (Optional)
 
@@ -63,7 +63,7 @@ The basic steps to build and run a sample using VS Code include:
 To learn more about the extensions and how to configure the oneAPI environment, see the 
 [Using Visual Studio Code with Intel® oneAPI Toolkits User Guide](https://www.intel.com/content/www/us/en/develop/documentation/using-vs-code-with-intel-oneapi/top.html).
 
-### On macOS*
+### On Linux*
 
 1. Build the program
    ```
@@ -89,7 +89,7 @@ There are two configurable options defined in the source code. Both parameters a
 - `constexpr int task_threshold` - This determines the minimum size of the list passed to the OpenMP merge sort function required to call itself and not the scalar version recursively. Its purpose is to reduce the threading overhead as it gets less efficient on smaller list sizes. Setting this value too small can reduce the OpenMP implementation's performance as it has more threading overhead for smaller workloads.
 - `constexpr int n` - This determines the size of the list used to test the merge sort functions. Setting it larger will result in longer runtime and is useful for analyzing the algorithm's runtime growth rate.
 
-### On macOS
+### On Linux
 
 1. Run the program.
    ```

--- a/DirectProgramming/C++/GraphTraversal/MergesortOMP/sample.json
+++ b/DirectProgramming/C++/GraphTraversal/MergesortOMP/sample.json
@@ -2,16 +2,16 @@
     "name": "MergeSort OMP",
     "categories": ["Toolkit/oneAPI Direct Programming/C++/Graph Traversal"],
     "description": "Classic OpenMP* (OMP) Mergesort algorithm",
-    "os": ["darwin"],
+    "os": ["linux"],
     "builder": ["make"],
     "languages": [{"cpp":{}}],
     "toolchain": ["icc"],
     "guid": "5AFED65F-F725-411D-B21C-B59008D1166D",
     "targetDevice": [ "CPU" ],
     "ciTests": {
-        "darwin": [ 
-            { "id": "standard", "steps": [ "make", "make run", "make clean" ] },
-            { "id": "perf_num", "env": [ "export perf_num=1" ], "steps": [ "make", "make run", "make clean" ] }
+        "linux": [ 
+            { "id": "standard", "steps": [ "make", "./release/MergeSort 0", "make clean" ] },
+            { "id": "perf_num", "env": [ "export perf_num=1" ], "steps": [ "make", "./release/MergeSort 0", "make clean" ] }
         ]
     },
     "expertise": "Concepts and Functionality"

--- a/DirectProgramming/Fortran/DenseLinearAlgebra/vectorize-vecmatmult/sample.json
+++ b/DirectProgramming/Fortran/DenseLinearAlgebra/vectorize-vecmatmult/sample.json
@@ -6,10 +6,10 @@
   "toolchain": [ "ifort" ],
   "languages": [ { "fortran": {} } ],
   "targetDevice": [ "CPU" ],
-  "os": [ "darwin" ],
+  "os": [ "linux" ],
   "builder": [ "make" ],
   "ciTests":{
-    "darwin": [
+    "linux": [
       {
         "id": "fort_vecsample_cpu",
         "steps": [


### PR DESCRIPTION
# Existing Sample Changes
## Description

Removed macOS support from samples for 2024.0 and replaced it with Linux. Updated the Makefile, sample.json and READMEs.

## Type of change

Please delete options that are not relevant. Add a 'X' to the one that is applicable. 

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Implement fixes for ONSAM Jiras

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [X] Command Line
- [ ] oneapi-cli
- [ ] Visual Studio
- [ ] Eclipse IDE
- [ ] VSCode
- [ ] When compiling the compliler flag "-Wall -Wformat-security -Werror=format-security" was used