### PR TITLE
 fix: GameOfLife and guided_HSOptical Flow

### DIFF
--- a/DirectProgramming/C++SYCL/StructuredGrids/guided_HSOpticalFlow_SYCLMigration/02_sycl_migrated/Samples/5_Domain_Specific/HSOpticalFlow/flowSYCL.dp.cpp
+++ b/DirectProgramming/C++SYCL/StructuredGrids/guided_HSOpticalFlow_SYCLMigration/02_sycl_migrated/Samples/5_Domain_Specific/HSOpticalFlow/flowSYCL.dp.cpp
@@ -58,7 +58,7 @@ void ComputeFlowCUDA(const float *I0, const float *I1, int width, int height,
                      int nSolverIters, float *u, float *v) {
   printf("Computing optical flow on Device...\n");
 
-  sycl::queue q{aspect_selector(sycl::aspect::image), sycl::property::queue::in_order()};
+  sycl::queue q{aspect_selector(sycl::aspect::ext_intel_legacy_image), sycl::property::queue::in_order()};
 
   std::cout << "\nRunning on "
             << q.get_device().get_info<sycl::info::device::name>() << "\n";

--- a/DirectProgramming/C++SYCL/StructuredGrids/guided_HSOpticalFlow_SYCLMigration/03_sycl_migrated_optimized/Samples/5_Domain_Specific/HSOpticalFlow/flowSYCL.dp.cpp
+++ b/DirectProgramming/C++SYCL/StructuredGrids/guided_HSOpticalFlow_SYCLMigration/03_sycl_migrated_optimized/Samples/5_Domain_Specific/HSOpticalFlow/flowSYCL.dp.cpp
@@ -58,7 +58,7 @@ void ComputeFlowCUDA(const float *I0, const float *I1, int width, int height,
                      int nSolverIters, float *u, float *v) {
   printf("Computing optical flow on Device...\n");
 
-  sycl::queue q{aspect_selector(sycl::aspect::image), sycl::property::queue::in_order()};
+  sycl::queue q{aspect_selector(sycl::aspect::ext_intel_legacy_image), sycl::property::queue::in_order()};
 
   std::cout << "\nRunning on "
             << q.get_device().get_info<sycl::info::device::name>() << "\n";

--- a/DirectProgramming/C++SYCL/VisualizedSamples/GameOfLife/CMakeLists.txt
+++ b/DirectProgramming/C++SYCL/VisualizedSamples/GameOfLife/CMakeLists.txt
@@ -2,6 +2,11 @@ cmake_minimum_required (VERSION 3.4)
 
 set(CMAKE_CXX_COMPILER icpx)
 
+if(UNIX)
+    set(UNIX TRUE)
+    add_compile_definitions(UNIX)
+endif()
+
 # Set default build type to RelWithDebInfo if not specified
 if (NOT CMAKE_BUILD_TYPE)
     message (STATUS "Default CMAKE_BUILD_TYPE not set using Release with Debug Info")

--- a/DirectProgramming/C++SYCL/VisualizedSamples/GameOfLife/GameOfLife.cpp
+++ b/DirectProgramming/C++SYCL/VisualizedSamples/GameOfLife/GameOfLife.cpp
@@ -167,3 +167,9 @@ int wmain()
 
 	return 0;
 }
+
+#ifdef UNIX
+int main() {
+	return wmain();
+}
+#endif


### PR DESCRIPTION
# Existing Sample Changes
## Description

* GameOfLife is using wmain which does not have support
    for Linux. Add main function
* aspect::image is deprecated. ext_intel_legacy_image used instead


## Type of change

Please delete options that are not relevant. Add a 'X' to the one that is applicable. 

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Implement fixes for ONSAM Jiras

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Command Line
- [ ] oneapi-cli
- [ ] Visual Studio
- [ ] Eclipse IDE
- [x] VSCode
- [ ] When compiling the compliler flag "-Wall -Wformat-security -Werror=format-security" was used

