### PR TITLE
IRTK embree pathtracer fixes for stb (2024.0)

### DIFF
--- a/RenderingToolkit/Tutorial/PathTracingWithEmbree/cpu/CMakeLists.txt
+++ b/RenderingToolkit/Tutorial/PathTracingWithEmbree/cpu/CMakeLists.txt
@@ -14,6 +14,7 @@ set(RKCOMMON_BASE_DIR "")
 set(TBB_BASE_DIR "")
 set(DEVUTILITIES_BASE_DIR "")
 set(COMPILERRUNTIMES_BASE_DIR "")
+set(PATHADDITIONS_DIRS "")
 if(EXISTS ${ONEAPI_ROOT}/oneapi-vars.sh OR EXISTS ${ONEAPI_ROOT}/oneapi-vars.bat)
   set(EMBREE_BASE_DIR ${ONEAPI_ROOT})
   set(RKCOMMON_BASE_DIR ${ONEAPI_ROOT})
@@ -21,6 +22,7 @@ if(EXISTS ${ONEAPI_ROOT}/oneapi-vars.sh OR EXISTS ${ONEAPI_ROOT}/oneapi-vars.bat
   set(DEVUTILITIES_BASE_DIR ${ONEAPI_ROOT})
   #Compiler runtimes help for windows MSVS debugger DLL help only
   set(COMPILERRUNTIMES_BASE_DIR ${ONEAPI_ROOT})
+  set(PATHADDITIONS_DIRS "PATH=%PATH%;${ONEAPI_ROOT}/bin")
 else()
   set(EMBREE_BASE_DIR ${ONEAPI_ROOT}/embree/latest)
   set(RKCOMMON_BASE_DIR ${ONEAPI_ROOT}/rkcommon/latest)
@@ -37,6 +39,11 @@ find_package(embree 4.0 REQUIRED PATHS ${EMBREE_BASE_DIR}/lib/cmake NO_DEFAULT_P
 
 #rkcommon objects for rendering are used in this example
 find_package(rkcommon REQUIRED CONFIG PATHS ${RKCOMMON_BASE_DIR}/lib/cmake NO_DEFAULT_PATH)
+
+if(PATHADDITIONS_DIRS STREQUAL "")
+  set(PATHADDITIONS_DIRS "PATH=%PATH%;${COMPILERRUNTIMES_BASE_DIR}/bin;${embree_DIR}/../../../bin;${rkcommon_DIR}/../../../bin;${tbb_DIR}/../../../bin;")
+endif(PATHADDITIONS_DIRS STREQUAL "")
+
 
 if(MSVC)
   set(CMAKE_CXX_STANDARD 11)
@@ -63,10 +70,11 @@ set(HEADERS src/CornellBox.h  src/DefaultCubeAndPlane.h  src/Geometry.h  src/Lig
 add_executable(rkPathTracer src/rkPathTracer.cpp ${HEADERS})
 
 if(MSVC)
+  message(STATUS "Using ${PATHADDITIONS_DIRS} for the MSVS Debugger env")
 # Set MSVS debugger environment variables so it is easier to attach the MSVS debugger after altering the application
-    set_target_properties(rkPathTracer
-	    PROPERTIES VS_DEBUGGER_ENVIRONMENT "PATH=%PATH%;${COMPILERRUNTIMES_BASE_DIR}/bin;${embree_DIR}/../../../bin;${rkcommon_DIR}/../../../bin;${tbb_DIR}/../../../bin;"
-    )
+  set_target_properties(rkPathTracer
+    PROPERTIES VS_DEBUGGER_ENVIRONMENT ${PATHADDITIONS_DIRS}
+  )
 endif(MSVC)
 target_link_libraries(rkPathTracer PRIVATE embree TBB::tbb rkcommon::rkcommon)
 

--- a/RenderingToolkit/Tutorial/PathTracingWithEmbree/cpu/CMakeLists.txt
+++ b/RenderingToolkit/Tutorial/PathTracingWithEmbree/cpu/CMakeLists.txt
@@ -6,21 +6,37 @@ if(DEFINED ENV{ONEAPI_ROOT})
   set(ONEAPI_ROOT "$ENV{ONEAPI_ROOT}")
   message(STATUS "ONEAPI_ROOT FROM ENVIRONMENT: ${ONEAPI_ROOT}")
 else()
-  if(WIN32)
-    set(ONEAPI_ROOT "C:/Program Files (x86)/Intel/oneAPI")
-  else()
-    set(ONEAPI_ROOT /opt/intel/oneapi)
-  endif()
-  message(STATUS "ONEAPI_ROOT DEFAULT: ${ONEAPI_ROOT}")
+  message(FATAL_ERROR "ONEAPI_ROOT not set. Please use a vars script (.bat/.sh) from the oneAPI deployment directory")
 endif(DEFINED ENV{ONEAPI_ROOT})
 
-#tbb is used for tasking in this example
-find_package(TBB REQUIRED PATHS ${ONEAPI_ROOT})
+set(EMBREE_BASE_DIR "")
+set(RKCOMMON_BASE_DIR "")
+set(TBB_BASE_DIR "")
+set(DEVUTILITIES_BASE_DIR "")
+set(COMPILERRUNTIMES_BASE_DIR "")
+if(EXISTS ${ONEAPI_ROOT}/oneapi-vars.sh OR EXISTS ${ONEAPI_ROOT}/oneapi-vars.bat)
+  set(EMBREE_BASE_DIR ${ONEAPI_ROOT})
+  set(RKCOMMON_BASE_DIR ${ONEAPI_ROOT})
+  set(TBB_BASE_DIR ${ONEAPI_ROOT})
+  set(DEVUTILITIES_BASE_DIR ${ONEAPI_ROOT})
+  #Compiler runtimes help for windows MSVS debugger DLL help only
+  set(COMPILERRUNTIMES_BASE_DIR ${ONEAPI_ROOT})
+else()
+  set(EMBREE_BASE_DIR ${ONEAPI_ROOT}/embree/latest)
+  set(RKCOMMON_BASE_DIR ${ONEAPI_ROOT}/rkcommon/latest)
+  set(TBB_BASE_DIR ${ONEAPI_ROOT}/tbb/latest)
+  set(DEVUTILITIES_BASE_DIR ${ONEAPI_ROOT}/dev-utilities/latest)
+  #Compiler runtimes help for windows MSVS debugger DLL help only
+  set(COMPILERRUNTIMES_BASE_DIR ${ONEAPI_ROOT}/compiler/latest)
+endif(EXISTS ${ONEAPI_ROOT}/oneapi-vars.sh OR EXISTS ${ONEAPI_ROOT}/oneapi-vars.bat)
 
-find_package(embree 4.0 REQUIRED PATHS ${ONEAPI_ROOT}/embree/latest/lib/cmake NO_DEFAULT_PATH)
+#tbb is used for tasking in this example
+find_package(TBB REQUIRED PATHS ${TBB_BASE_DIR}/lib/cmake NO_DEFAULT_PATH)
+
+find_package(embree 4.0 REQUIRED PATHS ${EMBREE_BASE_DIR}/lib/cmake NO_DEFAULT_PATH)
 
 #rkcommon objects for rendering are used in this example
-find_package(rkcommon REQUIRED CONFIG PATHS ${ONEAPI_ROOT}/rkcommon/latest/lib/cmake NO_DEFAULT_PATH)
+find_package(rkcommon REQUIRED CONFIG PATHS ${RKCOMMON_BASE_DIR}/lib/cmake NO_DEFAULT_PATH)
 
 if(MSVC)
   set(CMAKE_CXX_STANDARD 11)
@@ -40,8 +56,8 @@ if (NOT CMAKE_BUILD_TYPE)
 endif(NOT CMAKE_BUILD_TYPE)
 endif(NOT MSVC)
 
-#stb headers are located in dev-utilities. oneAPI 2022.2 release and earlier: these header only libraries are distributed with the oneAPI Base Toolkit.
-include_directories(${ONEAPI_ROOT}/dev-utilities/latest/include)
+#stb headers are located in dev-utilities with the old oneAPI dires layout
+include_directories(${DEVUTILITIES_BASE_DIR}/include)
 
 set(HEADERS src/CornellBox.h  src/DefaultCubeAndPlane.h  src/Geometry.h  src/Lights.h src/Materials.h src/PathTracer.h src/Pool.h src/Renderer.h src/SceneGraph.h src/Sphere.h src/definitions.h src/RandomSampler.h)
 add_executable(rkPathTracer src/rkPathTracer.cpp ${HEADERS})
@@ -49,7 +65,7 @@ add_executable(rkPathTracer src/rkPathTracer.cpp ${HEADERS})
 if(MSVC)
 # Set MSVS debugger environment variables so it is easier to attach the MSVS debugger after altering the application
     set_target_properties(rkPathTracer
-	    PROPERTIES VS_DEBUGGER_ENVIRONMENT "PATH=%PATH%;${embree_DIR}/../../../bin;${rkcommon_DIR}/../../../bin;${tbb_DIR}/../../../bin;"
+	    PROPERTIES VS_DEBUGGER_ENVIRONMENT "PATH=%PATH%;${COMPILERRUNTIMES_BASE_DIR}/bin;${embree_DIR}/../../../bin;${rkcommon_DIR}/../../../bin;${tbb_DIR}/../../../bin;"
     )
 endif(MSVC)
 target_link_libraries(rkPathTracer PRIVATE embree TBB::tbb rkcommon::rkcommon)

--- a/RenderingToolkit/Tutorial/PathTracingWithEmbree/cpu/README.md
+++ b/RenderingToolkit/Tutorial/PathTracingWithEmbree/cpu/README.md
@@ -1,6 +1,6 @@
 # Path Tracing with Intel&reg; Embree Sample Program
 
-This sample program illustrates path tracing using Intel Embree from the Intel&reg; oneAPI Rendering Toolkit (Render Kit).
+This sample program illustrates path tracing using Intel Embree from the Intel&reg; Rendering Toolkit (Render Kit).
 
 [![pathtracer-accu-cornell-spp1-accu4000-plength8-512x512.png](example-images/pathtracer-accu-cornell-spp1-accu4000-plength8-512x512.png)](example-images/pathtracer-accu-cornell-spp1-accu4000-plength8-512x512.png)
 
@@ -33,17 +33,17 @@ Make sure to try the [rkRayTracer](../IntroToRayTracingWithEmbree) sample progra
 
 | Minimum Requirements | Description                                                                                                                                                                                                                     |
 |:-------------------- |:------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| OS                   | Linux* Ubuntu* 18.04 <br>CentOS* 8 (or compatible) <br>Windows* 10 <br>macOS* 10.15+                                                                                                                                            |
+| OS                   | Linux* Ubuntu* 18.04 <br>CentOS* 8 (or compatible) <br>Windows* 10 or 11<br>macOS* 10.15+                                                                                                                                            |
 | Hardware             | <ul><li>Intel&reg; 64 (Intel 64 Penryn or higher with SSE4.1 extensions compatible) <ul><li>Intel Atom&reg; processors</li><li>Intel&reg; Core&trade; processor family</li><li>Intel&reg; Xeon&reg; processor family</li><li>Intel&reg; Xeon&reg; Scalable processor family</li></ul></li><li>ARM</li><ul><li>ARM64 with NEON extensions (ex: Apple* M1)</li></ul></li><li>Intel Embree is further optimized for Intel 64 Skylake or higher with AVX512 extensions</li></ul>  |
 | Compiler Toolchain   | Windows* OS: MSVS 2019 or MSVS 2022 with Windows* SDK and CMake* <br>Other platforms: C++14 compiler and CMake*                                                                                                                 |
-| Libraries            | Install Intel oneAPI Rendering Toolkit (Render Kit) for Intel Embree and Intel&reg; oneAPI Threading Building Blocks (oneTBB) <br>Install Intel&reg; oneAPI Base Toolkit for the `dev-utilities` default component |
+| Libraries            | Install Intel Rendering Toolkit (Render Kit) for Intel Embree and Intel&reg; oneAPI Threading Building Blocks (oneTBB) <br>Install Intel&reg; oneAPI Base Toolkit for the `dev-utilities` default component and Intel&reg; oneAPI DPC++ Compiler Runtimes |
 | Tools                | .png capable image viewer                                                                                                                                                                                                       |
 
 ## Build and Run
 
 ### Windows*
 
-1. Open an x64 Native Tools Command Prompt for VS 2019 (or 2022).
+1. Open an x64 Native Tools Command Prompt for VS 2022 (or 2019).
 
 2. Set toolkit environment variables.
 
@@ -51,8 +51,8 @@ Make sure to try the [rkRayTracer](../IntroToRayTracingWithEmbree) sample progra
 > environment by sourcing  the `setvars` script in the root of your oneAPI installation.
 >
 > Windows*:
-> - `C:\Program Files(x86)\Intel\oneAPI\setvars.bat`
-> - Windows PowerShell*, use the following command: `cmd.exe "/K" '"C:\Program Files (x86)\Intel\oneAPI\setvars.bat" && powershell'`
+> - `C:\Program Files(x86)\Intel\oneAPI\<version>\oneapi-vars.bat`
+> - Windows PowerShell*, use the following command: `cmd.exe "/K" '"C:\Program Files (x86)\Intel\oneAPI\<version>\oneapi-vars.bat" && powershell'`
 > For more information on configuring environment variables, see [Use the setvars Script with Windows*](https://www.intel.com/content/www/us/en/develop/documentation/oneapi-programming-guide/top/oneapi-development-environment-setup/use-the-setvars-script-with-windows.html).
 
 3. Build and run the application:
@@ -60,13 +60,13 @@ Make sure to try the [rkRayTracer](../IntroToRayTracingWithEmbree) sample progra
 ```
 mkdir build
 cd build
-cmake -G"Visual Studio 16 2019" -A x64 ..
+cmake -G"Visual Studio 17 2022" -A x64 ..
 cmake --build . --config Release
 cd Release
 .\rkPathTracer.exe
 ```
 
-**Note**: Visual Studio 2022 users should use the `-G"Visual Studio 17 2022"`
+**Note**: Visual Studio 2019 users should use the `-G"Visual Studio 16 2019"`
 generator flag.
 
 4. Open the resulting .png image files with an image viewer. The .png files will be in the working directory for the executing program.
@@ -87,9 +87,9 @@ devenv rkPathTracer.sln
 > environment by sourcing  the `setvars` script in the root of your oneAPI installation.
 >
 > Linux*:
-> - For system wide installations: `. /opt/intel/oneapi/setvars.sh`
-> - For private installations: ` . ~/intel/oneapi/setvars.sh`
-> - For non-POSIX shells, like csh, use the following command: `bash -c 'source <install-dir>/setvars.sh ; exec csh'`
+> - For system wide installations: `. /opt/intel/oneapi/<version>/oneapi-vars.sh`
+> - For private installations: ` . ~/intel/oneapi/<version>/oneapi-vars.sh`
+> - For non-POSIX shells, like csh, use the following command: `bash -c 'source <install-dir>/<version>/oneapi-vars.sh ; exec csh'`
 > For more information on configuring environment variables, see [Use the setvars Script with Linux* or macOS*](https://www.intel.com/content/www/us/en/develop/documentation/oneapi-programming-guide/top/oneapi-development-environment-setup/use-the-setvars-script-with-linux-or-macos.html).
 
 3. Build and run the application:
@@ -106,7 +106,7 @@ cmake --build .
 
 ### Build Troubleshoot
 
-Imaging headers are used from `%ONEAPI_ROOT%\dev-utilities\latest\include`. If needed, these headers are also available common resources from the [oneAPI-samples](https://github.com/oneapi-src/oneAPI-samples/tree/master/common) GitHub repository.
+Imaging headers are used from `%ONEAPI_ROOT%\dev-utilities\latest\include` in the `stb` folder. If needed, these headers are also available common resources from the [oneAPI-samples](https://github.com/oneapi-src/oneAPI-samples/tree/master/common) GitHub repository.
 
 ## Path Tracing Concepts
 


### PR DESCRIPTION
# Existing Sample Changes
## Description

Fixed RenderingToolkit/Tutorial/PathTracingWithEmbree sample for flat dirs... CMakeLists.txt and README.md updated.

Old and new vars files work OK.

CMakeLists: VS_DEBUGGER_ENVIRONMENT property appears to give bugged MSVS project generation per forums discussion, but probably best to leave it in the cmake file.

Fixes Issue# 
ONSAM-1708

## External Dependencies

Embree now requires sycl DSO even for CPU only targets. Added to README.md. Changed README to use new oneapi-vars.bat file.



## Type of change

Please delete options that are not relevant. Add a 'X' to the one that is applicable. 

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Implement fixes for ONSAM Jiras

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Command Line
- [ ] oneapi-cli
- [ ] Visual Studio
- [ ] Eclipse IDE
- [ ] VSCode
- [ ] When compiling the compliler flag "-Wall -Wformat-security -Werror=format-security" was used

Tested both oneapi-vars.bat and setvars.bat with a self-manually created pacakage for flatdirs, versions:
w_RenderKit_p_2024.0.0.49617 and w_RenderKit_p_2024.0.0.49617