### PR TITLE
FPGA: Remove use of get_pointer from lsu_control sample

### DIFF
--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/lsu_control/src/lsu_control.cpp
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/lsu_control/src/lsu_control.cpp
@@ -81,7 +81,8 @@ void KernelRun(const std::vector<int> &input_data, const size_t &input_size,
       h.single_task<KernelPrefetch>([=]() [[intel::kernel_args_restrict]] {
         auto input_ptr =
             input_a.template get_multi_ptr<access::decorated::no>();
-        auto output_ptr = output_a.get_pointer();
+        auto output_ptr = 
+            output_a.template get_multi_ptr<access::decorated::no>();
 
         int total = 0;
         for (size_t i = 0; i < input_size; i++) {
@@ -99,7 +100,8 @@ void KernelRun(const std::vector<int> &input_data, const size_t &input_size,
       h.single_task<KernelBurst>([=]() [[intel::kernel_args_restrict]] {
         auto input_ptr =
             input_a.template get_multi_ptr<access::decorated::no>();
-        auto output_ptr = output_a.get_pointer();
+        auto output_ptr = 
+            output_a.template get_multi_ptr<access::decorated::no>();
 
         int total = 0;
         for (size_t i = 0; i < input_size; i++) {
@@ -115,8 +117,10 @@ void KernelRun(const std::vector<int> &input_data, const size_t &input_size,
       
       // Kernel that uses the default LSUs
       h.single_task<KernelDefault>([=]() [[intel::kernel_args_restrict]] {
-        auto input_ptr = input_a.get_pointer();
-        auto output_ptr = output_a.get_pointer();
+        auto input_ptr = 
+            input_a.template get_multi_ptr<access::decorated::no>();
+        auto output_ptr = 
+            output_a.template get_multi_ptr<access::decorated::no>();
 
         int total = 0;
         for (size_t i = 0; i < input_size; i++) {


### PR DESCRIPTION
## Description

This PR updates all uses of `get_pointer` to `get_multi_ptr` as there is now a deprecation warning when using the latest sycl/rel version.

## External Dependencies

*N/A

## Type of change

Please delete options that are not relevant. Add a 'X' to the one that is applicable. 

- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [X] Command Line
- [ ] oneapi-cli
- [ ] Visual Studio
- [ ] Eclipse IDE
- [ ] VSCode
- [ ] When compiling the compliler flag "-Wall -Wformat-security -Werror=format-security" was used

Ran emulator and simulator runs and both are passing.