### PR TITLE
IRTK 2024.0 fixes for Tutorials/IntroToRayTracingWithEmbree (CPU and GPU)

### DIFF
--- a/RenderingToolkit/Tutorial/IntroToRayTracingWithEmbree/cpu/CMakeLists.txt
+++ b/RenderingToolkit/Tutorial/IntroToRayTracingWithEmbree/cpu/CMakeLists.txt
@@ -6,21 +6,43 @@ if(DEFINED ENV{ONEAPI_ROOT})
   set(ONEAPI_ROOT "$ENV{ONEAPI_ROOT}")
   message(STATUS "ONEAPI_ROOT FROM ENVIRONMENT: ${ONEAPI_ROOT}")
 else()
-  if(WIN32)
-    set(ONEAPI_ROOT "C:/Program Files (x86)/Intel/oneAPI")
-  else()
-    set(ONEAPI_ROOT /opt/intel/oneapi)
-  endif()
-  message(STATUS "ONEAPI_ROOT DEFAULT: ${ONEAPI_ROOT}")
+  message(FATAL_ERROR "ONEAPI_ROOT not set. Please use a vars script (.bat/.sh) from the oneAPI deployment directory")
 endif(DEFINED ENV{ONEAPI_ROOT})
 
-#tbb is used for tasking in this example
-find_package(TBB REQUIRED PATHS ${ONEAPI_ROOT})
+set(EMBREE_BASE_DIR "")
+set(RKCOMMON_BASE_DIR "")
+set(TBB_BASE_DIR "")
+set(DEVUTILITIES_BASE_DIR "")
+set(COMPILERRUNTIMES_BASE_DIR "")
+set(PATHADDITIONS_DIRS "")
+if(EXISTS ${ONEAPI_ROOT}/oneapi-vars.sh OR EXISTS ${ONEAPI_ROOT}/oneapi-vars.bat)
+  set(EMBREE_BASE_DIR ${ONEAPI_ROOT})
+  set(RKCOMMON_BASE_DIR ${ONEAPI_ROOT})
+  set(TBB_BASE_DIR ${ONEAPI_ROOT})
+  set(DEVUTILITIES_BASE_DIR ${ONEAPI_ROOT})
+  #Compiler runtimes help for windows MSVS debugger DLL help only
+  set(COMPILERRUNTIMES_BASE_DIR ${ONEAPI_ROOT})
+  set(PATHADDITIONS_DIRS "PATH=%PATH%;${ONEAPI_ROOT}/bin")
+else()
+  set(EMBREE_BASE_DIR ${ONEAPI_ROOT}/embree/latest)
+  set(RKCOMMON_BASE_DIR ${ONEAPI_ROOT}/rkcommon/latest)
+  set(TBB_BASE_DIR ${ONEAPI_ROOT}/tbb/latest)
+  set(DEVUTILITIES_BASE_DIR ${ONEAPI_ROOT}/dev-utilities/latest)
+  #Compiler runtimes help for windows MSVS debugger DLL help only
+  set(COMPILERRUNTIMES_BASE_DIR ${ONEAPI_ROOT}/compiler/latest)
+endif(EXISTS ${ONEAPI_ROOT}/oneapi-vars.sh OR EXISTS ${ONEAPI_ROOT}/oneapi-vars.bat)
 
-find_package(embree 4.0 REQUIRED PATHS ${ONEAPI_ROOT})
+#tbb is used for tasking in this example
+find_package(TBB REQUIRED PATHS ${TBB_BASE_DIR}/lib/cmake NO_DEFAULT_PATH)
+
+find_package(embree 4.0 REQUIRED PATHS ${EMBREE_BASE_DIR}/lib/cmake NO_DEFAULT_PATH)
 
 #rkcommon objects for rendering are used in this example
-find_package(rkcommon REQUIRED CONFIG PATHS ${ONEAPI_ROOT}/rkcommon/latest/lib/cmake)
+find_package(rkcommon REQUIRED CONFIG PATHS ${RKCOMMON_BASE_DIR}/lib/cmake NO_DEFAULT_PATH)
+
+if(PATHADDITIONS_DIRS STREQUAL "")
+  set(PATHADDITIONS_DIRS "PATH=%PATH%;${COMPILERRUNTIMES_BASE_DIR}/bin;${embree_DIR}/../../../bin;${rkcommon_DIR}/../../../bin;${tbb_DIR}/../../../bin;")
+endif(PATHADDITIONS_DIRS STREQUAL "")
 
 if(MSVC)
   set(CMAKE_CXX_STANDARD 11)
@@ -40,15 +62,16 @@ if (NOT CMAKE_BUILD_TYPE)
 endif(NOT CMAKE_BUILD_TYPE)
 endif(NOT MSVC)
 
-#stb headers are located in dev-utilities. oneAPI 2022.2 release and earlier: these header only libraries are distributed with the oneAPI Base Toolkit.
-include_directories(${ONEAPI_ROOT}/dev-utilities/latest/include)
+#stb headers are located in dev-utilities with the old oneAPI dires layout
+include_directories(${DEVUTILITIES_BASE_DIR}/include)
 
 add_executable(rkRayTracer src/rkRayTracer.cpp)
 if(MSVC)
+  message(STATUS "Using ${PATHADDITIONS_DIRS} for the MSVS Debugger env")
 # Set MSVS debugger environment variables so it is easier to attach the MSVS debugger after altering the application
-    set_target_properties(rkRayTracer
-	    PROPERTIES VS_DEBUGGER_ENVIRONMENT "PATH=%PATH%;${embree_DIR}/../../../bin;${rkcommon_DIR}/../../../bin;${tbb_DIR}/../../../bin;"
-    )
+set_target_properties(rkRayTracer
+    PROPERTIES VS_DEBUGGER_ENVIRONMENT "${PATHADDITIONS_DIRS}"
+  )
 endif(MSVC)
 target_link_libraries(rkRayTracer PRIVATE embree TBB::tbb rkcommon::rkcommon)
 

--- a/RenderingToolkit/Tutorial/IntroToRayTracingWithEmbree/cpu/README.md
+++ b/RenderingToolkit/Tutorial/IntroToRayTracingWithEmbree/cpu/README.md
@@ -26,17 +26,17 @@ output](example_images/rkRayTracer.png)
 
 | Minimum Requirements              | Description
 |:---                               |:---
-| OS                                | Linux* Ubuntu* 18.04 <br>CentOS* 8 (or compatible) <br>Windows* 10 <br>macOS* 10.15+
+| OS                                | Linux* Ubuntu* 18.04 <br>CentOS* 8 (or compatible) <br>Windows* 10 or 11<br>macOS* 10.15+
 | Hardware                          | Intel 64 Penryn or higher with SSE4.1 extensions; ARM64 with NEON extensions <br>(Optimization requirement: Intel&reg; Embree is further optimized for Intel 64 Skylake or higher with AVX512 extensions)
-| Compiler Toolchain                | Windows* OS: MSVS 2019 or MSVS 2022 with Windows* SDK and CMake* <br>Other platforms: C++11 compiler and CMake*
-| Libraries                         | Install Intel&reg; oneAPI Rendering Toolkit (Render Kit), including Intel&reg; Embree and Intel® oneAPI Threading Building Blocks (oneTBB) <br>Install Intel&reg; oneAPI Base Toolkit for the `dev-utilities` default component
+| Compiler Toolchain                | Windows* OS: MSVS 2022 or MSVS 2019 with Windows* SDK and CMake* <br>Other platforms: C++11 compiler and CMake*
+| Libraries                         | Install Intel&reg; Rendering Toolkit (Render Kit), including Intel&reg; Embree and Intel® oneAPI Threading Building Blocks (oneTBB) <br>Install Intel&reg; oneAPI Base Toolkit for the `dev-utilities` default component and Intel&reg; oneAPI DPC++ Compiler runtimes
 | Tools                             | .png capable image viewer
 
 ## Build and Run
 
 ### Windows*
 
-Open a new x64 Native Command Prompt for VS 2019. Navigate to the source folder:
+Open a new x64 Native Command Prompt for VS 2022 (or 2019). Navigate to the source folder:
 
 ```
 cd <path-to-oneAPI-Samples>\RenderingToolkit\Tutorial\IntroToRayTracingWithEmbree\cpu
@@ -47,12 +47,12 @@ Build and Run the Application:
 call <path-to-oneAPI>\setvars.bat
 mkdir build
 cd build
-cmake -G"Visual Studio 16 2019" -A x64 ..
+cmake -G"Visual Studio 17 2022" -A x64 ..
 cmake --build . --config Release
 cd Release
 .\rkRayTracer.exe
 ```
-**Note**: Visual Studio 2022 users should use the x64 NAtive Command Prompt for VS 2022 and `-G"Visual Studio 17 2022"`
+**Note**: Visual Studio 2019 users should use the x64 Native Command Prompt for VS 2019 and `-G"Visual Studio 16 2019"`
 generator flag.
 
 Open the resulting image file: `rkRayTracer.png` with an image viewer.
@@ -643,7 +643,7 @@ features available with Intel&reg; Embree are best observed in the Intel&reg;
 Embree tutorial codes. These codes reside within the [Embree
 repository](https://github.com/embree/embree).
 
-The Intel&reg; oneAPI Rendering Toolkit `rkRayTracer` sample
+The Intel&reg; Rendering Toolkit `rkRayTracer` sample
 forgoes use of the Embree common library found in the full codes. The Embree
 common library implements math, tasking, and system access routines that are
 common to rendering applications. The Intel&reg; Embree common library lives in

--- a/RenderingToolkit/Tutorial/IntroToRayTracingWithEmbree/gpu/CMakeLists.txt
+++ b/RenderingToolkit/Tutorial/IntroToRayTracingWithEmbree/gpu/CMakeLists.txt
@@ -6,17 +6,39 @@ if(DEFINED ENV{ONEAPI_ROOT})
   set(ONEAPI_ROOT "$ENV{ONEAPI_ROOT}")
   message(STATUS "ONEAPI_ROOT FROM ENVIRONMENT: ${ONEAPI_ROOT}")
 else()
-  if(WIN32)
-    set(ONEAPI_ROOT "C:/Program Files (x86)/Intel/oneAPI")
-  else()
-    set(ONEAPI_ROOT /opt/intel/oneapi)
-  endif()
-  message(STATUS "ONEAPI_ROOT DEFAULT: ${ONEAPI_ROOT}")
+  message(FATAL_ERROR "ONEAPI_ROOT not set. Please use a vars script (.bat/.sh) from the oneAPI deployment directory")
 endif(DEFINED ENV{ONEAPI_ROOT})
+
+set(EMBREE_BASE_DIR "")
+set(RKCOMMON_BASE_DIR "")
+set(TBB_BASE_DIR "")
+set(DEVUTILITIES_BASE_DIR "")
+set(COMPILERRUNTIMES_BASE_DIR "")
+set(PATHADDITIONS_DIRS "")
+if(EXISTS ${ONEAPI_ROOT}/oneapi-vars.sh OR EXISTS ${ONEAPI_ROOT}/oneapi-vars.bat)
+  set(EMBREE_BASE_DIR ${ONEAPI_ROOT})
+  set(RKCOMMON_BASE_DIR ${ONEAPI_ROOT})
+  set(TBB_BASE_DIR ${ONEAPI_ROOT})
+  set(DEVUTILITIES_BASE_DIR ${ONEAPI_ROOT})
+  #Compiler runtimes help for windows MSVS debugger DLL help only
+  set(COMPILERRUNTIMES_BASE_DIR ${ONEAPI_ROOT})
+  set(PATHADDITIONS_DIRS "PATH=%PATH%;${ONEAPI_ROOT}/bin")
+else()
+  set(EMBREE_BASE_DIR ${ONEAPI_ROOT}/embree/latest)
+  set(RKCOMMON_BASE_DIR ${ONEAPI_ROOT}/rkcommon/latest)
+  set(TBB_BASE_DIR ${ONEAPI_ROOT}/tbb/latest)
+  set(DEVUTILITIES_BASE_DIR ${ONEAPI_ROOT}/dev-utilities/latest)
+  #Compiler runtimes help for windows MSVS debugger DLL help only
+  set(COMPILERRUNTIMES_BASE_DIR ${ONEAPI_ROOT}/compiler/latest)
+endif(EXISTS ${ONEAPI_ROOT}/oneapi-vars.sh OR EXISTS ${ONEAPI_ROOT}/oneapi-vars.bat)
 
 find_package(embree 4.0 REQUIRED PATHS ${ONEAPI_ROOT})
 
-find_package(IntelDPCPP REQUIRED)
+find_package(IntelSYCL REQUIRED)
+
+if(PATHADDITIONS_DIRS STREQUAL "")
+  set(PATHADDITIONS_DIRS "PATH=%PATH%;${COMPILERRUNTIMES_BASE_DIR}/bin;${embree_DIR}/../../../bin;")
+endif(PATHADDITIONS_DIRS STREQUAL "")
 
 #Required for SYCL implementation support
 set(CMAKE_CXX_STANDARD 17)
@@ -54,15 +76,15 @@ endif(NOT MSVC)
     endif(NOT MSVC)
 
 
-#stb headers are located in dev-utilities. oneAPI 2022.2 release and earlier: these header only libraries are distributed with the oneAPI Base Toolkit.
-include_directories(${ONEAPI_ROOT}/dev-utilities/latest/include)
+#stb headers are located in dev-utilities with the old oneAPI dirs layout
+include_directories(${DEVUTILITIES_BASE_DIR}/include)
 include_directories(SYSTEM "${SYCL_COMPILER_DIR}/../include/sycl" "${SYCL_COMPILER_DIR}/../include")
 
 add_executable(rkRayTracerGPU src/rkRayTracerGPU.cpp)
 if(MSVC)
 # Set MSVS debugger environment variables so it is easier to attach the MSVS debugger after altering the application
     set_target_properties(rkRayTracerGPU
-	    PROPERTIES VS_DEBUGGER_ENVIRONMENT "PATH=%PATH%;${embree_DIR}/../../../bin"
+	    PROPERTIES VS_DEBUGGER_ENVIRONMENT "${PATHADDITIONS_DIRS}"
     )
 endif(MSVC)
 target_link_libraries(rkRayTracerGPU PRIVATE embree)

--- a/RenderingToolkit/Tutorial/IntroToRayTracingWithEmbree/gpu/README.md
+++ b/RenderingToolkit/Tutorial/IntroToRayTracingWithEmbree/gpu/README.md
@@ -19,11 +19,11 @@ output](example_images/rkRayTracerGPU.png)
 
 | Minimum Requirements              | Description
 |:---                               |:---
-| OS                                | Linux* Ubuntu* 22.04 <br>CentOS* 8 (or compatible) <br>Windows* 10 <br>macOS* 10.15+
+| OS                                | Linux* Ubuntu* 22.04 <br>CentOS* 8 (or compatible) <br>Windows* 10 or 11<br>macOS* 10.15+
 | Hardware                          | Intel&reg; Arc Graphics (Xe-HPG architecture, DG2-128, DG2-512) or higher
-| Libraries                         | Install Intel&reg; oneAPI Rendering Toolkit (Render Kit) including Intel&reg; oneAPI DPC++ Compiler, Intel&reg; Embree, and Intel® oneAPI Threading Building Blocks (oneTBB) <br>Install Intel&reg; oneAPI Base Toolkit for the `dev-utilities` default component
-| SYCL Compiler                     | oneAPI DPC++ 2023.0.0 compiler or higher
-| Compiler Toolchain                | Windows* OS: MSVS 2019 or MSVS 2022 with Windows* SDK and CMake* <br>Other platforms: C++17 compiler and CMake*
+| Libraries                         | Install Intel&reg; Rendering Toolkit (Render Kit) including Intel&reg; Embree, and Intel® oneAPI Threading Building Blocks (oneTBB) <br>Install Intel&reg; oneAPI Base Toolkit for the `dev-utilities` default component and Intel&reg; oneAPI DPC++ Compiler
+| SYCL Compiler                     | oneAPI DPC++ 2024.0.0 compiler or higher
+| Compiler Toolchain                | Windows* OS: MSVS 2022 or MSVS 2019 with Windows* SDK and CMake* <br>Other platforms: C++17 compiler and CMake*
 | Tools                             | .png capable image viewer
 | Knowledge                         | First, build and run the IntroToRayTracingWithEmbree `rkRayTracer` [CPU](../cpu) sample program
 
@@ -41,19 +41,22 @@ Open a new x64 Native Tools Command Prompt for VS 2022. Navigate to the source f
 cd <path-to-oneAPI-Samples>\RenderingToolkit\Tutorial\IntroToRayTracingWithEmbree\cpu
 ```
 
-Run the MSVS build script to generate the sample program and MSVS .sln files for source code review:
-```
-build-win-vs-dpcpp-toolchain.bat
-```
-
 If you prefer command line builds only, use an nmake script:
 ```
 build-win-nmake-icx-cl.bat
 ```
 
+Run the MSVS build script to generate the sample program and MSVS .sln files for source code review. Note this method is deprecated but some may prefer it:
+```
+build-win-vs-dpcpp-toolchain.bat
+```
+
+Set environment variables:
 ```
 call <path-to-oneAPI>\setvars.bat
 ```
+
+Run the program
 ```
 cd bin
 .\rkRayTracerGPU.exe
@@ -76,12 +79,23 @@ Run oneAPI setvars.bat:
 call <path-to-oneAPI>\setvars.bat
 
 ```
-Build and run the application:
 
+Configure the build (Option 1):
 ```
 mkdir build
 cd build
-cmake -G"Visual Studio 17 2022" -A x64 -T"Intel(R) oneAPI DPC++ Compiler 2023" ..
+cmake -G"NMake Makefiles" -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=icx-cl -DCMAKE_INSTALL_PREFIX=.. ..
+```
+
+Configure the build (Option 2 Deprecated but generates .sln files for code review):
+```
+mkdir build
+cd build
+cmake -G"Visual Studio 17 2022" -A x64 -T"Intel(R) oneAPI DPC++ Compiler 2024" ..
+```
+
+Build and run the application:
+```
 cmake --build . --config Release
 cmake --install . --config Release
 cd ..\bin
@@ -174,7 +188,7 @@ rendering API at a higher layer, perhaps at an _engine_ layer. Such developers
 should consider examining the Intel&reg; OSPRay API and library, which implements
 rendering facilities on top of Embree.
 
-You can find more information by visiting [Intel&reg; oneAPI Rendering
+You can find more information by visiting [Intel&reg; Rendering
 Toolkit](https://software.intel.com/content/www/us/en/develop/tools/oneapi/rendering-toolkit.html).
 
 ## License

--- a/RenderingToolkit/Tutorial/IntroToRayTracingWithEmbree/gpu/build-win-vs-dpcpp-toolchain.bat
+++ b/RenderingToolkit/Tutorial/IntroToRayTracingWithEmbree/gpu/build-win-vs-dpcpp-toolchain.bat
@@ -3,7 +3,7 @@ call "C:\Program Files (x86)\Intel\oneapi\setvars.bat"
 
 set CXX_COMPILER=icx-cl
 
-set "BUILD_COMMAND=cmake -G \"Visual Studio 17 2022\" -A x64 -T\"Intel(R) oneAPI DPC++ Compiler 2023\" -DCMAKE_INSTALL_PREFIX=.. .."
+set "BUILD_COMMAND=cmake -G \"Visual Studio 17 2022\" -A x64 -T\"Intel(R) oneAPI DPC++ Compiler 2024\" -DCMAKE_INSTALL_PREFIX=.. .."
 echo %BUILD_COMMAND:\=% > build-command.txt
 echo "CXX_COMPILER:" >> build-command.txt
 %CXX_COMPILER% --version >> build-command.txt


### PR DESCRIPTION
# Existing Sample Changes
## Description

Required updates to build this tutorial sample with the 2024.0 release of IRTK. This is one "sample" that has both cpu and gpu targets. The only files that have changed are CMakeLists.txt README.md and a helper script to launch the MSVS toolchain build for 2024.0 compiler.

Fixes Issue# 
N/A (No ticket)

## External Dependencies

Embree relies on sycl DSO even in CPU mode. This should be included in path automatically with toolkit vars.

## Type of change

Please delete options that are not relevant. Add a 'X' to the one that is applicable. 

- [x] Bug fix (non-breaking change which fixes an issue)


## How Has This Been Tested?

Tested on Windows w 2024.0 on CPU, and GPU (NMake and deprecated MSVS Toolchain)

- [x] Command Line
- [ ] oneapi-cli
- [ ] Visual Studio
- [ ] Eclipse IDE
- [ ] VSCode
- [ ] When compiling the compliler flag "-Wall -Wformat-security -Werror=format-security" was used

