### PR TITLE
Rename a macro for the oneMKL Monte-Carlo Sample #1661

### DIFF
--- a/Libraries/oneMKL/monte_carlo_european_opt/src/montecarlo.hpp
+++ b/Libraries/oneMKL/monte_carlo_european_opt/src/montecarlo.hpp
@@ -13,8 +13,8 @@
 #include <vector>
 #include <sycl/sycl.hpp>
 
-#ifndef DataType
-#define DataType double
+#ifndef DATA_TYPE
+#define DATA_TYPE double
 #endif
 
 #ifndef ITEMS_PER_WORK_ITEM
@@ -24,6 +24,8 @@
 #ifndef VEC_SIZE
 #define VEC_SIZE 8
 #endif
+
+using DataType = DATA_TYPE;
 
 //Should be > 1
 constexpr int num_options = 384000;


### PR DESCRIPTION
# Existing Sample Changes
## Description

The current name of macro (`DataType`) cause a compilation error for some non-default configurations and, honestly saying, `DataType` doesn't look like a macro name. `DATA_TYPE` looks much better and doesn't cause errors.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Test is passed if add `-DDATA_TYPE` for `GNUmakefile`

- [x] Command Line
- [ ] oneapi-cli
- [ ] Visual Studio
- [ ] Eclipse IDE
- [ ] VSCode
- [x] When compiling the compliler flag "-Wall -Wformat-security -Werror=format-security" was used

Signed-off-by: Fedorov, Andrey <andrey.fedorov@intel.com>
