### PR TITLE
FPGA: Cleanup platform_designer protocol

### DIFF
--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Tools/experimental/platform_designer/add-oneapi/src/add.cpp
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Tools/experimental/platform_designer/add-oneapi/src/add.cpp
@@ -12,38 +12,26 @@
 
 #include "exception_handler.hpp"
 
-// use host pipes to write into registers in the CSR address space
+// use pipes to write into registers in the CSR address space
 class OutputPipeID;
 
-// using protocol avalon_mm or avalon_mm_uses_ready allows this host pipe to
-// output to the CSR
-
-// WORKAROUND: protocol_name::avalon_mm does not currently work with simulation,
-// so simulate with avalon_mm_uses_ready for now. avalon_mm works in hardware.
-#if FPGA_SIMULATOR
-using OutputPipeProps = decltype(sycl::ext::oneapi::experimental::properties(
-    sycl::ext::intel::experimental::protocol<
-        sycl::ext::intel::experimental::protocol_name::avalon_mm_uses_ready>));
-#else
 using OutputPipeProps = decltype(sycl::ext::oneapi::experimental::properties(
     sycl::ext::intel::experimental::protocol<
         sycl::ext::intel::experimental::protocol_name::avalon_mm>));
-#endif
 
 using OutputPipe =
-    sycl::ext::intel::experimental::pipe<OutputPipeID, int, 1, OutputPipeProps>;
+    sycl::ext::intel::experimental::pipe<OutputPipeID, int, 0, OutputPipeProps>;
 
 // Forward declare the kernel name in the global scope. This is an FPGA best
 // practice that reduces name mangling in the optimization reports.
-class AdderID;
+class IDAdder;
 
-struct Adder {
+struct AdderKernel {
   int a;
   int b;
 
   void operator()() const {
     int sum = a + b;
-
     OutputPipe::write(sum);
   }
 };
@@ -79,9 +67,7 @@ int main() {
 
     std::cout << "add two integers using CSR for input." << std::endl;
 
-    // no need to wait() since the pipe read will block until `Adder` has some
-    // output.
-    q.single_task<AdderID>(Adder{a, b});
+    q.single_task<IDAdder>(AdderKernel{a, b}).wait();
 
     // verify that outputs are correct
     passed = true;

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Tools/experimental/platform_designer/add-oneapi/src/add.cpp
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Tools/experimental/platform_designer/add-oneapi/src/add.cpp
@@ -6,7 +6,6 @@
 #include <iostream>
 
 // oneAPI headers
-#include <sycl/ext/intel/experimental/pipes.hpp>
 #include <sycl/ext/intel/fpga_extensions.hpp>
 #include <sycl/sycl.hpp>
 


### PR DESCRIPTION
# Existing Sample Changes
## Description

This code sample used to use the blocking pipe write mode to store output to the CSR. This is a less desirable use case than the non-blocking pipe mode. Now that https://hsdes.intel.com/appstore/article/#/14019304561 is fixed, we can set this code sample to do what users actually want.

Fixes Issue# N/A

## External Dependencies

List any external dependencies created as a result of this change.

## Type of change

Please delete options that are not relevant. Add a 'X' to the one that is applicable. 

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Implement fixes for ONSAM Jiras

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [X] Command Line
- [ ] oneapi-cli
- [ ] Visual Studio
- [ ] Eclipse IDE
- [X] VSCode
- [X] Regtest [Spetc result](https://spetc.intel.com/testanalysis?trview=0&testRunIds=8613802&tapgsize=20&tasort=testCasePath&tasortdir=asc)
- [ ] When compiling the compliler flag "-Wall -Wformat-security -Werror=format-security" was used
