### PR TITLE
IntelPython_daal4py_GettingStarted (ONSAM-1650)

### DIFF
--- a/AI-and-Analytics/Getting-Started-Samples/IntelPython_daal4py_GettingStarted/sample.json
+++ b/AI-and-Analytics/Getting-Started-Samples/IntelPython_daal4py_GettingStarted/sample.json
@@ -12,7 +12,8 @@
     "linux": [
     {
       "env": [
-        "source activate base",
+        "source /opt/intel/oneapi/setvars.sh --force",
+        "conda activate base",
         "pip install -r requirements.txt"
       ],
       "id": "idp_d4p_GS_py",


### PR DESCRIPTION
added oneapi setvars. Refer [ONSAM-1650](https://jira.devtools.intel.com/browse/ONSAM-1650)