### PR TITLE
FPGA: remove CI tests for the `use_library` sample

### DIFF
--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Tools/use_library/sample.json
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Tools/use_library/sample.json
@@ -18,54 +18,6 @@
     "exclude": []
   },
   "ciTests": {
-    "linux": [
-      {
-        "id": "fpga_emu_2",
-        "steps": [
-          "icpx --version",
-          "mkdir build",
-          "cd build",
-          "cmake ..",
-          "make fpga_emu",
-          "./use_library.fpga_emu"
-        ]
-      },
-      {
-        "id": "report",
-        "steps": [
-          "icpx --version",
-          "mkdir build",
-          "cd build",
-          "cmake ..",
-          "make report"
-        ]
-      }
-    ],
-    "windows": [
-      {
-        "id": "fpga_emu",
-        "steps": [
-          "icpx --version",
-          "cd ../../..",
-          "mkdir build",
-          "cd build",
-          "cmake -G \"NMake Makefiles\" ../Tutorials/Tools/use_library",
-          "nmake fpga_emu",
-          "use_library.fpga_emu.exe"
-        ]
-      },
-      {
-        "id": "report",
-        "steps": [
-          "icpx --version",
-          "cd ../../..",
-          "mkdir build",
-          "cd build",
-          "cmake -G \"NMake Makefiles\" ../Tutorials/Tools/use_library",
-          "nmake report"
-        ]
-      }
-    ]
   },
   "expertise": "Getting Started"
 }


### PR DESCRIPTION
The `use_library` sample relies on the fpga_crossgen tool which is not installed on the CI machines.
The CI tests are therefore disabled for this sample.