### PR TITLE
Changed subgroup size from 8 to 16 in Publications/GPU-Opt-Guide/exec-model/vaddsync.cpp

### DIFF
--- a/Publications/GPU-Opt-Guide/exec-model/vaddsync.cpp
+++ b/Publications/GPU-Opt-Guide/exec-model/vaddsync.cpp
@@ -118,7 +118,7 @@ int main() {
 
   // check results
   Initialize(sum);
-  VectorAdd3<6, 320, 32>(q, a, b, sum, 1);
+  VectorAdd3<6, 320, 16>(q, a, b, sum, 1);
 
   for (int i = 0; i < mysize; i++)
     if (sum[i] != 2 * i) {
@@ -126,7 +126,7 @@ int main() {
     }
 
   Initialize(sum);
-  VectorAdd4<6, 320, 32>(q, a, b, sum, 1);
+  VectorAdd4<6, 320, 16>(q, a, b, sum, 1);
   for (int i = 0; i < mysize; i++)
     if (sum[i] != 2 * i) {
       std::cout << "add4 Did not match\n";
@@ -134,16 +134,16 @@ int main() {
 
   // group1
   Initialize(sum);
-  VectorAdd3<8, 320, 32>(q, a, b, sum, 10000);
+  VectorAdd3<8, 320, 16>(q, a, b, sum, 10000);
   Initialize(sum);
-  VectorAdd4<8, 320, 32>(q, a, b, sum, 10000);
+  VectorAdd4<8, 320, 16>(q, a, b, sum, 10000);
   // end group1
 
   // group2
   Initialize(sum);
-  VectorAdd3<24, 224, 32>(q, a, b, sum, 10000);
+  VectorAdd3<24, 224, 16>(q, a, b, sum, 10000);
   Initialize(sum);
-  VectorAdd4<24, 224, 32>(q, a, b, sum, 10000);
+  VectorAdd4<24, 224, 16>(q, a, b, sum, 10000);
   // end group2
   return 0;
 }

--- a/Publications/GPU-Opt-Guide/exec-model/vaddsync.cpp
+++ b/Publications/GPU-Opt-Guide/exec-model/vaddsync.cpp
@@ -114,11 +114,32 @@ int main() {
 
   std::cout << "Running on device: "
             << q.get_device().get_info<sycl::info::device::name>() << "\n";
+  
+  auto sgsizes = q.get_device().get_info<sycl::info::device::sub_group_sizes>();
+
+  constexpr int sgsize = 16;
+  bool supported = false;
+  std::cout << "Sub-group sizes supported:"; 
+  for (auto sz : sgsizes) {
+    std::cout << " " << sz;
+    if (sz == sgsize) {
+      supported = true;
+    }
+  }
+  std::cout << std::endl;
+  
+  if (!supported) {
+    std::cout << "Sub-group size " << sgsize << " is not supported. Please change sgsize to one of the supported sizes"
+              << std::endl;
+    return 0;
+  }
+  
+  std::cout << "Using sub-group size " << sgsize << std::endl;
   std::cout << "Vector size: " << a.size() << "\n";
 
   // check results
   Initialize(sum);
-  VectorAdd3<6, 320, 16>(q, a, b, sum, 1);
+  VectorAdd3<6, 320, sgsize>(q, a, b, sum, 1);
 
   for (int i = 0; i < mysize; i++)
     if (sum[i] != 2 * i) {
@@ -126,7 +147,7 @@ int main() {
     }
 
   Initialize(sum);
-  VectorAdd4<6, 320, 16>(q, a, b, sum, 1);
+  VectorAdd4<6, 320, sgsize>(q, a, b, sum, 1);
   for (int i = 0; i < mysize; i++)
     if (sum[i] != 2 * i) {
       std::cout << "add4 Did not match\n";
@@ -134,16 +155,16 @@ int main() {
 
   // group1
   Initialize(sum);
-  VectorAdd3<8, 320, 16>(q, a, b, sum, 10000);
+  VectorAdd3<8, 320, sgsize>(q, a, b, sum, 10000);
   Initialize(sum);
-  VectorAdd4<8, 320, 16>(q, a, b, sum, 10000);
+  VectorAdd4<8, 320, sgsize>(q, a, b, sum, 10000);
   // end group1
 
   // group2
   Initialize(sum);
-  VectorAdd3<24, 224, 16>(q, a, b, sum, 10000);
+  VectorAdd3<24, 224, sgsize>(q, a, b, sum, 10000);
   Initialize(sum);
-  VectorAdd4<24, 224, 16>(q, a, b, sum, 10000);
+  VectorAdd4<24, 224, sgsize>(q, a, b, sum, 10000);
   // end group2
   return 0;
 }

--- a/Publications/GPU-Opt-Guide/exec-model/vaddsync.cpp
+++ b/Publications/GPU-Opt-Guide/exec-model/vaddsync.cpp
@@ -118,7 +118,7 @@ int main() {
 
   // check results
   Initialize(sum);
-  VectorAdd3<6, 320, 8>(q, a, b, sum, 1);
+  VectorAdd3<6, 320, 32>(q, a, b, sum, 1);
 
   for (int i = 0; i < mysize; i++)
     if (sum[i] != 2 * i) {
@@ -126,7 +126,7 @@ int main() {
     }
 
   Initialize(sum);
-  VectorAdd4<6, 320, 8>(q, a, b, sum, 1);
+  VectorAdd4<6, 320, 32>(q, a, b, sum, 1);
   for (int i = 0; i < mysize; i++)
     if (sum[i] != 2 * i) {
       std::cout << "add4 Did not match\n";
@@ -134,16 +134,16 @@ int main() {
 
   // group1
   Initialize(sum);
-  VectorAdd3<8, 320, 8>(q, a, b, sum, 10000);
+  VectorAdd3<8, 320, 32>(q, a, b, sum, 10000);
   Initialize(sum);
-  VectorAdd4<8, 320, 8>(q, a, b, sum, 10000);
+  VectorAdd4<8, 320, 32>(q, a, b, sum, 10000);
   // end group1
 
   // group2
   Initialize(sum);
-  VectorAdd3<24, 224, 8>(q, a, b, sum, 10000);
+  VectorAdd3<24, 224, 32>(q, a, b, sum, 10000);
   Initialize(sum);
-  VectorAdd4<24, 224, 8>(q, a, b, sum, 10000);
+  VectorAdd4<24, 224, 32>(q, a, b, sum, 10000);
   // end group2
   return 0;
 }


### PR DESCRIPTION
# Existing Sample Changes

Publications/GPU-Opt-Guide/exec-model/vaddsync.cpp

## Description

Changed subgroup size from 8 to 16

Fixes Issue# 

$ ./exec-model/vaddsync 
Running on device: Intel(R) Data Center GPU Max 1100
Vector size: 27525120
terminate called after throwing an instance of 'sycl::_V1::exception'
  what():  Sub-group size 8 is not supported on the device
Aborted (core dumped)

## External Dependencies

None

## Type of change

Please delete options that are not relevant. Add a 'X' to the one that is applicable. 

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X ] Implement fixes for ONSAM Jiras

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ X] Command Line
- [ ] oneapi-cli
- [ ] Visual Studio
- [ ] Eclipse IDE
- [ ] VSCode
- [ ] When compiling the compliler flag "-Wall -Wformat-security -Werror=format-security" was used

