### PR TITLE
FPGA: add first draft of readme in ip authoring interfaces

### DIFF
--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/ip_authoring_interfaces/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/ip_authoring_interfaces/README.md
@@ -1,0 +1,3 @@
+# IP Authoring Interfaces
+
+This collection of code samples demonstrates how to effectively customize interfaces of FPGA IP produced with the Intel® oneAPI DPC++/C++ Compiler. Intel recommends that you begin by studying the [Component Interfaces Comparison](component_interfaces_comparison/) sample and its sub-samples to learn about the basics of how you can customize interfaces for FPGA IP produced with the Intel® oneAPI DPC++/C++ Compiler. Once you have familiarized yourself with the basic principles, you can study the other samples here to learn more advanced techniques and common stumbling blocks to watch out for.


### PR DESCRIPTION
# documentation update
add some patter to justify the existence of this directory and explain how to navigate the samples in it