### PR TITLE
FPGA: constrain while(1) loops in the convolution2d sample

### DIFF
--- a/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/convolution2d/src/convolution_kernel.hpp
+++ b/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/convolution2d/src/convolution_kernel.hpp
@@ -176,7 +176,7 @@ struct RGB2Grey {
   void operator()() const {
     // this loop is not necessary in hardware since I will pin the
     // `start` bit high, but it makes the testbench easier.
-    [[intel::initiation_interval(1)]]  //
+    [[intel::initiation_interval(1)]] // NO-FORMAT: Attribute
     while (1) {
       conv2d::RGBBeat rgb_beat = PipeIn::read();
       conv2d::GreyScaleBeat grey_beat;
@@ -295,7 +295,7 @@ struct Grey2RGB {
   void operator()() const {
     // this loop is not necessary in hardware since the `start` bit will be
     // pulled high, but it makes the testbench easier.
-    [[intel::initiation_interval(1)]]  //
+    [[intel::initiation_interval(1)]] // NO-FORMAT: Attribute
     while (1) {
       conv2d::GreyScaleBeat grey_beat = PipeIn::read();
       conv2d::RGBBeat rgb_beat;

--- a/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/convolution2d/src/convolution_kernel.hpp
+++ b/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/convolution2d/src/convolution_kernel.hpp
@@ -176,6 +176,7 @@ struct RGB2Grey {
   void operator()() const {
     // this loop is not necessary in hardware since I will pin the
     // `start` bit high, but it makes the testbench easier.
+    [[intel::initiation_interval(1)]]  //
     while (1) {
       conv2d::RGBBeat rgb_beat = PipeIn::read();
       conv2d::GreyScaleBeat grey_beat;
@@ -294,6 +295,7 @@ struct Grey2RGB {
   void operator()() const {
     // this loop is not necessary in hardware since the `start` bit will be
     // pulled high, but it makes the testbench easier.
+    [[intel::initiation_interval(1)]]  //
     while (1) {
       conv2d::GreyScaleBeat grey_beat = PipeIn::read();
       conv2d::RGBBeat rgb_beat;


### PR DESCRIPTION
# Existing Sample Changes
## Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes Issue# none

## External Dependencies

List any external dependencies created as a result of this change.

## Type of change

Please delete options that are not relevant. Add a 'X' to the one that is applicable. 

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Implement fixes for ONSAM Jiras

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [X] Command Line
- [ ] oneapi-cli
- [ ] Visual Studio
- [ ] Eclipse IDE
- [X] VSCode
- [ ] When compiling the compliler flag "-Wall -Wformat-security -Werror=format-security" was used
- [X] FPGA Regtests: 
    * Full Linux: https://spetc.intel.com/testanalysis?trview=0&testRunIds=9567514&tapgsize=20
    * Single kernel linux: https://spetc.intel.com/testanalysis?trview=0&testRunIds=9567535&tapgsize=20
    * Full Windows: https://spetc.intel.com/testanalysis?trview=0&testRunIds=9574476&tapgsize=20
    * Single kernel windows: https://spetc.intel.com/testsummary?testRunIds=9574478