### PR TITLE
Request CI to use PVC systems to run GPU Optimization SYCL Training sample so it doesn't time out

### DIFF
--- a/DirectProgramming/C++SYCL/Jupyter/gpu-optimization-sycl-training/sample.json
+++ b/DirectProgramming/C++SYCL/Jupyter/gpu-optimization-sycl-training/sample.json
@@ -8,6 +8,7 @@
   "os": [ "linux" ],
   "builder": [ "ide", "make" ],
   "targetDevice": [ "CPU", "GPU" ],
+  "gpuRequired": ["pvc"],
   "ciTests": {
     "linux": [
       {


### PR DESCRIPTION
# Existing Sample Changes
## Description

Fixes issue: ONSAM-1692

Please delete options that are not relevant. Add a 'X' to the one that is applicable. 

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Implement fixes for ONSAM Jiras

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [X] Command Line
- [ ] oneapi-cli
- [ ] Visual Studio
- [ ] Eclipse IDE
- [ ] VSCode
- [ ] When compiling the compliler flag "-Wall -Wformat-security -Werror=format-security" was used