### PR TITLE
added gpuRequired

### DIFF
--- a/Libraries/MPI/jacobian_solver/sample.json
+++ b/Libraries/MPI/jacobian_solver/sample.json
@@ -7,6 +7,7 @@
   "dependencies": [ "compiler|icpx,icx","mpi" ],
   "languages": [ { "cpp": { "properties": { "projectOptions": [ { "projectType": "makefile" } ] } } } ],
   "targetDevice": [ "GPU" ],
+  "gpuRequired": ["gen9"],
   "os": [ "linux" ],
   "builder": [ "make" ],
   "ciTests": {


### PR DESCRIPTION
The code sample failed in Alder lake because Gen12 does not support double precision (float64). Added `gpuRequired` tag to make sure only `gen9` GPUs are used. 

Refer [ONSAM-1721](https://jira.devtools.intel.com/browse/ONSAM-1721) for details