### PR TITLE
ONSAM-1820 IntelTensorFlow_ModelZoo_Inference 'models/benchmarks/launch_benchmark.py' not found

### DIFF
--- a/AI-and-Analytics/Features-and-Functionality/IntelTensorFlow_ModelZoo_Inference_with_FP32_Int8/ResNet50_Inference.ipynb
+++ b/AI-and-Analytics/Features-and-Functionality/IntelTensorFlow_ModelZoo_Inference_with_FP32_Int8/ResNet50_Inference.ipynb
@@ -67,7 +67,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%cd ~/intel/oneapi/ai_reference_models"
+    "%cd /intel/oneapi/ai_reference_models"
    ]
   },
   {

--- a/AI-and-Analytics/Features-and-Functionality/IntelTensorFlow_ModelZoo_Inference_with_FP32_Int8/ResNet50_Inference_gpu.ipynb
+++ b/AI-and-Analytics/Features-and-Functionality/IntelTensorFlow_ModelZoo_Inference_with_FP32_Int8/ResNet50_Inference_gpu.ipynb
@@ -70,7 +70,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%cd ~/intel/oneapi/ai_reference_models"
+    "%cd /intel/oneapi/ai_reference_models"
    ]
   },
   {


### PR DESCRIPTION
# Existing Sample Changes
## Description

Updated script paths in both cpu and gpu inference jupyter notebook files. 
The path reflects install path for oneAPI AI Kit form sample.json file.

Fixes Issue#ONSAM-1820

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] Implement fixes for ONSAM Jiras

## How Has This Been Tested?

- [X] Command Line