### PR TITLE
FPGA: Passing Functor Directly to Lambda

### DIFF
--- a/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/mvdr_beamforming/src/Transpose.hpp
+++ b/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/mvdr_beamforming/src/Transpose.hpp
@@ -45,7 +45,7 @@ event SubmitTransposeKernel(queue& q) {
                 "k_num_cols_in must be evenly divisible by k_pipe_width");
 
   return q.submit([&](handler& h) {
-    h.single_task<TransposeKernelName>(Transposer<T, k_num_cols_in, k_pipe_width, MatrixInPipe, MatrixOutPipe>);
+    h.single_task<TransposeKernelName>(Transposer<T, k_num_cols_in, k_pipe_width, MatrixInPipe, MatrixOutPipe>{});
   });
 }
 

--- a/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/mvdr_beamforming/src/Transpose.hpp
+++ b/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/mvdr_beamforming/src/Transpose.hpp
@@ -45,12 +45,7 @@ event SubmitTransposeKernel(queue& q) {
                 "k_num_cols_in must be evenly divisible by k_pipe_width");
 
   return q.submit([&](handler& h) {
-    h.single_task<TransposeKernelName>([=]() {
-      // start the transposer
-      Transposer<T, k_num_cols_in, k_pipe_width, MatrixInPipe, MatrixOutPipe>
-          TheTransposer;
-      TheTransposer();
-    });
+    h.single_task<TransposeKernelName>(Transposer<T, k_num_cols_in, k_pipe_width, MatrixInPipe, MatrixOutPipe>);
   });
 }
 

--- a/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/mvdr_beamforming/src/Transpose.hpp
+++ b/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/mvdr_beamforming/src/Transpose.hpp
@@ -44,9 +44,7 @@ event SubmitTransposeKernel(queue& q) {
   static_assert(k_num_cols_in % k_pipe_width == 0,
                 "k_num_cols_in must be evenly divisible by k_pipe_width");
 
-  return q.submit([&](handler& h) {
-    h.single_task<TransposeKernelName>(Transposer<T, k_num_cols_in, k_pipe_width, MatrixInPipe, MatrixOutPipe>{});
-  });
+  return q.single_task<TransposeKernelName>(Transposer<T, k_num_cols_in, k_pipe_width, MatrixInPipe, MatrixOutPipe>{});
 }
 
 // The generic transpose. We use classes here because we want to do partial


### PR DESCRIPTION
# Existing Sample Changes
## Description

Passing the functor object directly to the lambda.

## External Dependencies

List any external dependencies created as a result of this change.

## Type of change

Please delete options that are not relevant. Add a 'X' to the one that is applicable. 

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Implement fixes for ONSAM Jiras

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

Tested the `regtest/hld/sycl/oneapi_code_samples/mvdr_beamforming` regtest simulation flow with `custom_ipa:Arria10` on linux and windows.

- [x] Command Line
- [ ] oneapi-cli
- [ ] Visual Studio
- [ ] Eclipse IDE
- [ ] VSCode
- [ ] When compiling the compliler flag "-Wall -Wformat-security -Werror=format-security" was used