### PR TITLE
FPGA: wait for the fft kernel in the fft2d sample loop 

### DIFF
--- a/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/fft2d/src/fft2d_demo.cpp
+++ b/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/fft2d/src/fft2d_demo.cpp
@@ -239,7 +239,7 @@ void TestFFT(bool mangle, bool inverse) {
       auto fetch_event = q.single_task<class FetchKernel>(
           Fetch<kLogN, kLogParallelism, FetchToFFT, float>{to_read, mangle});
 
-      q.single_task<class FFTKernel>(
+      auto fft_event = q.single_task<class FFTKernel>(
           FFT<kLogN, kLogParallelism, FetchToFFT, FFTToTranspose, float>{
               inverse});
 
@@ -247,6 +247,7 @@ void TestFFT(bool mangle, bool inverse) {
           Transpose<kLogN, kLogParallelism, FFTToTranspose, float>{to_write,
                                                                    mangle});
 
+      fft_event.wait();
       transpose_event.wait();
 
       if (i == 0) {


### PR DESCRIPTION
Without this explicit wait, the runtime is crashing, this was reported as an internal bug. Adding this wait is a workaround.