### PR TITLE
FPGA: matmul updates for 2024.0

### DIFF
--- a/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/matmul/src/matmul.hpp
+++ b/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/matmul/src/matmul.hpp
@@ -5,7 +5,6 @@
 
 #include <sycl/ext/intel/ac_types/ac_int.hpp>
 #include <sycl/ext/intel/fpga_extensions.hpp>
-#include <sycl/ext/oneapi/annotated_arg/annotated_arg.hpp> // TODO: remove before 2024.0 release
 #include <sycl/sycl.hpp>
 
 #include "memory_transfers.hpp"

--- a/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/matmul/src/matmul.hpp
+++ b/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/matmul/src/matmul.hpp
@@ -5,7 +5,7 @@
 
 #include <sycl/ext/intel/ac_types/ac_int.hpp>
 #include <sycl/ext/intel/fpga_extensions.hpp>
-#include <sycl/ext/intel/prototype/interfaces.hpp>
+#include <sycl/ext/oneapi/annotated_arg/annotated_arg.hpp> // TODO: remove before 2024.0 release
 #include <sycl/sycl.hpp>
 
 #include "memory_transfers.hpp"

--- a/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/matmul/src/memory_transfers.hpp
+++ b/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/matmul/src/memory_transfers.hpp
@@ -31,21 +31,21 @@ template <typename TT,              // Datatype of the elements of the matrix
           typename PipeA,           // Input pipe for matrix
           typename PipeDone, // Pipe to notify compute kernel when to stop
                              // reading inputs
-          int dwidth = elems_per_ddr_access * sizeof(TT) * 8>
+          int datawidth = elems_per_ddr_access * sizeof(TT) * 8>
 class MatrixReadFromDDRToPipeA {
 public:
 #if !defined(IS_BSP)
   // Customizing mmhost only supported when targetting an FPGA part/family
-  mmhost(aspace, // buffer_location or aspace
-         28,     // address width
-         dwidth, // data width
-         0,      // latency
-         1,      // read_write_mode, 0: ReadWrite, 1: Read, 2: Write
-         1,      // maxburst
-         0,      // align, 0 defaults to alignment of the type
-         1)      // waitrequest, 0: false, 1: true
+  sycl::ext::oneapi::experimental::annotated_arg<TT *, 
+      decltype(sycl::ext::oneapi::experimental::properties{
+          sycl::ext::oneapi::experimental::buffer_location<aspace>,
+          sycl::ext::oneapi::experimental::dwidth<datawidth>,
+          sycl::ext::oneapi::experimental::latency<0>,
+          sycl::ext::oneapi::experimental::wait_request_requested})>
+#else
+  TT *
 #endif
-      TT *a_ptr;   // Input matrix pointer
+      a_ptr;       // Input matrix pointer
   int repetitions; // Number of times to write the same matrix to the pipe
 
   void operator()() const {
@@ -184,21 +184,21 @@ template <typename TT,              // Datatype of the elements of the matrix
           int elems_per_ddr_access, // Number of elements per DDR access
           int num_matrices,         // Number of pairs of matrices to multiply
           typename PipeB,           // Input pipe for matrix
-          int dwidth = elems_per_ddr_access * sizeof(TT) * 8>
+          int datawidth = elems_per_ddr_access * sizeof(TT) * 8>
 class MatrixReadFromDDRToPipeB {
 public:
 #if !defined(IS_BSP)
   // Customizing mmhost only supported when targetting an FPGA part/family
-  mmhost(aspace, // buffer_location or aspace
-         28,     // address width
-         dwidth, // data width
-         0,      // latency
-         1,      // read_write_mode, 0: ReadWrite, 1: Read, 2: Write
-         1,      // maxburst
-         0,      // align, 0 defaults to alignment of the type
-         1)      // waitrequest, 0: false, 1: true
+  sycl::ext::oneapi::experimental::annotated_arg<TT *, 
+      decltype(sycl::ext::oneapi::experimental::properties{
+          sycl::ext::oneapi::experimental::buffer_location<aspace>,
+          sycl::ext::oneapi::experimental::dwidth<datawidth>,
+          sycl::ext::oneapi::experimental::latency<0>,
+          sycl::ext::oneapi::experimental::wait_request_requested})>
+#else
+  TT *
 #endif
-      TT *b_ptr;   // Input matrix pointer
+      b_ptr;       // Input matrix pointer
   int repetitions; // Number of times to write the same matrix to the pipe
 
   void operator()() const {
@@ -329,21 +329,21 @@ template <typename TT,              // Datatype of the elements of the matrix
           int elems_per_ddr_access, // Number of elements per DDR access
           int num_matrices,         // Number of pairs of matrices to multiply
           typename PipeC,           // Output pipe for matrix
-          int dwidth = elems_per_ddr_access * sizeof(TT) * 8>
+          int datawidth = elems_per_ddr_access * sizeof(TT) * 8>
 class MatrixReadPipeToDDR {
 public:
 #if !defined(IS_BSP)
   // Customizing mmhost only supported when targetting an FPGA part/family
-  mmhost(aspace, // buffer_location or aspace
-         28,     // address width
-         dwidth, // data width
-         0,      // latency
-         2,      // read_write_mode, 0: ReadWrite, 1: Read, 2: Write
-         1,      // maxburst
-         0,      // align, 0 defaults to alignment of the type
-         1)      // waitrequest, 0: false, 1: true
+  sycl::ext::oneapi::experimental::annotated_arg<TT *, 
+      decltype(sycl::ext::oneapi::experimental::properties{
+          sycl::ext::oneapi::experimental::buffer_location<aspace>,
+          sycl::ext::oneapi::experimental::dwidth<datawidth>,
+          sycl::ext::oneapi::experimental::latency<0>,
+          sycl::ext::oneapi::experimental::wait_request_requested})>
+#else
+  TT *
 #endif
-      TT *c_ptr;   // Output matrix pointer
+      c_ptr;       // Input matrix pointer
   int repetitions; // Number of time to read the same matrix to the pipe
 
   void operator()() const {

--- a/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/matmul/src/memory_transfers.hpp
+++ b/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/matmul/src/memory_transfers.hpp
@@ -38,14 +38,13 @@ public:
   // Customizing mmhost only supported when targetting an FPGA part/family
   sycl::ext::oneapi::experimental::annotated_arg<TT *, 
       decltype(sycl::ext::oneapi::experimental::properties{
-          sycl::ext::oneapi::experimental::alignment<datawidth / 8>,
-          sycl::ext::oneapi::experimental::awidth<28>,
-          sycl::ext::oneapi::experimental::buffer_location<aspace>,
-          sycl::ext::oneapi::experimental::dwidth<datawidth>,
-          sycl::ext::oneapi::experimental::latency<0>,
-          sycl::ext::oneapi::experimental::maxburst<1>,
-          sycl::ext::oneapi::experimental::read_write_mode_read,
-          sycl::ext::oneapi::experimental::wait_request_requested})>
+          sycl::ext::intel::experimental::awidth<28>,
+          sycl::ext::intel::experimental::buffer_location<aspace>,
+          sycl::ext::intel::experimental::dwidth<datawidth>,
+          sycl::ext::intel::experimental::latency<0>,
+          sycl::ext::intel::experimental::maxburst<1>,
+          sycl::ext::intel::experimental::read_write_mode_read,
+          sycl::ext::intel::experimental::wait_request_requested})>
 #else
   TT *
 #endif
@@ -195,14 +194,13 @@ public:
   // Customizing mmhost only supported when targetting an FPGA part/family
   sycl::ext::oneapi::experimental::annotated_arg<TT *, 
       decltype(sycl::ext::oneapi::experimental::properties{
-          sycl::ext::oneapi::experimental::alignment<datawidth / 8>,
-          sycl::ext::oneapi::experimental::awidth<28>,
-          sycl::ext::oneapi::experimental::buffer_location<aspace>,
-          sycl::ext::oneapi::experimental::dwidth<datawidth>,
-          sycl::ext::oneapi::experimental::latency<0>,
-          sycl::ext::oneapi::experimental::maxburst<1>,
-          sycl::ext::oneapi::experimental::read_write_mode_read,
-          sycl::ext::oneapi::experimental::wait_request_requested})>
+          sycl::ext::intel::experimental::awidth<28>,
+          sycl::ext::intel::experimental::buffer_location<aspace>,
+          sycl::ext::intel::experimental::dwidth<datawidth>,
+          sycl::ext::intel::experimental::latency<0>,
+          sycl::ext::intel::experimental::maxburst<1>,
+          sycl::ext::intel::experimental::read_write_mode_read,
+          sycl::ext::intel::experimental::wait_request_requested})>
 #else
   TT *
 #endif
@@ -344,14 +342,13 @@ public:
   // Customizing mmhost only supported when targetting an FPGA part/family
   sycl::ext::oneapi::experimental::annotated_arg<TT *, 
       decltype(sycl::ext::oneapi::experimental::properties{
-          sycl::ext::oneapi::experimental::alignment<datawidth / 8>,
-          sycl::ext::oneapi::experimental::awidth<28>,
-          sycl::ext::oneapi::experimental::buffer_location<aspace>,
-          sycl::ext::oneapi::experimental::dwidth<datawidth>,
-          sycl::ext::oneapi::experimental::latency<0>,
-          sycl::ext::oneapi::experimental::maxburst<1>,
-          sycl::ext::oneapi::experimental::read_write_mode_write,
-          sycl::ext::oneapi::experimental::wait_request_requested})>
+          sycl::ext::intel::experimental::awidth<28>,
+          sycl::ext::intel::experimental::buffer_location<aspace>,
+          sycl::ext::intel::experimental::dwidth<datawidth>,
+          sycl::ext::intel::experimental::latency<0>,
+          sycl::ext::intel::experimental::maxburst<1>,
+          sycl::ext::intel::experimental::read_write_mode_write,
+          sycl::ext::intel::experimental::wait_request_requested})>
 #else
   TT *
 #endif

--- a/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/matmul/src/memory_transfers.hpp
+++ b/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/matmul/src/memory_transfers.hpp
@@ -38,9 +38,13 @@ public:
   // Customizing mmhost only supported when targetting an FPGA part/family
   sycl::ext::oneapi::experimental::annotated_arg<TT *, 
       decltype(sycl::ext::oneapi::experimental::properties{
+          sycl::ext::oneapi::experimental::alignment<datawidth / 8>,
+          sycl::ext::oneapi::experimental::awidth<28>,
           sycl::ext::oneapi::experimental::buffer_location<aspace>,
           sycl::ext::oneapi::experimental::dwidth<datawidth>,
           sycl::ext::oneapi::experimental::latency<0>,
+          sycl::ext::oneapi::experimental::maxburst<1>,
+          sycl::ext::oneapi::experimental::read_write_mode_read,
           sycl::ext::oneapi::experimental::wait_request_requested})>
 #else
   TT *
@@ -191,9 +195,13 @@ public:
   // Customizing mmhost only supported when targetting an FPGA part/family
   sycl::ext::oneapi::experimental::annotated_arg<TT *, 
       decltype(sycl::ext::oneapi::experimental::properties{
+          sycl::ext::oneapi::experimental::alignment<datawidth / 8>,
+          sycl::ext::oneapi::experimental::awidth<28>,
           sycl::ext::oneapi::experimental::buffer_location<aspace>,
           sycl::ext::oneapi::experimental::dwidth<datawidth>,
           sycl::ext::oneapi::experimental::latency<0>,
+          sycl::ext::oneapi::experimental::maxburst<1>,
+          sycl::ext::oneapi::experimental::read_write_mode_read,
           sycl::ext::oneapi::experimental::wait_request_requested})>
 #else
   TT *
@@ -336,9 +344,13 @@ public:
   // Customizing mmhost only supported when targetting an FPGA part/family
   sycl::ext::oneapi::experimental::annotated_arg<TT *, 
       decltype(sycl::ext::oneapi::experimental::properties{
+          sycl::ext::oneapi::experimental::alignment<datawidth / 8>,
+          sycl::ext::oneapi::experimental::awidth<28>,
           sycl::ext::oneapi::experimental::buffer_location<aspace>,
           sycl::ext::oneapi::experimental::dwidth<datawidth>,
           sycl::ext::oneapi::experimental::latency<0>,
+          sycl::ext::oneapi::experimental::maxburst<1>,
+          sycl::ext::oneapi::experimental::read_write_mode_write,
           sycl::ext::oneapi::experimental::wait_request_requested})>
 #else
   TT *


### PR DESCRIPTION
# Existing Sample Changes
## Description

Updating matmul sample to use annotated_arg pointers for customizing mm hosts in the IP authoring flow.

Fixes Issue# 

## External Dependencies

List any external dependencies created as a result of this change.

## Type of change

Please delete options that are not relevant. Add a 'X' to the one that is applicable. 

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Implement fixes for ONSAM Jiras

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Command Line
- [ ] oneapi-cli
- [ ] Visual Studio
- [ ] Eclipse IDE
- [ ] VSCode
- [ ] When compiling the compliler flag "-Wall -Wformat-security -Werror=format-security" was used

