### PR TITLE
Update ResNet50_Inference.ipynb ONEAPI_ROOT to ONEAPI_INSTALL

### DIFF
--- a/AI-and-Analytics/Getting-Started-Samples/Intel_Extension_For_PyTorch_GettingStarted/ResNet50_Inference.ipynb
+++ b/AI-and-Analytics/Getting-Started-Samples/Intel_Extension_For_PyTorch_GettingStarted/ResNet50_Inference.ipynb
@@ -116,7 +116,7 @@
    "source": [
     "%%writefile run.sh\n",
     "#!/bin/bash\n",
-    "source $ONEAPI_ROOT/setvars.sh --force > /dev/null 2>&1\n",
+    "source $ONEAPI_INSTALL/setvars.sh --force > /dev/null 2>&1\n",
     "source activate pytorch\n",
     "echo \"########## Executing the run\"\n",
     "DNNL_VERBOSE=1 python resnet50_general_inference_script.py > infer_rn50_cpu.csv\n",
@@ -182,7 +182,7 @@
    "source": [
     "%%writefile run.sh\n",
     "#!/bin/bash\n",
-    "source $ONEAPI_ROOT/setvars.sh --force > /dev/null 2>&1\n",
+    "source $ONEAPI_INSTALL/setvars.sh --force > /dev/null 2>&1\n",
     "source activate pytorch-gpu\n",
     "echo \"########## Executing the run\"\n",
     "DNNL_VERBOSE=1 python resnet50_general_inference_script_gpu.py > infer_rn50_gpu.csv\n",


### PR DESCRIPTION
ONEAPI_ROOT throws error:

./run.sh: line 3: activate: No such file or directory.

Change it to ONEAPI_INSTALL to be consistent with TensorFlow Getting Started Code