### PR TITLE
fix: Add script for SDL2 library GameOfLife sample

### DIFF
--- a/DirectProgramming/C++SYCL/VisualizedSamples/GameOfLife/get_sdl2.sh
+++ b/DirectProgramming/C++SYCL/VisualizedSamples/GameOfLife/get_sdl2.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+git clone https://github.com/libsdl-org/SDL.git
+cd SDL
+
+git checkout release-2.0.20
+mkdir build
+mkdir install
+cd build
+cmake ../ -D CMAKE_INSTALL_PREFIX=../install
+make && make install
+

--- a/DirectProgramming/C++SYCL/VisualizedSamples/GameOfLife/sample.json
+++ b/DirectProgramming/C++SYCL/VisualizedSamples/GameOfLife/sample.json
@@ -12,9 +12,10 @@
 	"linux": [{
 		"steps": [
 			"mkdir build",
-      		        "cd build",
-           		"cmake ..",
-           		"make",
+      		"cd build",
+			"../get_sdl2.sh",
+           	"SDL2_DIR=SDL/install/ cmake ..",
+           	"make",
 			"make run"
 		 ]
 	}],


### PR DESCRIPTION


# Existing Sample Changes
## Description

* add script for SDL library build for easier CI building

## External Dependencies

List any external dependencies created as a result of this change.

## Type of change

Please delete options that are not relevant. Add a 'X' to the one that is applicable. 

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Implement fixes for ONSAM Jiras

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Command Line
- [ ] oneapi-cli
- [ ] Visual Studio
- [ ] Eclipse IDE
- [ ] VSCode
- [ ] When compiling the compliler flag "-Wall -Wformat-security -Werror=format-security" was used

