### PR TITLE
Use sycl::address_space_cast instead of sycl::multi_ptr constructor

### DIFF
--- a/Publications/GPU-Opt-Guide/reduction/reduction_1.cpp
+++ b/Publications/GPU-Opt-Guide/reduction/reduction_1.cpp
@@ -895,13 +895,16 @@ int ComputeParallel9(sycl::queue &q, std::vector<int> &data,
             size_t loc_id = item.get_local_id(0);
             sycl::sub_group sg = item.get_sub_group();
             sycl::vec<int, 8> sum{0, 0, 0, 0, 0, 0, 0, 0};
-            using global_ptr =
-                sycl::multi_ptr<int, sycl::access::address_space::global_space>;
             int base = (group_id * work_group_size +
                         sg.get_group_id()[0] * sg.get_local_range()[0]) *
                        elements_per_work_item;
-            for (int i = 0; i < elements_per_work_item / 8; ++i)
-              sum += sg.load<8>(global_ptr(&buf_acc[base + i * 128]));
+            for (int i = 0; i < elements_per_work_item / 8; ++i) {
+	       auto buf_ptr = sycl::address_space_cast<
+		 sycl::access::address_space::global_space,
+		 sycl::access::decorated::yes>(&buf_acc[base + i * 128]);
+
+               sum += sg.load<8>(buf_ptr);
+	    }
             scratch[loc_id] = sum;
             for (int i = work_group_size / 2; i > 0; i >>= 1) {
               item.barrier(sycl::access::fence_space::local_space);

--- a/Publications/GPU-Opt-Guide/sub-group/sub-group-7.cpp
+++ b/Publications/GPU-Opt-Guide/sub-group/sub-group-7.cpp
@@ -6,6 +6,15 @@
 #include <CL/sycl.hpp>
 #include <iostream>
 
+template <typename T>
+auto get_multi_ptr(T *raw_ptr) {
+  auto multi_ptr =
+    sycl::address_space_cast<
+      sycl::access::address_space::global_space,
+      sycl::access::decorated::yes>(raw_ptr);
+  return multi_ptr;
+}
+
 int main() {
   sycl::queue q{sycl::gpu_selector_v,
                 sycl::property::queue::enable_profiling{}};
@@ -29,42 +38,30 @@ int main() {
                       sg.get_group_id()[0] * sg.get_local_range()[0]) *
                      16;
 
-          x = sg.load<4>(
-              (sycl::
-                   multi_ptr<int, sycl::access::address_space::global_space>)(&(
-                  data2[base + 0])));
-          sg.store<4>(
-              (sycl::
-                   multi_ptr<int, sycl::access::address_space::global_space>)(&(
-                  data[base + 0])),
-              x);
-          x = sg.load<4>(
-              (sycl::
-                   multi_ptr<int, sycl::access::address_space::global_space>)(&(
-                  data2[base + 64])));
-          sg.store<4>(
-              (sycl::
-                   multi_ptr<int, sycl::access::address_space::global_space>)(&(
-                  data[base + 64])),
-              x);
-          x = sg.load<4>(
-              (sycl::
-                   multi_ptr<int, sycl::access::address_space::global_space>)(&(
-                  data2[base + 128])));
-          sg.store<4>(
-              (sycl::
-                   multi_ptr<int, sycl::access::address_space::global_space>)(&(
-                  data[base + 128])),
-              x);
-          x = sg.load<4>(
-              (sycl::
-                   multi_ptr<int, sycl::access::address_space::global_space>)(&(
-                  data2[base + 192])));
-          sg.store<4>(
-              (sycl::
-                   multi_ptr<int, sycl::access::address_space::global_space>)(&(
-                  data[base + 192])),
-              x);
+	  auto load_ptr0 = get_multi_ptr(&(data2[base + 0*64]));
+          x = sg.load<4>(load_ptr0);
+
+	  auto store_ptr0 = get_multi_ptr(&(data[base + 0*64]));
+          sg.store<4>(store_ptr0, x);
+
+	  auto load_ptr1 = get_multi_ptr(&(data2[base + 1*64]));
+          x = sg.load<4>(load_ptr1);
+
+	  auto store_ptr1 = get_multi_ptr(&(data[base + 1*64]));
+          sg.store<4>(store_ptr1, x);
+
+	  auto load_ptr2 = get_multi_ptr(&(data2[base + 2*64]));
+          x = sg.load<4>(load_ptr2);
+
+	  auto store_ptr2 = get_multi_ptr(&(data[base + 2*64]));
+          sg.store<4>(store_ptr2, x);
+
+	  auto load_ptr3 = get_multi_ptr(&(data2[base + 3*64]));
+          x = sg.load<4>(load_ptr3);
+
+	  auto store_ptr3 = get_multi_ptr(&(data[base + 3*64]));
+          sg.store<4>(store_ptr3, x);
+
         });
   });
   // Snippet end


### PR DESCRIPTION
Use of ``sycl::multi_ptr`` constructor to create `multi_ptr` from a raw pointer spews SYCL-2020 deprecation warnings when using SYCLOS.

The SYCL-2020 spec mandates use of `sycl::address_space_cast` to create `sycl::multi_ptr` from raw pointers.

# Existing Sample Changes

Changed [GPU-Opt-Guide/reduction/reduction_1.cpp](https://github.com/oneapi-src/oneAPI-samples/compare/master...oleksandr-pavlyk:oneAPI-samples:sycl-2020-deprecated?expand=1#diff-4977671236d63fbdcdc23af2803ada7c957883be704ef60cb9e74b56ac50469c), [GPU-Opt-Guide/registers/block-load-store.cpp](https://github.com/oneapi-src/oneAPI-samples/compare/master...oleksandr-pavlyk:oneAPI-samples:sycl-2020-deprecated?expand=1#diff-73d3dd8d2561c206a438995e200e426669907b2514290a85c6718491acd55960), [GPU-Opt-Guide/sub-group/sub-group-6.cpp](https://github.com/oneapi-src/oneAPI-samples/compare/master...oleksandr-pavlyk:oneAPI-samples:sycl-2020-deprecated?expand=1#diff-981a5bec637822a757cecacd632ba0cda60d42f0aa48fd9428731c0b2d858534), and [GPU-Opt-Guide/sub-group/sub-group-7.cpp](https://github.com/oneapi-src/oneAPI-samples/compare/master...oleksandr-pavlyk:oneAPI-samples:sycl-2020-deprecated?expand=1#diff-4f47f7cd104e9ea348ff9aa5f1063ad38f924e8fc97d5fcfb9586f4978536aeb).

## Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes Issue# 

## External Dependencies

List any external dependencies created as a result of this change.

## Type of change

Please delete options that are not relevant. Add a 'X' to the one that is applicable. 

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Implement fixes for ONSAM Jiras

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Command Line
- [ ] oneapi-cli
- [ ] Visual Studio
- [ ] Eclipse IDE
- [ ] VSCode
- [ ] When compiling the compliler flag "-Wall -Wformat-security -Werror=format-security" was used

**_Delete this line and everything below if this is not a PR for a new code sample_**

**_Delete this line and all above it if this PR is for a new code sample_**
# Adding a New Sample(s)

## Description

Please include a description of the sample

## Checklist
Administrative
- [ ] Review sample design with the appropriate [Domain Expert](https://github.com/oneapi-src/oneAPI-samples/wiki/Reviewers-and-Domain-Experts): <insert Name Here>
- [ ] If you have any new dependencies/binaries, inform the oneAPI Code Samples Project Manager

Code Development
- [ ] Implement coding guidelines and ensure code quality. [see wiki for details](https://github.com/oneapi-src/oneAPI-samples/wiki/General-Code-Guidelines)
- [ ] Adhere to readme template 
- [ ] Enforce format via clang-format config file
- [ ] Adhere to sample.json specification. https://github.com/oneapi-src/oneAPI-samples/wiki/sample-json-specification
- [ ] Ensure/create CI test configurations for sample (ciTests field) https://github.com/oneapi-src/oneAPI-samples/wiki/sample-json-ci-test-object
- [ ] Run jsonlint on sample.json to verify json syntax. www.jsonlint.com

Security and Legal
- [ ] OSPDT Approval (see Project Manager for assistance)
- [ ] Compile using the following compiler flags and fix any warnings, the falgs are: "/Wall -Wformat-security -Werror=format-security"
- [ ] Bandit Scans (Python only)
- [ ] Virus scan

Review
- [ ] Review DPC++ code with Paul Peterseon. (GitHub User: pmpeter1)
- [ ] Review readme with Tom Lenth(@tomlenth) and/or Project Manager
- [ ] Tested using Dev Cloud when applicable
