### PR TITLE
FPGA: move the include of `stdint` in the GZIP sample from the `.cpp` to the `.hpp` file

### DIFF
--- a/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/fft2d/src/fft2d_demo.cpp
+++ b/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/fft2d/src/fft2d_demo.cpp
@@ -239,7 +239,7 @@ void TestFFT(bool mangle, bool inverse) {
       auto fetch_event = q.single_task<class FetchKernel>(
           Fetch<kLogN, kLogParallelism, FetchToFFT, float>{to_read, mangle});
 
-      q.single_task<class FFTKernel>(
+      auto fft_event = q.single_task<class FFTKernel>(
           FFT<kLogN, kLogParallelism, FetchToFFT, FFTToTranspose, float>{
               inverse});
 
@@ -247,6 +247,7 @@ void TestFFT(bool mangle, bool inverse) {
           Transpose<kLogN, kLogParallelism, FFTToTranspose, float>{to_write,
                                                                    mangle});
 
+      fft_event.wait();
       transpose_event.wait();
 
       if (i == 0) {

--- a/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/fft2d/src/fft2d_demo.cpp
+++ b/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/fft2d/src/fft2d_demo.cpp
@@ -239,7 +239,7 @@ void TestFFT(bool mangle, bool inverse) {
       auto fetch_event = q.single_task<class FetchKernel>(
           Fetch<kLogN, kLogParallelism, FetchToFFT, float>{to_read, mangle});
 
-      auto fft_event = q.single_task<class FFTKernel>(
+      q.single_task<class FFTKernel>(
           FFT<kLogN, kLogParallelism, FetchToFFT, FFTToTranspose, float>{
               inverse});
 
@@ -247,7 +247,6 @@ void TestFFT(bool mangle, bool inverse) {
           Transpose<kLogN, kLogParallelism, FFTToTranspose, float>{to_write,
                                                                    mangle});
 
-      fft_event.wait();
       transpose_event.wait();
 
       if (i == 0) {

--- a/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/gzip/src/WriteGzip.cpp
+++ b/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/gzip/src/WriteGzip.cpp
@@ -3,7 +3,6 @@
 
 #include <fcntl.h>
 #include <memory.h>
-#include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <sys/stat.h>

--- a/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/gzip/src/WriteGzip.hpp
+++ b/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/gzip/src/WriteGzip.hpp
@@ -4,6 +4,7 @@
 
 #include <iostream>
 #include <string>
+#include <stdint.h>
 
 // returns 0 on success, otherwise failure
 int WriteBlockGzip(


### PR DESCRIPTION
The GZIP sample was failing to compile when using GCC 13.1.0 because of the missing include in `WriteGzip.hpp`.
This header was included from the associated `.cpp`, but is now moved to the `.hpp` file directly.