### PR TITLE
[IRTK fix]: macos vklsample validation for setvars env only

### DIFF
--- a/RenderingToolkit/GettingStarted/03_openvkl_gsg/sample.json
+++ b/RenderingToolkit/GettingStarted/03_openvkl_gsg/sample.json
@@ -60,7 +60,6 @@
                     "cd build",
                     "cmake ..",
                     "cmake --build . ",
-                    "export DYLD_LIBRARY_PATH=${ONEAPI_ROOT}/lib && ./vklTutorialCPU",
                     "export DYLD_LIBRARY_PATH=${ONEAPI_ROOT}/openvkl/latest/lib:${ONEAPI_ROOT}/rkcommon/latest/lib:${ONEAPI_ROOT}/tbb/latest/lib:${ONEAPI_ROOT}/embree/latest/lib && ./vklTutorialCPU"
                  ]
                  }


### PR DESCRIPTION
# Existing Sample Changes
## Description

Addresses MacOS validation in sample.json for ONSAM-1782.

Background: Env vars appeared to need to be reexported because I was told the testing environment does python forks... and those forks don't allow for inheriting dynamic runtime search paths.

Per expectations set on that system under test, this should unblock macOS runs for the 03_openvkl_gsg sample. On macOS this sample is CPU only.

The removed json script assumed (and confused) oneapi-vars and setvars.

Fixes Issue# 

ONSAM-1782.

## External Dependencies

None


## Type of change

Please delete options that are not relevant. Add a 'X' to the one that is applicable. 

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Implement fixes for ONSAM Jiras

## How Has This Been Tested?

N/A (Can't test a work around specifically for the test SUT)


