### PR TITLE
Disabled atomic_inr and atomic_dec for guided_simpleAtomicIntrinsics_SYCLMigration sample

### DIFF
--- a/DirectProgramming/C++SYCL/guided_simpleAtomicIntrinsics_SYCLMigration/02_sycl_migrated/Samples/0_Introduction/simpleAtomicIntrinsics/simpleAtomicIntrinsics_cpu.cpp
+++ b/DirectProgramming/C++SYCL/guided_simpleAtomicIntrinsics_SYCLMigration/02_sycl_migrated/Samples/0_Introduction/simpleAtomicIntrinsics/simpleAtomicIntrinsics_cpu.cpp
@@ -103,7 +103,7 @@ int computeGold(int *gpuData, const int len) {
     return false;
   }
 
-  int limit = 17;
+/*  int limit = 17;
   val = 0;
 
   for (int i = 0; i < len; ++i) {
@@ -125,7 +125,7 @@ int computeGold(int *gpuData, const int len) {
   if (val != gpuData[6]) {
     printf("atomicDec failed\n");
     return false;
-  }
+  }*/
 
   found = false;
 

--- a/DirectProgramming/C++SYCL/guided_simpleAtomicIntrinsics_SYCLMigration/02_sycl_migrated/Samples/0_Introduction/simpleAtomicIntrinsics/simpleAtomicIntrinsics_kernel.dp.hpp
+++ b/DirectProgramming/C++SYCL/guided_simpleAtomicIntrinsics_SYCLMigration/02_sycl_migrated/Samples/0_Introduction/simpleAtomicIntrinsics/simpleAtomicIntrinsics_kernel.dp.hpp
@@ -65,14 +65,14 @@ void testKernel(int *g_odata, const sycl::nd_item<3> &item_ct1) {
   // Atomic minimum
   dpct::atomic_fetch_min<sycl::access::address_space::generic_space>(
       &g_odata[4], tid);
-
+//Note: The DPC++ compiler is currently in the process of incorporating native support for atomic increment/decrement operations, along with ongoing performance enhancements.
   // Atomic increment (modulo 17+1)
-  dpct::atomic_fetch_compare_inc<sycl::access::address_space::generic_space>(
-      (unsigned int *)&g_odata[5], 17);
+ //dpct::atomic_fetch_compare_inc<sycl::access::address_space::generic_space>(
+ //     (unsigned int *)&g_odata[5], 17);
 
   // Atomic decrement
-  dpct::atomic_fetch_compare_dec<sycl::access::address_space::generic_space>(
-      (unsigned int *)&g_odata[6], 137);
+  //dpct::atomic_fetch_compare_dec<sycl::access::address_space::generic_space>(
+  //    (unsigned int *)&g_odata[6], 137);
 
   // Atomic compare-and-swap
   dpct::atomic_compare_exchange_strong<

--- a/DirectProgramming/C++SYCL/guided_simpleAtomicIntrinsics_SYCLMigration/README.md
+++ b/DirectProgramming/C++SYCL/guided_simpleAtomicIntrinsics_SYCLMigration/README.md
@@ -41,8 +41,9 @@ This sample demonstrates the migration of the following prominent CUDA features:
 
 - Atomic Intrinsics
 
-The kernel `testKernel` demonstrates SYCL arithmetic atomic functions in device code such as `atomic_fetch_add`, `atomic_fetch_sub`, `atomic_exchange`, `atomic_fetch_max`, `atomic_fetch_min`, `atomic_fetch_compare_inc`, `atomic_fetch_compare_dec`, `atomic_compare_exchange_strong`, `atomic_fetch_and`, `atomic_fetch_or`, and `atomic_fetch_xor` migrated from CUDA atomic instructions.
+The kernel `testKernel` demonstrates SYCL arithmetic atomic functions in device code such as `atomic_fetch_add`, `atomic_fetch_sub`, `atomic_exchange`, `atomic_fetch_max`, `atomic_fetch_min`, `atomic_compare_exchange_strong`, `atomic_fetch_and`, `atomic_fetch_or`, and `atomic_fetch_xor` migrated from CUDA atomic instructions.
 
+>**Note**: The DPC++ compiler is currently in the process of incorporating native support for atomic increment/decrement operations, along with ongoing performance enhancements.
 >**Note**: Refer to [Workflow for a CUDA* to SYCL* Migration](https://www.intel.com/content/www/us/en/developer/tools/oneapi/training/cuda-sycl-migration-workflow.html) for general information about the migration workflow.
 
 ## CUDA source code evaluation


### PR DESCRIPTION
# Existing Sample Changes
## Description

In the source code Atomic Inr and Atomic Dec are disabled as it has a performance issue.
