### PR TITLE
FPGA: revise Sync function exit condition in HostStreamer API

### DIFF
--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/buffered_host_streaming/src/HostStreamer.hpp
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/buffered_host_streaming/src/HostStreamer.hpp
@@ -618,7 +618,7 @@ public:
     flush_ = true;
   }
 
-  // This synchronizes with the KernelLaunchAndWaitThread. This should be called
+  // This synchronizes with the KernelLaunchAndWaitThread.
   // This should be called once the user is done performing ALL request
   // (i.e. both Produce and Consume request).
   // NOTE: this API call is blocking. It will block until all of the kernels
@@ -627,8 +627,10 @@ public:
     // flush the launch queue
     Flush();
 
-    // wait until the launch queue is empty
-    while (!LaunchQueueEmpty()){}
+    // wait until the all of the queues are empty
+    while (
+      !(LaunchQueueEmpty() && ProducerQueueEmpty() && ConsumerQueueEmpty())) {
+    }
   }
   //////////////////////////////////////////////////////////////////////////////
 


### PR DESCRIPTION
# Existing Sample Changes
## Description

This change modifies the exit condition of HostStreamer API's Sync function to check whether all of the queues, i.e., the launch queue, the producer queue, and the consumer queue, are empty.

This fixes intermittent functional error where the code reaches HostStreamer::Sync after producer events are submitted to the producer queue but before they get transferred to the launch queue, thereby exiting too early before all user requests are finished, leading to results not yet available upon error check.

## External Dependencies

N/A

## Type of change

Please delete options that are not relevant. Add a 'X' to the one that is applicable. 

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Implement fixes for ONSAM Jiras

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Command Line (100 consecutive runs passed)
- [ ] oneapi-cli
- [ ] Visual Studio
- [ ] Eclipse IDE
- [ ] VSCode
- [ ] When compiling the compliler flag "-Wall -Wformat-security -Werror=format-security" was used
