### PR TITLE
FPGA: Update emulation_model flag in use_library sample

### DIFF
--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Tools/use_library/CMakeLists.txt
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Tools/use_library/CMakeLists.txt
@@ -76,7 +76,7 @@ endif()
 set(USER_FPGA_FLAGS ${USER_FPGA_FLAGS};-Xsoptimize=latency)
 
 # Use cmake -DUSER_FLAGS=<flags> to set extra flags for general compilation.
-# use -Wno-return-type-c-linkage to disable warnings caused by using ac_int types in the emulation model
+# use -Wno-return-type-c-linkage to disable warnings caused by using ac_int types in the C++ model
 set(USER_FLAGS ${USER_FLAGS};-Wno-return-type-c-linkage)
 
 # Use cmake -DUSER_INCLUDE_PATHS=<paths> to set extra paths for general
@@ -161,7 +161,7 @@ endif()
 # The RTL file (specified in lib_rtl_spec.xml) must be copied to the CMake working directory for the final stage of FPGA hardware compilation
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/${RTL_V} ${RTL_V} @ONLY)
 
-set(FPGA_CROSSGEN_COMMAND fpga_crossgen ${CMAKE_CURRENT_SOURCE_DIR}/${RTL_SPEC} --emulation_model ${CMAKE_CURRENT_SOURCE_DIR}/${RTL_C_MODEL} --target sycl -o ${RTL_SOURCE_OBJECT} ${USER_FLAGS})
+set(FPGA_CROSSGEN_COMMAND fpga_crossgen ${CMAKE_CURRENT_SOURCE_DIR}/${RTL_SPEC} --cpp_model ${CMAKE_CURRENT_SOURCE_DIR}/${RTL_C_MODEL} --target sycl -o ${RTL_SOURCE_OBJECT} ${USER_FLAGS})
 
 # Create RTL source object
 add_custom_target(

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Tools/use_library/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Tools/use_library/README.md
@@ -66,9 +66,9 @@ Files needed to create a SYCL target library from RTL source include:
 - Verilog, System Verilog, or VHDL files that define the RTL component
 - An Object Manifest File (.xml) which contains properties needed to integrate RTL component into SYCL pipeline
 - A header file containing valid SYCL kernel language and declares the signatures of functions implemented by the RTL component.
-- A SYCL based emulation model file for RTL component
+- A SYCL based C++ model file for RTL component
 
-The RTL is used when compiling for hardware and simulation, and the emulation model is used when compiling for the FPGA emulator.
+The RTL is used when compiling for hardware and simulation, and the C++ model is used when compiling for the FPGA emulator.
 After having created the library file, the function in the library can be called from the SYCL kernel, without the need to know the hardware design or implementation details on underlying functions in the library.
 
 Given a workable RTL module, one may need to apply some modifications in order to integrate it into oneAPI program.
@@ -93,15 +93,15 @@ To create a library from  source code, use the following steps:
 
    ```bash
    # Linux
-   fpga_crossgen lib_rtl_spec.xml --emulation_model lib_rtl_model.cpp --target sycl -o lib_rtl.o
+   fpga_crossgen lib_rtl_spec.xml --cpp_model lib_rtl_model.cpp --target sycl -o lib_rtl.o
 
    # Windows
-   fpga_crossgen lib_rtl_spec.xml --emulation_model lib_rtl_model.cpp --target sycl -o lib_rtl.obj
+   fpga_crossgen lib_rtl_spec.xml --cpp_model lib_rtl_model.cpp --target sycl -o lib_rtl.obj
    ```
 
-   Note that generating an RTL library requires that an `xml` file and a C++ emulation model be provided in addition to the Verilog source code. The RTL is used when compiling for the hardware whereas the emulation model is used when the oneAPI program is run on the FPGA emulator. Examine the tutorial source code and the comments in `use_library.cpp` for more details.
+   Note that generating an RTL library requires that an `xml` file and a C++ model be provided in addition to the Verilog source code. The RTL is used when compiling for the hardware whereas the C++ model is used when the oneAPI program is run on the FPGA emulator. Examine the tutorial source code and the comments in `use_library.cpp` for more details.
 
-   **Note**: When you use special datatypes (such as ac_int in this sample) in the emulation model, the compiler may warn about "incomplete type which could be incompatible with C". This warning can be disabled with the -Wno-return-type-c-linkage flag.
+   **Note**: When you use special datatypes (such as ac_int in this sample) in the C++ model, the compiler may warn about "incomplete type which could be incompatible with C". This warning can be disabled with the -Wno-return-type-c-linkage flag.
 
    ```bash
    warning: 'RtlDSPm27x27u' has C-linkage specified, but returns incomplete type 'MyInt54' (aka 'ac_int<54, false>') which could be incompatible with C [-Wreturn-type-c-linkage]

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Tools/use_library/src/lib_rtl_model.cpp
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Tools/use_library/src/lib_rtl_model.cpp
@@ -5,7 +5,7 @@
 // =============================================================
 #include "lib_rtl.hpp"
 
-// This emulation model is only used during emulation, so it should functionally
+// This C++ model is only used during emulation, so it should functionally
 // match the RTL in lib_rtl.v.
 
 SYCL_EXTERNAL extern "C" MyInt54 RtlDSPm27x27u (MyInt27 x, MyInt27 y) {


### PR DESCRIPTION
# Existing Sample Changes
## Description
The `fpga_crossgen` flag `emulation_model` has been renamed to `cpp_model`. The former flag is still supported, but produces a deprecation notice `Warning: --emulation_model is deprecated. Use --cpp_model instead`. This change updates the use_library sample to use the new flag.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Built the use_library sample as usual.
- [x] Command Line