### PR TITLE
FPGA: Replace mentions to "IP Authoring flow" to "SYCL HLS flow"

### DIFF
--- a/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/fft2d/src/fft2d.hpp
+++ b/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/fft2d/src/fft2d.hpp
@@ -506,7 +506,7 @@ struct Transpose {
 #if defined IS_BSP
   ac_complex<T> *dest;
 #else
-  // Specify the memory interface when in the IP Authoring flow
+  // Specify the memory interface when in the SYCL HLS flow
   // The buffer location is set to 1 (identical as the malloc performed in
   // fft2d_demo.cpp)
   // The data width is equal to width of the DDR burst performed by the function

--- a/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/fft2d/src/fft2d_demo.cpp
+++ b/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/fft2d/src/fft2d_demo.cpp
@@ -145,13 +145,13 @@ void TestFFT(bool mangle, bool inverse) {
       temp_data = sycl::malloc_device<ac_complex<float>>(kN * kN, q);
     } else if (q.get_device().has(sycl::aspect::usm_host_allocations)) {
       std::cout << "Using USM host allocations" << std::endl;
-      // No device allocations means that we are probably in an IP authoring
+      // No device allocations means that we are probably in a SYCL HLS
       // flow
 
 #if defined IS_BSP
       auto prop_list = sycl::property_list{};
 #else
-      // In the IP Authoring flow, we need to define the memory interface.
+      // In the SYCL HLS flow, we need to define the memory interface.
       // For, that we need to assign a location to the memory being accessed.
       auto prop_list = sycl::property_list{
           sycl::ext::intel::experimental::property::usm::buffer_location(1)};

--- a/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/matmul/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/matmul/README.md
@@ -141,7 +141,7 @@ This achieves the same objective of increasing throughput, though this design is
 | 256x256     | 256              | 256       | 341.08 MHz
 
 
-These results were gathered from targeting the Arria® 10 device family using the IP authoring flow, and the fMAX values were averaged across 6 seeds.
+These results were gathered from targeting the Arria® 10 device family using the SYCL HLS flow, and the fMAX values were averaged across 6 seeds.
 
 ### Compiler Flags Used
 

--- a/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/pca/src/pca.hpp
+++ b/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/pca/src/pca.hpp
@@ -99,7 +99,7 @@ void PCAKernel(
         sycl::malloc_device<ac_int<1, false>>(matrix_count, q);
   } else if (q.get_device().has(sycl::aspect::usm_shared_allocations)) {
     std::cout << "Using shared allocations" << std::endl;
-    // No device allocations means that we are probably in an IP authoring flow
+    // No device allocations means that we are probably in a SYCL HLS flow
     input_matrix_device =
         sycl::malloc_shared<T>(kInputMatrixSize * matrix_count, q);
     eigen_vectors_device =

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/explicit_data_movement/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/explicit_data_movement/README.md
@@ -85,7 +85,7 @@ SYCL USM allocations enable the use of raw *C-style* pointers in SYCL.
 When copying data to or from the FPGA DDR, the data transfer must be done explicitly by the programmer, typically using the SYCL `memcpy` function. 
 Additionally, synchronization between kernels accessing the same device pointers must be expressed explicitly by the programmer using either the `wait` function of a SYCL `event` or the `depends_on` signal between events.
 
-In this tutorial, the `SubmitImplicitKernel` function demonstrates the basic SYCL buffer model, while the `SubmitExplicitKernel` function demonstrates how you may use these USM device allocations (in full stack flow) or USM host allocations (in IP Authoring flow) to perform the same task and manually manage the movement of data.
+In this tutorial, the `SubmitImplicitKernel` function demonstrates the basic SYCL buffer model, while the `SubmitExplicitKernel` function demonstrates how you may use these USM device allocations (in full stack flow) or USM host allocations (in the SYCL HLS flow) to perform the same task and manually manage the movement of data.
 
 ### Deciding Which Style to Use
 
@@ -93,7 +93,7 @@ The main advantage of explicit data movement is that it gives you full control o
 
 Choosing a data movement strategy largely depends on the specific application and personal preference. However, when starting a new design, it is typically easier to begin by using implicit data movement since all of the data movement is handled automatically, allowing the user to focus on expressing and validating the computation. Once the design is validated, one can:
 - profile the application in the full stack flow. If there is still performance on the table, it may be worthwhile switching to explicit data movement.
-- customize the IP interface in the IP authoring flow. One can annotate these raw pointers to direct the compiler into implementing different protocols. An overview of the different interfaces can be found in the [component_interfaces_comparison](/DirectProgramming/C%2B%2BSYCL_FPGA/Tutorials/Features/ip_authoring_interfaces/component_interfaces_comparison) sample.
+- customize the IP interface in the SYCL HLS flow. One can annotate these raw pointers to direct the compiler into implementing different protocols. An overview of the different interfaces can be found in the [component_interfaces_comparison](/DirectProgramming/C%2B%2BSYCL_FPGA/Tutorials/Features/ip_authoring_interfaces/component_interfaces_comparison) sample.
 
 Alternatively, in the full stack flow, there is a hybrid approach that uses some implicit data movement and some explicit data movement. This technique, demonstrated in the **Double Buffering** (double_buffering) and  **N-Way Buffering** (n_way_buffering) tutorials, uses implicit data movement for some buffers where the control does not affect performance, and explicit data movement for buffers whose movement has a substantial effect on performance. In this hybrid approach, we do **not** use device allocations but rather specific `buffer` API calls (e.g., `update_host`) to trigger the movement of data.
 

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/experimental/device_global/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/experimental/device_global/README.md
@@ -93,7 +93,7 @@ int main () {
   q.copy(val, &x).wait(); // Read from device_global into x
 }
 ```
->**Note**: `sycl::queue::copy()` currently only works in the IP Authoring flow since Intel does not ship a BSP that supports a dedicated interface for accessing a `device global`.
+>**Note**: `sycl::queue::copy()` currently only works in the SYCL HLS flow since Intel does not ship a BSP that supports a dedicated interface for accessing a `device global`.
 
 ## Build the `device_global` Tutorial
 
@@ -123,7 +123,7 @@ int main () {
    >  ```
    >  cmake .. -DFPGA_DEVICE=<FPGA device family or FPGA part number>
    >  ```
-   > This tutorial only uses the IP Authoring flow since Intel does not ship a BSP that supports a dedicated interface for accessing a `device global`.
+   > This tutorial only uses the SYCL HLS flow since Intel does not ship a BSP that supports a dedicated interface for accessing a `device global`.
 
 3. Compile the design. (The provided targets match the recommended development flow.)
 
@@ -157,7 +157,7 @@ int main () {
    >  ```
    >  cmake -G "NMake Makefiles" .. -DFPGA_DEVICE=<FPGA device family or FPGA part number>
    >  ```
-   > This tutorial only uses the IP Authoring flow since Intel does not ship a BSP that supports a dedicated interface for accessing a `device global`.
+   > This tutorial only uses the SYCL HLS flow since Intel does not ship a BSP that supports a dedicated interface for accessing a `device global`.
 
 3. Compile the design. (The provided targets match the recommended development flow.)
 
@@ -191,7 +191,7 @@ int main () {
    ```bash
    CL_CONTEXT_MPSIM_DEVICE_INTELFPGA=1 ./device_global.fpga_sim
    ```
-   > **Note**: Running this sample on an actual FPGA device requires a BSP that supports device_globals with host access from a dedicated interface. As there are currently no commercial BSPs with such support, only the IP Authoring flow is enabled for this code sample.
+   > **Note**: Running this sample on an actual FPGA device requires a BSP that supports device_globals with host access from a dedicated interface. As there are currently no commercial BSPs with such support, only the SYCL HLS flow is enabled for this code sample.
 
 ### On Windows
 
@@ -205,7 +205,7 @@ int main () {
    device_global.fpga_sim.exe
    set CL_CONTEXT_MPSIM_DEVICE_INTELFPGA=
    ```
-   > **Note**: Running this sample on an actual FPGA device requires a BSP that supports device_globals with host access from a dedicated interface. As there are currently no commercial BSPs with such support, only the IP Authoring flow is enabled for this code sample.
+   > **Note**: Running this sample on an actual FPGA device requires a BSP that supports device_globals with host access from a dedicated interface. As there are currently no commercial BSPs with such support, only the SYCL HLS flow is enabled for this code sample.
 
 
 ## Example Output

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/experimental/device_global/src/CMakeLists.txt
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/experimental/device_global/src/CMakeLists.txt
@@ -17,11 +17,11 @@ else()
     # Check if the target is a BSP
     if(IS_BSP MATCHES "1")
         set(IS_BSP "1")
-        message(FATAL_ERROR "ERROR: This tutorial does not support a BSP target as uses IPA flow only.")
+        message(FATAL_ERROR "ERROR: This tutorial does not support a BSP target as it uses the SYCL HLS flow only.")
     else()
         set(IS_BSP "0")
         message(STATUS "The selected target ${FPGA_DEVICE} is assumed to be an FPGA part number.")
-        message(STATUS "This tutorial does not support a BSP target as it uses IPA flow only.")
+        message(STATUS "This tutorial does not support a BSP target as it uses the SYCL HLS flow only.")
     endif()
 endif()
 

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/experimental/hostpipes/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/experimental/hostpipes/README.md
@@ -284,7 +284,7 @@ In the latter launch-collect test, the entire contents of the `in` vector are wr
    >  cmake .. -DFPGA_DEVICE=<FPGA device family or FPGA part number>
    >  ```
    >
-   > This tutorial only uses the IP Authoring flow and does not support targeting an explicit FPGA board variant and BSP.
+   > This tutorial only uses the SYCL HLS flow and does not support targeting an explicit FPGA board variant and BSP.
 
 3. Compile the design. (The provided targets match the recommended development flow.)
 
@@ -319,7 +319,7 @@ In the latter launch-collect test, the entire contents of the `in` vector are wr
    >  cmake -G "NMake Makefiles" .. -DFPGA_DEVICE=<FPGA device family or FPGA part number>
    >  ```
    >
-   > This tutorial only uses the IP Authoring flow and does not support targeting an explicit FPGA board variant and BSP.
+   > This tutorial only uses the SYCL HLS flow and does not support targeting an explicit FPGA board variant and BSP.
 
 3. Compile the design. (The provided targets match the recommended development flow.)
 
@@ -380,7 +380,7 @@ using D2HPipe = cl::sycl::ext::intel::experimental::pipe<
    ```
    CL_CONTEXT_MPSIM_DEVICE_INTELFPGA=1 ./hostpipes.fpga_sim
    ```
-> **Note**: Running this sample on an actual FPGA device requires a BSP that supports host pipes. As there are currently no commercial BSPs with such support, only the IP Authoring flow is enabled for this code sample.
+> **Note**: Running this sample on an actual FPGA device requires a BSP that supports host pipes. As there are currently no commercial BSPs with such support, only the SYCL HLS flow is enabled for this code sample.
 	
 ### On Windows
 
@@ -394,7 +394,7 @@ using D2HPipe = cl::sycl::ext::intel::experimental::pipe<
    hostpipes.fpga_sim.exe
    set CL_CONTEXT_MPSIM_DEVICE_INTELFPGA=
    ```
-> **Note**: Running this sample on an actual FPGA device requires a BSP that supports host pipes. As there are currently no commercial BSPs with such support, only the IP Authoring flow is enabled for this code sample.
+> **Note**: Running this sample on an actual FPGA device requires a BSP that supports host pipes. As there are currently no commercial BSPs with such support, only the SYCL HLS flow is enabled for this code sample.
 
 ## Example Output
 

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/experimental/hostpipes/src/CMakeLists.txt
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/experimental/hostpipes/src/CMakeLists.txt
@@ -17,11 +17,11 @@ else()
     # Check if the target is a BSP
     if(IS_BSP MATCHES "1")
         set(IS_BSP "1")
-        message(FATAL_ERROR "ERROR: This tutorial does not support a BSP target as uses IPA flow only.")
+        message(FATAL_ERROR "ERROR: This tutorial does not support a BSP target as it uses the SYCL HLS flow only.")
     else()
         set(IS_BSP "0")
         message(STATUS "The selected target ${FPGA_DEVICE} is assumed to be an FPGA part number.")
-        message(STATUS "This tutorial does not support a BSP target as it uses IPA flow only.")
+        message(STATUS "This tutorial does not support a BSP target as it uses the SYCL HLS flow only.")
     endif()
 endif()
 

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/ip_authoring_interfaces/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/ip_authoring_interfaces/README.md
@@ -1,3 +1,3 @@
-# IP Authoring Interfaces
+# SYCL HLS Flow Interfaces
 
 This collection of code samples demonstrates how to effectively customize interfaces of FPGA IP produced with the Intel® oneAPI DPC++/C++ Compiler. Intel recommends that you begin by studying the [Component Interfaces Comparison](component_interfaces_comparison/) sample and its sub-samples to learn about the basics of how you can customize interfaces for FPGA IP produced with the Intel® oneAPI DPC++/C++ Compiler. Once you have familiarized yourself with the basic principles, you can study the other samples here to learn more advanced techniques and common stumbling blocks to watch out for.

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/ip_authoring_interfaces/component_interfaces_comparison/sample.json
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/ip_authoring_interfaces/component_interfaces_comparison/sample.json
@@ -1,8 +1,8 @@
 {
     "guid": "7d8482f5-39f1-4cf1-aa2e-a1f72cfc47cb",
-    "name": "IP Authoring Interfaces Overview",
+    "name": "SYCL HLS Flow Interfaces Overview",
     "categories": ["Toolkit/oneAPI Direct Programming/C++SYCL FPGA/Tutorials/Features"],
-    "description": "Intel® FPGA example designs oversewing different interfaces for IP Authoring",
+    "description": "Intel® FPGA example designs oversewing different interfaces for the SYCL HLS flow",
     "toolchain": ["icpx"],
     "os": ["linux", "windows"],
     "targetDevice": ["FPGA"],

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/ip_authoring_interfaces/invocation_interfaces/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/ip_authoring_interfaces/invocation_interfaces/README.md
@@ -77,7 +77,7 @@ The invocation interface and any argument interfaces are specified independently
 
 If you would like an argument to have its own **dedicated** ready/valid handshake, implement that argument using a [streaming interface](../streaming_data_interfaces/).
 
-> **Note**: The register-mapped and streaming interface features are **only** supported in the IP Authoring flow. The IP Authoring flow compiles SYCL* source code to IPs that can be deployed into your Intel® Quartus® Prime projects. Emulator and simulator executables are still generated to allow you to validate your IP. You can compile the generated RTL with Intel® Quartus® Prime to generate accurate f<sub>MAX</sub> and area estimates. However, the six `.fpga` executables generated in this tutorial are **not** designed to run on FPGA devices directly.
+> **Note**: The register-mapped and streaming interface features are **only** supported in the SYCL HLS flow. The SYCL HLS flow compiles SYCL* source code to IPs that can be deployed into your Intel® Quartus® Prime projects. Emulator and simulator executables are still generated to allow you to validate your IP. You can compile the generated RTL with Intel® Quartus® Prime to generate accurate f<sub>MAX</sub> and area estimates. However, the six `.fpga` executables generated in this tutorial are **not** designed to run on FPGA devices directly.
 
 ### Declaring a Register-Mapped Invocation Interface
 

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/ip_authoring_interfaces/invocation_interfaces/src/CMakeLists.txt
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/ip_authoring_interfaces/invocation_interfaces/src/CMakeLists.txt
@@ -54,7 +54,7 @@ else()
 endif()
 
 if((IS_BSP STREQUAL "1"))
-    message(FATAL_ERROR "ERROR: This tutorial is only supported in the IP Authoring flow and therefore does not support BSPs as a target.")
+    message(FATAL_ERROR "ERROR: This tutorial is only supported in the SYCL HLS flow and therefore does not support BSPs as a target.")
 endif()
 
 

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/ip_authoring_interfaces/mmhost/CMakeLists.txt
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/ip_authoring_interfaces/mmhost/CMakeLists.txt
@@ -55,7 +55,7 @@ else()
 endif()
 
 if((IS_BSP STREQUAL "1"))
-    message(FATAL_ERROR "ERROR: This tutorial is only supported in the IP Authoring flow and therefore does not support BSPs as a target.")
+    message(FATAL_ERROR "ERROR: This tutorial is only supported in the SYCL HLS flow and therefore does not support BSPs as a target.")
 endif()
 
 # Use cmake -DUSER_FPGA_FLAGS=<flags> to set extra flags for FPGA backend

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/ip_authoring_interfaces/mmhost/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/ip_authoring_interfaces/mmhost/README.md
@@ -20,7 +20,7 @@ This tutorial demonstrates how to configure Avalon memory-mapped host data inter
 
 > **Note**: Make sure you add the device files associated with the FPGA that you are targeting to your Intel® Quartus® Prime installation.
 
-> **Note**: This tutorial will not work for a Full System compile as it demonstrates an IP Authoring specific feature.
+> **Note**: This tutorial will not work for a Full System compile as it demonstrates a SYCL HLS flow specific feature.
 
 ## Prerequisites
 

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/ip_authoring_interfaces/streaming_data_interfaces/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/ip_authoring_interfaces/streaming_data_interfaces/README.md
@@ -180,7 +180,7 @@ See the [Host Pipes](https://github.com/oneapi-src/oneAPI-samples/tree/master/Di
    >  cmake .. -DFPGA_DEVICE=<FPGA device family or FPGA part number>
    >  ```
    >
-   > This tutorial is only intended for use in the IP Authoring flow and does not support targeting an explicit FPGA board variant and BSP.
+   > This tutorial is only intended for use in the SYCL HLS flow and does not support targeting an explicit FPGA board variant and BSP.
 
 3. Compile the design. (The provided targets match the recommended development flow.)
 
@@ -215,7 +215,7 @@ See the [Host Pipes](https://github.com/oneapi-src/oneAPI-samples/tree/master/Di
    >  cmake -G "NMake Makefiles" .. -DFPGA_DEVICE=<FPGA device family or FPGA part number>
    >  ```
    >
-   > This tutorial is only intended for use in the IP Authoring flow and does not support targeting an explicit FPGA board variant and BSP.
+   > This tutorial is only intended for use in the SYCL HLS flow and does not support targeting an explicit FPGA board variant and BSP.
 
 3. Compile the design. (The provided targets match the recommended development flow.)
 

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/max_reinvocation_delay/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/max_reinvocation_delay/README.md
@@ -120,7 +120,7 @@ Now, the first iteration of the `i+1`th  invocation of the inner loop will launc
    >  ```
    >  cmake .. -DFPGA_DEVICE=<FPGA device family or FPGA part number>
    >  ```
-   > For simplicity, this tutorial only uses the IP Authoring flow and does not support targeting an explicit FPGA board variant and BSP.
+   > For simplicity, this tutorial only uses the SYCL HLS flow and does not support targeting an explicit FPGA board variant and BSP.
 
 3. Compile the design. (The provided targets match the recommended development flow.)
 
@@ -154,7 +154,7 @@ Now, the first iteration of the `i+1`th  invocation of the inner loop will launc
    >  ```
    >  cmake -G "NMake Makefiles" .. -DFPGA_DEVICE=<FPGA device family or FPGA part number>
    >  ```
-   > For simplicity, this tutorial only uses the IP Authoring flow and does not support targeting an explicit FPGA board variant and BSP.
+   > For simplicity, this tutorial only uses the SYCL HLS flow and does not support targeting an explicit FPGA board variant and BSP.
 
 3. Compile the design. (The provided targets match the recommended development flow.)
 
@@ -189,7 +189,7 @@ Now, the first iteration of the `i+1`th  invocation of the inner loop will launc
    ```
    CL_CONTEXT_MPSIM_DEVICE_INTELFPGA=1 ./max_reinvocation_delay.fpga_sim
    ```
-> **Note**: Running this sample on an actual FPGA device requires a BSP that supports host pipes. As there are currently no commercial BSPs with such support, only the IP Authoring flow is enabled for this code sample.
+> **Note**: Running this sample on an actual FPGA device requires a BSP that supports host pipes. As there are currently no commercial BSPs with such support, only the SYCL HLS flow is enabled for this code sample.
 
 ### On Windows
 
@@ -203,7 +203,7 @@ Now, the first iteration of the `i+1`th  invocation of the inner loop will launc
    max_reinvocation_delay.fpga_sim.exe
    set CL_CONTEXT_MPSIM_DEVICE_INTELFPGA=
    ```
-> **Note**: Running this sample on an actual FPGA device requires a BSP that supports host pipes. As there are currently no commercial BSPs with such support, only the IP Authoring flow is enabled for this code sample.
+> **Note**: Running this sample on an actual FPGA device requires a BSP that supports host pipes. As there are currently no commercial BSPs with such support, only the SYCL HLS flow is enabled for this code sample.
 
 ## Example Output
 


### PR DESCRIPTION
The IP Authoring flow is being renamed to SYCL HLS flow.