### PR TITLE
FPGA: reduce use of mallocs

### DIFF
--- a/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/board_test/src/board_test.hpp
+++ b/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/board_test/src/board_test.hpp
@@ -422,13 +422,11 @@ int ShimMetrics::HostSpeed(sycl::queue &q) {
   // struct Speed in defined in hostspeed.hpp and is used to store transfer
   // times Creating array of struct to store output from each iteration The
   // values from each iteration are analyzed to report bandwidth
-  struct Speed* rd_bw = (struct Speed*) malloc(iterations * sizeof(struct Speed));
-  struct Speed* wr_bw = (struct Speed*) malloc(iterations * sizeof(struct Speed));
+  std::vector<struct Speed> rd_bw;
+  rd_bw.resize(iterations);
 
-  if (!rd_bw || !wr_bw) {
-    std::cerr << "failed to allocated host DDR" << std::endl;
-    std::terminate();
-  }
+  std::vector<struct Speed> wr_bw;
+  wr_bw.resize(iterations);
 
   // std::cout is manipulated to format output
   // Storing old state of std::cout to restore
@@ -503,9 +501,6 @@ int ShimMetrics::HostSpeed(sycl::queue &q) {
     // correct format in current loop
     std::cout.copyfmt(old_state);
   }
-
-  free(rd_bw);
-  free(wr_bw);
 
   h2d_rd_bw_ = read_topspeed;
   h2d_wr_bw_ = write_topspeed;

--- a/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/gzip/src/gzipkernel.hpp
+++ b/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/gzip/src/gzipkernel.hpp
@@ -11,7 +11,7 @@ extern "C" void SubmitGzipTasks(
     size_t block_size,  // size of block to compress.
     buffer<char, 1> *pibuf, buffer<char, 1> *pobuf,
     buffer<struct GzipOutInfo, 1> *gzip_out_buf,
-    buffer<unsigned, 1> *current_crc, bool last_block, event &e_crc,
-    event &e_lz, event &e_huff, size_t engineID);
+    buffer<unsigned, 1> *current_crc, bool last_block, std::vector<event> &e_crc,
+    std::vector<event> &e_lz, std::vector<event> &e_huff, size_t engineID, int buffer_index);
 
 #endif  //__GZIPKERNEL_H__


### PR DESCRIPTION
Reduce the use of mallocs and prefer `std::vectors` instead.