### PR TITLE
End-End Machine Learning for Census code sample failing to run (ONSAM-1747)

### DIFF
--- a/AI-and-Analytics/End-to-end-Workloads/Census/sample.json
+++ b/AI-and-Analytics/End-to-end-Workloads/Census/sample.json
@@ -15,13 +15,12 @@
         "id": "Intel_Modin_E2E_py",
         "steps": [
           "set -e # Terminate the script on first error",
-          "source $(conda info --base)/etc/profile.d/conda.sh # Bypassing conda's disability to activate environments inside a bash script: https://github.com/conda/conda/issues/7980",
+          "source ~/intel/oneapi/intelpython/bin/activate",
           "conda create -n modin-hdk python=3.9 -y",
           "conda activate modin-hdk",
           "conda install modin-hdk -c conda-forge -y",
-          "conda install -y jupyter # Installing 'jupyter' for extended abilities to execute the notebook",
-          "pip install scikit-learn-intelex # Installing Intel® Extension for Scikit-learn*",
-          "pip install matplotlib",
+          "pip install scikit-learn scikit-learn-intelex matplotlib jupyter ipykernel",
+          "python -m ipykernel install --name modin-hdk",
           "jupyter nbconvert --to notebook --execute census_modin.ipynb"
         ]
       }


### PR DESCRIPTION
updated `samples.json` to use AI toolkit 2024.0. Refer [ONSAM-1747](https://jira.devtools.intel.com/projects/ONSAM/issues/ONSAM-1747?filter=allopenissues)