### PR TITLE
Fix ONSAM-1677 due to incorrect path in sample.json files

### DIFF
--- a/Publications/GPU-Opt-Guide/MPI/01_omp_mpich/sample.json
+++ b/Publications/GPU-Opt-Guide/MPI/01_omp_mpich/sample.json
@@ -30,9 +30,9 @@
     "linux": [
       {
         "steps": [
-          "rm -rf ../build || true",
-          "mkdir ../build",
-          "cd ../build",
+          "rm -rf ../../build || true",
+          "mkdir ../../build",
+          "cd ../../build",
           "cmake ..",
           "make omp_mpich",
           "make clean"

--- a/Publications/GPU-Opt-Guide/OpenMP/00_omp_thread_num/sample.json
+++ b/Publications/GPU-Opt-Guide/OpenMP/00_omp_thread_num/sample.json
@@ -30,9 +30,9 @@
     "linux": [
       {
         "steps": [
-          "rm -rf ../build || true",
-          "mkdir ../build",
-          "cd ../build",
+          "rm -rf ../../build || true",
+          "mkdir ../../build",
+          "cd ../../build",
           "cmake ..",
           "make test_omp_thread_num_1 test_omp_thread_num_2 test_omp_thread_num_3",
           "make clean"

--- a/Publications/GPU-Opt-Guide/OpenMP/01_collapse/sample.json
+++ b/Publications/GPU-Opt-Guide/OpenMP/01_collapse/sample.json
@@ -30,9 +30,9 @@
     "linux": [
       {
         "steps": [
-          "rm -rf ../build || true",
-          "mkdir ../build",
-          "cd ../build",
+          "rm -rf ../../build || true",
+          "mkdir ../../build",
+          "cd ../../build",
           "cmake ..",
           "make test_collapse_2levels test_collapse_3levels test_collapse_4levels test_no_collapse",
           "make clean"

--- a/Publications/GPU-Opt-Guide/OpenMP/02_teams_distribute/sample.json
+++ b/Publications/GPU-Opt-Guide/OpenMP/02_teams_distribute/sample.json
@@ -30,9 +30,9 @@
     "linux": [
       {
         "steps": [
-          "rm -rf ../build || true",
-          "mkdir ../build",
-          "cd ../build",
+          "rm -rf ../../build || true",
+          "mkdir ../../build",
+          "cd ../../build",
           "cmake ..",
           "make test_no_teams_distribute test_teams_distribute",
           "make clean"

--- a/Publications/GPU-Opt-Guide/OpenMP/03_target_enter_exit_data/sample.json
+++ b/Publications/GPU-Opt-Guide/OpenMP/03_target_enter_exit_data/sample.json
@@ -30,9 +30,9 @@
     "linux": [
       {
         "steps": [
-          "rm -rf ../build || true",
-          "mkdir ../build",
-          "cd ../build",
+          "rm -rf ../../build || true",
+          "mkdir ../../build",
+          "cd ../../build",
           "cmake ..",
           "make test_no_target_enter_exit_data test_target_enter_exit_data",
           "make clean"

--- a/Publications/GPU-Opt-Guide/OpenMP/04_target_nowait/sample.json
+++ b/Publications/GPU-Opt-Guide/OpenMP/04_target_nowait/sample.json
@@ -30,9 +30,9 @@
     "linux": [
       {
         "steps": [
-          "rm -rf ../build || true",
-          "mkdir ../build",
-          "cd ../build",
+          "rm -rf ../../build || true",
+          "mkdir ../../build",
+          "cd ../../build",
           "cmake ..",
           "make  test_target_no_nowait test_target_nowait test_target_nowait_f",
           "make clean"

--- a/Publications/GPU-Opt-Guide/OpenMP/05_scalars_fp/sample.json
+++ b/Publications/GPU-Opt-Guide/OpenMP/05_scalars_fp/sample.json
@@ -30,9 +30,9 @@
     "linux": [
       {
         "steps": [
-          "rm -rf ../build || true",
-          "mkdir ../build",
-          "cd ../build",
+          "rm -rf ../../build || true",
+          "mkdir ../../build",
+          "cd ../../build",
           "cmake ..",
           "make test_scalars_fp test_scalars_map test_scalars_nofp_nomap",
           "make clean"

--- a/Publications/GPU-Opt-Guide/OpenMP/06_scalars_private/sample.json
+++ b/Publications/GPU-Opt-Guide/OpenMP/06_scalars_private/sample.json
@@ -30,9 +30,9 @@
     "linux": [
       {
         "steps": [
-          "rm -rf ../build || true",
-          "mkdir ../build",
-          "cd ../build",
+          "rm -rf ../../build || true",
+          "mkdir ../../build",
+          "cd ../../build",
           "cmake ..",
           "make test_scalars test_scalars_private_2 test_scalars_private",
           "make clean"

--- a/Publications/GPU-Opt-Guide/OpenMP/07_loop_bounds/sample.json
+++ b/Publications/GPU-Opt-Guide/OpenMP/07_loop_bounds/sample.json
@@ -30,9 +30,9 @@
     "linux": [
       {
         "steps": [
-          "rm -rf ../build || true",
-          "mkdir ../build",
-          "cd ../build",
+          "rm -rf ../../build || true",
+          "mkdir ../../build",
+          "cd ../../build",
           "cmake ..",
           "make test_loop_bounds_fp test_loop_bounds_map test_loop_bounds_nofp_nomap",
           "make clean"

--- a/Publications/GPU-Opt-Guide/OpenMP/08_num_teams/sample.json
+++ b/Publications/GPU-Opt-Guide/OpenMP/08_num_teams/sample.json
@@ -30,9 +30,9 @@
     "linux": [
       {
         "steps": [
-          "rm -rf ../build || true",
-          "mkdir ../build",
-          "cd ../build",
+          "rm -rf ../../build || true",
+          "mkdir ../../build",
+          "cd ../../build",
           "cmake ..",
           "make test_no_num_teams test_num_teams",
           "make clean"

--- a/Publications/GPU-Opt-Guide/OpenMP/09_invariant_computations/sample.json
+++ b/Publications/GPU-Opt-Guide/OpenMP/09_invariant_computations/sample.json
@@ -30,9 +30,9 @@
     "linux": [
       {
         "steps": [
-          "rm -rf ../build || true",
-          "mkdir ../build",
-          "cd ../build",
+          "rm -rf ../../build || true",
+          "mkdir ../../build",
+          "cd ../../build",
           "cmake ..",
           "make test_loop_invariant test_no_loop_invariant",
           "make clean"

--- a/Publications/GPU-Opt-Guide/OpenMP/10_map/sample.json
+++ b/Publications/GPU-Opt-Guide/OpenMP/10_map/sample.json
@@ -30,9 +30,9 @@
     "linux": [
       {
         "steps": [
-          "rm -rf ../build || true",
-          "mkdir ../build",
-          "cd ../build",
+          "rm -rf ../../build || true",
+          "mkdir ../../build",
+          "cd ../../build",
           "cmake ..",
           "make test_map_tofrom test_map_to_or_from",
           "make clean"

--- a/Publications/GPU-Opt-Guide/OpenMP/11_device_alloc/sample.json
+++ b/Publications/GPU-Opt-Guide/OpenMP/11_device_alloc/sample.json
@@ -30,9 +30,9 @@
     "linux": [
       {
         "steps": [
-          "rm -rf ../build || true",
-          "mkdir ../build",
-          "cd ../build",
+          "rm -rf ../../build || true",
+          "mkdir ../../build",
+          "cd ../../build",
           "cmake ..",
           "make test_declare_target test_map_alloc test_map_to test_target_alloc",
           "make clean"

--- a/Publications/GPU-Opt-Guide/OpenMP/21_omp_target_alloc/sample.json
+++ b/Publications/GPU-Opt-Guide/OpenMP/21_omp_target_alloc/sample.json
@@ -30,9 +30,9 @@
     "linux": [
       {
         "steps": [
-          "rm -rf ../build || true",
-          "mkdir ../build",
-          "cd ../build",
+          "rm -rf ../../build || true",
+          "mkdir ../../build",
+          "cd ../../build",
           "cmake ..",
           "make test_omp_target_alloc test_omp_target_alloc_device test_omp_target_alloc_host test_omp_target_alloc_shared test_omp_target_memcpy test_target_map test_target_map2",
           "make test_omp_target_alloc_device_f test_omp_target_alloc_host_f test_omp_target_alloc_shared_f test_target_map_f test_target_map2_f",

--- a/Publications/GPU-Opt-Guide/OpenMP/22_mkl_dispatch/sample.json
+++ b/Publications/GPU-Opt-Guide/OpenMP/22_mkl_dispatch/sample.json
@@ -30,9 +30,9 @@
     "linux": [
       {
         "steps": [
-          "rm -rf ../build || true",
-          "mkdir ../build",
-          "cd ../build",
+          "rm -rf ../../build || true",
+          "mkdir ../../build",
+          "cd ../../build",
           "cmake ..",
           "make dgemm_target_variant_dispatch_c dgemm_dispatch_c dgemm_example_01 dgemm_example_02 dgemm_example_03 dgemm_batch_example_01 dgemm_batch_example_02 dgemm_dispatch_f",
           "make clean"

--- a/Publications/GPU-Opt-Guide/OpenMP/22_mkl_pad/sample.json
+++ b/Publications/GPU-Opt-Guide/OpenMP/22_mkl_pad/sample.json
@@ -30,9 +30,9 @@
     "linux": [
       {
         "steps": [
-          "rm -rf ../build || true",
-          "mkdir ../build",
-          "cd ../build",
+          "rm -rf ../../build || true",
+          "mkdir ../../build",
+          "cd ../../build",
           "cmake ..",
           "make dgemm_pad_c_01 dgemm_pad_f_01",
           "make clean"

--- a/Publications/GPU-Opt-Guide/OpenMP/23_omp_work_group/sample.json
+++ b/Publications/GPU-Opt-Guide/OpenMP/23_omp_work_group/sample.json
@@ -30,9 +30,9 @@
     "linux": [
       {
         "steps": [
-          "rm -rf ../build || true",
-          "mkdir ../build",
-          "cd ../build",
+          "rm -rf ../../build || true",
+          "mkdir ../../build",
+          "cd ../../build",
           "cmake ..",
           "make test_omp_work_group",
           "make clean"

--- a/Publications/GPU-Opt-Guide/OpenMP/24_device_ptr_addr_clauses/sample.json
+++ b/Publications/GPU-Opt-Guide/OpenMP/24_device_ptr_addr_clauses/sample.json
@@ -30,9 +30,9 @@
     "linux": [
       {
         "steps": [
-          "rm -rf ../build || true",
-          "mkdir ../build",
-          "cd ../build",
+          "rm -rf ../../build || true",
+          "mkdir ../../build",
+          "cd ../../build",
           "cmake ..",
           "make c_is_device_ptr_01 c_use_device_ptr_01 f_has_device_addr_01 f_use_device_addr_01",
           "make clean"

--- a/Publications/GPU-Opt-Guide/OpenMP/25_NWChem_based_example_1/sample.json
+++ b/Publications/GPU-Opt-Guide/OpenMP/25_NWChem_based_example_1/sample.json
@@ -30,9 +30,9 @@
     "linux": [
       {
         "steps": [
-          "rm -rf ../build || true",
-          "mkdir ../build",
-          "cd ../build",
+          "rm -rf ../../build || true",
+          "mkdir ../../build",
+          "cd ../../build",
           "cmake ..",
           "make test-Map-UpdateTo",
           "make clean"

--- a/Publications/GPU-Opt-Guide/OpenMP/25_NWChem_based_example_2/sample.json
+++ b/Publications/GPU-Opt-Guide/OpenMP/25_NWChem_based_example_2/sample.json
@@ -30,9 +30,9 @@
     "linux": [
       {
         "steps": [
-          "rm -rf ../build || true",
-          "mkdir ../build",
-          "cd ../build",
+          "rm -rf ../../build || true",
+          "mkdir ../../build",
+          "cd ../../build",
           "cmake ..",
           "make ",
           "make clean"

--- a/Publications/GPU-Opt-Guide/OpenMP/25_NWChem_based_example_3/sample.json
+++ b/Publications/GPU-Opt-Guide/OpenMP/25_NWChem_based_example_3/sample.json
@@ -30,9 +30,9 @@
     "linux": [
       {
         "steps": [
-          "rm -rf ../build || true",
-          "mkdir ../build",
-          "cd ../build",
+          "rm -rf ../../build || true",
+          "mkdir ../../build",
+          "cd ../../build",
           "cmake ..",
           "make test-HostMem-DeviceMem-Map-UpdateTo",
           "make clean"

--- a/Publications/GPU-Opt-Guide/OpenMP/26_omp_prefetch/c/sample.json
+++ b/Publications/GPU-Opt-Guide/OpenMP/26_omp_prefetch/c/sample.json
@@ -30,9 +30,9 @@
     "linux": [
       {
         "steps": [
-          "rm -rf ../build || true",
-          "mkdir ../build",
-          "cd ../build",
+          "rm -rf ../../../build || true",
+          "mkdir ../../../build",
+          "cd ../../../build",
           "cmake ..",
           "make nbody_c",
           "make clean"

--- a/Publications/GPU-Opt-Guide/OpenMP/26_omp_prefetch/c_simd/sample.json
+++ b/Publications/GPU-Opt-Guide/OpenMP/26_omp_prefetch/c_simd/sample.json
@@ -30,9 +30,9 @@
     "linux": [
       {
         "steps": [
-          "rm -rf ../build || true",
-          "mkdir ../build",
-          "cd ../build",
+          "rm -rf ../../../build || true",
+          "mkdir ../../../build",
+          "cd ../../../build",
           "cmake ..",
           "make nbody_c_simd",
           "make clean"

--- a/Publications/GPU-Opt-Guide/OpenMP/26_omp_prefetch/fortran/sample.json
+++ b/Publications/GPU-Opt-Guide/OpenMP/26_omp_prefetch/fortran/sample.json
@@ -30,9 +30,9 @@
     "linux": [
       {
         "steps": [
-          "rm -rf ../build || true",
-          "mkdir ../build",
-          "cd ../build",
+          "rm -rf ../../../build || true",
+          "mkdir ../../../build",
+          "cd ../../../build",
           "cmake ..",
           "make nbody_f",
           "make clean"

--- a/Publications/GPU-Opt-Guide/explicit-scaling/01_memory_order/sample.json
+++ b/Publications/GPU-Opt-Guide/explicit-scaling/01_memory_order/sample.json
@@ -30,9 +30,9 @@
     "linux": [
       {
         "steps": [
-          "rm -rf ../build || true",
-          "mkdir ../build",
-          "cd ../build",
+          "rm -rf ../../build || true",
+          "mkdir ../../build",
+          "cd ../../build",
           "cmake ..",
           "make memory_order",
           "make clean"

--- a/Publications/GPU-Opt-Guide/explicit-scaling/07_explicit_subdevice/sample.json
+++ b/Publications/GPU-Opt-Guide/explicit-scaling/07_explicit_subdevice/sample.json
@@ -30,9 +30,9 @@
     "linux": [
       {
         "steps": [
-          "rm -rf ../build || true",
-          "mkdir ../build",
-          "cd ../build",
+          "rm -rf ../../build || true",
+          "mkdir ../../build",
+          "cd ../../build",
           "cmake ..",
           "make explicit_subdevice",
           "make clean"

--- a/Publications/GPU-Opt-Guide/explicit-scaling/13_openmp_explicit_subdevice/sample.json
+++ b/Publications/GPU-Opt-Guide/explicit-scaling/13_openmp_explicit_subdevice/sample.json
@@ -30,9 +30,9 @@
     "linux": [
       {
         "steps": [
-          "rm -rf ../build || true",
-          "mkdir ../build",
-          "cd ../build",
+          "rm -rf ../../build || true",
+          "mkdir ../../build",
+          "cd ../../build",
           "cmake ..",
           "make openmp_explicit_subdevice",
           "make clean"

--- a/Publications/GPU-Opt-Guide/explicit-scaling/14_explicit_subsubdevice/sample.json
+++ b/Publications/GPU-Opt-Guide/explicit-scaling/14_explicit_subsubdevice/sample.json
@@ -30,9 +30,9 @@
     "linux": [
       {
         "steps": [
-          "rm -rf ../build || true",
-          "mkdir ../build",
-          "cd ../build",
+          "rm -rf ../../build || true",
+          "mkdir ../../build",
+          "cd ../../build",
           "cmake ..",
           "make ccs",
           "make clean"

--- a/Publications/GPU-Opt-Guide/grf-mode-selection/perf/large/sample.json
+++ b/Publications/GPU-Opt-Guide/grf-mode-selection/perf/large/sample.json
@@ -30,9 +30,9 @@
     "linux": [
       {
         "steps": [
-          "rm -rf ../build || true",
-          "mkdir ../build",
-          "cd ../build",
+          "rm -rf ../../../build || true",
+          "mkdir ../../../build",
+          "cd ../../../build",
           "cmake ..",
           "make ax-static-large",
           "make clean"

--- a/Publications/GPU-Opt-Guide/grf-mode-selection/perf/small/sample.json
+++ b/Publications/GPU-Opt-Guide/grf-mode-selection/perf/small/sample.json
@@ -30,9 +30,9 @@
     "linux": [
       {
         "steps": [
-          "rm -rf ../build || true",
-          "mkdir ../build",
-          "cd ../build",
+          "rm -rf ../../../build || true",
+          "mkdir ../../../build",
+          "cd ../../../build",
           "cmake ..",
           "make ax-static-small",
           "make clean"

--- a/Publications/GPU-Opt-Guide/implicit-scaling/03_stream/sample.json
+++ b/Publications/GPU-Opt-Guide/implicit-scaling/03_stream/sample.json
@@ -30,9 +30,9 @@
     "linux": [
       {
         "steps": [
-          "rm -rf ../build || true",
-          "mkdir ../build",
-          "cd ../build",
+          "rm -rf ../../build || true",
+          "mkdir ../../build",
+          "cd ../../build",
           "cmake ..",
           "make stream",
           "make clean"

--- a/Publications/GPU-Opt-Guide/implicit-scaling/04_stream_3D/sample.json
+++ b/Publications/GPU-Opt-Guide/implicit-scaling/04_stream_3D/sample.json
@@ -30,9 +30,9 @@
     "linux": [
       {
         "steps": [
-          "rm -rf ../build || true",
-          "mkdir ../build",
-          "cd ../build",
+          "rm -rf ../../build || true",
+          "mkdir ../../build",
+          "cd ../../build",
           "cmake ..",
           "make stream_3D",
           "make clean"

--- a/Publications/GPU-Opt-Guide/implicit-scaling/05_stream_cross_stack/sample.json
+++ b/Publications/GPU-Opt-Guide/implicit-scaling/05_stream_cross_stack/sample.json
@@ -30,9 +30,9 @@
     "linux": [
       {
         "steps": [
-          "rm -rf ../build || true",
-          "mkdir ../build",
-          "cd ../build",
+          "rm -rf ../../build || true",
+          "mkdir ../../build",
+          "cd ../../build",
           "cmake ..",
           "make stream_cross_stack",
           "make clean"

--- a/Publications/GPU-Opt-Guide/implicit-scaling/05_stream_cross_tile/sample.json
+++ b/Publications/GPU-Opt-Guide/implicit-scaling/05_stream_cross_tile/sample.json
@@ -30,9 +30,9 @@
     "linux": [
       {
         "steps": [
-          "rm -rf ../build || true",
-          "mkdir ../build",
-          "cd ../build",
+          "rm -rf ../../build || true",
+          "mkdir ../../build",
+          "cd ../../build",
           "cmake ..",
           "make stream_cross_tile",
           "make clean"


### PR DESCRIPTION
# Existing Sample Changes
## Description
Fix ONSAM-1677 due to incorrect path in sample.json files

Fixes Issue# 
ONSAM-1677

## External Dependencies
None

## Type of change

Please delete options that are not relevant. Add a 'X' to the one that is applicable. 

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Implement fixes for ONSAM Jiras

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [X] Command Line
- [ ] oneapi-cli
- [ ] Visual Studio
- [ ] Eclipse IDE
- [ ] VSCode
- [ ] When compiling the compliler flag "-Wall -Wformat-security -Werror=format-security" was used
