### PR TITLE
ApplicationDebugger: simplify AoT compile command and supply "-g" flag.

### DIFF
--- a/Tools/ApplicationDebugger/array-transform/CMakeLists.txt
+++ b/Tools/ApplicationDebugger/array-transform/CMakeLists.txt
@@ -14,7 +14,7 @@ endif ()
 
 set (CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -fsycl")
 
-set (CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -O0")
+set (CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -O0 -g")
 message (STATUS "Optimization level is set to -O0.")
 
 # Check that debugger executables exist in PATH
@@ -37,7 +37,7 @@ elseif (SYCL_COMPILE_TARGET MATCHES fpga-emu)
   set (CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -fsycl-targets=spir64_fpga")
 else ()
   set (CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -fsycl-targets=spir64_gen")
-  set (CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -Xs \"-device ${SYCL_COMPILE_TARGET} -internal_options -cl-kernel-debug-enable -options -cl-opt-disable\"")
+  set (CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -Xs \"-device ${SYCL_COMPILE_TARGET}\"")
 endif ()
 message (STATUS "SYCL_COMPILE_TARGET is '${SYCL_COMPILE_TARGET}'")
 

--- a/Tools/ApplicationDebugger/array-transform/README.md
+++ b/Tools/ApplicationDebugger/array-transform/README.md
@@ -184,18 +184,7 @@ For example, to do AoT compilation for a specific GPU device ID:
 ```
 $ cmake .. -DSYCL_COMPILE_TARGET=<device id>
 ```
-where the `<device id>` must be replaced with the actual device ID in the hex format.
-Use `sycl-ls` command to list available devices on your target machine:
-
-```
-$ sycl-ls
-[ext_oneapi_level_zero:gpu:0] Intel(R) Level-Zero, Intel(R) Graphics [0x56c1] 1.3 [1.3.0]
-[ext_oneapi_level_zero:gpu:1] Intel(R) Level-Zero, Intel(R) Graphics [0x56c1] 1.3 [1.3.0]
-[ext_oneapi_level_zero:gpu:2] Intel(R) Level-Zero, Intel(R) Graphics [0x56c1] 1.3 [1.3.0]
-[ext_oneapi_level_zero:gpu:3] Intel(R) Level-Zero, Intel(R) Graphics [0x56c1] 1.3 [1.3.0]
-```
-
-In the above example, the device ID is `0x56c1`.
+where the `<device id>` specifies the target device, e.g., "xe".
 
 > *Hint:* Run `ocloc compile --help` to see all available GPU device options.
 

--- a/Tools/ApplicationDebugger/jacobi/CMakeLists.txt
+++ b/Tools/ApplicationDebugger/jacobi/CMakeLists.txt
@@ -14,7 +14,7 @@ endif ()
 
 set (CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -fsycl")
 
-set (CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -O0")
+set (CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -O0 -g")
 message (STATUS "Optimization level is set to -O0.")
 
 # Check that debugger executables exist in PATH


### PR DESCRIPTION
# Existing Sample Changes
## Description

Some users have reported that "-g" flag is not always present in their debug builds by default.

The AoT command for the debug build does not require anymore to pass the internal options to the device compiler, and these options are actually harmful. 

sycl-ls stopped showing the device-id, so I removed that from the Readme.

Fixes Issue# 

If "-g" flag is not passed -- the debugger does not stop inside the kernel.

With the previous AoT command there was an internal BP generated at the kernel entry, so w/o the debugger the application seemed hanging.
 
## Type of change

Please delete options that are not relevant. Add a 'X' to the one that is applicable. 

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Command Line
- [ ] oneapi-cli
- [ ] Visual Studio
- [ ] Eclipse IDE
- [ ] VSCode
- [ ] When compiling the compliler flag "-Wall -Wformat-security -Werror=format-security" was used

Please include this change in 2024.0