### PR TITLE
Fix numba knn sample kernel issue

### DIFF
--- a/AI-and-Analytics/Features-and-Functionality/IntelPython_Numpy_Numba_dpex_kNN/IntelPython_Numpy_Numba_dpex_kNN.ipynb
+++ b/AI-and-Analytics/Features-and-Functionality/IntelPython_Numpy_Numba_dpex_kNN/IntelPython_Numpy_Numba_dpex_kNN.ipynb
@@ -312,8 +312,7 @@
    "source": [
     "## Numba_dpex k-NN\n",
     "\n",
-    "Numba_dpex implementation use `numba_dpex.kernel()` decorator. We define the access type for all the input parameters for the defined function there. \n",
-    "For more information about programming, SYCL kernels go to: https://intelpython.github.io/numba-dpex/latest/user_guides/kernel_programming_guide/index.html.\n",
+    "Numba_dpex implementation use `numba_dpex.kernel()` decorator. For more information about programming, SYCL kernels go to: https://intelpython.github.io/numba-dpex/latest/user_guides/kernel_programming_guide/index.html.\n",
     "\n",
     "Calculating distance is like in the NumPy example. We are using Euclidean distance. Later, we create the queue of the neighbours by the calculated distance and count in provided *k* votes for dedicated classes of neighbours.\n",
     "\n",
@@ -328,11 +327,7 @@
    "source": [
     "import   numba_dpex\n",
     "\n",
-    "@numba_dpex.kernel(\n",
-    "        access_types={\n",
-    "        \"read_only\": [\"train\", \"train_labels\", \"test\", \"votes_to_classes_lst\"],\n",
-    "        \"write_only\": [\"predictions\"],   }\n",
-    ")\n",
+    "@numba_dpex.kernel\n",
     "def knn_numba_dpex(train, train_labels, test, k, predictions, votes_to_classes_lst):\n",
     "    i = numba_dpex.get_global_id(0)\n",
     "    queue_neighbors = numba_dpex.private.array(shape=(3, 2), dtype=np.float64)\n",

--- a/AI-and-Analytics/Features-and-Functionality/IntelPython_Numpy_Numba_dpex_kNN/IntelPython_Numpy_Numba_dpex_kNN.py
+++ b/AI-and-Analytics/Features-and-Functionality/IntelPython_Numpy_Numba_dpex_kNN/IntelPython_Numpy_Numba_dpex_kNN.py
@@ -30,9 +30,9 @@ import pandas as pd
 # 
 # Then, let's download the dataset and prepare it for future computations.
 # 
-# We are using wine dataset avalable in sci-kit learn library. For our purposes we will be using only 2 features: alcohol and malic_acid.
+# We are using the wine dataset available in the sci-kit learn library. For our purposes, we will be using only 2 features: alcohol and malic_acid.
 # 
-# So first we need to load dataset and create DataFrame from it. Later we will limit the dataframe to just target and 2 classes we choose for this problem.
+# So first we need to load the dataset and create DataFrame from it. Later we will limit the DataFrame to just target and 2 classes we choose for this problem.
 
 # In[ ]:
 
@@ -51,7 +51,7 @@ df = df[['target', 'alcohol', 'malic_acid']]
 df.head()
 
 
-# We are planning to compare the results of the numpy, namba and IDP numba_dpex so we need to make sure that the results are reproducable. We are able to do this through the use of random seed function that initialize random number generator.
+# We are planning to compare the results of the numpy, namba and IDP numba_dpex so we need to make sure that the results are reproducible. We can do this through the use of a random seed function that initializes a random number generator.
 
 # In[ ]:
 
@@ -59,7 +59,7 @@ df.head()
 np.random.seed(42)
 
 
-# The next step is to prepare dataset for trainin and testing. To do this, we divide the downloaded wine dataset randomly into a training set (containing 90% of the data) and a test set (containing 10% of the data). 
+# The next step is to prepare the dataset for training and testing. To do this, we randomly divided the downloaded wine dataset into a training set (containing 90% of the data) and a test set (containing 10% of the data). 
 # 
 # In addition, we take from both sets (training and test) data *X* (features) and label *y* (target).
 
@@ -92,12 +92,12 @@ def distance(vector1, vector2):
 
 # Then, the k-nearest neighbour algorithm itself.
 # 
-# 1. We are starting by definig container for predictions the same size as a test set.
-# 2. Then, for each row in test set we are calculating distances between then and every training record.
-# 3. We are sorting training dataset based on calcualted distances
-# 4. And choose k of the first elements in sorted training list.
+# 1. We are starting by defining a container for predictions the same size as a test set.
+# 2. Then, for each row in the test set, we calculate distances between then and every training record.
+# 3. We are sorting training datasets based on calculated distances
+# 4. Choose k of the first elements in the sorted training list.
 # 5. We are counting labels appearances
-# 6. The most common label is set as a prediction for the test row. 
+# 6. The most common label is set as a prediction. 
 
 # In[ ]:
 
@@ -130,7 +130,7 @@ def knn(X_train, y_train, X_test, k):
 
 
 # Let's use our prepared knn function on the wine dataset. Let's assume `k = 3`.
-# The accuracy of the predicted labels is measured as mean of the truly prediced values.
+# The accuracy of the predicted labels is measured as the mean of the truly predicted values.
 
 # In[ ]:
 
@@ -144,11 +144,11 @@ print('Numpy accuracy:', accuracy)
 
 # ## Numba k-NN
 # 
-# Now, let's move to the numba implementation of the k-NN algorithm. We will start the same, by defining distance function and importing necessery packages.
+# Now, let's move to the numba implementation of the k-NN algorithm. We will start the same, by defining the distance function and importing the necessary packages.
 # 
-# For numba implementation we are using the core functionality which is `numba.jit()` decorator.
+# For numba implementation, we are using the core functionality which is `numba.jit()` decorator.
 # 
-# We are staring with defining distance funcion. Like before it is an euqlidean distance. For additional optimization we are using `np.linalg.norm`.
+# We are starting with defining the distance function. Like before it is a euclidean distance. For additional optimization we are using `np.linalg.norm`.
 
 # In[ ]:
 
@@ -161,7 +161,7 @@ def euclidean_distance_numba(vector1, vector2):
     return dist
 
 
-# Next step is to implement the k-NN algorythm. Like before, there is `numba.jit()` decorator used. Other steps for the algorithm are the same like for the NumPy example.
+# The next step is to implement the k-NN algorithm. Like before, there is `numba.jit()` decorator used. Other steps for the algorithm are the same as for the NumPy example.
 
 # In[ ]:
 
@@ -206,9 +206,9 @@ def knn_numba(X_train, y_train, X_test, k):
     return predictions
 
 
-# Simillary, as in the NumPy example, we are testing implemented method for the `k = 3`. 
+# Similarly, as in the NumPy example, we are testing implemented method for the `k = 3`. 
 # 
-# Accuracy of the method is exacly the same as in the NumPy implementation.
+# The accuracy of the method is the same as in the NumPy implementation.
 
 # In[ ]:
 
@@ -222,23 +222,18 @@ print('Numba accuracy:', accuracy)
 
 # ## Numba_dpex k-NN
 # 
-# Numba_dpex impelmentation is using `numba_dpex.kernel()` decorator, where we define acces type for all the input parameters for the defined function. 
-# For more information about programing SYCL kernels go to: https://intelpython.github.io/numba-dpex/latest/user_guides/kernel_programming_guide/index.html
+# Numba_dpex implementation use `numba_dpex.kernel()` decorator. For more information about programming, SYCL kernels go to: https://intelpython.github.io/numba-dpex/latest/user_guides/kernel_programming_guide/index.html.
 # 
-# Calculating distance is  like in NumPy example, we are using euqlidesian distance. Later, we are creating the queue of the nighbours by the calulated distance and counting in provided *k* votes for dedicated classes of nighbours.
+# Calculating distance is like in the NumPy example. We are using Euclidean distance. Later, we create the queue of the neighbours by the calculated distance and count in provided *k* votes for dedicated classes of neighbours.
 # 
-# At the end we are taking class that achive the maximum value of votes and setting it for the current global iteration.
+# In the end, we are taking a class that achieves the maximum value of votes and setting it for the current global iteration.
 
 # In[ ]:
 
 
 import   numba_dpex
 
-@numba_dpex.kernel(
-        access_types={
-        "read_only": ["train", "train_labels", "test", "votes_to_classes_lst"],
-        "write_only": ["predictions"],   }
-)
+@numba_dpex.kernel
 def knn_numba_dpex(train, train_labels, test, k, predictions, votes_to_classes_lst):
     i = numba_dpex.get_global_id(0)
     queue_neighbors = numba_dpex.private.array(shape=(3, 2), dtype=np.float64)
@@ -310,11 +305,11 @@ def knn_numba_dpex(train, train_labels, test, k, predictions, votes_to_classes_l
     predictions[i] = max_ind
 
 
-# Next, like before, let's test prapared k-NN function.
+# Next, like before, let's test the prepared k-NN function.
 # 
-# In this case we will need to provide the container for predictions: `pedictions_numba` and container for votes per class: `votes_to_classes_lst` (the size of the container is 3 as we have 3 lasses in our dataset).
+# In this case, we will need to provide the container for predictions: `pedictions_numba` and the container for votes per class: `votes_to_classes_lst` (the container size is 3, as we have 3 classes in our dataset).
 # 
-# We are running preapred k-NN function using `dctl.device_context()` which allows us to select divice. For more information, go to: https://intelpython.github.io/dpctl/latest/docfiles/user_guides/manual/dpctl/device_selection.html
+# We are running a prepared k-NN function using `dctl.device_context()`, which allows us to select a divice. For more information, go to: https://intelpython.github.io/dpctl/latest/docfiles/user_guides/manual/dpctl/device_selection.html.
 
 # In[ ]:
 
@@ -328,7 +323,7 @@ with dpctl.device_context("opencl:cpu:0"):
     knn_numba_dpex[len(X_test.values), numba_dpex.DEFAULT_LOCAL_SIZE](X_train.values, y_train.values, X_test.values, 3, predictions_numba, votes_to_classes_lst)
 
 
-# Like before, let's measue the accuracy of the prepared implementation. It is measured as the number of well-assigned classes for the test set. Final result is the same for all: NumPy, numba and numba-dpex implementations.
+# Like before, let's measure the accuracy of the prepared implementation. It is measured as the number of well-assigned classes for the test set. The final result is the same for all: NumPy, numba and numba-dpex implementations.
 
 # In[ ]:
 


### PR DESCRIPTION
# Existing Sample Changes
## Description

Fix problem with TypeError: kernel() got an unexpected keyword argument 'access_types' for kNN numba vs numpy sample.
Update *.ipynb and *.py files.

Fixes Issue #ONSAM-1651

## Type of change

Please delete options that are not relevant. Add a 'X' to the one that is applicable. 

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Implement fixes for ONSAM Jiras ONSAM-1651

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Command Line
- [ ] oneapi-cli
- [ ] Visual Studio
- [ ] Eclipse IDE
- [ ] VSCode
- [ ] When compiling the compliler flag "-Wall -Wformat-security -Werror=format-security" was used
