### PR TITLE
ApplicationDebugger: add ZET_ENABLE_PROGRAM_DEBUGGING to VS config fo…

### DIFF
--- a/Tools/ApplicationDebugger/array-transform/array-transform.vcxproj.user
+++ b/Tools/ApplicationDebugger/array-transform/array-transform.vcxproj.user
@@ -3,6 +3,7 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <LocalDebuggerEnvironment>ONEAPI_DEVICE_SELECTOR=*:cpu</LocalDebuggerEnvironment>
     <DebuggerFlavor>WindowsLocalDebugger</DebuggerFlavor>
+    <RemoteDebuggerEnvironment>ZET_ENABLE_PROGRAM_DEBUGGING=1</RemoteDebuggerEnvironment>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <LocalDebuggerEnvironment>ONEAPI_DEVICE_SELECTOR=*:cpu</LocalDebuggerEnvironment>


### PR DESCRIPTION
…r remote...

...debugger.  This variable is required to debug a kernel offloaded to GPU.


## Type of change

Please delete options that are not relevant. Add a 'X' to the one that is applicable. 

- [x] Bug fix (non-breaking change which fixes an issue) -- only user-experience improvement: we set the variable which needed to be set manually otherwise

## How Has This Been Tested?

Check in VS solution that the variable is set for the remote debugger. This would be a nice-to-have in 2024.0.