### PR TITLE
removed deprecated SYCL code to resolve warning messages

### DIFF
--- a/Libraries/oneDPL/maxloc_reductions/maxloc_operator.cpp
+++ b/Libraries/oneDPL/maxloc_reductions/maxloc_operator.cpp
@@ -19,7 +19,7 @@ const size_t L = 1;
 
 int main(int argc, char **argv)
 {
-    sycl::queue Q(sycl::default_selector{});
+    sycl::queue Q;
 
     const size_t n = 7;
     auto data = sycl::malloc_shared<int>(n, Q);


### PR DESCRIPTION
# Existing Sample Changes
## Description

Removed deprecated SYCL features to resolve compiler warnings.

## Type of change

Please delete options that are not relevant. Add a 'X' to the one that is applicable. 

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Command Line

I compiled and ran the sample using the current oneAPI release and the sample's GNUmakefile to confirm that the previous warnings were gone.