### PR TITLE
ONSAM-1820 IntelTensorFlow_ModelZoo "jupyter_client.kernelspec.NoSuchKernel" error

### DIFF
--- a/AI-and-Analytics/Features-and-Functionality/IntelTensorFlow_ModelZoo_Inference_with_FP32_Int8/ResNet50_Inference.ipynb
+++ b/AI-and-Analytics/Features-and-Functionality/IntelTensorFlow_ModelZoo_Inference_with_FP32_Int8/ResNet50_Inference.ipynb
@@ -116,7 +116,7 @@
   "kernelspec": {
    "display_name": "Python [conda env:user_tensorflow] *",
    "language": "python",
-   "name": "conda-env-user_tensorflow-py"
+   "name": "tensorflow"
   },
   "language_info": {
    "codemirror_mode": {


### PR DESCRIPTION
# Existing Sample Changes
## Description

Update jupyter notebook metadata to use tensorflow kernel from sample.json file instead of custom named kernel

Fixes Issue#ONSAM-1820

## Type of change

Please delete options that are not relevant. Add a 'X' to the one that is applicable. 

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] Implement fixes for ONSAM Jiras

## How Has This Been Tested?

Change tested on IDC using command line

- [X] Command Line