### PR TITLE
FPGA: Switch to default seed 2 to avoid Stratix10 timing failures in the stall_enable sample

### DIFF
--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/stall_enable/src/CMakeLists.txt
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/stall_enable/src/CMakeLists.txt
@@ -30,6 +30,21 @@ if(WIN32)
     set(WIN_FLAG "/EHsc")
 endif()
 
+# Choose the random seed for the hardware compile
+# e.g. cmake .. -DSEED=7
+if(NOT DEFINED SEED)
+    # Seed 1 fails for S10 on Windows
+    set(SEED 2)
+else()
+    message(STATUS "Seed explicitly set to ${SEED}")
+endif()
+
+if(IGNORE_DEFAULT_SEED)
+    set(SEED_FLAG "")
+else()
+    set(SEED_FLAG "-Xsseed=${SEED}")
+endif()
+
 # A SYCL ahead-of-time (AoT) compile processes the device code in two stages.
 # 1. The "compile" stage compiles the device code to an intermediate representation (SPIR-V).
 # 2. The "link" stage invokes the compiler's FPGA backend before linking.
@@ -39,7 +54,7 @@ set(EMULATOR_LINK_FLAGS "-fsycl -fintelfpga")
 set(SIMULATOR_COMPILE_FLAGS "-fsycl -fintelfpga -Wall ${WIN_FLAG} ${HYPER_FLAG} -Xssimulation -DFPGA_SIMULATOR")
 set(SIMULATOR_LINK_FLAGS "-fsycl -fintelfpga -Xssimulation -Xstarget=${FPGA_DEVICE} ${HYPER_FLAG} ${USER_HARDWARE_FLAGS}")
 set(HARDWARE_COMPILE_FLAGS "-fsycl -fintelfpga -Wall ${WIN_FLAG} ${HYPER_FLAG} -DFPGA_HARDWARE")
-set(HARDWARE_LINK_FLAGS "-fsycl -fintelfpga -Xshardware -Xstarget=${FPGA_DEVICE} ${HYPER_FLAG} ${USER_HARDWARE_FLAGS}")
+set(HARDWARE_LINK_FLAGS "-fsycl -fintelfpga -Xshardware ${SEED_FLAG} -Xstarget=${FPGA_DEVICE} ${HYPER_FLAG} ${USER_HARDWARE_FLAGS}")
 # use cmake -D USER_HARDWARE_FLAGS=<flags> to set extra flags for FPGA backend compilation
 
 ###############################################################################


### PR DESCRIPTION
Port of https://github.com/oneapi-src/oneAPI-samples/pull/2034

# Existing Sample Changes
## Description

This avoids a timing failure on Stratix10 for the default seed

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Implement fixes for ONSAM Jiras

## How Has This Been Tested?
Generated the makefiles using cmake and looked for -Xsseed=2 argument

- [X] Command Line
- [ ] oneapi-cli
- [ ] Visual Studio
- [ ] Eclipse IDE
- [ ] VSCode
- [ ] When compiling the compliler flag "-Wall -Wformat-security -Werror=format-security" was used