### PR TITLE
FPGA: fix `board_test` `sample.json` file

### DIFF
--- a/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/board_test/CMakeLists.txt
+++ b/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/board_test/CMakeLists.txt
@@ -271,7 +271,7 @@ endif()
 # Display the compile instructions in the emulation flow
 getCompileCommands("${COMMON_COMPILE_FLAGS}" "${EMULATOR_COMPILE_FLAGS}" "${COMMON_LINK_FLAGS}" "${EMULATOR_LINK_FLAGS}" "${EMULATOR_TARGET}" "${EMULATOR_OUTPUT_NAME}${EXECUTABLE_EXTENSION}")
 
-add_custom_target(  displayEmulationCompileCommands ALL
+add_custom_target(  displayEmulationCompileCommands
                     ${CMAKE_COMMAND} -E cmake_echo_color --cyan ""
                     COMMENT "To compile manually:\n${COMPILE_COMMAND}\nTo link manually:\n${LINK_COMMAND}")
 add_dependencies(${EMULATOR_TARGET} displayEmulationCompileCommands)
@@ -279,7 +279,7 @@ add_dependencies(${EMULATOR_TARGET} displayEmulationCompileCommands)
 # Display the compile instructions in the simulation flow
 getCompileCommands("${COMMON_COMPILE_FLAGS}" "${SIMULATOR_COMPILE_FLAGS}" "${COMMON_LINK_FLAGS}" "${SIMULATOR_LINK_FLAGS}" "${SIMULATOR_TARGET}" "${SIMULATOR_OUTPUT_NAME}${EXECUTABLE_EXTENSION}")
 
-add_custom_target(  displaySimulationCompileCommands ALL
+add_custom_target(  displaySimulationCompileCommands
                     ${CMAKE_COMMAND} -E cmake_echo_color --cyan ""
                     COMMENT "To compile manually:\n${COMPILE_COMMAND}\nTo link manually:\n${LINK_COMMAND}")
 add_dependencies(${SIMULATOR_TARGET} displaySimulationCompileCommands)
@@ -287,7 +287,7 @@ add_dependencies(${SIMULATOR_TARGET} displaySimulationCompileCommands)
 # Display the compile instructions in the report flow
 getCompileCommands("${COMMON_COMPILE_FLAGS}" "${REPORT_COMPILE_FLAGS}" "${MODIFIED_COMMON_LINK_FLAGS_REPORT}" "${REPORT_LINK_FLAGS}" "${REPORT_TARGET}" "${REPORT_OUTPUT_NAME}${EXECUTABLE_EXTENSION}")
 
-add_custom_target(  displayReportCompileCommands ALL
+add_custom_target(  displayReportCompileCommands
                     ${CMAKE_COMMAND} -E cmake_echo_color --cyan ""
                     COMMENT "To compile manually:\n${COMPILE_COMMAND}\nTo link manually:\n${LINK_COMMAND}")
 add_dependencies(${REPORT_TARGET} displayReportCompileCommands)
@@ -295,7 +295,7 @@ add_dependencies(${REPORT_TARGET} displayReportCompileCommands)
 # Display the compile instructions in the fpga flow
 getCompileCommands("${COMMON_COMPILE_FLAGS}" "${FPGA_COMPILE_FLAGS}" "${COMMON_LINK_FLAGS}" "${FPGA_LINK_FLAGS}" "${FPGA_TARGET}" "${FPGA_OUTPUT_NAME}${EXECUTABLE_EXTENSION}")
 
-add_custom_target(  displayFPGACompileCommands ALL
+add_custom_target(  displayFPGACompileCommands
                     ${CMAKE_COMMAND} -E cmake_echo_color --cyan ""
                     COMMENT "To compile manually:\n${COMPILE_COMMAND}\nTo link manually:\n${LINK_COMMAND}")
 add_dependencies(${FPGA_TARGET} displayFPGACompileCommands)

--- a/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/board_test/sample.json
+++ b/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/board_test/sample.json
@@ -25,7 +25,7 @@
           "icpx --version",
           "mkdir build",
           "cd build",
-          "cmake ..",
+          "cmake .. -DFPGA_DEVICE=Agilex7",
           "make fpga_emu",
           "./board_test.fpga_emu"
         ]
@@ -35,7 +35,7 @@
         "steps": [
           "icpx --version",
           "mkdir build",
-          "cd build",
+          "cd build -DFPGA_DEVICE=Agilex7",
           "cmake ..",
           "make report"
         ]
@@ -49,7 +49,7 @@
           "cd ../..",
           "mkdir build",
           "cd build",
-          "cmake -G \"NMake Makefiles\" ../ReferenceDesigns/board_test",
+          "cmake -G \"NMake Makefiles\" ../ReferenceDesigns/board_test -DFPGA_DEVICE=Agilex7",
           "nmake fpga_emu",
           "board_test.fpga_emu.exe"
         ]
@@ -61,7 +61,7 @@
           "cd ../..",
           "mkdir build",
           "cd build",
-          "cmake -G \"NMake Makefiles\" ../ReferenceDesigns/board_test",
+          "cmake -G \"NMake Makefiles\" ../ReferenceDesigns/board_test -DFPGA_DEVICE=Agilex7",
           "nmake report"
         ]
       }


### PR DESCRIPTION
The `board_test` sample was recently updated to not have a default BSP target. 
This broke the CI tests as the `cmake` configuration failed.
This change sets a target for the CI to run, even if this IPA flow does not really make sense for this test - at least we can test the compiler with the CI.