### PR TITLE
oneDNN samples failed due to No module named 'IPython.kernel' (ONSAM-1592)

### DIFF
--- a/Libraries/oneDNN/tutorials/sample.json
+++ b/Libraries/oneDNN/tutorials/sample.json
@@ -1,45 +1,53 @@
 {
- "guid": "FC7A16DE-9594-4F40-AFA2-71ACABF366B3",
- "name": "Tutorials",
- "categories": ["Toolkit/oneAPI Libraries/oneDNN"],
- "description": "Intel® oneDNN Tutorials",
- "toolchain": ["dpcpp"],
- "languages": [{"cpp":{}}],
- "dependencies": ["dnnl", "tbb"],
- "os": ["linux"],
- "builder": ["ide","cmake"],
- "targetDevice": ["CPU", "GPU"],
- "ciTests": {
-	"linux": [
-	{
-		"env": ["source /opt/intel/oneapi/setvars.sh --dnnl-configuration=cpu_dpcpp_gpu_dpcpp --force" ],
-		"id": "dnn gsg",
-		"steps": [
-			"runipy tutorial_getting_started.ipynb"
-		 ]
-	},
-	{
-		"env": ["source /opt/intel/oneapi/setvars.sh --dnnl-configuration=cpu_dpcpp_gpu_dpcpp --force" ],
-		"id": "verbose_jit",
-		"steps": [
-			"runipy tutorial_verbose_jitdump.ipynb"
-		 ]
-	},
-	{
-		"env": ["source /opt/intel/oneapi/setvars.sh --dnnl-configuration=cpu_gomp --force" ],
-		"id": "isa",
-		"steps": [
-			"runipy tutorial_analyze_isa_with_dispatcher_control.ipynb"
-		 ]
-	},
-	{
-		"env": ["source activate base",
-			"source /opt/intel/oneapi/setvars.sh --dnnl-configuration=cpu_gomp --force" ],
-		"id": "vtune_itt",
-		"steps": [
-			"runipy tutorial_vtune_profiling.ipynb"
-		 ]
+	"guid": "FC7A16DE-9594-4F40-AFA2-71ACABF366B3",
+	"name": "Tutorials",
+	"categories": ["Toolkit/oneAPI Libraries/oneDNN"],
+	"description": "Intel® oneDNN Tutorials",
+	"toolchain": ["dpcpp"],
+	"languages": [{"cpp":{}}],
+	"dependencies": ["dnnl", "tbb"],
+	"os": ["linux"],
+	"builder": ["ide","cmake"],
+	"targetDevice": ["CPU", "GPU"],
+	"ciTests": {
+	   "linux": [
+	   {
+		   "env": ["source /opt/intel/oneapi/setvars.sh --dnnl-configuration=cpu_dpcpp_gpu_dpcpp --force" ],
+		   "id": "dnn gsg",
+		   "steps": [
+			   "pip install jupyter ipykernel",
+			   "python3 -m ipykernel install --user --name=base",
+			   "jupyter nbconvert --ExecutePreprocessor.kernel_name=base --to notebook --execute tutorial_getting_started.ipynb"
+			]
+	   },
+	   {
+		   "env": ["source /opt/intel/oneapi/setvars.sh --dnnl-configuration=cpu_dpcpp_gpu_dpcpp --force" ],
+		   "id": "verbose_jit",
+		   "steps": [
+			   "pip install jupyter ipykernel",
+			   "python3 -m ipykernel install --user --name=base",
+			   "jupyter nbconvert --ExecutePreprocessor.kernel_name=base --to notebook --execute tutorial_verbose_jitdump.ipynb"
+			]
+	   },
+	   {
+		   "env": ["source /opt/intel/oneapi/setvars.sh --dnnl-configuration=cpu_gomp --force" ],
+		   "id": "isa",
+		   "steps": [
+			   "pip install jupyter ipykernel",
+			   "python3 -m ipykernel install --user --name=base",
+			   "jupyter nbconvert --ExecutePreprocessor.kernel_name=base --to notebook --execute tutorial_analyze_isa_with_dispatcher_control.ipynb"
+			]
+	   },
+	   {
+		   "env": ["source /opt/intel/oneapi/setvars.sh --dnnl-configuration=cpu_gomp --force" ],
+		   "id": "vtune_itt",
+		   "steps": [
+			   "pip install jupyter ipykernel",
+			   "python3 -m ipykernel install --user --name=base",
+			   "jupyter nbconvert --ExecutePreprocessor.kernel_name=base --to notebook --execute tutorial_vtune_profiling.ipynb"
+			]
+	   }
+		]
 	}
-     ]
- }
-}
+   }
+   


### PR DESCRIPTION
removed runipy and using OS python3. Refer [ONSAM-1592](https://jira.devtools.intel.com/projects/ONSAM/issues/ONSAM-1592?filter=allopenissues)