### PR TITLE
fix: Do not run VisualSamples UI on CI

### DIFF
--- a/DirectProgramming/C++SYCL/VisualizedSamples/GameOfLife/sample.json
+++ b/DirectProgramming/C++SYCL/VisualizedSamples/GameOfLife/sample.json
@@ -15,15 +15,13 @@
       		"cd build",
 			"../get_sdl2.sh",
            	"SDL2_DIR=SDL/install/ cmake ..",
-           	"make",
-			"make run"
+           	"make"
 		 ]
 	}],
 	"windows": [{
 		"steps": [
 			"MSBuild GameOfLife.sln /t:Rebuild /p:Configuration=\"Release\"",
-			"cd x64/Release",
-            		"GameOfLife.exe"
+			"cd x64/Release"
 		]
 	}]
 

--- a/DirectProgramming/C++SYCL/VisualizedSamples/VisualMandlebrot/sample.json
+++ b/DirectProgramming/C++SYCL/VisualizedSamples/VisualMandlebrot/sample.json
@@ -21,8 +21,7 @@
 	"windows": [{
 		"steps": [
 			"MSBuild MandelbrotSDL.sln /t:Rebuild /p:Configuration=\"Release\"",
-			"cd x64/Release",
-			"MandelbrotSDL.exe"
+			"cd x64/Release"
 		]
 	}]
 


### PR DESCRIPTION
# Existing Sample Changes
## Description

Do not run VisualSamples UI on CI

## Type of change

Please delete options that are not relevant. Add a 'X' to the one that is applicable. 

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Implement fixes for ONSAM Jiras

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Command Line
- [ ] oneapi-cli
- [ ] Visual Studio
- [ ] Eclipse IDE
- [ ] VSCode
- [ ] When compiling the compliler flag "-Wall -Wformat-security -Werror=format-security" was used

