### PR TITLE
Added OpenMP target dummy region to DO CONCURRENT example

### DIFF
--- a/DirectProgramming/Fortran/EdgeDetection/sobel-edge-detection/sobel_do_concurrent.F90
+++ b/DirectProgramming/Fortran/EdgeDetection/sobel-edge-detection/sobel_do_concurrent.F90
@@ -58,6 +58,10 @@ program sobel_do_conc
     gv     = reshape([-1, -2, -1,  0,  0,  0,  1,  2,  1], [3, 3])
     smooth = reshape([ 1,  2,  1,  2,  4,  2,  1,  2,  1], [3, 3])
 
+    ! Dummy target region to avoid measuring startup time
+    !$omp target
+    !$omp end target
+
     call system_clock(start_time)   ! Start timer
 
     do concurrent (c = 2:img_width - 1, r = 2:img_height - 1)


### PR DESCRIPTION
# Existing Sample Changes
## Description

I added a dummy target region to the Fortran DO CONCURRENT example, as per our OpenMP offload best practices recommendations at https://www.intel.com/content/www/us/en/docs/oneapi/optimization-guide-gpu/2024-0/openmp-offload-best-practices.html.

Fixes Issue# 

## External Dependencies

None

## Type of change

- [X] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- [X] Command Line
