### PR TITLE
Remove INTELFPGAOCLSDKROOT from tutorials

### DIFF
--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/ip_authoring_interfaces/invocation_interfaces/src/CMakeLists.txt
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/ip_authoring_interfaces/invocation_interfaces/src/CMakeLists.txt
@@ -63,13 +63,6 @@ if(WIN32)
     set(WIN_FLAG "/EHsc")
 endif()
 
-# This is for finding the install path to the necessary include files
-if(DEFINED ENV{INTELFPGAOCLSDKROOT})
-   set(SDK_ROOT_PATH $ENV{INTELFPGAOCLSDKROOT})
-else()
-   message(FATAL_ERROR "The INTELFPGAOCLSDKROOT environment variable must be defined for this tutorial to compile.")
-endif()
-
 # A DPC++ ahead-of-time (AoT) compile processes the device code in two stages.
 # 1. The "compile" stage compiles the device code to an intermediate representation (SPIR-V).
 # 2. The "link" stage invokes the compiler's FPGA backend before linking.


### PR DESCRIPTION
# Existing Sample Changes
## Description

Remove an unnecessary check for INTELFPGAOCLSDKROOT in DirectProgramming/C++SYCL_FPGA/Tutorials/Features/ip_authoring_interfaces/invocation_interfaces/src/CMakeLists.txt

The setup scripts should set these variables and the user shouldn't need to worry about this. 

Fixes Issue# n/a

## External Dependencies

n/a

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Ran the test locally with just the base toolkit and fpga addon. 

- [x] Command Line
- [ ] oneapi-cli
- [ ] Visual Studio
- [ ] Eclipse IDE
- [ ] VSCode
- [ ] When compiling the compliler flag "-Wall -Wformat-security -Werror=format-security" was used
