### PR TITLE
FPGA: update `streaming_data_interfaces` to use correct type

### DIFF
--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/hls_flow_interfaces/streaming_data_interfaces/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/hls_flow_interfaces/streaming_data_interfaces/README.md
@@ -69,9 +69,7 @@ Each pipe is a class declaration of the templated `pipe` class. A pipe declarati
 | `min_capacity`                          | User-defined minimum number of words (in units of `dataT`) that the pipe must be able to store without any being read out. This parameter is optional, and defaults to 0.
 | `properties`                            | An unordered list of SYCL properties that define additional semantic properties for a pipe. This parameter is optional.**
 
-> :warning: * There is currently a known issue with using structure types whose first field is 8-bits wide, and hence also data types which are themselves 8-bits wide (for example, `unsigned char`). For the time being, please use a wider datatype where applicable (for example, `unsigned short`).
-
-> **Note**: ** Omitting a single property from the properties class instructs the compiler to assume the default value for that property, so you can just define the properties you would like to change from the default. Omitting the properties template parameter entirely instructs the compiler to assume the default values for all properties.
+> **Note**: Omitting a single property from the properties class instructs the compiler to assume the default value for that property, so you can just define the properties you would like to change from the default. Omitting the properties template parameter entirely instructs the compiler to assume the default values for all properties.
 
 Below is a summary of all relevant SYCL properties which can be applied to a `pipe` using the `properties` template parameter. Please note that this table is not complete; see the [FPGA Optimization Guide for Intel® oneAPI Toolkits](https://www.intel.com/content/www/us/en/docs/oneapi-fpga-add-on/optimization-guide/current/host-pipe-declaration.html) for more information on how to use pipes in other applications.
 

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/hls_flow_interfaces/streaming_data_interfaces/src/streaming_data_interfaces.cpp
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/hls_flow_interfaces/streaming_data_interfaces/src/streaming_data_interfaces.cpp
@@ -16,7 +16,7 @@ class Threshold;
 
 // StreamingBeat struct enables sideband signals in Avalon streaming interface
 using StreamingBeatT = sycl::ext::intel::experimental::StreamingBeat<
-    unsigned short, // type carried over this Avalon streaming interface's data
+    unsigned char,  // type carried over this Avalon streaming interface's data
                     // signal
     true,           // enable startofpacket and endofpacket signals
     false>;         // disable the empty signal
@@ -24,30 +24,29 @@ using StreamingBeatT = sycl::ext::intel::experimental::StreamingBeat<
 // Pipe properties
 using PipePropertiesT = decltype(sycl::ext::oneapi::experimental::properties(
     sycl::ext::intel::experimental::ready_latency<0>,
-    sycl::ext::intel::experimental::bits_per_symbol<16>,
+    sycl::ext::intel::experimental::bits_per_symbol<8>,
     sycl::ext::intel::experimental::uses_valid<true>,
     sycl::ext::intel::experimental::first_symbol_in_high_order_bits<true>,
     sycl::ext::intel::experimental::protocol_avalon_streaming_uses_ready));
 
 // Image streams
 using InPixelPipe = sycl::ext::intel::experimental::pipe<
-    InStream,       // An identifier for the pipe
-    StreamingBeatT, // The type of data in the pipe
-    0,              // The capacity of the pipe
-    PipePropertiesT // Customizable pipe properties
+    InStream,        // An identifier for the pipe
+    StreamingBeatT,  // The type of data in the pipe
+    0,               // The capacity of the pipe
+    PipePropertiesT  // Customizable pipe properties
     >;
 using OutPixelPipe = sycl::ext::intel::experimental::pipe<
-    OutStream,      // An identifier for the pipe
-    StreamingBeatT, // The type of data in the pipe
-    0,              // The capacity of the pipe
-    PipePropertiesT // Customizable pipe properties
+    OutStream,       // An identifier for the pipe
+    StreamingBeatT,  // The type of data in the pipe
+    0,               // The capacity of the pipe
+    PipePropertiesT  // Customizable pipe properties
     >;
 
 // A kernel that thresholds pixel values in an image over a stream. Uses start
 // of packet and end of packet signals on the streams to determine the beginning
 // and end of the image.
 struct ThresholdKernel {
-
   void operator()() const {
     bool start_of_packet = false;
     bool end_of_packet = false;
@@ -60,8 +59,7 @@ struct ThresholdKernel {
       end_of_packet = in_beat.eop;
 
       // Threshold
-      if (pixel > kThreshold)
-        pixel = kThreshold;
+      if (pixel > kThreshold) pixel = kThreshold;
 
       // Write out result
       StreamingBeatT out_beat(pixel, start_of_packet, end_of_packet);
@@ -71,14 +69,12 @@ struct ThresholdKernel {
 };
 
 int main() {
-
   try {
-
 #if FPGA_SIMULATOR
     auto selector = sycl::ext::intel::fpga_simulator_selector_v;
 #elif FPGA_HARDWARE
     auto selector = sycl::ext::intel::fpga_selector_v;
-#else // #if FPGA_EMULATOR
+#else  // #if FPGA_EMULATOR
     auto selector = sycl::ext::intel::fpga_emulator_selector_v;
 #endif
     sycl::queue q(selector, fpga_tools::exception_handler);


### PR DESCRIPTION
# Existing Sample Changes
## Description

Fixes Issue# https://hsdes.intel.com/appstore/article/#/14019166650

also ran clang-format on the code sample

## Type of change

Please delete options that are not relevant. Add a 'X' to the one that is applicable. 

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Implement fixes for ONSAM Jiras

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [X] Command Line
- [ ] oneapi-cli
- [ ] Visual Studio
- [ ] Eclipse IDE
- [ ] VSCode
- [ ] When compiling the compliler flag "-Wall -Wformat-security -Werror=format-security" was used
- [X] FPGA Regtest 
  - [X] Linux https://spetc.intel.com/testanalysis?trview=0&testRunIds=9665786&tapgsize=20
  - [X] Windows https://spetc.intel.com/testanalysis?trview=0&testRunIds=9665867&tapgsize=20