### PR TITLE
Add default input values for stream-triad-modified-*.cpp and spec-const3.cpp

### DIFF
--- a/Publications/GPU-Opt-Guide/exec-model/vaddsync.cpp
+++ b/Publications/GPU-Opt-Guide/exec-model/vaddsync.cpp
@@ -118,7 +118,7 @@ int main() {
 
   // check results
   Initialize(sum);
-  VectorAdd3<6, 320, 32>(q, a, b, sum, 1);
+  VectorAdd3<6, 320, 16>(q, a, b, sum, 1);
 
   for (int i = 0; i < mysize; i++)
     if (sum[i] != 2 * i) {
@@ -126,7 +126,7 @@ int main() {
     }
 
   Initialize(sum);
-  VectorAdd4<6, 320, 32>(q, a, b, sum, 1);
+  VectorAdd4<6, 320, 16>(q, a, b, sum, 1);
   for (int i = 0; i < mysize; i++)
     if (sum[i] != 2 * i) {
       std::cout << "add4 Did not match\n";
@@ -134,16 +134,16 @@ int main() {
 
   // group1
   Initialize(sum);
-  VectorAdd3<8, 320, 32>(q, a, b, sum, 10000);
+  VectorAdd3<8, 320, 16>(q, a, b, sum, 10000);
   Initialize(sum);
-  VectorAdd4<8, 320, 32>(q, a, b, sum, 10000);
+  VectorAdd4<8, 320, 16>(q, a, b, sum, 10000);
   // end group1
 
   // group2
   Initialize(sum);
-  VectorAdd3<24, 224, 32>(q, a, b, sum, 10000);
+  VectorAdd3<24, 224, 16>(q, a, b, sum, 10000);
   Initialize(sum);
-  VectorAdd4<24, 224, 32>(q, a, b, sum, 10000);
+  VectorAdd4<24, 224, 16>(q, a, b, sum, 10000);
   // end group2
   return 0;
 }

--- a/Publications/GPU-Opt-Guide/exec-model/vaddsync.cpp
+++ b/Publications/GPU-Opt-Guide/exec-model/vaddsync.cpp
@@ -114,11 +114,32 @@ int main() {
 
   std::cout << "Running on device: "
             << q.get_device().get_info<sycl::info::device::name>() << "\n";
+  
+  auto sgsizes = q.get_device().get_info<sycl::info::device::sub_group_sizes>();
+
+  constexpr int sgsize = 16;
+  bool supported = false;
+  std::cout << "Sub-group sizes supported:"; 
+  for (auto sz : sgsizes) {
+    std::cout << " " << sz;
+    if (sz == sgsize) {
+      supported = true;
+    }
+  }
+  std::cout << std::endl;
+  
+  if (!supported) {
+    std::cout << "Sub-group size " << sgsize << " is not supported. Please change sgsize to one of the supported sizes"
+              << std::endl;
+    return 0;
+  }
+  
+  std::cout << "Using sub-group size " << sgsize << std::endl;
   std::cout << "Vector size: " << a.size() << "\n";
 
   // check results
   Initialize(sum);
-  VectorAdd3<6, 320, 16>(q, a, b, sum, 1);
+  VectorAdd3<6, 320, sgsize>(q, a, b, sum, 1);
 
   for (int i = 0; i < mysize; i++)
     if (sum[i] != 2 * i) {
@@ -126,7 +147,7 @@ int main() {
     }
 
   Initialize(sum);
-  VectorAdd4<6, 320, 16>(q, a, b, sum, 1);
+  VectorAdd4<6, 320, sgsize>(q, a, b, sum, 1);
   for (int i = 0; i < mysize; i++)
     if (sum[i] != 2 * i) {
       std::cout << "add4 Did not match\n";
@@ -134,16 +155,16 @@ int main() {
 
   // group1
   Initialize(sum);
-  VectorAdd3<8, 320, 16>(q, a, b, sum, 10000);
+  VectorAdd3<8, 320, sgsize>(q, a, b, sum, 10000);
   Initialize(sum);
-  VectorAdd4<8, 320, 16>(q, a, b, sum, 10000);
+  VectorAdd4<8, 320, sgsize>(q, a, b, sum, 10000);
   // end group1
 
   // group2
   Initialize(sum);
-  VectorAdd3<24, 224, 16>(q, a, b, sum, 10000);
+  VectorAdd3<24, 224, sgsize>(q, a, b, sum, 10000);
   Initialize(sum);
-  VectorAdd4<24, 224, 16>(q, a, b, sum, 10000);
+  VectorAdd4<24, 224, sgsize>(q, a, b, sum, 10000);
   // end group2
   return 0;
 }

--- a/Publications/GPU-Opt-Guide/exec-model/vaddsync.cpp
+++ b/Publications/GPU-Opt-Guide/exec-model/vaddsync.cpp
@@ -118,7 +118,7 @@ int main() {
 
   // check results
   Initialize(sum);
-  VectorAdd3<6, 320, 8>(q, a, b, sum, 1);
+  VectorAdd3<6, 320, 32>(q, a, b, sum, 1);
 
   for (int i = 0; i < mysize; i++)
     if (sum[i] != 2 * i) {
@@ -126,7 +126,7 @@ int main() {
     }
 
   Initialize(sum);
-  VectorAdd4<6, 320, 8>(q, a, b, sum, 1);
+  VectorAdd4<6, 320, 32>(q, a, b, sum, 1);
   for (int i = 0; i < mysize; i++)
     if (sum[i] != 2 * i) {
       std::cout << "add4 Did not match\n";
@@ -134,16 +134,16 @@ int main() {
 
   // group1
   Initialize(sum);
-  VectorAdd3<8, 320, 8>(q, a, b, sum, 10000);
+  VectorAdd3<8, 320, 32>(q, a, b, sum, 10000);
   Initialize(sum);
-  VectorAdd4<8, 320, 8>(q, a, b, sum, 10000);
+  VectorAdd4<8, 320, 32>(q, a, b, sum, 10000);
   // end group1
 
   // group2
   Initialize(sum);
-  VectorAdd3<24, 224, 8>(q, a, b, sum, 10000);
+  VectorAdd3<24, 224, 32>(q, a, b, sum, 10000);
   Initialize(sum);
-  VectorAdd4<24, 224, 8>(q, a, b, sum, 10000);
+  VectorAdd4<24, 224, 32>(q, a, b, sum, 10000);
   // end group2
   return 0;
 }

--- a/Publications/GPU-Opt-Guide/jitting/spec-const3.cpp
+++ b/Publications/GPU-Opt-Guide/jitting/spec-const3.cpp
@@ -11,7 +11,7 @@ class SpecializedKernel;
 // Identify the specialization constant.
 constexpr sycl::specialization_id<int> nx_sc;
 
-int main() {
+int main(int argc, char *argv[]) {
   sycl::queue queue;
 
   std::cout << "Running on "
@@ -23,8 +23,13 @@ int main() {
 
     // Application execution stops here asking for input from user
     int Nx;
-    std::cout << "Enter input number ..." << std::endl;
-    std::cin >> Nx;
+    if (argc > 1) {
+      Nx = std::stoi(argv[1]);
+    } else {
+      Nx = 1024;
+    }
+
+    std::cout << "Nx = " << Nx << std::endl;
 
     queue.submit([&](sycl::handler &h) {
       sycl::accessor acc(buf, h, sycl::write_only, sycl::no_init);

--- a/Publications/GPU-Opt-Guide/jitting/stream-triad-modified-constant.cpp
+++ b/Publications/GPU-Opt-Guide/jitting/stream-triad-modified-constant.cpp
@@ -105,9 +105,8 @@ int main(int argc, char *argv[]) {
     array_size = std::stoi(argv[1]);
     inner_loop_size = std::stoi(argv[2]);
   } else {
-    std::cout
-        << "Run as ./<progname> <arraysize in elements> <inner loop size>\n";
-    return 1;
+    array_size = 134217728;
+    inner_loop_size = 10;
   }
   std::cout << "Running with stream size of " << array_size << " elements ("
             << (array_size * sizeof(double)) / (double)1024 / 1024 << "MB)\n";

--- a/Publications/GPU-Opt-Guide/jitting/stream-triad-modified-runtime-var.cpp
+++ b/Publications/GPU-Opt-Guide/jitting/stream-triad-modified-runtime-var.cpp
@@ -105,9 +105,8 @@ int main(int argc, char *argv[]) {
     array_size = std::stoi(argv[1]);
     inner_loop_size = std::stoi(argv[2]);
   } else {
-    std::cout
-        << "Run as ./<progname> <arraysize in elements> <inner loop size>\n";
-    return 1;
+    array_size = 134217728;
+    inner_loop_size = 10;
   }
   std::cout << "Running with stream size of " << array_size << " elements ("
             << (array_size * sizeof(double)) / (double)1024 / 1024 << "MB)\n";

--- a/Publications/GPU-Opt-Guide/jitting/stream-triad-modified-spec-const.cpp
+++ b/Publications/GPU-Opt-Guide/jitting/stream-triad-modified-spec-const.cpp
@@ -110,9 +110,8 @@ int main(int argc, char *argv[]) {
     array_size = std::stoi(argv[1]);
     inner_loop_size = std::stoi(argv[2]);
   } else {
-    std::cout
-        << "Run as ./<progname> <arraysize in elements> <inner loop size>\n";
-    return 1;
+    array_size = 134217728;
+    inner_loop_size = 10;
   }
   std::cout << "Running with stream size of " << array_size << " elements ("
             << (array_size * sizeof(double)) / (double)1024 / 1024 << "MB)\n";


### PR DESCRIPTION
# Existing Sample Changes

## Description

Add default input values for stream-triad-modified-*.cpp and spec-const3.cpp so they don't need to take user interaction for inputs by default if no arguments are specified

Fixes Issue# 
CMPLRTST-23361

## External Dependencies

None

## Type of change

Please delete options that are not relevant. Add a 'X' to the one that is applicable. 

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Implement fixes for ONSAM Jiras

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x ] Command Line
- [ ] oneapi-cli
- [ ] Visual Studio
- [ ] Eclipse IDE
- [ ] VSCode
- [ ] When compiling the compliler flag "-Wall -Wformat-security -Werror=format-security" was used