### PR TITLE
Fix ONSAM 1636 - change tokenization padding to max_length

### DIFF
--- a/AI-and-Analytics/Features-and-Functionality/INC_QuantizationAwareTraining_TextClassification/INC_QuantizationAwareTraining_TextClassification.ipynb
+++ b/AI-and-Analytics/Features-and-Functionality/INC_QuantizationAwareTraining_TextClassification/INC_QuantizationAwareTraining_TextClassification.ipynb
@@ -146,7 +146,7 @@
       "outputs": [],
       "source": [
         "def tokenize_data(example):\n",
-        "    return tokenizer(example['text'], padding=True, max_length=128)\n",
+        "    return tokenizer(example['text'], padding='max_length', max_length=128)\n",
         "\n",
         "dataset = dataset.map(tokenize_data, batched=True)\n",
         "dataset"

--- a/AI-and-Analytics/Features-and-Functionality/INC_QuantizationAwareTraining_TextClassification/INC_QuantizationAwareTraining_TextClassification.py
+++ b/AI-and-Analytics/Features-and-Functionality/INC_QuantizationAwareTraining_TextClassification/INC_QuantizationAwareTraining_TextClassification.py
@@ -104,7 +104,7 @@ plt.show()
 
 
 def tokenize_data(example):
-    return tokenizer(example['text'], padding=True, max_length=128)
+    return tokenizer(example['text'], padding='max_length', max_length=128)
 
 dataset = dataset.map(tokenize_data, batched=True)
 dataset

--- a/AI-and-Analytics/Features-and-Functionality/INC_QuantizationAwareTraining_TextClassification/requirements.txt
+++ b/AI-and-Analytics/Features-and-Functionality/INC_QuantizationAwareTraining_TextClassification/requirements.txt
@@ -3,4 +3,4 @@ evaluate
 accelerate 
 datasets 
 neural-compressor 
-git+https://github.com/huggingface/optimum.git#egg=optimum[neural-compressor]
+optimum[neural-compressor]


### PR DESCRIPTION
# Existing Sample Changes
## Description
Change method for data tokenization to use padding='max_length'
Fixes Issue #1636

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] Implement fixes for ONSAM Jiras

## How Has This Been Tested?

I was able to test this change on IDC. 

- [x] Command Line
- [ ] oneapi-cli
- [ ] Visual Studio
- [ ] Eclipse IDE
- [ ] VSCode
- [ ] When compiling the compliler flag "-Wall -Wformat-security -Werror=format-security" was used