### PR TITLE
Remove ivdep attribute in the CRR code sample

### DIFF
--- a/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/crr/src/main.cpp
+++ b/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/crr/src/main.cpp
@@ -264,7 +264,7 @@ double CrrSolver(const int n_items, vector<CRRMeta> &in_params,
               // L4:
               // Calculate all the elements in optval[] -- all the tree nodes
               // for one level of the tree
-              [[intel::ivdep]] // NO-FORMAT: Attribute
+              [[intel::initiation_interval(1)]] // NO-FORMAT: Attribute
               for (int n = 0; n <= steps - 1 - t; n += INNER_UNROLL) {
 
                 #pragma unroll


### PR DESCRIPTION
# Existing Sample Changes
## Description

Previously the CRR code sample was using the ivdep attribute incorrectly on the innermost loop, called L. Consider the case where OUTER_UNROLL=1, OUTER_UNROLL_POW2=1, and INNER_UNROLL=64.

Iteration n=0 is the first iteration of L. This first iteration reads from `optval[1,...,64]`, and writes to `optval[0,...,63]`.
Iteration n=64 is the second iteration of L. This second iteration reads from `optval[65,...,128]`, and writes to `optval[64,...,127]`.

Therefore, `optval[64]` is read from in the first iteration, and written to in the second iteration. This is a WAR dependence between the two iterations, meaning that the iterations of the loop have a loop-carried dependence on array `optval[]`. Therefore using ivdep on this loop is an undefined behavior.

However, the memory dependence is guaranteed by another loop carried data dependence. In the first iteration of L, `optval[64]` is read and assigned to `reg[64]`. `reg[64]` is then read and assigned to `reg[0]`. In the second iteration of L, `reg[0]` is used in the calculation of `val`, and the value of `val` is assigned to `optval[64]`. Note that the `reg[]` array is marked as fpga_register. This effectively guarantees that in the second iteration when `optval[64]` is assigned, we must have read `optval[64]` in the first iteration, satisfying the memory dependence. In addition, we can achieve II=1 on this loop.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [X] Command Line