### PR TITLE
FPGA: Rewrite of Max Interleaving Code Sample So That Interleaving Is Possible

### DIFF
--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/max_interleaving/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/max_interleaving/README.md
@@ -90,26 +90,26 @@ Notice how `temp_r[i]` is a loop carried dependency in the inner loop. **Crucial
 Without interleaving, this is what the pipelined registers of the inner loop will look like, for II of the inner loop = 5 and II of the outer loop = 1. Each cell shows the (i, j) iteration that is currently in that stage of the inner loop:
 
 | Cycle | Stage 1 | Stage 2 | Stage 3 | Stage 4 | Stage 5 |
-|---|---|---|---|---|---|
-|1|(0, 0)|
-|2||(0, 0)|
-|3|||(0, 0)|
-|4||||(0, 0)|
-|5|||||(0, 0)|
-|6|(0, 1)
+| ---   | ---     | ---     | ---     | ---     | ---     |
+| 1     | (0, 0)  |
+| 2     |         | (0, 0)  |
+| 3     |         |         | (0, 0)  |
+| 4     |         |         |         | (0, 0)  |
+| 5     |         |         |         |         | (0, 0)  |
+| 6     | (0, 1)  |
 
 Notice how the majority of the stages are empty, caused by the loop carried dependency.
 
 With interleaving, we get the following: 
 
 | Cycle | Stage 1 | Stage 2 | Stage 3 | Stage 4 | Stage 5 |
-|---|---|---|---|---|---|
-|1|(0, 0)|
-|2|(1, 0)|(0, 0)|
-|3|(2, 0)|(1, 0)|(0, 0)|
-|4|(3, 0)|(2, 0)|(1, 0)|(0, 0)|
-|5|(4, 0)|(3, 0)|(2, 0)|(1, 0)|(0, 0)|
-|6|(0, 1)|(4, 0)|(3, 0)|(2, 0)|(1, 0)|
+| ---   | ---     | ---     | ---     | ---     | ---     |
+| 1     | (0, 0)  | 
+| 2     | (1, 0)  | (0, 0)  |
+| 3     | (2, 0)  | (1, 0)  | (0, 0)  |
+| 4     | (3, 0)  | (2, 0)  | (1, 0)  | (0, 0)  |
+| 5     | (4, 0)  | (3, 0)  | (2, 0)  | (1, 0)  | (0, 0)  |
+| 6     | (0, 1)  | (4, 0)  | (3, 0)  | (2, 0)  | (1, 0)  |
 
 Since the loop carried dependency is not with respect to the outer loop, different *invocations* of the inner loop can be pipelined into the inner loop. Notice how after an initial ramp-up period, the inner loop hardware reaches full occupancy - which will correspond to a higher throughput. 
 
@@ -237,10 +237,10 @@ Locate `report.html` in the `max_interleaving_report.prj/reports/` directory.
 1. Go to `Summary` (top navigation bar). In the `Summary` pane, go to `Quartus® Fitter Resource Utilization Summary`. For less accurate estimates (but you can obtain these numbers after compiling to report instead of the full hardware flow), go to `Compile Estimated Kernel Resource Utilization Summary`.
 2. Verify that `KernelCompute<1>` (interleaving disabled) uses slightly fewer resources (ALMs, ALUTs, REGs, etc.) than `KernelCompute<0>` (interleaving enabled). For example, at the time of writing this tutorial, this is the final resource usage when compiling for the Terasic DE10-Agilex Development Board:
 
-| | ALM | ALUT | REG | MLAB | RAM | DSP |
-|---|---|---|---|---|---|---|
-KernelCompute_0 | 3564 | 3957 | 11898 | 38 | 66 | 6 |
-KernelCompute_1 | 3380 | 3768 | 11177| 35 | 66 | 6 | 
+|                 | ALM  | ALUT | REG   | MLAB | RAM | DSP |
+| ---             | ---  | ---  | ---   | ---  | --- | --- |
+| KernelCompute_0 | 3564 | 3957 | 11898 | 38   | 66  | 6   |
+| KernelCompute_1 | 3380 | 3768 | 11177 | 35   | 66  | 6   | 
 
 ## Run the `max_interleaving` Sample
 

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/max_interleaving/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/max_interleaving/README.md
@@ -68,8 +68,10 @@ The sample illustrates the following important concepts.
 
 ### Description of the `max_interleaving` Attribute
 
-In short, place the `[[intel::max_interleaving(0 or 1)]]` attribute above a loop that you want to control interleaving. A parameter of `0` (the default if the attribute is not used) enables interleaving when possible, and `1` forcibly disables interleaving, even if it is possible.  
+#### Quick Reference
+Place the `[[intel::max_interleaving(0 or 1)]]` attribute above a loop that you want to control interleaving. A parameter of `0` (the default if the attribute is not used) enables interleaving when possible, and `1` forcibly disables interleaving, even if it is possible.  
 
+#### Detailed Explanation
 Consider the following pipelined doubly nested loops: 
 ```cpp
 float temp_r[kSize] = ...;
@@ -222,7 +224,7 @@ Locate `report.html` in the `max_interleaving_report.prj/reports/` directory.
 
 #### Verify That Interleaving Is Enabled/Disabled
 1. Go to `Throughput Analysis` (dropdown) -> `Loop Analysis`.
-2. Under `Loop List`, the 4 loops of interest are:
+2. Under `Loop List`, the 2 loops of interest are:
    1. `KernelCompute_0.inner` - inner loop of interleaving **enabled** kernel
    2. `KernelCompute_1.inner` - inner loop of interleaving **disabled** kernel
 3. Find the row in the `Loop Analysis` pane corresponding to `KernelCompute_0.inner`. Notice how the II is high (>> 1) and `Max Interleaving Iterations` is greater than 1, meaning interleaving is enabled.
@@ -230,14 +232,15 @@ Locate `report.html` in the `max_interleaving_report.prj/reports/` directory.
 
 **IMPORTANT**: As mentioned above, the compiler will do some memory dependency analysis on loops. If it can determine that interleaving cannot happen, interleaving will automatically be disabled (which can be verified in the reports) and the attribute will have no effect. 
 
-In the "Loops analysis" view from the "Throughput Analysis" drop-down menu, in the Details pane for loop L1 (choose either Compute<0>.B6 or Compute<1>.B6 from the "Loop List" pane, then the click the "Source Location" link in the "Loop Analysis" pane):
-
-Iteration executed serially across KernelCompute<0>.B8. Only a single loop iteration will execute inside this region due to data dependency on variable(s):
-
 #### View the Hardware Area Savings
 **NOTE**: For the most accurate numbers, you must compile to hardware so that `Quartus®` can decide where to place each hardware unit on the board.
 1. Go to `Summary` (top navigation bar). In the `Summary` pane, go to `Quartus® Fitter Resource Utilization Summary`. For less accurate estimates (but you can obtain these numbers after compiling to report instead of the full hardware flow), go to `Compile Estimated Kernel Resource Utilization Summary`.
-2. Verify that `KernelCompute<1>` (interleaving disabled) uses slightly fewer resources (ALMs, ALUTs, REGs, etc.) than `KernelCompute<0>` (interleaving enabled). 
+2. Verify that `KernelCompute<1>` (interleaving disabled) uses slightly fewer resources (ALMs, ALUTs, REGs, etc.) than `KernelCompute<0>` (interleaving enabled). For example, at the time of writing this tutorial, this is the final resource usage when compiling for the Terasic DE10-Agilex Development Board:
+
+| | ALM | ALUT | REG | MLAB | RAM | DSP |
+|---|---|---|---|---|---|---|
+KernelCompute_0 | 3564 | 3957 | 11898 | 38 | 66 | 6 |
+KernelCompute_1 | 3380 | 3768 | 11177| 35 | 66 | 6 | 
 
 ## Run the `max_interleaving` Sample
 
@@ -273,21 +276,25 @@ Iteration executed serially across KernelCompute<0>.B8. Only a single loop itera
    max_interleaving.fpga.exe
    ```
 
-## Example Output
+## Example Output On FPGA Hardware
 
 ```
-Max interleaving 0 kernel time : 0.019088 ms
-Throughput for kernel with max_interleaving 0: 0.007 GFlops
-Max interleaving 1 kernel time : 0.015 ms
-Throughput for kernel with max_interleaving 1: 0.009 GFlops
+Running on device: de10_agilex : Agilex Reference Platform (aclde10_agilex0)
+Max interleaving 0 kernel time : 1.00186 ms
+Throughput for kernel with max_interleaving 0: 1.047 GFlops
+Running on device: de10_agilex : Agilex Reference Platform (aclde10_agilex0)
+Max interleaving 1 kernel time : 14.467 ms
+Throughput for kernel with max_interleaving 1: 0.072 GFlops
 PASSED: The results are correct
 ```
 
 The stdout output shows the giga-floating point operations per second (GFlops) for each kernel.
 
-When run on an Intel® PAC with Intel Arria® 10® 10 GX FPGA hardware board, we see that the throughput remains unchanged when using `max_interleaving(0)` or `max_interleaving(1)`. However, the kernel using `max_interleaving(1)` uses fewer hardware resources, as shown in the reports.
+When run on Terasic's DE10-Agilex Development Board, we see that the throughput is significantly higher for `max_interleaving(0)` (interleaving enabled) than `max_interleaving(1)`, showing the effectiveness of interleaving. However, the kernel using `max_interleaving(1)` uses slightly fewer hardware resources, as shown in the reports. 
 
-When run on the FPGA emulator, the `max_interleaving` attribute has no effect on runtime. You may notice that the emulator achieved higher throughput than the FPGA in this example. This anomaly occurs because this trivial example uses only a tiny fraction of the compute resources available on the FPGA.
+While the throughput differences are substantial, if the interleaving loops were a small part of a kernel whose total runtime was an order of magnitude greater than these loops, it may be worth it to disable interleaving for hardware savings.
+
+When run on the FPGA emulator, the `max_interleaving` attribute has no effect on runtime. Additionally, the emulator may sometimes achieve higher throughput than the FPGA. This is especially true if the kernel uses a tiny fraction of the compute resources available on the FPGA.
 
 ## License
 

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/max_interleaving/src/CMakeLists.txt
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/max_interleaving/src/CMakeLists.txt
@@ -23,11 +23,11 @@ endif()
 # 1. The "compile" stage compiles the device code to an intermediate representation (SPIR-V).
 # 2. The "link" stage invokes the compiler's FPGA backend before linking.
 #    For this reason, FPGA backend flags must be passed as link flags in CMake.
-set(EMULATOR_COMPILE_FLAGS "-fsycl -fintelfpga -Wall ${WIN_FLAG} -DFPGA_EMULATOR")
+set(EMULATOR_COMPILE_FLAGS "-fsycl -fintelfpga -Wall ${WIN_FLAG} -DFPGA_EMULATOR -Wno-unused-label")
 set(EMULATOR_LINK_FLAGS "-fsycl -fintelfpga")
-set(SIMULATOR_COMPILE_FLAGS "-fsycl -fintelfpga -Wall ${WIN_FLAG} -Xssimulation -DFPGA_SIMULATOR")
+set(SIMULATOR_COMPILE_FLAGS "-fsycl -fintelfpga -Wall ${WIN_FLAG} -Xssimulation -DFPGA_SIMULATOR -Wno-unused-label")
 set(SIMULATOR_LINK_FLAGS "-fsycl -fintelfpga -Xssimulation -Xsghdl -Xstarget=${FPGA_DEVICE} ${USER_HARDWARE_FLAGS}")
-set(HARDWARE_COMPILE_FLAGS "-fsycl -fintelfpga -Wall ${WIN_FLAG} -DFPGA_HARDWARE")
+set(HARDWARE_COMPILE_FLAGS "-fsycl -fintelfpga -Wall ${WIN_FLAG} -DFPGA_HARDWARE -Wno-unused-label")
 set(HARDWARE_LINK_FLAGS "-fsycl -fintelfpga -Xshardware -Xstarget=${FPGA_DEVICE} ${USER_HARDWARE_FLAGS}")
 # use cmake -D USER_HARDWARE_FLAGS=<flags> to set extra flags for FPGA simulator compilation and backend compilation
 

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/max_interleaving/src/max_interleaving.cpp
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/max_interleaving/src/max_interleaving.cpp
@@ -13,7 +13,11 @@
 
 using namespace sycl;
 
+#if FPGA_SIMULATOR
+constexpr size_t kSize = 32;
+#else
 constexpr size_t kSize = 512;
+#endif
 constexpr float kErrorThreshold = 0.5;
 constexpr int kTotalOps = 4 * kSize * kSize;
 

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/max_interleaving/src/max_interleaving.cpp
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/max_interleaving/src/max_interleaving.cpp
@@ -13,7 +13,10 @@
 
 using namespace sycl;
 
-#if FPGA_SIMULATOR
+#if defined(FPGA_SIMULATOR) || defined(FPGA_EMULATOR)
+// Simulator runs too slowly for large array sizes
+// Emulator has stack issues for large array sizes -
+// (malloc can be used but is out of scope of this tutorial)
 constexpr size_t kSize = 32;
 #else
 constexpr size_t kSize = 512;

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/max_interleaving/src/max_interleaving.cpp
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/max_interleaving/src/max_interleaving.cpp
@@ -102,7 +102,7 @@ void Transform(const TwoDimFloatArray &array_a, FloatArray &array_r) {
           // One final note - the loop induction variables decrease (i--) instead of increase (i++)
           // in these two loops to prevent loop fusion optimizations, which makes it harder to 
           // keep track of loops in the optimization reports. Interleaving will still occur if  
-          // `i` and `j` were incremented instead.
+          // `i` and `j` were instead incremented.
         }
 
         for (size_t i = 0; i < kSize; i++) {

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/max_interleaving/src/max_interleaving.cpp
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/max_interleaving/src/max_interleaving.cpp
@@ -13,9 +13,9 @@
 
 using namespace sycl;
 
-constexpr size_t kSize = 8;
-constexpr float kErrorThreshold = 0.001;
-constexpr int kTotalOps = kSize * (2 * kSize + 1);
+constexpr size_t kSize = 512;
+constexpr float kErrorThreshold = 0.5;
+constexpr int kTotalOps = 4 * kSize * kSize;
 
 using FloatArray = std::array<float, kSize>;
 using TwoDimFloatArray = std::array<float, kSize*kSize>;
@@ -34,8 +34,7 @@ class KernelCompute;
 // The kernel's functionality is designed to show the
 // performance impact of the max_interleaving attribute.
 template <int interleaving>
-void Transform(const TwoDimFloatArray &array_a, const FloatArray &array_b, 
-               FloatArray &array_r) {
+void Transform(const TwoDimFloatArray &array_a, FloatArray &array_r) {
 #if FPGA_SIMULATOR
   auto selector = sycl::ext::intel::fpga_simulator_selector_v;
 #elif FPGA_HARDWARE
@@ -57,38 +56,53 @@ void Transform(const TwoDimFloatArray &array_a, const FloatArray &array_b,
               << std::endl;
 
     buffer array_a_buffer(array_a);
-    buffer array_b_buffer(array_b);
     buffer array_r_buffer(array_r);
 
     event e = q.submit([&](handler &h) {
       accessor array_a_accessor(array_a_buffer, h, read_only);
-      accessor array_b_accessor(array_b_buffer, h, read_only);
       accessor accessor_array_r(array_r_buffer, h, write_only, no_init);
 
       h.single_task<KernelCompute<interleaving>>([=]() 
                                                  [[intel::kernel_args_restrict]] {
         float temp_a[kSize*kSize];
-        float temp_b[kSize];
         float temp_r[kSize];
 
         for (size_t i = 0; i < kSize; i++) {
           for (size_t j = 0; j < kSize; j++) {
             temp_a[i*kSize+j] = array_a_accessor[i*kSize+j];
           }
-          temp_b[i] = array_b_accessor[i];
           temp_r[i] = 1.0;
         }
 
-        for (size_t i = 0; i < kSize; i++) {
-          // only one iteration of the outer loop can be executing the
-          // inner loop at a time so that accesses to temp_r occur
-          // in the correct order -- use max_interleaving to simplify
-          // the datapath and reduce hardware resource usage
-          [[intel::max_interleaving(interleaving)]] 
-          for (size_t j = 0; j < kSize; j++) {
-            temp_r[j] = SomethingComplicated(temp_a[i*kSize+j], temp_r[j]);
+        // A simple row reduction where row i of temp_a is summed and 
+        // stored in temp_r[i].
+        // Notice how temp_r[i] is a loop carried dependency in the inner loop as it is updated 
+        // every iteration. As a result, the *inner loop II is very high* as a new iteration from 
+        // the *same* outer loop invocation must wait for the previous iteration to finish updating
+        // temp_r[i].
+        // However, notice how *no* loop carried memory dependency exists with respect to 
+        // the outer loop - for different i-iterations, the temp_r array is read and written to
+        // in different locations. 
+        // The lack of outer loop carried memory dependencies and a high inner loop II is what 
+        // allows interleaving to happen - where multiple invocations of the inner loop
+        // concurrently execute on the same inner loop hardware. This is like pipelining, 
+        // but each iteration executing in the inner loop is from *different* invocations.
+        outer: 
+        for (int i = kSize - 1; i >= 0; i--) {
+          // You can explicitly disable interleaving with this attribute by providing `1` as 
+          // a parameter. `0` keeps it enabled, so long as interleaving is possible.
+          // This may result in area savings at the cost of throughput, which could 
+          // be useful for non-critical data paths in low-area settings. 
+          inner: 
+          [[intel::max_interleaving(interleaving)]]
+          for (int j = kSize - 1; j >= 0; j--) {
+            temp_r[i] +=
+                SomethingComplicated(temp_a[i * kSize + j], temp_r[i]);
           }
-          temp_r[i] += temp_b[i];
+          // One final note - the loop induction variables decrease (i--) instead of increase (i++)
+          // in these two loops to prevent loop fusion optimizations, which makes it harder to 
+          // keep track of loops in the optimization reports. Interleaving will still occur if  
+          // `i` and `j` were incremented instead.
         }
 
         for (size_t i = 0; i < kSize; i++) {
@@ -135,20 +149,18 @@ void Transform(const TwoDimFloatArray &array_a, const FloatArray &array_b,
 
 // Calculates the expected results. Used to verify that the kernel
 // is functionally correct.
-void GoldenResult(const TwoDimFloatArray &A, const FloatArray &B,
-                  FloatArray &R) {
-  for (size_t i = 0; i < kSize; i++) {
-    for (size_t j = 0; j < kSize; j++) {
-      R[j] = SomethingComplicated(A[i*kSize+j], R[j]);
+void GoldenResult(const TwoDimFloatArray &A, FloatArray &R) {
+  outer: for (int i = kSize - 1; i >= 0; i--) {
+    inner: for (int j = kSize - 1; j >= 0; j--) {
+      R[i] +=
+          SomethingComplicated(A[i * kSize + j], R[i]);
     }
-    R[i] += B[i];
   }
 }
 
 int main() {
 
   TwoDimFloatArray indata_A;
-  FloatArray indata_B;
   FloatArray outdata_R_compute_0;
   FloatArray outdata_R_compute_1;
   FloatArray outdata_R_golden;
@@ -156,25 +168,25 @@ int main() {
   // initialize the input data
   srand(7);
   for (size_t i = 0; i < kSize; i++) {
-    indata_B[i] = (float)(rand() % 256);
     for (size_t j = 0; j < kSize; j++) {
-      indata_A[i*kSize+j] = (float)(rand() % 256);
+      indata_A[i*kSize+j] = (float)(rand() % 32);
     }
     outdata_R_golden[i] = 1.0;
   }
 
   // Run the kernel with two different values of the max_interleaving
-  // attribute. In this case, unlimited interleaving (max_interleaving
-  // set to 0) gives no improvement in runtime performance over
-  // restricted interleaving (max_interleaving set to 1), despite
-  // requiring more hardware resources (see README.md for details
+  // attribute: 
+  //   Enabled - max_interleaving = 0
+  //   Disabled - max_interleaving = 1
+  // When interleaving is disabled, runtime performance may decrease while
+  // hardware resources may increase (see README.md for details
   // on confirming this difference in hardware resource usage in
   // the reports).
-  Transform<0>(indata_A, indata_B, outdata_R_compute_0);
-  Transform<1>(indata_A, indata_B, outdata_R_compute_1);
+  Transform<0>(indata_A, outdata_R_compute_0);
+  Transform<1>(indata_A, outdata_R_compute_1);
 
   // compute the actual result here
-  GoldenResult(indata_A, indata_B, outdata_R_golden);
+  GoldenResult(indata_A, outdata_R_golden);
 
   // error check for Transform<0>
   bool failed = false;


### PR DESCRIPTION
# Existing Sample Changes
## Description

The loops in the old code sample had memory dependencies that prevented interleaving from occurring and relied on the compiler's inability to analyze memory dependencies to demonstrate the area savings of interleaving. 
An upcoming internal compiler PR improves our compiler's analysis abilities, rendering the old sample obsolete. 

As such, the code sample has been modified to contain loops that support interleaving. The README.md has been updated with the new hardware runtime data and some structural changes, as the old README.md frequently stated how the loops did not support interleaving, which is no longer the case.

Fixes Issue# N/A

## External Dependencies

N/A

## Type of change

Please delete options that are not relevant. Add a 'X' to the one that is applicable. 
- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [X] Command Line (CMake - note that aside from one additional warning flag, I did not modify `CMakeLists.txt`, nor change how the sample was compiled)
- [ ] oneapi-cli
- [ ] Visual Studio
- [ ] Eclipse IDE
- [ ] VSCode
- [ ] When compiling the compiler flag "-Wall -Wformat-security -Werror=format-security" was used
