### PR TITLE
2024.0_updates branch fix: README issues only for IRTK (GPU instructions + Product Names)

### DIFF
--- a/RenderingToolkit/GettingStarted/01_ospray_gsg/README.md
+++ b/RenderingToolkit/GettingStarted/01_ospray_gsg/README.md
@@ -9,11 +9,14 @@ Volume Kernel Library (Intel&reg; Open VKL), and Intel&reg; Open Image Denoise.
 | Minimum Requirements              | Description
 |:---                               |:---
 | OS                                | Linux* Ubuntu* 22.04 <br>CentOS 8 (or compatible) <br>Windows* 10 or 11<br>macOS* 10.15+
-| Hardware                          | Intel 64 Penryn or newer with SSE4.1 extensions, ARM64 with NEON extensions <br>(Optimized requirements: Intel 64 Skylake or newer with AVX512 extentions, ARM64 with NEON extensions)
+| Hardware                          | <ul><li>Intel 64 Penryn CPU or higher with SSE4.1 extensions</li><ul><li>Optimized requirements: Intel 64 Skylake CPU or higher with AVX512 extentions) </li></ul><li>ARM64 with NEON extensions</li><li>GPUs: Xe-HPG, or Xe-HPC architecture based Intel&reg; Graphics devices including Intel&reg; Arc&trade; Graphics and Intel&reg; Data Center Graphics</li></ul>
 | Compiler Toolchain                | Windows OS: MSVS 2022 (or 2019) installed with Windows SDK and CMake*; Other platforms: C++11 compiler, a C99 compiler (for example, gcc/c++/clang), and CMake*
-| Libraries                         | Install Intel&reg; oneAPI Rendering Toolkit (Render Kit), including Intel&reg; OSPRay, Intel&reg; Embree, Intel&reg; Open VKL, and Intel&reg; Open Image Denoise; Install Intel&reg; oneAPI Base Toolkit (Base Kit) for Intel&reg; oneAPI DPC++ Compiler and Runtimes
+| Libraries                         | <ul><li>Install Intel&reg; Rendering Toolkit (Render Kit), including Intel&reg; OSPRay, Intel&reg; Embree, Intel&reg; Open VKL, and Intel&reg; Open Image Denoise</li><li> Install Intel&reg; oneAPI Base Toolkit (Base Kit) for Intel&reg; oneAPI DPC++ Compiler and Runtimes</li></ul>
 | Image Display Tool                | A .ppm filetype viewer (for example, [ImageMagick](https://www.imagemagick.org)).
 
+| Optional Requirement                    | Description
+|:---                                     |:---
+| Intel GPU Configuration                 | **System BIOS**: [Quick Start](https://www.intel.com/content/www/us/en/support/articles/000091128/graphics.html) <br> **Windows\***: [Drivers for Intel&reg; Graphics products](https://www.intel.com/content/www/us/en/support/articles/000090440/graphics.html ) <br> **Linux\***: [Install Guide](https://dgpu-docs.intel.com/installation-guides/index.html#)
 
 | Objective                         | Description
 |:---                               |:---

--- a/RenderingToolkit/GettingStarted/01_ospray_gsg/README.md
+++ b/RenderingToolkit/GettingStarted/01_ospray_gsg/README.md
@@ -91,7 +91,7 @@ REM close imdisplay and delete get started images
 del firstFrameCpp.ppm
 del AccumulatedFrameCpp.ppm
 REM run program
-.\ospTutorialCpp.exe
+.\ospTutorialCpp.exe --osp:load-modules=gpu --osp:device=gpu
 
 ```
 
@@ -142,7 +142,7 @@ picked geometry [instance: 0000028FEA8F9860, model: 0000028FEA8CAE50, primitive:
 rm firstFrameCpp.ppm
 rm AccumulatedFrameCpp.ppm
 # run program
-./ospTutorialCpp
+./ospTutorialCpp --osp:load-modules=gpu --osp:device=gpu
 
 ```
 

--- a/RenderingToolkit/GettingStarted/02_embree_gsg/README.md
+++ b/RenderingToolkit/GettingStarted/02_embree_gsg/README.md
@@ -1,4 +1,4 @@
-# Getting Started Sample for Intel&reg; oneAPI Rendering Toolkit (Render Kit): Intel&reg; Embree
+# Getting Started Sample for Intel&reg; Rendering Toolkit (Render Kit): Intel&reg; Embree
 
 Intel Embree is a library of high-performance ray tracing kernels. Improve performance of photo-realistic rendering applications with Intel Embree.
 
@@ -6,7 +6,7 @@ Intel Embree is a library of high-performance ray tracing kernels. Improve perfo
 
 1. [CPU](./cpu/) - for Intel64 (x86-64) Host)
 - This version of the `minimal` program uses a C++11 (or C99) compiler to target the host processor.
-2. [GPU](./gpu/) - for Intel&reg; Arc&trade; hardware (Xe-HPG))
+2. [GPU](./gpu/) - for Intel&reg; Arc&trade; Graphics, Intel&reg; Data Center GPU Flex Series, or Intel&reg; Data Center GPU MAX Series or higher (Xe-HPG, Xe-HPC, DG2-128, DG2-512 or higher)
 - This `minimal_sycl` program uses Intel&reg; oneAPI DPC/C++ Compiler and SYCL* Runtimes to target the GPU.
 
 

--- a/RenderingToolkit/GettingStarted/02_embree_gsg/cpu/README.md
+++ b/RenderingToolkit/GettingStarted/02_embree_gsg/cpu/README.md
@@ -1,4 +1,4 @@
-# `Getting Started` CPU Sample for Intel&reg; oneAPI Rendering Toolkit (Render Kit): Intel&reg; Embree
+# `Getting Started` CPU Sample for Intel&reg; Rendering Toolkit (Render Kit): Intel&reg; Embree
 
 This sample program, `minimal`, performs two ray-to-triangle-intersect tests with the Intel Embree API. One test is a successful intersection, and the second test misses. The program performs intersection tests on the CPU device. The program writes output results to the console (stdout).
 
@@ -14,7 +14,7 @@ This sample program, `minimal`, performs two ray-to-triangle-intersect tests wit
 | OS                                | Linux* Ubuntu* 18.04 <br>CentOS* 8 (or compatible) <br>Windows* 10 or higher<br>macOS* 10.15+
 | Hardware                          | Intel 64 Penryn or newer with SSE4.1 extensions; ARM64 with NEON extensions <br>(Optimized requirements: Intel 64 Skylake or newer with AVX512 extentions, ARM64 with NEON extensions)
 | Compiler Toolchain                | **Windows\***: MSVS 2019 or higher with Windows* SDK and CMake*; Other platforms: C++11 compiler, a C99 compiler (for example gcc/c++/clang), and CMake*
-| Libraries                         | Install Intel&reg; oneAPI Rendering Toolkit (Render Kit), includes Embree
+| Libraries                         | Install Intel&reg; Rendering Toolkit (Render Kit), includes Embree
 
 ## Build and Run the `Getting Started` Sample Program
 

--- a/RenderingToolkit/GettingStarted/02_embree_gsg/gpu/README.md
+++ b/RenderingToolkit/GettingStarted/02_embree_gsg/gpu/README.md
@@ -12,7 +12,7 @@ This sample program, `minimal_sycl`, performs two ray-to-triangle-intersect test
 | Minimum Requirements              | Description
 |:---                               |:---
 | OS                                | Ubuntu* 22.04 <br> RHEL 8.5, 8.6 (or compatible) <br>Windows* 10 64-bit 20H2 or higher<br>Windows 11* 64-bit
-| Hardware                          | Intel&reg; Arc&trade; GPU or higher, compatible with Intel Xe-HPG architecture
+| Hardware                          | Intel&reg; Arc&trade; GPU or higher, compatible with Intel Xe-HPG or Intel Xe-HPC architectures
 | Compiler Toolchain                | **Windows\***: Intel&reg; oneAPI DPC++ Compiler 2024.0 or higher, MSVS 2019 or higher with Windows* SDK and CMake*<br>**Linux\***: Intel&reg; oneAPI DPC++ Compiler 2024.0 or higher, C++17 system compiler (for example g++), and CMake*
 | Libraries                         | Intel&reg; oneAPI DPC++ Compiler and Runtime Library (Base Toolkit)<br>Intel&reg; Rendering Toolkit (Render Kit), includes Embree
 | GPU Configuration                 | **System BIOS**: [Quick Start](https://www.intel.com/content/www/us/en/support/articles/000091128/graphics.html) <br> **Windows\***: [Drivers for Intel&reg; Graphics products](https://www.intel.com/content/www/us/en/support/articles/000090440/graphics.html ) <br> **Linux\***: [Install Guide](https://dgpu-docs.intel.com/installation-guides/index.html#) 

--- a/RenderingToolkit/GettingStarted/03_openvkl_gsg/README.md
+++ b/RenderingToolkit/GettingStarted/03_openvkl_gsg/README.md
@@ -1,4 +1,4 @@
-# Getting Started Sample for Intel&reg; oneAPI Rendering Toolkit (Render Kit): Intel&reg; Open Volume Kernel Library (Intel&reg; Open VKL)
+# Getting Started Sample for Intel&reg; Rendering Toolkit (Render Kit): Intel&reg; Open Volume Kernel Library (Intel&reg; Open VKL)
 
 Intel&reg; Open Volume Kernel Library (Intel&reg; Open VKL) is a collection of
 high-performance volume computation kernels. Improve performance of volume
@@ -9,7 +9,7 @@ sampling functionality for a variety of data formats.
 
 1. [CPU](./cpu/) - for Intel64 (x86-64) Host
 - This version of the `vklTutorialCPU` program uses a C++11 (or C99) system compiler to target the host processor.
-2. [GPU](./gpu/) - for Intel&reg; Arc&trade; Graphics, Intel&reg; Data Center Flex Series, or Intel&reg; Data Center Max Series or higher (Xe-HPG, DG2-128, DG2-512 or higher)
+2. [GPU](./gpu/) - for Intel&reg; Arc&trade; Graphics, Intel&reg; Data Center GPU Flex Series, or Intel&reg; Data Center GPU MAX Series or higher (Xe-HPG, Xe-HPC, DG2-128, DG2-512 or higher)
 - This `vklTutorialGPU` program uses Intel&reg; oneAPI DPC/C++ Compiler and SYCL* Runtimes to target the GPU.
 
 

--- a/RenderingToolkit/GettingStarted/03_openvkl_gsg/gpu/README.md
+++ b/RenderingToolkit/GettingStarted/03_openvkl_gsg/gpu/README.md
@@ -8,10 +8,11 @@ sampling functionality for a variety of data formats.
 | Minimum Requirements              | Description
 |:---                               |:---
 | OS                                | Linux* Ubuntu* 22.04 <br>CentOS 8 (or compatible) <br> Windows* 10 or 11
-| Hardware                          | Intel&reg; Arc Graphics (Xe-HPG architecture, DG2-128, DG2-512) or higher
-| Compiler Toolchain                | Windows OS: MSVS 2022 (or 2019) installed with Windows* SDK and CMake*; All Platforms: Intel&reg; oneAPI DPC++ Compiler from the Intel&reg; oneAPI Base Toolkit
+| Hardware                          | Intel&reg; Arc&trade; GPU (DG2-128, DG2-512) or higher, compatible with Intel Xe-HPG or Intel Xe-HPC architectures
+| Compiler Toolchain                | <ul><li>Windows* OS only: MSVS 2022 (or 2019) installed with Windows* SDK and CMake*</li><li> All Platforms: Intel&reg; oneAPI DPC++ Compiler from the Intel&reg; oneAPI Base Toolkit</li></ul>
 | SYCL Compiler                     | oneAPI DPC++ 2024.0.0 compiler or higher
-| Libraries                         | Install Intel&reg; Rendering Toolkit (Render Kit), including Intel&reg; Embree and Intel&reg; Open VKL
+| Libraries                         | <ul><li>Install Intel&reg; Rendering Toolkit (Render Kit) including Intel&reg; Embree, Intel&reg; Open VKL</li><li> Install Intel&reg; oneAPI Base Toolkit (Base Kit) for Intel&reg; oneAPI DPC++ Compiler and Runtime Libraries</li></ul>
+| GPU Configuration                 | **System BIOS**: [Quick Start](https://www.intel.com/content/www/us/en/support/articles/000091128/graphics.html) <br> **Windows\***: [Drivers for Intel&reg; Graphics products](https://www.intel.com/content/www/us/en/support/articles/000090440/graphics.html ) <br> **Linux\***: [Install Guide](https://dgpu-docs.intel.com/installation-guides/index.html#)
 | Knowledge                         | First, build and run the [CPU](../cpu) get started program `vklTutorialCPU`
 
 | Objective                         | Description
@@ -27,7 +28,7 @@ Open VKL. Output is written to the console (stdout).
 
 ## Key Implementation Details
 
-`vklTutorialGPU` is written for C++17 with SYCL. It is constructed to build with the Intel&reg; oneAPI DPC++ Compiler. On Windows* OS it must also build with MSVS system libraries.
+`vklTutorialGPU` is written for C++17 with SYCL. The application is constructed to build with the Intel&reg; oneAPI DPC++ Compiler. On Windows* OS, it must also link to MSVS system libraries.
 
 ## Build and Run
 

--- a/RenderingToolkit/GettingStarted/04_oidn_gsg/README.md
+++ b/RenderingToolkit/GettingStarted/04_oidn_gsg/README.md
@@ -1,4 +1,4 @@
-# Getting Started Sample for Intel&reg; oneAPI Rendering Toolkit (Render Kit): Intel&reg; Open Image Denoise
+# Getting Started Sample for Intel&reg; Rendering Toolkit (Render Kit): Intel&reg; Open Image Denoise
 
 
 The Intel&reg; Open Image Denoise (Intel &reg; OIDN) is an open source library of high-performance,
@@ -7,12 +7,16 @@ high-quality, denoising filters for images rendered with ray tracing. Significan
 | Minimum Requirements              | Description
 |:---                               |:---
 | OS                                | Linux* Ubuntu* 18.04, 22.04 (or compatible) <br>CentOS 8 (or compatible) <br>Windows8, 10, 11 <br>macOS 10.15+
-| Hardware                          | <ul><li>Intel 64 Penryn CPU or higher with SSE4.1 extensions</li><ul><li>Optimized requirements: Intel 64 Skylake CPU or hiigher with AVX512 extentions) </li></ul><li>ARM64 with NEON extensions</li><li>Xe-LP, Xe-HPG, or Xe-HPC architecture based Intel&reg; Graphics devices including Intel&reg; Processor Graphics, Intel&reg; Arc&trade; Graphics, and Intel&reg; Data Center Graphics</li><li>Volta, Turing, Ampere, Ada Lovelace, and Hopper architecture based NVIDIA* GPU devices</li><li>RDNA2 (Navi 21) and RDNA3 (Navi 3x) architecture based AMD* GPU devices</li></ul>
+| Hardware                          | <ul><li>Intel 64 Penryn CPU or higher with SSE4.1 extensions</li><ul><li>Optimized requirements: Intel 64 Skylake CPU or higher with AVX512 extentions) </li></ul><li>ARM64 with NEON extensions</li><li>GPUs: Xe-LP, Xe-HPG, or Xe-HPC architecture based Intel&reg; Graphics devices including Intel&reg; Processor Graphics, Intel&reg; Arc&trade; Graphics, and Intel&reg; Data Center Graphics</li><li>Volta, Turing, Ampere, Ada Lovelace, and Hopper architecture based NVIDIA* GPU devices</li><li>RDNA2 (Navi 21) and RDNA3 (Navi 3x) architecture based AMD* GPU devices</li></ul>
 | Compiler Toolchain                | Windows* OS: MSVS 2019 or higher installed with Windows* SDK and CMake*<br> Other platforms: C++11 compiler, a C99 compiler (ex: gcc/c++/clang), and CMake*
-| Libraries                         | <ul><li>Install Intel&reg; oneAPI Rendering Toolkit (Render Kit), including Intel&reg; Open Image Denoise and Intel&reg; oneTBB</li><li>Install Intel&reg; oneAPI Base Toolkit (Base Kit) for included Intel&reg; oneAPI DPC/C++ Compiler Runtimes (SYCL* library)</li></ul>
+| Libraries                         | <ul><li>Install Intel&reg; Rendering Toolkit (Render Kit), including Intel&reg; Open Image Denoise and Intel&reg; oneTBB</li><li>Install Intel&reg; oneAPI Base Toolkit (Base Kit) for included Intel&reg; oneAPI DPC/C++ Compiler Runtimes (SYCL* library)</li></ul>
+| Intel GPU Configuration                 | **System BIOS**: [Quick Start](https://www.intel.com/content/www/us/en/support/articles/000091128/graphics.html) <br> **Windows\***: [Drivers for Intel&reg; Graphics products](https://www.intel.com/content/www/us/en/support/articles/000090440/graphics.html ) <br> **Linux\***: [Install Guide](https://dgpu-docs.intel.com/installation-guides/index.html#)
 | Image Display Tool                | A `.ppm`/`.pfm` filetype viewer (for example, [ImageMagick](https://www.imagemagick.org)).
 | Image Conversion Tool             | A converter for `.ppm`, `.pfm`, and endian conversions (for example, ImageMagick).
 
+| Optional Requirement                    | Description
+|:---                                     | :---
+| Intel GPU Configuration                 | **System BIOS**: [Quick Start](https://www.intel.com/content/www/us/en/support/articles/000091128/graphics.html) <br> **Windows\***: [Drivers for Intel&reg; Graphics products](https://www.intel.com/content/www/us/en/support/articles/000090440/graphics.html ) <br> **Linux\***: [Install Guide](https://dgpu-docs.intel.com/installation-guides/index.html#)
 
 | Objective                         | Description
 |:---                               |:---

--- a/RenderingToolkit/GettingStarted/05_ispc_gsg/README.md
+++ b/RenderingToolkit/GettingStarted/05_ispc_gsg/README.md
@@ -1,4 +1,4 @@
-# Getting Started Sample for Intel&reg; oneAPI Rendering Toolkit (Render Kit): Intel&reg; Implicit SPMD Program Compiler (Intel&reg; ISPC)
+# Getting Started Sample for Intel&reg; Rendering Toolkit (Render Kit): Intel&reg; Implicit SPMD Program Compiler (Intel&reg; ISPC)
 
 The Intel&reg; Implicit SPMD Program Compiler (Intel&reg; ISPC) optimizes single
 program, multiple data kernels for execution on modern SIMD hardware. Intel&reg;
@@ -6,14 +6,14 @@ ISPC is often used with high performing Intel&reg; Embree and Intel&reg; Open
 Volume Kernel Library (Intel® Open VKL) based programs. Intel&reg; ISPC compiles
 a C programming language variant, and the language includes helpful constructs
 for modern parallelism. This sample introduces Intel&reg; ISPC within the scope
-of the Intel&reg; oneAPI Rendering Toolkit (Render Kit).
+of the Intel&reg; Rendering Toolkit (Render Kit).
 
 | Minimum Requirements              | Description
 |:---                               |:---
 | OS                                | Linux*Ubuntu* 18.04 <br>CentOS*8 (or compatible) <br> Windows* 10 <br>macOS* 10.15+
 | Hardware                          | Intel 64 Penryn or newer with SSE4.1 extensions; or an ARM64 with NEON extensions <br>(Optimized requirements: Intel 64 Skylake or newer with AVX512 extensions; or ARM64 with NEON extensions)
 | Compiler Toolchain                | Windows*OS: MSVS 2019 installed with Windows* SDK and CMake*; Other platforms: C++11 compiler and CMake*
-| Libraries                         | Install Intel&reg; oneAPI Rendering Toolkit (Render Kit), including the Intel&reg; Implicit SPMD Program Compiler
+| Libraries                         | Install Intel&reg; Rendering Toolkit (Render Kit), including the Intel&reg; Implicit SPMD Program Compiler
 
 | Objective                         | Description
 |:---                               |:---

--- a/RenderingToolkit/GettingStarted/README.md
+++ b/RenderingToolkit/GettingStarted/README.md
@@ -1,6 +1,6 @@
-# Getting Started Samples for Intel® oneAPI Rendering Toolkit (Render Kit)
+# Getting Started Samples for Intel® Rendering Toolkit (Render Kit)
 
-The Intel&reg; oneAPI Rendering Toolkit (Render Kit) is designed to accelerate
+The Intel&reg; Rendering Toolkit (Render Kit) is designed to accelerate
 photorealistic rendering workloads with rendering and ray-tracing libraries to
 create high-performance, high-fidelity visual experiences. You can get the most
 from Intel&reg; hardware by optimizing performance at any scale with these
@@ -8,7 +8,7 @@ libraries. Creators, scientists, and engineers can push the boundaries of
 visualization by using the toolkit to develop studio animation and visual
 effects or to create scientific and industrial visualizations.
 
-You can find more information at [Intel&reg; oneAPI Rendering
+You can find more information at [Intel&reg; Rendering
 Toolkit](https://software.intel.com/content/www/us/en/develop/tools/oneapi/rendering-toolkit.html).
 
 | Minimum Requirements              | Description
@@ -16,7 +16,7 @@ Toolkit](https://software.intel.com/content/www/us/en/develop/tools/oneapi/rende
 | OS                                | Linux* Ubuntu* 18.04 <BR>CentOS 8 (or compatible) <BR>Windows* 10 <BR>macOS* 10.15+
 | Hardware                          | Intel 64 Penryn or newer with SSE4.1 extensions, ARM64 with NEON extensions<br>(Optimized requirement: Intel 64 Skylake or newer with AVX512 extensions, ARM64 with NEON extensions)
 | Compiler Toolchain                | Windows OS: MSVS 2019 with Windows SDK and CMake*<BR>Other platforms: C++11 compiler, a C99 compiler (for example, gcc/c++/clang), and CMake*
-| Libraries                         | Install Intel&reg; oneAPI Rendering Toolkit, including Intel&reg; OSPRay, Intel&reg; Embree, Intel&reg; Open Volume Kernel Library (Intel&reg; Open VKL), and Intel&reg; Open Image Denoise
+| Libraries                         | Install Intel&reg; Rendering Toolkit, including Intel&reg; OSPRay, Intel&reg; Embree, Intel&reg; Open Volume Kernel Library (Intel&reg; Open VKL), and Intel&reg; Open Image Denoise
 | Image Display Tool                | A .ppm and .pfm filetype viewer (for example, [ImageMagick*](https://www.imagemagick.org)).
 | Image Conversion Tool             | A converter for .ppm, .pfm, and endian conversions (for example, ImageMagick).
 
@@ -31,11 +31,11 @@ Toolkit](https://software.intel.com/content/www/us/en/develop/tools/oneapi/rende
 The getting started samples demonstrate an ordered source code introduction to
 the functionality of Render Kit libraries. These samples supplement the Get
 Started Guides:
-- [Get Started with the Intel&reg; oneAPI Rendering Toolkit for
+- [Get Started with the Intel&reg; Rendering Toolkit for
   Windows](https://www.intel.com/content/www/us/en/develop/documentation/get-started-with-intel-oneapi-render-windows/top.html)
-- [Get Started with the Intel&reg; oneAPI Rendering Toolkit for
+- [Get Started with the Intel&reg; Rendering Toolkit for
   Linux](https://www.intel.com/content/www/us/en/develop/documentation/get-started-with-intel-oneapi-render-linux/top.html)
-- [Get Started with the Intel&reg; oneAPI Rendering Toolkit for
+- [Get Started with the Intel&reg; Rendering Toolkit for
   macOS](https://www.intel.com/content/www/us/en/develop/documentation/get-started-with-intel-oneapi-render-macos/top.html)
 
 

--- a/RenderingToolkit/Tutorial/IntroToRayTracingWithEmbree/README.md
+++ b/RenderingToolkit/Tutorial/IntroToRayTracingWithEmbree/README.md
@@ -38,7 +38,7 @@ rendering API at a higher layer, perhaps at an _engine_ layer. Such developers
 should consider examining the Intel&reg; OSPRay API and library, which implements
 rendering facilities on top of Embree.
 
-You can find more information by visiting [Intel&reg; oneAPI Rendering
+You can find more information by visiting [Intel&reg; Rendering
 Toolkit](https://software.intel.com/content/www/us/en/develop/tools/oneapi/rendering-toolkit.html).
 
 ## License

--- a/RenderingToolkit/Tutorial/IntroToRayTracingWithEmbree/cpu/README.md
+++ b/RenderingToolkit/Tutorial/IntroToRayTracingWithEmbree/cpu/README.md
@@ -865,7 +865,7 @@ rendering API at a higher layer, perhaps at an _engine_ layer. Such developers
 should consider examining the Intel OSPRay API and library, which implements
 rendering facilities on top of Embree.
 
-You can find more information by visiting [Intel&reg; oneAPI Rendering
+You can find more information by visiting [Intel&reg; Rendering
 Toolkit](https://software.intel.com/content/www/us/en/develop/tools/oneapi/rendering-toolkit.html).
 
 ## License

--- a/RenderingToolkit/Tutorial/IntroToRayTracingWithEmbree/gpu/README.md
+++ b/RenderingToolkit/Tutorial/IntroToRayTracingWithEmbree/gpu/README.md
@@ -20,11 +20,12 @@ output](example_images/rkRayTracerGPU.png)
 | Minimum Requirements              | Description
 |:---                               |:---
 | OS                                | Linux* Ubuntu* 22.04 <br>CentOS* 8 (or compatible) <br>Windows* 10 or 11<br>macOS* 10.15+
-| Hardware                          | Intel&reg; Arc Graphics (Xe-HPG architecture, DG2-128, DG2-512) or higher
+| Hardware                          | Intel&reg; Arc&trade; GPU (DG2-128, DG2-512) or higher, compatible with Intel Xe-HPG or Intel Xe-HPC architectures
 | Libraries                         | Install Intel&reg; Rendering Toolkit (Render Kit) including Intel&reg; Embree, and Intel® oneAPI Threading Building Blocks (oneTBB) <br>Install Intel&reg; oneAPI Base Toolkit for the `dev-utilities` default component and Intel&reg; oneAPI DPC++ Compiler
 | SYCL Compiler                     | oneAPI DPC++ 2024.0.0 compiler or higher
 | Compiler Toolchain                | Windows* OS: MSVS 2022 or MSVS 2019 with Windows* SDK and CMake* <br>Other platforms: C++17 compiler and CMake*
 | Tools                             | .png capable image viewer
+| Intel GPU Configuration                 | **System BIOS**: [Quick Start](https://www.intel.com/content/www/us/en/support/articles/000091128/graphics.html) <br> **Windows\***: [Drivers for Intel&reg; Graphics products](https://www.intel.com/content/www/us/en/support/articles/000090440/graphics.html ) <br> **Linux\***: [Install Guide](https://dgpu-docs.intel.com/installation-guides/index.html#)
 | Knowledge                         | First, build and run the IntroToRayTracingWithEmbree `rkRayTracer` [CPU](../cpu) sample program
 
 ## Build and Run

--- a/RenderingToolkit/Tutorial/PathTracingWithEmbree/cpu/README.md
+++ b/RenderingToolkit/Tutorial/PathTracingWithEmbree/cpu/README.md
@@ -1025,7 +1025,7 @@ We do not cover texturing in this sample. Review the Embree repository source to
 Transparent materials are omitted in this tutorial. The full Intel Embree path tracer demonstrates [transparency]( https://github.com/embree/embree/blob/v3.13.4/tutorials/pathtracer/pathtracer_device.cpp#L1630) in materials. 
 
 ## More Information
-You can find more information at the [ Intel oneAPI Rendering Toolkit portal ](https://software.intel.com/content/www/us/en/develop/tools/oneapi/rendering-toolkit.html).
+You can find more information at the [ Intel Rendering Toolkit portal ](https://software.intel.com/content/www/us/en/develop/tools/oneapi/rendering-toolkit.html).
 
 # License
 


### PR DESCRIPTION
# Existing Sample Changes
## Description

Same description as https://github.com/oneapi-src/oneAPI-samples/pull/2106

README issues only with 2024.0 updates for IRTK:
- OSPRay documentation now correctly instructs required toggles to target GPU (oops) `--osp:load-modules=gpu --osp:device=gpu`
- README review: Improved GPU configuration and expectation setting for applicable programs, req'd fixes to product names.


Fixes Issue# 
N/A

## External Dependencies

N/A

## Type of change

Please delete options that are not relevant. Add a 'X' to the one that is applicable. 

- [x] Bug fix (non-breaking change which fixes an issue)


## How Has This Been Tested?

Required toggle added to documentation. Testing preexisting in samples.json validation.  

- [ ] Command Line
- [ ] oneapi-cli
- [ ] Visual Studio
- [ ] Eclipse IDE
- [ ] VSCode
- [ ] When compiling the compliler flag "-Wall -Wformat-security -Werror=format-security" was used
