### PR TITLE
FPGA: Fix interface width in the fft2d sample

### DIFF
--- a/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/fft2d/src/fft2d.hpp
+++ b/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/fft2d/src/fft2d.hpp
@@ -514,7 +514,7 @@ struct Transpose {
       ac_complex<T> *, decltype(sycl::ext::oneapi::experimental::properties{
                            sycl::ext::intel::experimental::buffer_location<1>,
                            sycl::ext::intel::experimental::dwidth<
-                               sizeof(ac_complex<T>) * (1 << log_points)>,
+                               sizeof(ac_complex<T>) * 8 * (1 << log_points)>,
                            sycl::ext::intel::experimental::latency<0>})>
       dest;
 #endif


### PR DESCRIPTION
The interface width used to be expressed in bytes, where it should have been expressed in bits.