### PR TITLE
FPGA: Document compiler bug exposed by `use_library` tutorial on Windows

### DIFF
--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Tools/use_library/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Tools/use_library/README.md
@@ -29,6 +29,31 @@ This FPGA tutorial demonstrates how to build SYCL device libraries from RTL sour
 >
 > :warning: Make sure you add the device files associated with the FPGA that you are targeting to your Intel® Quartus® Prime installation.
 
+> :warning: This tutorial currently exposes a bug in the Windows* version of the Intel DPC++/C++ oneAPI compiler. Make sure you install the Intel DPC++/C++ oneAPI compiler in a path that does not include spaces (for example, `C:\oneAPI\`, or you may see an error message like this when you compile this tutorial:
+> ```
+> [100%] Linking CXX executable use_library.report.exe
+> Intel(R) oneAPI DPC++/C++ Compiler for applications running on Intel(R) 64, Version 2024.1.0 Build 20240308
+> Copyright (C) 1985-2024 Intel Corporation. All rights reserved.
+> 
+> icx-cl: warning: unknown argument ignored in clang-cl: '-lkernel32' [-Wunknown-argument]
+> icx-cl: warning: unknown argument ignored in clang-cl: '-luser32' [-Wunknown-argument]
+> icx-cl: warning: unknown argument ignored in clang-cl: '-lgdi32' [-Wunknown-argument]
+> icx-cl: warning: unknown argument ignored in clang-cl: '-lwinspool' [-Wunknown-argument]
+> icx-cl: warning: unknown argument ignored in clang-cl: '-lshell32' [-Wunknown-argument]
+> icx-cl: warning: unknown argument ignored in clang-cl: '-lole32' [-Wunknown-argument]
+> icx-cl: warning: unknown argument ignored in clang-cl: '-loleaut32' [-Wunknown-argument]
+> icx-cl: warning: unknown argument ignored in clang-cl: '-luuid' [-Wunknown-argument]
+> icx-cl: warning: unknown argument ignored in clang-cl: '-lcomdlg32' [-Wunknown-argument]
+> icx-cl: warning: unknown argument ignored in clang-cl: '-ladvapi32' [-Wunknown-argument]
+> 'C:/Program' is not recognized as an internal or external command,
+> operable program or batch file.
+> Couldn't find section with name '.acl.target'.
+> Error: Can't get value into file: 'pkg_editor c:/Users/whitepau/AppData/Local/Temp/use_library-6d1544-4f742f.32024.temp_value.txt get .acl.target c:/Users/whitepau/AppData/Local/Temp/use_library-6d1544-4f742f.32024.temp_value.txt' failed
+> 
+> llvm-foreach:
+> icx-cl: error: fpga compiler command failed with exit code 1 (use -v to see invocation)
+> ```
+
 
 This sample is part of the FPGA code samples.
 It is categorized as a Tier 3 sample that demonstrates the usage of a tool.

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Tools/use_library/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Tools/use_library/README.md
@@ -35,16 +35,6 @@ This FPGA tutorial demonstrates how to build SYCL device libraries from RTL sour
 > Intel(R) oneAPI DPC++/C++ Compiler for applications running on Intel(R) 64, Version 2024.1.0 Build 20240308
 > Copyright (C) 1985-2024 Intel Corporation. All rights reserved.
 > 
-> icx-cl: warning: unknown argument ignored in clang-cl: '-lkernel32' [-Wunknown-argument]
-> icx-cl: warning: unknown argument ignored in clang-cl: '-luser32' [-Wunknown-argument]
-> icx-cl: warning: unknown argument ignored in clang-cl: '-lgdi32' [-Wunknown-argument]
-> icx-cl: warning: unknown argument ignored in clang-cl: '-lwinspool' [-Wunknown-argument]
-> icx-cl: warning: unknown argument ignored in clang-cl: '-lshell32' [-Wunknown-argument]
-> icx-cl: warning: unknown argument ignored in clang-cl: '-lole32' [-Wunknown-argument]
-> icx-cl: warning: unknown argument ignored in clang-cl: '-loleaut32' [-Wunknown-argument]
-> icx-cl: warning: unknown argument ignored in clang-cl: '-luuid' [-Wunknown-argument]
-> icx-cl: warning: unknown argument ignored in clang-cl: '-lcomdlg32' [-Wunknown-argument]
-> icx-cl: warning: unknown argument ignored in clang-cl: '-ladvapi32' [-Wunknown-argument]
 > 'C:/Program' is not recognized as an internal or external command,
 > operable program or batch file.
 > Couldn't find section with name '.acl.target'.


### PR DESCRIPTION
# Existing Sample Changes
## Description

Document compiler bug exposed by use_library tutorial on Windows.

Fixes Issue# https://hsdes.intel.com/appstore/article/#/15015624709

## Type of change

Please delete options that are not relevant. Add a 'X' to the one that is applicable. 

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Implement fixes for ONSAM Jiras
- [x] Document workaround for un-fixable bug

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [X] Command Line
- [ ] oneapi-cli
- [ ] Visual Studio
- [ ] Eclipse IDE
- [ ] VSCode
- [ ] When compiling the compliler flag "-Wall -Wformat-security -Werror=format-security" was used

