### PR TITLE
FPGA: Stop using variable length arrays in FPGA samples

### DIFF
--- a/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/board_test/src/board_test.hpp
+++ b/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/board_test/src/board_test.hpp
@@ -422,8 +422,13 @@ int ShimMetrics::HostSpeed(sycl::queue &q) {
   // struct Speed in defined in hostspeed.hpp and is used to store transfer
   // times Creating array of struct to store output from each iteration The
   // values from each iteration are analyzed to report bandwidth
-  struct Speed rd_bw[iterations];
-  struct Speed wr_bw[iterations];
+  struct Speed* rd_bw = (struct Speed*) malloc(iterations * sizeof(struct Speed));
+  struct Speed* wr_bw = (struct Speed*) malloc(iterations * sizeof(struct Speed));
+
+  if (!rd_bw || !wr_bw) {
+    std::cerr << "failed to allocated host DDR" << std::endl;
+    std::terminate();
+  }
 
   // std::cout is manipulated to format output
   // Storing old state of std::cout to restore
@@ -498,6 +503,9 @@ int ShimMetrics::HostSpeed(sycl::queue &q) {
     // correct format in current loop
     std::cout.copyfmt(old_state);
   }
+
+  free(rd_bw);
+  free(wr_bw);
 
   h2d_rd_bw_ = read_topspeed;
   h2d_wr_bw_ = write_topspeed;

--- a/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/board_test/src/host_speed.hpp
+++ b/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/board_test/src/host_speed.hpp
@@ -42,13 +42,12 @@ struct Speed WriteSpeed(sycl::queue &q, sycl::buffer<char, 1> &device_buffer,
   assert(num_xfers > 0);
 
   // Sycl event for each transfer
-  sycl::event evt[num_xfers];
+  std::vector<sycl::event> evt;
 
   // **** Write to device **** //
-
   for (size_t i = 0; i < num_xfers; i++) {
     // Submit copy operation (explicit copy from host to device)
-    evt[i] = q.submit([&](sycl::handler &h) {
+    evt.push_back(q.submit([&](sycl::handler &h) {
       // Range of buffer that needs to accessed
       auto buf_range = block_bytes / sizeof(char);
       // offset starts at 0 - incremented by transfer size each iteration (i.e.
@@ -58,7 +57,7 @@ struct Speed WriteSpeed(sycl::queue &q, sycl::buffer<char, 1> &device_buffer,
       sycl::accessor<char, 1, sycl::access::mode::write> mem(
           device_buffer, h, buf_range, buf_offset);
       h.copy(&hostbuf_wr[buf_offset], mem);
-    });
+    }));
   }
   // Wait for copy to complete
   q.wait();
@@ -120,13 +119,13 @@ struct Speed ReadSpeed(sycl::queue &q, sycl::buffer<char, 1> &device_buffer,
   assert(num_xfers > 0);
 
   // Sycl event for each transfer
-  sycl::event evt[num_xfers];
+  std::vector<sycl::event> evt;
 
   // **** Read from device **** //
 
   for (size_t i = 0; i < num_xfers; i++) {
     // Submit copy operation (explicit copy from device to host)
-    evt[i] = q.submit([&](sycl::handler &h) {
+    evt.push_back(q.submit([&](sycl::handler &h) {
       // Range of buffer that needs to accessed
       auto buf_range = block_bytes / sizeof(char);
       // offset starts at 0 - incremented by transfer size each iteration (i.e
@@ -136,7 +135,7 @@ struct Speed ReadSpeed(sycl::queue &q, sycl::buffer<char, 1> &device_buffer,
       sycl::accessor<char, 1, sycl::access::mode::read> mem(
           device_buffer, h, buf_range, buf_offset);
       h.copy(mem, &hostbuf_rd[buf_offset]);
-    });
+    }));
   }
   // Wait for copy to complete
   q.wait();

--- a/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/pca/src/golden_pca.hpp
+++ b/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/pca/src/golden_pca.hpp
@@ -159,7 +159,12 @@ class GoldenPCA {
     int offset = matrix_index * samples * features;
 
     // Compute the mean of each column
-    double mean[features];
+    double* mean = (double*) malloc(features * sizeof(double));
+
+    if (!mean) {
+        std::cerr << "failed to allocated host DDR" << std::endl;
+        std::terminate();
+    }
 
     if (debug) std::cout << "\nMean of each column: " << std::endl;
     for (int column = 0; column < features; column++) {
@@ -173,7 +178,12 @@ class GoldenPCA {
     if (debug) std::cout << std::endl;
 
     // Compute the standard deviation of each column
-    double standard_deviation[features];
+    double* standard_deviation = (double*)malloc(features * sizeof(double));
+    
+    if (!standard_deviation) {
+        std::cerr << "failed to allocated host DDR" << std::endl;
+        std::terminate();
+    }
 
     if (debug)
       std::cout << "\nStandard deviation of each column: " << std::endl;
@@ -202,7 +212,11 @@ class GoldenPCA {
                     << " ";
       }
       if (debug) std::cout << std::endl;
-    }
+    }   
+
+    free(mean);
+    free(standard_deviation);
+
   }
 
   // Standardize all the A matrices


### PR DESCRIPTION
A recent change to the compiler now makes it emit warnings about variable length arrays as not being part of C++.
This change replaces the variable lengths arrays with mallocs/vectors to avoid this warning.