### PR TITLE
Fix numba_dpex kernel problem

### DIFF
--- a/AI-and-Analytics/Features-and-Functionality/IntelPython_Numpy_Numba_dpex_kNN/IntelPython_Numpy_Numba_dpex_kNN.ipynb
+++ b/AI-and-Analytics/Features-and-Functionality/IntelPython_Numpy_Numba_dpex_kNN/IntelPython_Numpy_Numba_dpex_kNN.ipynb
@@ -325,7 +325,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import   numba_dpex\n",
+    "import numba_dpex\n",
     "\n",
     "@numba_dpex.kernel\n",
     "def knn_numba_dpex(train, train_labels, test, k, predictions, votes_to_classes_lst):\n",
@@ -405,9 +405,9 @@
    "source": [
     "Next, like before, let's test the prepared k-NN function.\n",
     "\n",
-    "In this case, we will need to provide the container for predictions: `pedictions_numba` and the container for votes per class: `votes_to_classes_lst` (the container size is 3, as we have 3 classes in our dataset).\n",
+    "In this case, we will need to provide the container for predictions: `predictions` and the container for votes per class: `votes_to_classes_lst` (the container size is 3, as we have 3 classes in our dataset).\n",
     "\n",
-    "We are running a prepared k-NN function using `dctl.device_context()`, which allows us to select a divice. For more information, go to: https://intelpython.github.io/dpctl/latest/docfiles/user_guides/manual/dpctl/device_selection.html."
+    "We are running a prepared k-NN function using `dctl.device_context()`, which allows us to select a device. For more information, go to: https://intelpython.github.io/dpctl/latest/docfiles/user_guides/manual/dpctl/device_selection.html."
    ]
   },
   {
@@ -418,11 +418,16 @@
    "source": [
     "import dpctl\n",
     "\n",
-    "predictions_numba = np.empty(len(X_test.values))\n",
+    "predictions = dpctl.tensor.empty(len(X_test.values))\n",
     "# we have 3 classes\n",
-    "votes_to_classes_lst = np.zeros((len(X_test.values), 3))\n",
+    "votes_to_classes_lst = dpctl.tensor.zeros((len(X_test.values), 3))\n",
+    "\n",
+    "X_train_dpt = dpctl.tensor.asarray(X_train.values)\n",
+    "y_train_dpt = dpctl.tensor.asarray(y_train.values)\n",
+    "X_test_dpt = dpctl.tensor.asarray(X_test.values)\n",
+    "\n",
     "with dpctl.device_context(\"opencl:cpu:0\"):\n",
-    "    knn_numba_dpex[len(X_test.values), numba_dpex.DEFAULT_LOCAL_SIZE](X_train.values, y_train.values, X_test.values, 3, predictions_numba, votes_to_classes_lst)"
+    "    knn_numba_dpex[numba_dpex.Range(len(X_test.values))](X_train_dpt, y_train_dpt, X_test_dpt, 3, predictions, votes_to_classes_lst)"
    ]
   },
   {
@@ -438,6 +443,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "predictions_numba = dpctl.tensor.to_numpy(predictions)\n",
     "true_values = y_test.to_numpy()\n",
     "accuracy = np.mean(predictions_numba == true_values)\n",
     "print('Numba_dpex accuracy:', accuracy)"


### PR DESCRIPTION
# Existing Sample Changes
## Description

Change type of data provided to the numba_dpex kernel to enable proper execution of the code sample.

Fixes Issue #ONSAM-1651

## External Dependencies

List any external dependencies created as a result of this change.

## Type of change

Please delete options that are not relevant. Add a 'X' to the one that is applicable. 

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Implement fixes for ONSAM Jiras

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Command Line
- [ ] oneapi-cli
- [ ] Visual Studio
- [ ] Eclipse IDE
- [ ] VSCode
- [ ] When compiling the compliler flag "-Wall -Wformat-security -Werror=format-security" was used
