### PR TITLE
FPGA: Revert "Remove uses of the deprecated `--target` flag in the library flow tools (#2120)"

### DIFF
--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Tools/use_library/CMakeLists.txt
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Tools/use_library/CMakeLists.txt
@@ -161,7 +161,7 @@ endif()
 # The RTL file (specified in lib_rtl_spec.xml) must be copied to the CMake working directory for the final stage of FPGA hardware compilation
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/${RTL_V} ${RTL_V} @ONLY)
 
-set(FPGA_CROSSGEN_COMMAND fpga_crossgen ${CMAKE_CURRENT_SOURCE_DIR}/${RTL_SPEC} --cpp_model ${CMAKE_CURRENT_SOURCE_DIR}/${RTL_C_MODEL} -o ${RTL_SOURCE_OBJECT} ${USER_FLAGS})
+set(FPGA_CROSSGEN_COMMAND fpga_crossgen ${CMAKE_CURRENT_SOURCE_DIR}/${RTL_SPEC} --cpp_model ${CMAKE_CURRENT_SOURCE_DIR}/${RTL_C_MODEL} --target sycl -o ${RTL_SOURCE_OBJECT} ${USER_FLAGS})
 
 # Create RTL source object
 add_custom_target(
@@ -171,9 +171,9 @@ add_custom_target(
 
 # Create library archive
 # This executes:
-# fpga_libtool lib_rtl.o --create lib.a
+# fpga_libtool lib_rtl.o --target sycl --create lib.a
 add_custom_target(create_library_archive DEPENDS ${CMAKE_ARCHIVE_OUTPUT_DIRECTORY}/${LIBRARY_ARCHIVE})
-set(FPGA_LIBTOOL_COMMAND fpga_libtool ${RTL_SOURCE_OBJECT} --create ${CMAKE_ARCHIVE_OUTPUT_DIRECTORY}/${LIBRARY_ARCHIVE})
+set(FPGA_LIBTOOL_COMMAND fpga_libtool ${RTL_SOURCE_OBJECT} --target sycl --create ${CMAKE_ARCHIVE_OUTPUT_DIRECTORY}/${LIBRARY_ARCHIVE})
 add_custom_command(OUTPUT ${CMAKE_ARCHIVE_OUTPUT_DIRECTORY}/${LIBRARY_ARCHIVE}
                    COMMAND ${FPGA_LIBTOOL_COMMAND}
                    DEPENDS create_rtl_source_object)

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Tools/use_library/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Tools/use_library/README.md
@@ -93,10 +93,10 @@ To create a library from  source code, use the following steps:
 
    ```bash
    # Linux
-   fpga_crossgen lib_rtl_spec.xml --cpp_model lib_rtl_model.cpp -o lib_rtl.o
+   fpga_crossgen lib_rtl_spec.xml --cpp_model lib_rtl_model.cpp --target sycl -o lib_rtl.o
 
    # Windows
-   fpga_crossgen lib_rtl_spec.xml --cpp_model lib_rtl_model.cpp -o lib_rtl.obj
+   fpga_crossgen lib_rtl_spec.xml --cpp_model lib_rtl_model.cpp --target sycl -o lib_rtl.obj
    ```
 
    Note that generating an RTL library requires that an `xml` file and a C++ model be provided in addition to the Verilog source code. The RTL is used when compiling for the hardware whereas the C++ model is used when the oneAPI program is run on the FPGA emulator. Examine the tutorial source code and the comments in `use_library.cpp` for more details.
@@ -111,10 +111,10 @@ To create a library from  source code, use the following steps:
 
    ```bash
    # Linux
-   fpga_libtool lib_rtl.o --create lib_rtl.a
+   fpga_libtool lib_rtl.o --target sycl --create lib_rtl.a
 
    # Windows
-   fpga_libtool lib_rtl.obj --create lib_rtl.lib
+   fpga_libtool lib_rtl.obj --target sycl --create lib_rtl.lib
 
    ```
 


### PR DESCRIPTION
This reverts commit 920e25d5d95091c8f854070fd9df35e839fb0f3d on 2024.1.
The change will be re-submitted to 2024.2 later.

## External Dependencies

N/A

## Type of change

- [x] CMake/README cleanup