### PR TITLE
libraries tutorials::vtune_itt sample failed due to "Converting notebook tutorial_vtune_profiling.ipynb to notebook" error [ONSAM-1796]

### DIFF
--- a/Libraries/oneDNN/tutorials/sample.json
+++ b/Libraries/oneDNN/tutorials/sample.json
@@ -37,15 +37,6 @@
 			"python3 -m ipykernel install --user --name=base",
 			"jupyter nbconvert --ExecutePreprocessor.kernel_name=base --to notebook --execute tutorial_analyze_isa_with_dispatcher_control.ipynb"
 		 ]
-	},
-	{
-		"env": ["source /opt/intel/oneapi/setvars.sh --dnnl-configuration=cpu_gomp --force" ],
-		"id": "vtune_itt",
-		"steps": [
-			"pip install jupyter ipykernel",
-			"python3 -m ipykernel install --user --name=base",
-			"jupyter nbconvert --ExecutePreprocessor.kernel_name=base --to notebook --execute tutorial_vtune_profiling.ipynb"
-		 ]
 	}
  ]}
 }


### PR DESCRIPTION
Removed `tutorial_vtune_profiling.ipynb` conversion step because it times out.