### PR TITLE
FPGA: Add new flows to optimization_targets README

### DIFF
--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/optimization_targets/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/optimization_targets/README.md
@@ -14,11 +14,13 @@ This tutorial shows compiling with the minimum latency optimization target to ac
 
 This FPGA tutorial demonstrates how to set optimization targets for your compile to target different performance metrics.
 
-The `-Xsoptimize=<flag>` command-line option sets optimization targets, and it supports the following flag:
+The `-Xsoptimize=<flag>` command-line option sets optimization targets, and it supports the following flags:
 
-| Flag      | Explanation      | Documentation
-|:---       |:---              |:---
-|`latency`  | Minimum latency  | [*Minimum Latency Flow*](https://www.intel.com/content/www/us/en/docs/oneapi-fpga-add-on/optimization-guide/current/minimum-latency-flow.html) topic in the *FPGA Optimization Guide for Intel® oneAPI Toolkits Developer Guide*.
+|Flag                      |Explanation                        |Documentation
+|:---                      |:---                               |:---
+|`latency`                 |Minimum latency                    |[*Minimum Latency Flow*](https://www.intel.com/content/www/us/en/docs/oneapi-fpga-add-on/optimization-guide/current/minimum-latency-flow.html)
+|`throughput-area-balanced`|Balanced throughput-area trade-offs|[*Balanced Throughput-Area Trade-Offs Flow*](https://www.intel.com/content/www/us/en/docs/oneapi-fpga-add-on/optimization-guide/current/???.html)
+|`area`                    |Minimum area                       |[*Minimum Area Flow*](https://www.intel.com/content/www/us/en/docs/oneapi-fpga-add-on/optimization-guide/current/???.html)
 
 To compile your design with the minimum latency optimization target, use the flag option `-Xsoptimize=latency`.
 

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/optimization_targets/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/optimization_targets/README.md
@@ -18,9 +18,9 @@ The `-Xsoptimize=<flag>` command-line option sets optimization targets, and it s
 
 |Flag                      |Explanation                        |Documentation
 |:---                      |:---                               |:---
-|`latency`                 |Minimum latency                    |[*Minimum Latency Flow*](https://www.intel.com/content/www/us/en/docs/oneapi-fpga-add-on/developer-guide/current/minimum-latency-flow.html)
-|`throughput-area-balanced`|Balanced throughput-area trade-offs|[*Balanced Throughput-Area Trade-Offs Flow*](https://www.intel.com/content/www/us/en/docs/oneapi-fpga-add-on/developer-guide/current/max-throughput.html)
-|`area`                    |Minimum area                       |[*Minimum Area Flow*](https://www.intel.com/content/www/us/en/docs/oneapi-fpga-add-on/developer-guide/current/minimum-area.html)
+|`latency`                 |Minimum latency: minimize kernel latency at the cost of decreased f<sub>MAX</sub> |[*Minimum Latency Flow*](https://www.intel.com/content/www/us/en/docs/oneapi-fpga-add-on/developer-guide/current/minimum-latency-flow.html)
+|`throughput-area-balanced`|Balanced throughput-area trade-offs: disable throughput-area trade-off heuristics that increase the throughput at the cost of area |[*Balanced Throughput-Area Trade-Offs Flow*](https://www.intel.com/content/www/us/en/docs/oneapi-fpga-add-on/developer-guide/current/max-throughput.html)
+|`area`                    |Minimum area: minimize kernel area at the cost of decreased f<sub>MAX</sub> |[*Minimum Area Flow*](https://www.intel.com/content/www/us/en/docs/oneapi-fpga-add-on/developer-guide/current/minimum-area.html)
 
 To compile your design with the minimum latency optimization target, use the flag option `-Xsoptimize=latency`.
 

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/optimization_targets/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/optimization_targets/README.md
@@ -18,9 +18,9 @@ The `-Xsoptimize=<flag>` command-line option sets optimization targets, and it s
 
 |Flag                      |Explanation                        |Documentation
 |:---                      |:---                               |:---
-|`latency`                 |Minimum latency                    |[*Minimum Latency Flow*](https://www.intel.com/content/www/us/en/docs/oneapi-fpga-add-on/optimization-guide/current/minimum-latency-flow.html)
-|`throughput-area-balanced`|Balanced throughput-area trade-offs|[*Balanced Throughput-Area Trade-Offs Flow*](https://www.intel.com/content/www/us/en/docs/oneapi-fpga-add-on/optimization-guide/current/???.html)
-|`area`                    |Minimum area                       |[*Minimum Area Flow*](https://www.intel.com/content/www/us/en/docs/oneapi-fpga-add-on/optimization-guide/current/???.html)
+|`latency`                 |Minimum latency                    |[*Minimum Latency Flow*](https://www.intel.com/content/www/us/en/docs/oneapi-fpga-add-on/developer-guide/current/minimum-latency-flow.html)
+|`throughput-area-balanced`|Balanced throughput-area trade-offs|[*Balanced Throughput-Area Trade-Offs Flow*](https://www.intel.com/content/www/us/en/docs/oneapi-fpga-add-on/developer-guide/current/max-throughput.html)
+|`area`                    |Minimum area                       |[*Minimum Area Flow*](https://www.intel.com/content/www/us/en/docs/oneapi-fpga-add-on/developer-guide/current/minimum-area.html)
 
 To compile your design with the minimum latency optimization target, use the flag option `-Xsoptimize=latency`.
 


### PR DESCRIPTION
## Description

Add new supported flows to the README of optimization_targets.

## External Dependencies

The README will refer to the new documentation links for individual optimization targets:
- Minimum latency flow: https://www.intel.com/content/www/us/en/docs/oneapi-fpga-add-on/developer-guide/current/minimum-latency-flow.html
- Balanced Throughput-Area Trade-Offs Flow: https://www.intel.com/content/www/us/en/docs/oneapi-fpga-add-on/developer-guide/current/max-throughput.html
- Minimum Area Flow (the link will be created in 2024.1 doc): https://www.intel.com/content/www/us/en/docs/oneapi-fpga-add-on/developer-guide/current/minimum-area.html

## Type of change

- [x] README update 