### PR TITLE
FPGA: fix build type in simple-add/vector-add sample.json files

### DIFF
--- a/DirectProgramming/C++SYCL/DenseLinearAlgebra/simple-add/sample.json
+++ b/DirectProgramming/C++SYCL/DenseLinearAlgebra/simple-add/sample.json
@@ -7,7 +7,7 @@
   "languages": [{"cpp": {"properties": {"projectOptions": [{"projectType": "makefile"}]}}}],
   "targetDevice": ["CPU", "GPU", "FPGA"],
   "os": ["linux", "windows"],
-  "builder": ["ide", "make"],
+  "builder": ["ide", "cmake"],
   "ciTests": {
     "linux": [
       {

--- a/DirectProgramming/C++SYCL/DenseLinearAlgebra/vector-add/sample.json
+++ b/DirectProgramming/C++SYCL/DenseLinearAlgebra/vector-add/sample.json
@@ -7,7 +7,7 @@
   "languages": [{"cpp": {"properties": {"projectOptions": [{"projectType": "makefile"}]}}}],
   "targetDevice": ["CPU", "GPU", "FPGA"],
   "os": ["linux", "windows"],
-  "builder": ["ide", "make"],
+  "builder": ["ide", "cmake"],
   "ciTests": {
     "linux": [
       {


### PR DESCRIPTION
These two samples were not working using the Eclipse plugin because the incorrect build type was specified in their `sample.json` files. 