### PR TITLE
FPGA: remove os section in `use_library` `sample.json` file

### DIFF
--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Tools/use_library/sample.json
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Tools/use_library/sample.json
@@ -4,7 +4,7 @@
   "categories": ["Toolkit/oneAPI Direct Programming/C++SYCL FPGA/Tutorials/Tools"],
   "description": "An Intel® FPGA Tutorial demonstrating how to create Intel® FPGA libraries and to incorporate them in a Intel® oneAPI SYCL project",
   "toolchain": ["icpx"],
-  "os": ["linux", "windows"],
+  "os": [],
   "targetDevice": ["FPGA"],
   "builder": ["ide", "cmake"],
   "languages": [{"cpp":{}}],


### PR DESCRIPTION
The CI tests are not running for this sample, so no OS should be specified.