### PR TITLE
ignore unused label warning

### DIFF
--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/max_interleaving/CMakeLists.txt
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/max_interleaving/CMakeLists.txt
@@ -39,7 +39,7 @@ endif()
 set(USER_FPGA_FLAGS ${USER_FPGA_FLAGS})
 
 # Use cmake -DUSER_FLAGS=<flags> to set extra flags for general compilation.
-set(USER_FLAGS ${USER_FLAGS})
+set(USER_FLAGS -Wno-unused-label;${USER_FLAGS})
 
 # Use cmake -DUSER_INCLUDE_PATHS=<paths> to set extra paths for general
 # compilation.
@@ -113,7 +113,7 @@ else()
     set(SEED_FLAG "-Xsseed=${SEED}")
 endif()
 
-set(COMMON_COMPILE_FLAGS -fsycl -fintelfpga -Wall -Wno-unused-label ${WIN_FLAG} ${DEBUG_FLAGS} ${QACTYPES} ${USER_FLAGS})
+set(COMMON_COMPILE_FLAGS -fsycl -fintelfpga -Wall ${WIN_FLAG} ${DEBUG_FLAGS} ${QACTYPES} ${USER_FLAGS})
 set(COMMON_LINK_FLAGS -fsycl -fintelfpga ${QACTYPES} ${USER_FLAGS})
 
 # A SYCL ahead-of-time (AoT) compile processes the device code in two stages.

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/max_interleaving/CMakeLists.txt
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/max_interleaving/CMakeLists.txt
@@ -39,6 +39,8 @@ endif()
 set(USER_FPGA_FLAGS ${USER_FPGA_FLAGS})
 
 # Use cmake -DUSER_FLAGS=<flags> to set extra flags for general compilation.
+# This design uses loop labels in the source code to improve report readability, 
+# so add -Wno-unused-label to disable warnings about unused labels. 
 set(USER_FLAGS -Wno-unused-label;${USER_FLAGS})
 
 # Use cmake -DUSER_INCLUDE_PATHS=<paths> to set extra paths for general

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/max_interleaving/CMakeLists.txt
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/max_interleaving/CMakeLists.txt
@@ -113,7 +113,7 @@ else()
     set(SEED_FLAG "-Xsseed=${SEED}")
 endif()
 
-set(COMMON_COMPILE_FLAGS -fsycl -fintelfpga -Wall ${WIN_FLAG} ${DEBUG_FLAGS} ${QACTYPES} ${USER_FLAGS})
+set(COMMON_COMPILE_FLAGS -fsycl -fintelfpga -Wall -Wno-unused-label ${WIN_FLAG} ${DEBUG_FLAGS} ${QACTYPES} ${USER_FLAGS})
 set(COMMON_LINK_FLAGS -fsycl -fintelfpga ${QACTYPES} ${USER_FLAGS})
 
 # A SYCL ahead-of-time (AoT) compile processes the device code in two stages.


### PR DESCRIPTION
# Existing Sample Changes
## Description

Add -Wno-unused-label to the compile flags. The unused label in the source code is part of the FPGA loop label feature, and will be used in the FPGA report. 

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [X] Command Line
- [ ] oneapi-cli
- [ ] Visual Studio
- [ ] Eclipse IDE
- [ ] VSCode
- [ ] When compiling the compliler flag "-Wall -Wformat-security -Werror=format-security" was used