### PR TITLE
FPGA: Update Buffer Locations in Matrix Multiply sample to start from 1

### DIFF
--- a/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/matmul/src/matmul.hpp
+++ b/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/matmul/src/matmul.hpp
@@ -62,9 +62,9 @@ void MatmulImpl(sycl::queue &q,            // Device queue
   constexpr int kMatsizeC = rows_a * cols_b;
 
   // Buffer locations for mmhost interfaces
-  constexpr int kBL1 = 0;
-  constexpr int kBL2 = 1;
-  constexpr int kBL3 = 2;
+  constexpr int kBL1 = 1;
+  constexpr int kBL2 = 2;
+  constexpr int kBL3 = 3;
 
   // Allocate FPGA DDR memory
 #if defined(IS_BSP)


### PR DESCRIPTION
# Existing Sample Changes
## Description

Updating buffer locations in Matrix Multiply sample to match requirements (BLs start at 1 instead of 0) for 2024.0 release.

Fixes Issue# 

## External Dependencies

List any external dependencies created as a result of this change.

## Type of change

Please delete options that are not relevant. Add a 'X' to the one that is applicable. 

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Implement fixes for ONSAM Jiras

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Command Line
- [ ] oneapi-cli
- [ ] Visual Studio
- [ ] Eclipse IDE
- [ ] VSCode
- [ ] When compiling the compliler flag "-Wall -Wformat-security -Werror=format-security" was used