### PR TITLE
Fix 2d fcorr makefile

### DIFF
--- a/Libraries/oneMKL/fourier_correlation/makefile
+++ b/Libraries/oneMKL/fourier_correlation/makefile
@@ -4,7 +4,7 @@ default: run_all
 
 all: run_all
 
-run_all: fcorr_1d_buff.exe fcorr_1d_usm.exe fcorr_2d_usm
+run_all: fcorr_1d_buff.exe fcorr_1d_usm.exe fcorr_2d_usm.exe
 	.\fcorr_1d_buff 1024
 	.\fcorr_1d_usm 1024
 	.\fcorr_2d_usm

--- a/Libraries/oneMKL/fourier_correlation/makefile
+++ b/Libraries/oneMKL/fourier_correlation/makefile
@@ -4,7 +4,7 @@ default: run_all
 
 all: run_all
 
-run_all: fcorr_1d_buff.exe fcorr_1d_usm.exe
+run_all: fcorr_1d_buff.exe fcorr_1d_usm.exe fcorr_2d_usm
 	.\fcorr_1d_buff 1024
 	.\fcorr_1d_usm 1024
 	.\fcorr_2d_usm


### PR DESCRIPTION
# Existing Sample Changes
## Description

I added a .exe extension on one of the executables in the Windows makefile.

Fixes Issue# ONSAM-1688

## External Dependencies

None

## Type of change

Please delete options that are not relevant. Add a 'X' to the one that is applicable. 

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] Implement fixes for ONSAM Jiras

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [X] Command Line
- [ ] oneapi-cli
- [ ] Visual Studio
- [ ] Eclipse IDE
- [ ] VSCode
- [ ] When compiling the compliler flag "-Wall -Wformat-security -Werror=format-security" was used