### PR TITLE
improve fMAX of Convolution 2D Reference design

### DIFF
--- a/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/convolution2d/CMakeLists.txt
+++ b/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/convolution2d/CMakeLists.txt
@@ -20,7 +20,7 @@ set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})
 ### Customize these build variables
 ###############################################################################
 set(SOURCE_FILES src/main.cpp)
-set(TARGET_NAME convolution)
+set(TARGET_NAME conv)
 
 # Use cmake -DFPGA_DEVICE=<board-support-package>:<board-variant> to choose a
 # different device.
@@ -36,7 +36,7 @@ endif()
 
 # Use cmake -DUSER_FPGA_FLAGS=<flags> to set extra flags for FPGA backend
 # compilation. 
-set(USER_FPGA_FLAGS ${USER_FPGA_FLAGS};-Xsclock=300MHz;-Xsoptimize=latency)
+set(USER_FPGA_FLAGS ${USER_FPGA_FLAGS};-Xsclock=600MHz;-Xsoptimize=latency)
 
 if(NOT DEFINED PARALLEL_PIXELS)
     SET(PARALLEL_PIXELS 2)

--- a/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/convolution2d/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/convolution2d/README.md
@@ -62,10 +62,10 @@ Performance results are based on testing conducted with a pre-release version of
 
 | Parallel Pixels | Window Dimensions | Coefficient Type | Input Type     | f<sub>MAX</sub> (MHz) | ALMs  | DSP blocks | M20K Block RAM
 |---              |---                |---               |---             |---                    |---    |---         |---
-| 1               | 3x3               | `float`          | 10-bit Integer | 550.97                | 2705  |   9        | 18
-| 2               | 3x3               | `float`          | 10-bit Integer | 548.65                | 4324  |  18        | 18
-| 4               | 3x3               | `float`          | 10-bit Integer | 547.58                | 6938  |  36        | 17
-| 8               | 3x3               | `float`          | 10-bit Integer | 525.12                | 14226 |  72        | 18
+| 1               | 3x3               | `float`          | 10-bit Integer | 639.8                 | 2742  |   9        | 19
+| 2               | 3x3               | `float`          | 10-bit Integer | 639.8                 | 4326  |  18        | 19
+| 4               | 3x3               | `float`          | 10-bit Integer | 639.8                 | 7341  |  36        | 18
+| 8               | 3x3               | `float`          | 10-bit Integer | 639.8                 | 13791 |  72        | 19
 
 > **Note**: This design uses a relatively large number of ALM resources because of the floating-point conversions in `ConvolutionFunction()` in `src/convolution_kernel.hpp`. The coefficients for this design were specified as floating-point for maximal flexibility in coefficient values, but the enthusiastic user is encouraged to convert this function to fixed-point using the `ac_fixed` types, as described in [this sample](/DirectProgramming/C%2B%2BSYCL_FPGA/Tutorials/Features/ac_fixed).
 
@@ -364,6 +364,8 @@ This design uses CMake to generate a build script for  `nmake`.
    >  ```
    >  cmake -G "NMake Makefiles" .. -DFPGA_DEVICE=<FPGA device family or FPGA part number>
    >  ```
+
+   > **Note**: The performance table above was produced by compiling with the `-DTEST_CONV2D_ISOLATED=1` compiler flag, or by adding `#define TEST_CONV2D_ISOLATED 1` in `src/main.cpp`.
 
 3. Compile the design through the generated `Makefile`. The following build targets are provided, matching the recommended development flow:
 

--- a/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/convolution2d/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/convolution2d/README.md
@@ -271,7 +271,7 @@ bool TestTinyFrameOnStencil(sycl::queue q) {
   // extra pixels to flush out the FIFO
   int dummy_pixels = cols_small * conv2d::kWindowSize;
   vvp_stream_adapters::WriteDummyPixelsToPipe<InputImageStreamGrey>(
-      q, dummy_pixels, (uint16_t)69);
+      q, dummy_pixels, (uint16_t)15);
 
   // disable bypass, since it's on by default
   BypassCSR::write(q, false);

--- a/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/convolution2d/src/convolution_kernel.hpp
+++ b/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/convolution2d/src/convolution_kernel.hpp
@@ -127,9 +127,9 @@ conv2d::PixelType ConvolutionFunction(
       // handle the case where the center of the window is at the image edge.
       // In this design, simply 'reflect' pixels that are already in the
       // window.
-      SaturateWindowCoordinates(w_row, w_col,  //
-                                row, col,      //
-                                rows, cols,    //
+      SaturateWindowCoordinates(w_row, w_col,  // NO-FORMAT: Alignment
+                                row, col,      // NO-FORMAT: Alignment
+                                rows, cols,    // NO-FORMAT: Alignment
                                 r_select, c_select);
       conv2d::PixelType pixel =
           buffer[c_select + r_select * conv2d::kWindowSize];
@@ -176,7 +176,7 @@ struct RGB2Grey {
   void operator()() const {
     // this loop is not necessary in hardware since I will pin the
     // `start` bit high, but it makes the testbench easier.
-    [[intel::initiation_interval(1)]] // NO-FORMAT: Attribute
+    [[intel::initiation_interval(1)]]  // NO-FORMAT: Attribute
     while (1) {
       conv2d::RGBBeat rgb_beat = PipeIn::read();
       conv2d::GreyScaleBeat grey_beat;
@@ -187,9 +187,9 @@ struct RGB2Grey {
 
 #pragma unroll
       for (int i = 0; i < conv2d::kParallelPixels; i++) {
-        grey_beat.data[i] = (rgb_beat.data[i].r / 4) +  //
-                            (rgb_beat.data[i].g / 2) +  //
-                            (rgb_beat.data[i].b / 4);   //
+        grey_beat.data[i] = (rgb_beat.data[i].r / 4) +  // NO-FORMAT: Alignment
+                            (rgb_beat.data[i].g / 2) +  // NO-FORMAT: Alignment
+                            (rgb_beat.data[i].b / 4);   // NO-FORMAT: Alignment
       }
       PipeOut::write(grey_beat);
     }
@@ -230,7 +230,7 @@ struct Convolution2d {
     bool keep_going = true;
     bool bypass = true;
 
-    [[intel::initiation_interval(1)]]  //
+    [[intel::initiation_interval(1)]]  // NO-FORMAT: Attribute
     while (keep_going) {
       // do non-blocking reads so that the kernel can be interrupted at any
       // time.
@@ -295,7 +295,7 @@ struct Grey2RGB {
   void operator()() const {
     // this loop is not necessary in hardware since the `start` bit will be
     // pulled high, but it makes the testbench easier.
-    [[intel::initiation_interval(1)]] // NO-FORMAT: Attribute
+    [[intel::initiation_interval(1)]]  // NO-FORMAT: Attribute
     while (1) {
       conv2d::GreyScaleBeat grey_beat = PipeIn::read();
       conv2d::RGBBeat rgb_beat;

--- a/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/convolution2d/src/main.cpp
+++ b/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/convolution2d/src/main.cpp
@@ -190,7 +190,7 @@ bool TestTinyFrameOnStencil(sycl::queue q) {
   // have been added
   int dummy_pixels = cols_small * conv2d::kWindowSize;
   vvp_stream_adapters::WriteDummyPixelsToPipe<InputImageStreamGrey>(
-      q, dummy_pixels, (uint16_t)69);
+      q, dummy_pixels, (uint16_t)15);
 
   // disable bypass, since it's on by default
   BypassCSR::write(q, false);
@@ -250,7 +250,7 @@ bool TestBypass(sycl::queue q) {
   // have been added
   int dummy_pixels = cols_small * conv2d::kWindowSize;
   vvp_stream_adapters::WriteDummyPixelsToPipe<InputImageStreamGrey>(
-      q, dummy_pixels, (uint16_t)69);
+      q, dummy_pixels, (uint16_t)15);
 
   // enable bypass
   BypassCSR::write(q, true);


### PR DESCRIPTION
# Existing Sample Changes
## Description

Minor code change to the device code to improve fMAX.
Also shorten paths for Windows to avoid long path issues.

Fixes Issue# N/A

## Type of change

Please delete options that are not relevant. Add a 'X' to the one that is applicable. 

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Implement fixes for ONSAM Jiras

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [X] Command Line
- [X] FPGA Regtest (Linux): https://spetc.intel.com/testanalysis?trview=0&testRunIds=9704180&tapg=1&tapgsize=20&tasort=testCasePath&tasortdir=asc
- [X] FPGA Regtest (Windows): https://spetc.intel.com/testanalysis?trview=0&testRunIds=9711975&tapgsize=20
- [ ] oneapi-cli
- [ ] Visual Studio
- [ ] Eclipse IDE
- [ ] VSCode
- [ ] When compiling the compliler flag "-Wall -Wformat-security -Werror=format-security" was used

**_Delete this line and everything below if this is not a PR for a new code sample_**

**_Delete this line and all above it if this PR is for a new code sample_**
# Adding a New Sample(s)

## Description

Please include a description of the sample

## Checklist
Administrative
- [ ] Review sample design with the appropriate [Domain Expert](https://github.com/oneapi-src/oneAPI-samples/wiki/Reviewers-and-Domain-Experts): <insert Name Here>
- [ ] If you have any new dependencies/binaries, inform the oneAPI Code Samples Project Manager

Code Development
- [ ] Implement coding guidelines and ensure code quality. [see wiki for details](https://github.com/oneapi-src/oneAPI-samples/wiki/General-Code-Guidelines)
- [ ] Adhere to readme template 
- [ ] Enforce format via clang-format config file
- [ ] Adhere to sample.json specification. https://github.com/oneapi-src/oneAPI-samples/wiki/sample-json-specification
- [ ] Ensure/create CI test configurations for sample (ciTests field) https://github.com/oneapi-src/oneAPI-samples/wiki/sample-json-ci-test-object
- [ ] Run jsonlint on sample.json to verify json syntax. www.jsonlint.com

Security and Legal
- [ ] OSPDT Approval (see Project Manager for assistance)
- [ ] Compile using the following compiler flags and fix any warnings, the falgs are: "/Wall -Wformat-security -Werror=format-security"
- [ ] Bandit Scans (Python only)
- [ ] Virus scan

Review
- [ ] Review DPC++ code with Paul Peterseon. (GitHub User: pmpeter1)
- [ ] Review readme with Tom Lenth(@tomlenth) and/or Project Manager
- [ ] Tested using Dev Cloud when applicable
