### PR TITLE
fix: Make sure that VisualMandlebrot builds on linux

### DIFF
--- a/DirectProgramming/C++SYCL/VisualizedSamples/VisualMandlebrot/get_sdl2.sh
+++ b/DirectProgramming/C++SYCL/VisualizedSamples/VisualMandlebrot/get_sdl2.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+git clone https://github.com/libsdl-org/SDL.git
+cd SDL
+
+git checkout release-2.0.20
+mkdir build
+mkdir install
+cd build
+cmake ../ -D CMAKE_INSTALL_PREFIX=../install
+make && make install
+

--- a/DirectProgramming/C++SYCL/VisualizedSamples/VisualMandlebrot/sample.json
+++ b/DirectProgramming/C++SYCL/VisualizedSamples/VisualMandlebrot/sample.json
@@ -13,7 +13,8 @@
 		"steps": [
 			"mkdir build",
 			"cd build",
-			"cmake ..",
+			"../get_sdl2.sh",
+			"SDL2_DIR=SDL/install/ cmake ..",
 			"make"
 		 ]
 	}],


### PR DESCRIPTION


# Existing Sample Changes
## Description

* Add script that will download and install SDL2
* Update CI build steps

## External Dependencies

List any external dependencies created as a result of this change.

## Type of change

Please delete options that are not relevant. Add a 'X' to the one that is applicable. 

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Implement fixes for ONSAM Jiras

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Command Line
- [ ] oneapi-cli
- [ ] Visual Studio
- [ ] Eclipse IDE
- [x] VSCode
- [ ] When compiling the compliler flag "-Wall -Wformat-security -Werror=format-security" was used

