### PR TITLE
FPGA: Fix broken sample.json files in the ip_authoring_interfaces folder

### DIFF
--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/ip_authoring_interfaces/component_interfaces_comparison/sample.json
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/ip_authoring_interfaces/component_interfaces_comparison/sample.json
@@ -9,7 +9,7 @@
     "builder": ["ide", "cmake"],
     "languages": [{"cpp":{}}],
     "commonFolder": {
-      "base": "../../..",
+      "base": "../../../..",
       "include": [
         "README.md",
         "Tutorials/Features/ip_authoring_interfaces/component_interfaces_comparison",
@@ -130,7 +130,7 @@
           "id": "fpga_emu_1",
           "steps": [
             "icpx --version",
-            "cd ../../..",
+            "cd ../../../..",
             "mkdir build",
             "cd build",
             "cmake -G \"NMake Makefiles\" ../Tutorials/Features/ip_authoring_interfaces_overview/csr-pipes",
@@ -142,7 +142,7 @@
           "id": "fpga_emu_2",
           "steps": [
             "icpx --version",
-            "cd ../../..",
+            "cd ../../../..",
             "mkdir build",
             "cd build",
             "cmake -G \"NMake Makefiles\" ../Tutorials/Features/ip_authoring_interfaces_overview/streaming-invocation",
@@ -154,7 +154,7 @@
           "id": "report_1",
           "steps": [
             "icpx --version",
-            "cd ../../..",
+            "cd ../../../..",
             "mkdir build",
             "cd build",
             "cmake -G \"NMake Makefiles\" ../Tutorials/Features/ip_authoring_interfaces_overview/csr-pipes",
@@ -165,7 +165,7 @@
           "id": "report_2",
           "steps": [
             "icpx --version",
-            "cd ../../..",
+            "cd ../../../..",
             "mkdir build",
             "cd build",
             "cmake -G \"NMake Makefiles\" ../Tutorials/Features/ip_authoring_interfaces_overview/streaming-invocation",
@@ -176,7 +176,7 @@
           "id": "fpga_emu_3",
           "steps": [
             "icpx --version",
-            "cd ../../..",
+            "cd ../../../..",
             "mkdir build",
             "cd build",
             "cmake -G \"NMake Makefiles\" ../Tutorials/Features/ip_authoring_interfaces_overview/pipes",
@@ -188,7 +188,7 @@
           "id": "report_3",
           "steps": [
             "icpx --version",
-            "cd ../../..",
+            "cd ../../../..",
             "mkdir build",
             "cd build",
             "cmake -G \"NMake Makefiles\" ../Tutorials/Features/ip_authoring_interfaces_overview/pipes",
@@ -199,7 +199,7 @@
           "id": "fpga_emu_4",
           "steps": [
             "icpx --version",
-            "cd ../../..",
+            "cd ../../../..",
             "mkdir build",
             "cd build",
             "cmake -G \"NMake Makefiles\" ../Tutorials/Features/ip_authoring_interfaces_overview/mm-host",
@@ -211,7 +211,7 @@
           "id": "report_4",
           "steps": [
             "icpx --version",
-            "cd ../../..",
+            "cd ../../../..",
             "mkdir build",
             "cd build",
             "cmake -G \"NMake Makefiles\" ../Tutorials/Features/ip_authoring_interfaces_overview/mm-host",
@@ -222,7 +222,7 @@
           "id": "fpga_emu_5",
           "steps": [
             "icpx --version",
-            "cd ../../..",
+            "cd ../../../..",
             "mkdir build",
             "cd build",
             "cmake -G \"NMake Makefiles\" ../Tutorials/Features/ip_authoring_interfaces_overview/naive",
@@ -234,7 +234,7 @@
           "id": "report_5",
           "steps": [
             "icpx --version",
-            "cd ../../..",
+            "cd ../../../..",
             "mkdir build",
             "cd build",
             "cmake -G \"NMake Makefiles\" ../Tutorials/Features/ip_authoring_interfaces_overview/naive",

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/ip_authoring_interfaces/invocation_interfaces/sample.json
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/ip_authoring_interfaces/invocation_interfaces/sample.json
@@ -1,7 +1,7 @@
 {
   "guid": "69415BED-D452-449A-8F5A-DB01ACCE38DC",
   "name": "Invocation Interfaces",
-  "categories": ["Toolkit/oneAPI Direct Programming/C++SYCL FPGA/Tutorials/Features/experimental"],
+  "categories": ["Toolkit/oneAPI Direct Programming/C++SYCL FPGA/Tutorials/Features/ip_authoring_interfaces"],
   "description": "An Intel® FPGA tutorial demonstrating the usage of register_map and streaming invocation interfaces",
   "toolchain": ["icpx"],
   "os": ["linux", "windows"],
@@ -12,7 +12,7 @@
     "base": "../../../..",
     "include": [
       "README.md",
-      "Tutorials/Features/experimental/invocation_interfaces",
+      "Tutorials/Features/ip_authoring_interfaces/invocation_interfaces",
       "include"
     ],
     "exclude": []
@@ -54,7 +54,7 @@
           "cd ../../../..",
           "mkdir build",
           "cd build",
-          "cmake -G \"NMake Makefiles\" ../Tutorials/Features/experimental/invocation_interfaces",
+          "cmake -G \"NMake Makefiles\" ../Tutorials/Features/ip_authoring_interfaces/invocation_interfaces",
           "nmake fpga_emu",
           "reg_map_functor.fpga_emu.exe",
           "stream_functor.fpga_emu.exe",
@@ -71,7 +71,7 @@
           "cd ../../../..",
           "mkdir build",
           "cd build",
-          "cmake -G \"NMake Makefiles\" ../Tutorials/Features/experimental/invocatoin_interfaces",
+          "cmake -G \"NMake Makefiles\" ../Tutorials/Features/ip_authoring_interfaces/invocatoin_interfaces",
           "nmake report"
         ]
       }

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/ip_authoring_interfaces/streaming_data_interfaces/sample.json
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/ip_authoring_interfaces/streaming_data_interfaces/sample.json
@@ -1,7 +1,7 @@
 {
   "guid": "aeaca2ce-126e-452b-a6e3-2a3d5b1dbf55",
   "name": "Streaming Interfaces",
-  "categories": ["Toolkit/oneAPI Direct Programming/C++SYCL FPGA/Tutorials/experimental/streaming_data_interfaces"],
+  "categories": ["Toolkit/oneAPI Direct Programming/C++SYCL FPGA/Tutorials/ip_authoring_interfaces/streaming_data_interfaces"],
   "description": "An Intel® FPGA tutorial demonstrating how to use pipes to implement streaming interfaces on IP Components",
   "toolchain": ["icpx"],
   "os": ["linux", "windows"],
@@ -9,10 +9,10 @@
   "builder": ["ide", "cmake"],
   "languages": [{"cpp":{}}],
   "commonFolder": {
-    "base": "../../..",
+    "base": "../../../..",
     "include": [
       "README.md",
-      "Tutorials/Features/experimental/streaming_data_interfaces",
+      "Tutorials/Features/ip_authoring_interfaces/streaming_data_interfaces",
       "include"
     ],
     "exclude": []
@@ -46,10 +46,10 @@
         "id": "fpga_emu",
         "steps": [
           "icpx --version",
-          "cd ../../..",
+          "cd ../../../..",
           "mkdir build",
           "cd build",
-          "cmake -G \"NMake Makefiles\" ../Tutorials/Features/experimental/streaming_data_interfaces",
+          "cmake -G \"NMake Makefiles\" ../Tutorials/Features/ip_authoring_interfaces/streaming_data_interfaces",
           "nmake fpga_emu",
           "streaming_data_interfaces.fpga_emu.exe"
         ]
@@ -58,10 +58,10 @@
         "id": "report",
         "steps": [
           "icpx --version",
-          "cd ../../..",
+          "cd ../../../..",
           "mkdir build",
           "cd build",
-          "cmake -G \"NMake Makefiles\" ../Tutorials/Features/experimental/streaming_data_interfaces",
+          "cmake -G \"NMake Makefiles\" ../Tutorials/Features/ip_authoring_interfaces/streaming_data_interfaces",
           "nmake report"
         ]
       }


### PR DESCRIPTION
Some samples were recently moved to the new `ip_authoring_folder`.
Their `sample.json` files should have been updated in the process.