### PR TITLE
FPGA: add missing fstream include to PCA and MVDR Beamforming

### DIFF
--- a/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/mvdr_beamforming/src/mvdr_beamforming.cpp
+++ b/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/mvdr_beamforming/src/mvdr_beamforming.cpp
@@ -6,6 +6,7 @@
 #include <iomanip>
 #include <thread>
 #include <vector>
+#include <fstream>
 
 #include <sycl/sycl.hpp>
 #include <sycl/ext/intel/fpga_extensions.hpp>

--- a/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/pca/src/golden_pca.hpp
+++ b/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/pca/src/golden_pca.hpp
@@ -2,6 +2,7 @@
 
 #include <iomanip>
 #include <random>
+#include <fstream>
 
 /*
 This file implements the steps to


### PR DESCRIPTION
# Existing Sample Changes
## Description

This change adds an include which is now necessary as not included by default with sycl.hpp anymore.

Fixes Issue# 

## Type of change

Please delete options that are not relevant. Add a 'X' to the one that is applicable. 

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Implement fixes for ONSAM Jiras

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Command Line
- [ ] oneapi-cli
- [ ] Visual Studio
- [ ] Eclipse IDE
- [ ] VSCode
- [ ] When compiling the compliler flag "-Wall -Wformat-security -Werror=format-security" was used
