### PR TITLE
FPGA: rename target name in the `convolution` sample

### DIFF
--- a/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/convolution2d/CMakeLists.txt
+++ b/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/convolution2d/CMakeLists.txt
@@ -20,7 +20,7 @@ set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})
 ### Customize these build variables
 ###############################################################################
 set(SOURCE_FILES src/main.cpp)
-set(TARGET_NAME conv)
+set(TARGET_NAME convolution)
 
 # Use cmake -DFPGA_DEVICE=<board-support-package>:<board-variant> to choose a
 # different device.


### PR DESCRIPTION
Renamed the exe target name from `conv` to `convolution`.