### PR TITLE
[particle-diffuesion] Fix crash on Iris Xe Graphics due to missing fp64 support

### DIFF
--- a/DirectProgramming/C++SYCL/StructuredGrids/particle-diffusion/src/motionsim_kernel.cpp
+++ b/DirectProgramming/C++SYCL/StructuredGrids/particle-diffusion/src/motionsim_kernel.cpp
@@ -72,11 +72,11 @@ template <typename AccRandom, typename AccGrid, bool HasFp64> class ParticleMoti
       int iX;
       int iY;
       if constexpr (HasFp64) {
-        // Algorithm using sycl::half type
+        // Algorithm using double precision
         iX = sycl::floor(particle_X_a[p] + 0.5);
         iY = sycl::floor(particle_Y_a[p] + 0.5);
       } else {
-        // Fall back code for devices that don't support sycl::half
+        // Fall back code for single precision
         iX = sycl::floor(particle_X_a[p] + 0.5f);
         iY = sycl::floor(particle_Y_a[p] + 0.5f);
       }

--- a/DirectProgramming/C++SYCL/StructuredGrids/particle-diffusion/src/motionsim_kernel.cpp
+++ b/DirectProgramming/C++SYCL/StructuredGrids/particle-diffusion/src/motionsim_kernel.cpp
@@ -15,6 +15,203 @@ using namespace oneapi;
 using namespace sycl;
 using namespace std;
 
+template <typename AccRandom, typename AccGrid, bool HasFp64> class ParticleMotionKernel {
+ public:
+  ParticleMotionKernel(accessor<float> particle_X_a, accessor<float> particle_Y_a,
+    AccRandom random_X_a, AccRandom random_Y_a, AccGrid grid_a, const size_t grid_size,
+    const size_t n_particles, const size_t n_iterations, const size_t gs2, const float radius):
+    particle_X_a(particle_X_a), particle_Y_a(particle_Y_a),
+    random_X_a(random_X_a), random_Y_a(random_Y_a), grid_a(grid_a), grid_size(grid_size),
+    n_particles(n_particles), n_iterations(n_iterations), gs2(gs2), radius(radius) {
+     
+    }
+  void operator()(id<1> i) const {
+    // Particle number (used for indexing)
+    size_t p = i[0];
+    // True when particle is found to be in a cell
+    bool inside_cell = false;
+    // Coordinates of the last known cell this particle resided in
+    unsigned int prev_known_cell_coordinate_X;
+    unsigned int prev_known_cell_coordinate_Y;
+
+    // Motion simulation algorithm
+    // --Start iterations--
+    // Each iteration:
+    //    1. Updates the position of all particles
+    //    2. Checks if particle is inside a cell or not
+    //    3. Updates counters in cells array (grid)
+    //
+
+    // Each particle performs this loop
+    for (size_t iter = 0; iter < n_iterations; ++iter) {
+      // Set the displacements to the random numbers
+      float displacement_X = random_X_a[iter * n_particles + p];
+      float displacement_Y = random_Y_a[iter * n_particles + p];
+      // Displace particles
+      particle_X_a[p] += displacement_X;
+      particle_Y_a[p] += displacement_Y;
+      // Compute distances from particle position to grid point i.e.,
+      // the particle's distance from center of cell. Subtract the
+      // integer value from floating point value to get just the
+      // decimal portion. Use this value to later determine if the
+      // particle is inside or outside of the cell
+      float dX = sycl::abs(particle_X_a[p] - sycl::round(particle_X_a[p]));
+      float dY = sycl::abs(particle_Y_a[p] - sycl::round(particle_Y_a[p]));
+      /* Grid point indices closest the particle, defined by the following:
+      ------------------------------------------------------------------
+      |               Condition               |         Result         |
+      |---------------------------------------|------------------------|
+      |particle_X + 0.5 >= ceiling(particle_X)|iX = ceiling(particle_X)|
+      |---------------------------------------|------------------------|
+      |particle_Y + 0.5 >= ceiling(particle_Y)|iY = ceiling(particle_Y)|
+      |---------------------------------------|------------------------|
+      |particle_X + 0.5 < ceiling(particle_X) |iX = floor(particle_X)  |
+      |---------------------------------------|------------------------|
+      |particle_Y + 0.5 < ceiling(particle_Y) |iY = floor(particle_Y)  |
+      ------------------------------------------------------------------  */
+      int iX;
+      int iY;
+      if constexpr (HasFp64) {
+        // Algorithm using sycl::half type
+        iX = sycl::floor(particle_X_a[p] + 0.5);
+        iY = sycl::floor(particle_Y_a[p] + 0.5);
+      } else {
+        // Fall back code for devices that don't support sycl::half
+        iX = sycl::floor(particle_X_a[p] + 0.5f);
+        iY = sycl::floor(particle_Y_a[p] + 0.5f);
+      }
+      /* There are 5 cases when considering particle movement about the
+         grid.
+
+         All 5 cases are distinct from one another; i.e., any particle's
+         motion falls under one and only one of the following cases:
+
+         Case 1: Particle moves from outside cell to inside cell
+               --Increment counters 1-3
+               --Turn on inside_cell flag
+               --Store the coordinates of the
+                 particle's new cell location
+
+         Case 2: Particle moves from inside cell to outside
+                       cell (and possibly outside of the grid)
+                       --Decrement counter 2 for old cell
+                       --Turn off inside_cell flag
+
+         Case 3: Particle moves from inside one cell to inside
+                       another cell
+                       --Decrement counter 2 for old cell
+                       --Increment counters 1-3 for new cell
+                       --Store the coordinates of the particle's new cell
+                         location
+
+         Case 4: Particle moves and remains inside original
+                       cell (does not leave cell)
+                       --Increment counter 1
+
+         Case 5: Particle moves and remains outside of cell
+                       --No action.                                      */
+
+      // Atomic operations flags
+      bool increment_C1 = false;
+      bool increment_C2 = false;
+      bool increment_C3 = false;
+      bool decrement_C2_for_previous_cell = false;
+      bool update_coordinates = false;
+
+      // Check if particle's grid indices are still inside computation grid
+      if ((iX < grid_size) && (iY < grid_size) && (iX >= 0) && (iY >= 0)) {
+        // Compare the radius to particle's distance from center of cell
+        if (radius >= sycl::sqrt(dX * dX + dY * dY)) {
+          // Satisfies counter 1 requirement for cases 1, 3, 4
+          increment_C1 = true;
+          // Case 1
+          if (!inside_cell) {
+            increment_C2 = true;
+            increment_C3 = true;
+            inside_cell = true;
+            update_coordinates = true;
+          }
+          // Case 3
+          else if (prev_known_cell_coordinate_X != iX ||
+                    prev_known_cell_coordinate_Y != iY) {
+            increment_C2 = true;
+            increment_C3 = true;
+            update_coordinates = true;
+            decrement_C2_for_previous_cell = true;
+          }
+          // Else: Case 4 --No action required. Counter 1 already updated
+
+        }  // End inside cell if statement
+
+        // Case 2a --Particle remained inside grid and moved outside cell
+        else if (inside_cell) {
+          inside_cell = false;
+          decrement_C2_for_previous_cell = true;
+        }
+        // Else: Case 5a --Particle remained inside grid and outside cell
+        // --No action required
+
+      }  // End inside grid if statement
+
+      // Case 2b --Particle moved outside grid and outside cell
+      else if (inside_cell) {
+        inside_cell = false;
+        decrement_C2_for_previous_cell = true;
+      }
+      // Else: Case 5b --Particle remained outside of grid.
+      // --No action required
+
+      // Index variable for 3rd dimension of grid
+      size_t layer;
+      // Current and previous cell coordinates
+      size_t curr_coordinates = iX + iY * grid_size;
+      size_t prev_coordinates = prev_known_cell_coordinate_X +
+                                prev_known_cell_coordinate_Y * grid_size;
+      // gs2 variable (used below) equals grid_size * grid_size
+      //
+
+      // Counter 2 layer of the grid (1 * grid_size * grid_size)
+      layer = gs2;
+      if (decrement_C2_for_previous_cell)
+        atomic_fetch_sub<size_t>(grid_a[prev_coordinates + layer], 1);
+
+      if (update_coordinates) {
+        prev_known_cell_coordinate_X = iX;
+        prev_known_cell_coordinate_Y = iY;
+      }
+
+      // Counter 1 layer of the grid (0 * grid_size * grid_size)
+      layer = 0;
+      if (increment_C1)
+        atomic_fetch_add<size_t>(grid_a[curr_coordinates + layer], 1);
+
+      // Counter 2 layer of the grid (1 * grid_size * grid_size)
+      layer = gs2;
+      if (increment_C2)
+      atomic_fetch_add<size_t>(grid_a[curr_coordinates + layer], 1);
+
+      // Counter 3 layer of the grid (2 * grid_size * grid_size)
+      layer = gs2 + gs2;
+      if (increment_C3)
+        atomic_fetch_add<size_t>(grid_a[curr_coordinates + layer], 1);
+
+    }  // Next iteration
+  }
+
+  private:
+    accessor<float> particle_X_a;
+    accessor<float> particle_Y_a;
+    AccRandom random_X_a;
+    AccRandom random_Y_a;
+    AccGrid grid_a;
+    
+    const size_t grid_size;
+    const size_t n_particles;
+    const size_t n_iterations;
+    const size_t gs2;
+    const float radius;
+};
+
 // This function distributes simulation work
 void ParticleMotion(queue& q, const int seed, float* particle_X,
                     float* particle_Y, float* random_X, float* random_Y,
@@ -22,6 +219,10 @@ void ParticleMotion(queue& q, const int seed, float* particle_X,
                     const size_t n_particles, const size_t n_iterations,
                     const float radius) {
   auto device = q.get_device();
+  if (!device.has(aspect::fp64)) {
+    std::cout << "Device " << device.get_info<info::device::name>() << " does not support double precision!"
+      << " Single precision will be used instead." << std::endl;
+  }
   auto maxBlockSize = device.get_info<info::device::max_work_group_size>();
   auto maxEUCount = device.get_info<info::device::max_compute_units>();
   // Total number of motion events
@@ -66,171 +267,15 @@ void ParticleMotion(queue& q, const int seed, float* particle_X,
       // Use SYCL atomic access mode to create atomic accessors
       accessor grid_a = grid_buf.get_access<access::mode::atomic>(h);
 
-      // Send a SYCL kernel (lambda) for parallel execution
-      h.parallel_for(range(n_particles), [=](auto item) {
-        // Particle number (used for indexing)
-        size_t p = item.get_id(0);
-        // True when particle is found to be in a cell
-        bool inside_cell = false;
-        // Coordinates of the last known cell this particle resided in
-        unsigned int prev_known_cell_coordinate_X;
-        unsigned int prev_known_cell_coordinate_Y;
-
-        // Motion simulation algorithm
-        // --Start iterations--
-        // Each iteration:
-        //    1. Updates the position of all particles
-        //    2. Checks if particle is inside a cell or not
-        //    3. Updates counters in cells array (grid)
-        //
-
-        // Each particle performs this loop
-        for (size_t iter = 0; iter < n_iterations; ++iter) {
-          // Set the displacements to the random numbers
-          float displacement_X = random_X_a[iter * n_particles + p];
-          float displacement_Y = random_Y_a[iter * n_particles + p];
-          // Displace particles
-          particle_X_a[p] += displacement_X;
-          particle_Y_a[p] += displacement_Y;
-          // Compute distances from particle position to grid point i.e.,
-          // the particle's distance from center of cell. Subtract the
-          // integer value from floating point value to get just the
-          // decimal portion. Use this value to later determine if the
-          // particle is inside or outside of the cell
-          float dX = sycl::abs(particle_X_a[p] - sycl::round(particle_X_a[p]));
-          float dY = sycl::abs(particle_Y_a[p] - sycl::round(particle_Y_a[p]));
-          /* Grid point indices closest the particle, defined by the following:
-          ------------------------------------------------------------------
-          |               Condition               |         Result         |
-          |---------------------------------------|------------------------|
-          |particle_X + 0.5 >= ceiling(particle_X)|iX = ceiling(particle_X)|
-          |---------------------------------------|------------------------|
-          |particle_Y + 0.5 >= ceiling(particle_Y)|iY = ceiling(particle_Y)|
-          |---------------------------------------|------------------------|
-          |particle_X + 0.5 < ceiling(particle_X) |iX = floor(particle_X)  |
-          |---------------------------------------|------------------------|
-          |particle_Y + 0.5 < ceiling(particle_Y) |iY = floor(particle_Y)  |
-          ------------------------------------------------------------------  */
-          int iX = sycl::floor(particle_X_a[p] + 0.5);
-          int iY = sycl::floor(particle_Y_a[p] + 0.5);
-
-          /* There are 5 cases when considering particle movement about the
-             grid.
-
-             All 5 cases are distinct from one another; i.e., any particle's
-             motion falls under one and only one of the following cases:
-
-               Case 1: Particle moves from outside cell to inside cell
-                       --Increment counters 1-3
-                       --Turn on inside_cell flag
-                       --Store the coordinates of the
-                         particle's new cell location
-
-               Case 2: Particle moves from inside cell to outside
-                       cell (and possibly outside of the grid)
-                       --Decrement counter 2 for old cell
-                       --Turn off inside_cell flag
-
-               Case 3: Particle moves from inside one cell to inside
-                       another cell
-                       --Decrement counter 2 for old cell
-                       --Increment counters 1-3 for new cell
-                       --Store the coordinates of the particle's new cell
-                         location
-
-               Case 4: Particle moves and remains inside original
-                       cell (does not leave cell)
-                       --Increment counter 1
-
-               Case 5: Particle moves and remains outside of cell
-                       --No action.                                      */
-
-          // Atomic operations flags
-          bool increment_C1 = false;
-          bool increment_C2 = false;
-          bool increment_C3 = false;
-          bool decrement_C2_for_previous_cell = false;
-          bool update_coordinates = false;
-
-          // Check if particle's grid indices are still inside computation grid
-          if ((iX < grid_size) && (iY < grid_size) && (iX >= 0) && (iY >= 0)) {
-            // Compare the radius to particle's distance from center of cell
-            if (radius >= sycl::sqrt(dX * dX + dY * dY)) {
-              // Satisfies counter 1 requirement for cases 1, 3, 4
-              increment_C1 = true;
-              // Case 1
-              if (!inside_cell) {
-                increment_C2 = true;
-                increment_C3 = true;
-                inside_cell = true;
-                update_coordinates = true;
-              }
-              // Case 3
-              else if (prev_known_cell_coordinate_X != iX ||
-                       prev_known_cell_coordinate_Y != iY) {
-                increment_C2 = true;
-                increment_C3 = true;
-                update_coordinates = true;
-                decrement_C2_for_previous_cell = true;
-              }
-              // Else: Case 4 --No action required. Counter 1 already updated
-
-            }  // End inside cell if statement
-
-            // Case 2a --Particle remained inside grid and moved outside cell
-            else if (inside_cell) {
-              inside_cell = false;
-              decrement_C2_for_previous_cell = true;
-            }
-            // Else: Case 5a --Particle remained inside grid and outside cell
-            // --No action required
-
-          }  // End inside grid if statement
-
-          // Case 2b --Particle moved outside grid and outside cell
-          else if (inside_cell) {
-            inside_cell = false;
-            decrement_C2_for_previous_cell = true;
-          }
-          // Else: Case 5b --Particle remained outside of grid.
-          // --No action required
-
-          // Index variable for 3rd dimension of grid
-          size_t layer;
-          // Current and previous cell coordinates
-          size_t curr_coordinates = iX + iY * grid_size;
-          size_t prev_coordinates = prev_known_cell_coordinate_X +
-                                    prev_known_cell_coordinate_Y * grid_size;
-          // gs2 variable (used below) equals grid_size * grid_size
-          //
-
-          // Counter 2 layer of the grid (1 * grid_size * grid_size)
-          layer = gs2;
-          if (decrement_C2_for_previous_cell)
-            atomic_fetch_sub<size_t>(grid_a[prev_coordinates + layer], 1);
-
-          if (update_coordinates) {
-            prev_known_cell_coordinate_X = iX;
-            prev_known_cell_coordinate_Y = iY;
-          }
-
-          // Counter 1 layer of the grid (0 * grid_size * grid_size)
-          layer = 0;
-          if (increment_C1)
-            atomic_fetch_add<size_t>(grid_a[curr_coordinates + layer], 1);
-
-          // Counter 2 layer of the grid (1 * grid_size * grid_size)
-          layer = gs2;
-          if (increment_C2)
-            atomic_fetch_add<size_t>(grid_a[curr_coordinates + layer], 1);
-
-          // Counter 3 layer of the grid (2 * grid_size * grid_size)
-          layer = gs2 + gs2;
-          if (increment_C3)
-            atomic_fetch_add<size_t>(grid_a[curr_coordinates + layer], 1);
-
-        }  // Next iteration
-      });  // End parallel for
-    });    // End queue submit. End accessor scope
-  }        // End buffer scope
+      if (device.has(aspect::fp64)) {
+        h.parallel_for(range (n_particles ),
+                        ParticleMotionKernel<decltype(random_X_a), decltype(grid_a), true>(particle_X_a, particle_Y_a,
+                          random_X_a, random_Y_a, grid_a, grid_size, n_particles, n_iterations, gs2, radius));
+      } else {
+        h.parallel_for(range (n_particles),
+                        ParticleMotionKernel<decltype(random_X_a), decltype(grid_a), false>(particle_X_a, particle_Y_a,
+                        random_X_a, random_Y_a, grid_a, grid_size, n_particles, n_iterations, gs2, radius));
+      }     // End parallel for
+    });     // End queue submit. End accessor scope
+  }         // End buffer scope
 }  // End of function ParticleMotion()


### PR DESCRIPTION
# Existing Sample Changes
## Description
The particle diffusion example was failing on Iris Xe graphics due to a lack of double precision. 

Fixes Issue# 
* Check if fp64 is supported on the device
* Fallback to single precision if double is not supported
* Add templated kernel to address the issue

## Type of change

Please delete options that are not relevant. Add a 'X' to the one that is applicable. 

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Implement fixes for ONSAM Jiras

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Command Line
- [ ] oneapi-cli
- [ ] Visual Studio
- [ ] Eclipse IDE
- [ ] VSCode
- [x] When compiling the compliler flag "-Wall -Wformat-security -Werror=format-security" was used
