### PR TITLE
FPGA: Remove fpga_register annotations from fifo_sort

### DIFF
--- a/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/db/src/db_utils/fifo_sort.hpp
+++ b/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/db/src/db_utils/fifo_sort.hpp
@@ -272,9 +272,9 @@ class Preloader {
   // preloaded_data_: registers for storing the preloaded data
   // data_in_flight_: data in flight
   // valids_in_flight_: load decisions in flight
-  [[intel::fpga_register]] T preloaded_data_[sz_preload];
-  [[intel::fpga_register]] T data_in_flight_[ld_dist];
-  [[intel::fpga_register]] bool valids_in_flight_[ld_dist];
+  T preloaded_data_[sz_preload];
+  T data_in_flight_[ld_dist];
+  bool valids_in_flight_[ld_dist];
 
   // preload_count_ stores the address where to insert the next item in
   // preloaded_data_.
@@ -312,12 +312,12 @@ class Preloader {
 
   // Computation of each index of preloaded_data_ == preload_count_, precomputed
   // in advance of EnqueueFront to remove compare from the critical path
-  [[intel::fpga_register]] bool preload_count_equal_indices_[sz_preload];
+  bool preload_count_equal_indices_[sz_preload];
 
   // Computation of each index of preloaded_data_ == preload_count_dec_,
   // precomputed in advance of EnqueueFront to remove compare from the critical
   // path
-  [[intel::fpga_register]] bool preload_count_dec_equal_indices_[sz_preload];
+  bool preload_count_dec_equal_indices_[sz_preload];
 
   bool CheckEmpty() { return empty_counter_ < 0; }
 


### PR DESCRIPTION
## Description

A recent update to the SYCL front-end uncovered an issue in the compiler. The `fpga_register` attributes were never being applied to the member variables of the `Preloader` class. Instead, the compiler was using it's own heuristics to registerize the entire `Preloader` object (`preloadersA`). With the update, the compiler now sees the correct attributes to the member variables, but cannot break apart the struct/class to actually apply the attribute to the member variables so emits an error.

This change removes the attributes so we can have the same registerization behaviour that we got in previous releases.

## External Dependencies
 
* N/A

## Type of change

Please delete options that are not relevant. Add a 'X' to the one that is applicable. 

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Implement fixes for ONSAM Jiras

## How Has This Been Tested?

- [X] Command Line
- [ ] oneapi-cli
- [ ] Visual Studio
- [ ] Eclipse IDE
- [ ] VSCode
- [ ] When compiling the compliler flag "-Wall -Wformat-security -Werror=format-security" was used

