### PR TITLE
Update sample.json in vector-add to support Eclipse

### DIFF
--- a/DirectProgramming/C++SYCL/DenseLinearAlgebra/vector-add/sample.json
+++ b/DirectProgramming/C++SYCL/DenseLinearAlgebra/vector-add/sample.json
@@ -7,7 +7,7 @@
   "languages": [{"cpp": {"properties": {"projectOptions": [{"projectType": "makefile"}]}}}],
   "targetDevice": ["CPU", "GPU", "FPGA"],
   "os": ["linux", "windows"],
-  "builder": ["ide", "make"],
+  "builder": ["ide", "cmake"],
   "ciTests": {
     "linux": [
       {


### PR DESCRIPTION
# Existing Sample Changes

Modified sample.json in vector-add to support Eclipse IDE.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Implement fixes for ONSAM Jiras

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Command Line
- [ ] oneapi-cli
- [ ] Visual Studio
- [ ] Eclipse IDE
- [ ] VSCode
- [ ] When compiling the compliler flag "-Wall -Wformat-security -Werror=format-security" was used