### PR TITLE
Updated Concurrent Kernels - oneAPI 2024.0 

### DIFF
--- a/DirectProgramming/C++SYCL/guided_concurrentKernels_SYCLMigration/02_sycl_migrated/Samples/0_Introduction/concurrentKernels/concurrentKernels.dp.cpp
+++ b/DirectProgramming/C++SYCL/guided_concurrentKernels_SYCLMigration/02_sycl_migrated/Samples/0_Introduction/concurrentKernels/concurrentKernels.dp.cpp
@@ -34,6 +34,7 @@
 // Devices of compute capability 2.0 or higher can overlap the kernels
 //
 #include <sycl/sycl.hpp>
+#include <fstream>
 #include <dpct/dpct.hpp>
 #include <stdio.h>
 
@@ -41,7 +42,6 @@
 #include <helper_functions.h>
 #include <time.h>
 #include <chrono>
-#include <fstream>
 
 // This is a kernel that does no real work but runs at least for a specified
 // number of count

--- a/DirectProgramming/C++SYCL/guided_concurrentKernels_SYCLMigration/02_sycl_migrated/Samples/0_Introduction/concurrentKernels/concurrentKernels.dp.cpp
+++ b/DirectProgramming/C++SYCL/guided_concurrentKernels_SYCLMigration/02_sycl_migrated/Samples/0_Introduction/concurrentKernels/concurrentKernels.dp.cpp
@@ -41,6 +41,7 @@
 #include <helper_functions.h>
 #include <time.h>
 #include <chrono>
+#include <fstream>
 
 // This is a kernel that does no real work but runs at least for a specified
 // number of count

--- a/DirectProgramming/C++SYCL/guided_concurrentKernels_SYCLMigration/02_sycl_migrated/Samples/0_Introduction/concurrentKernels/concurrentKernels.dp.cpp
+++ b/DirectProgramming/C++SYCL/guided_concurrentKernels_SYCLMigration/02_sycl_migrated/Samples/0_Introduction/concurrentKernels/concurrentKernels.dp.cpp
@@ -102,16 +102,15 @@ int main(int argc, char **argv) {
   //cuda_device = findCudaDevice(argc, (const char **)argv);
 
   dpct::device_info deviceProp;
-  checkCudaErrors(cuda_device = dpct::dev_mgr::instance().current_device_id());
+  DPCT_CHECK_ERROR(cuda_device = dpct::dev_mgr::instance().current_device_id());
 
-  checkCudaErrors((dpct::dev_mgr::instance()
+  DPCT_CHECK_ERROR(dpct::dev_mgr::instance()
                        .get_device(cuda_device)
-                       .get_device_info(deviceProp),
-                   0));
+                       .get_device_info(deviceProp));
 
   if ((true == 0)) {
     printf("> GPU does not support concurrent kernel execution\n");
-    printf("  CUDA kernel runs will be serialized\n");
+    printf("  SYCL kernel runs will be serialized\n");
   }
 
   printf("> Detected Compute SM %d.%d hardware with %d multi-processors\n",
@@ -120,15 +119,14 @@ int main(int argc, char **argv) {
 
   // allocate host memory
   long *a = 0;  // pointer to the array data in host memory
-  checkCudaErrors(
-      (a = (long *)sycl::malloc_host(nbytes, dpct::get_default_queue()), 0));
+  DPCT_CHECK_ERROR(
+      (a = (long *)sycl::malloc_host(nbytes, dpct::get_default_queue())));
 
   // allocate device memory
   long *d_a = 0;  // pointers to data and init value in the device memory
 
-  checkCudaErrors(
-      (d_a = (long *)sycl::malloc_device(nbytes, dpct::get_default_queue()),
-       0));
+  DPCT_CHECK_ERROR(
+      (d_a = (long *)sycl::malloc_device(nbytes, dpct::get_default_queue())));
 
   // allocate and initialize an array of stream handles
   dpct::queue_ptr *streams =
@@ -136,8 +134,8 @@ int main(int argc, char **argv) {
 
   for (int i = 0; i < nstreams; i++) {
 
-    checkCudaErrors(
-        ((streams[i]) = dpct::get_current_device().create_queue(), 0));
+    DPCT_CHECK_ERROR(
+        ((streams[i]) = dpct::get_current_device().create_queue()));
   }
 
   // create CUDA event handles
@@ -145,8 +143,8 @@ int main(int argc, char **argv) {
   std::chrono::time_point<std::chrono::steady_clock> start_event_ct1;
   std::chrono::time_point<std::chrono::steady_clock> stop_event_ct1;
 
-  checkCudaErrors((start_event = new sycl::event(), 0));
-  checkCudaErrors((stop_event = new sycl::event(), 0));
+  DPCT_CHECK_ERROR(start_event = new sycl::event());
+  DPCT_CHECK_ERROR(stop_event = new sycl::event());
 
   // the events are used for synchronization only and hence do not need to
   // record timings this also makes events not introduce global sync points when
@@ -156,7 +154,7 @@ int main(int argc, char **argv) {
   kernelEvent = (dpct::event_ptr *)malloc(nkernels * sizeof(dpct::event_ptr));
 
   for (int i = 0; i < nkernels; i++) {
-    checkCudaErrors((kernelEvent[i] = new sycl::event(), 0));
+    DPCT_CHECK_ERROR(kernelEvent[i] = new sycl::event());
   }
 
   //////////////////////////////////////////////////////////////////////
@@ -189,13 +187,12 @@ int main(int argc, char **argv) {
     total_count += time_count;
 
     kernelEvent_ct1_i = std::chrono::steady_clock::now();
-    checkCudaErrors(
-        (*kernelEvent[i] = streams[i]->ext_oneapi_submit_barrier(), 0));
+    DPCT_CHECK_ERROR(
+        *kernelEvent[i] = streams[i]->ext_oneapi_submit_barrier());
 
     // make the last stream wait for the kernel event to be recorded
-    checkCudaErrors(
-        (streams[nstreams - 1]->ext_oneapi_submit_barrier({*kernelEvent[i]}),
-         0));
+    DPCT_CHECK_ERROR(
+        streams[nstreams - 1]->ext_oneapi_submit_barrier({*kernelEvent[i]}));
   }
 
   // queue a sum kernel and a copy back to host in the last stream.
@@ -211,9 +208,8 @@ int main(int argc, char **argv) {
         });
   });
 
-  checkCudaErrors((stop_event_streams_nstreams_1 =
-                       streams[nstreams - 1]->memcpy(a, d_a, sizeof(long)),
-                   0));
+  DPCT_CHECK_ERROR(stop_event_streams_nstreams_1 =
+                       streams[nstreams - 1]->memcpy(a, d_a, sizeof(long)));
 
   // at this point the CPU has dispatched all work for the GPU and can continue
   // processing other tasks in parallel
@@ -223,14 +219,13 @@ int main(int argc, char **argv) {
   dpct::get_current_device().queues_wait_and_throw();
   stop_event_streams_nstreams_1.wait();
   stop_event_ct1 = std::chrono::steady_clock::now();
-  checkCudaErrors(
-      (*stop_event = dpct::get_default_queue().ext_oneapi_submit_barrier(), 0));
-  checkCudaErrors(0);
+  DPCT_CHECK_ERROR(
+      *stop_event = dpct::get_default_queue().ext_oneapi_submit_barrier());
 
-  checkCudaErrors((elapsed_time = std::chrono::duration<float, std::milli>(
+  DPCT_CHECK_ERROR((elapsed_time = std::chrono::duration<float, std::milli>(
                                       stop_event_ct1 - start_event_ct1)
                                       .count(),
-                   0));
+                       0));
 
   printf("Expected time for serial execution of %d kernels = %.3fs\n", nkernels,
          nkernels * kernel_time / 1000.0f);

--- a/DirectProgramming/C++SYCL/guided_concurrentKernels_SYCLMigration/README.md
+++ b/DirectProgramming/C++SYCL/guided_concurrentKernels_SYCLMigration/README.md
@@ -1,6 +1,6 @@
 # `Concurrent Kernels` Sample
 
-The `Concurrent Kernels` sample demonstrates the use of SYCL queues for concurrent execution of several kernels on GPU devices. It is implemented using SYCL by migrating Native CUDA source code for offloading computations to a GPU or CPU and further demonstrates how to optimize and improve processing time.
+The `Concurrent Kernels` sample demonstrates the use of SYCL queues for concurrent execution of several kernels on GPU devices to optimize and improve processing time. The original CUDA* source code is migrated to SYCL for portability across GPUs from multiple vendors.
 
 | Area                   | Description
 |:---                    |:---
@@ -30,9 +30,9 @@ The `Concurrent Kernels` sample demonstrates the use of SYCL queues for concurre
 
 | Optimized for         | Description
 |:---                   |:---
-| OS                    | Ubuntu* 20.04
+| OS                    | Ubuntu* 22.04
 | Hardware              | Intel® Gen9 <br>Intel® Gen11 <br>Intel® Xeon CPU <br>Intel® Data Center GPU Max <br> Nvidia Tesla P100 <br> Nvidia A100 <br> Nvidia H100 
-| Software              | SYCLomatic (Tag - 20230720) <br> Intel® oneAPI Base Toolkit (Base Kit) version 2023.2.1 <br> oneAPI for NVIDIA GPU plugin from Codeplay (to run SYCL™ applications on NVIDIA® GPUs)
+| Software              | SYCLomatic (Tag - 20230720) <br> Intel® oneAPI Base Toolkit (Base Kit) version 2024.0.0 <br> oneAPI for NVIDIA GPU plugin from Codeplay (to run SYCL™ applications on NVIDIA® GPUs)
 
 For more information on how to install Syclomatic Tool & DPC++ CUDA® plugin, visit [Migrate from CUDA* to C++ with SYCL*](https://www.intel.com/content/www/us/en/developer/tools/oneapi/training/migrate-from-cuda-to-cpp-with-sycl.html#gs.v354cy) .<br>
 How to run SYCL™ applications on NVIDIA® GPUs, refer to 
@@ -151,20 +151,8 @@ the `VERBOSE=1` argument:
 ```
 make VERBOSE=1
 ```
-If you receive an error message, troubleshoot the problem using the **Diagnostics Utility for Intel® oneAPI Toolkits**. The diagnostic utility provides configuration and system checks to help find missing dependencies, permissions errors, and other issues. See the [Diagnostics Utility for Intel® oneAPI Toolkits User Guide](https://www.intel.com/content/www/us/en/develop/documentation/diagnostic-utility-user-guide/top.html) for more information on using the utility.
+If you receive an error message, troubleshoot the problem using the **Diagnostics Utility for Intel® oneAPI Toolkits**. The diagnostic utility provides configuration and system checks to help find missing dependencies, permissions errors, and other issues. See the [Diagnostics Utility for Intel® oneAPI Toolkits User Guide](https://www.intel.com/content/www/us/en/docs/oneapi/user-guide-diagnostic-utility/2024-0/overview.html) for more information on using the utility.
 
-
-## Example Output
-
-The following example is for `02_sycl_migrated` for GPU on **Intel(R) UHD Graphics [0x9a60]**.
-```
-[./a.out] - Starting...
-> Detected Compute SM 3.0 hardware with 12 multi-processors
-Expected time for serial execution of 8 kernels = 0.080s
-Expected time for concurrent execution of 8 kernels = 0.010s
-Measured time for sample = 0.256s
-Test passed
-```
 
 ## License
 


### PR DESCRIPTION
# Existing Sample Changes
## Description

Re-tested with oneAPI 2024.0.0.
Removed checkCudaErrors from migrated source code.
Updated the Readme.
  

## How Has This Been Tested?

- [X] Command Line
- [ ] oneapi-cli
- [ ] Visual Studio
- [ ] Eclipse IDE
- [ ] VSCode
- [X] When compiling the compliler flag "-Wall -Wformat-security -Werror=format-security" was used

