### PR TITLE
FPGA: remove RHEL8 from OS compatibility in the niosv sample

### DIFF
--- a/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/niosv/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/niosv/README.md
@@ -34,7 +34,7 @@ You can also find more information about [troubleshooting build errors](/DirectP
 
 | Optimized for                     | Description
 |:---                               |:---
-| OS                                | Ubuntu* 20.04 <br> RHEL*/CentOS* 8 <br> SUSE* 15 <br> Windows* 10 <br> Windows Server* 2019
+| OS                                | Ubuntu* 20.04 <br> SUSE* 15 <br> Windows* 10 <br> Windows Server* 2019
 | Hardware                          | Intel® Agilex® 7, Arria® 10, and Stratix® 10 FPGAs
 | Software                          | Intel® oneAPI DPC++/C++ Compiler<br> Intel® Quartus® Prime Pro Edition Version 23.1 or later
 


### PR DESCRIPTION
The `niosv` sample relies on the `niosv-shell` toolkit which is not supported on RHEL8 