### PR TITLE
[GPU opt guide][OpenMP][omp prefetch] Add missing SIMD flags to link step

### DIFF
--- a/Publications/GPU-Opt-Guide/OpenMP/26_omp_prefetch/c_simd/CMakeLists.txt
+++ b/Publications/GPU-Opt-Guide/OpenMP/26_omp_prefetch/c_simd/CMakeLists.txt
@@ -1,2 +1,3 @@
 add_compile_options(-fopenmp-target-simd)
+add_link_options(-fopenmp-target-simd)
 add_openmp_example(nbody_c_simd)


### PR DESCRIPTION
# Existing Sample Changes
## Description

Added missing link flags to the nbody simd prefetch example in the GPU optimization guide.

## External Dependencies

GPU optimization guide

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] Implement fixes for ONSAM Jiras

## How Has This Been Tested?

Tested on PVC as follows. Needs latest GPU drivers.

cd Publications/GPU-Opt-Guide
mkdir build
cd build
cmake ..
make nbody_c_simd
ZE_AFFINITY_MASK=0 LIBOMPTARGET_PLUGIN_PROFILE=T,usec OpenMP/26_omp_prefetch/c_simd/nbody_c_simd

