### PR TITLE
IRTK2024.0: gsg vkl gpusample.json and README for NMake Release Mode (fix linking)

### DIFF
--- a/RenderingToolkit/GettingStarted/03_openvkl_gsg/gpu/README.md
+++ b/RenderingToolkit/GettingStarted/03_openvkl_gsg/gpu/README.md
@@ -41,8 +41,7 @@ cd <path-to-oneAPI-samples>\RenderingToolkit\GettingStarted\03_openvkl_gsg\gpu
 mkdir build
 cd build
 cmake -G"NMake Makefiles" -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=icx-cl ..
-cmake --build . --config Release
-cd Release
+cmake --build .
 .\vklTutorialGPU.exe
 ```
 

--- a/RenderingToolkit/GettingStarted/03_openvkl_gsg/sample.json
+++ b/RenderingToolkit/GettingStarted/03_openvkl_gsg/sample.json
@@ -43,8 +43,8 @@
 		    "cd gpu",
 		    "mkdir build",
 		    "cd build",
-		    "cmake -G\"NMake Makefiles\" -DCMAKE_CXX_COMPILER=icx-cl ..",
-		    "cmake --build . --config Release",
+		    "cmake -G\"NMake Makefiles\" -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=icx-cl ..",
+		    "cmake --build .",
 		    ".\\vklTutorialGPU.exe"
                 ]
 


### PR DESCRIPTION
# Existing Sample Changes
## Description

Fixes validation and spot testing for RenderingToolkit gsg 03_openvkl_gsg gpu sample. Proper release mode flags are needed for linking match in Windows.

Fixes Issue# 
Reported by @jimmytwei over teams chat.

## External Dependencies

N/A

## Type of change



- [x] Bug fix (non-breaking change which fixes an issue)


## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Command Line
- [ ] oneapi-cli
- [ ] Visual Studio
- [ ] Eclipse IDE
- [ ] VSCode
- [ ] When compiling the compliler flag "-Wall -Wformat-security -Werror=format-security" was used

