### PR TITLE
[ONSAM-1817] IntelPytorch_Interactive_Chat_Quantization 

### DIFF
--- a/AI-and-Analytics/Features-and-Functionality/IntelPytorch_Interactive_Chat_Quantization/sample.json
+++ b/AI-and-Analytics/Features-and-Functionality/IntelPytorch_Interactive_Chat_Quantization/sample.json
@@ -19,8 +19,7 @@
           ],
           "id": "ipex_chat_quantization_py",
           "steps": [
-            "python IntelPytorch_Interactive_Chat_Quantization.py < insert.txt",
-            "jupyter nbconvert --to notebook --execute IntelPytorch_Interactive_Chat_Quantization.ipynb" 
+            "python IntelPytorch_Interactive_Chat_Quantization.py < insert.txt"
            ]
       }
     ]


### PR DESCRIPTION
# Existing Sample Changes
## Description

Remove jupyter nbconvert from sample.json

Jupyter kernel dosen't support std input. As the python script and jupyter notebook are the same, I suggest to leave only the *.py script during CI testing.

Fixes Issue# ONSAM-1817

## Type of change
- [X] Implement fixes for ONSAM Jiras

## How Has This Been Tested?
- [X] Command Line
