### PR TITLE
[ONSAM-1856] fix for tensorflow-hub dependency issue

### DIFF
--- a/AI-and-Analytics/Getting-Started-Samples/Intel_Extension_For_TensorFlow_GettingStarted/README.md
+++ b/AI-and-Analytics/Getting-Started-Samples/Intel_Extension_For_TensorFlow_GettingStarted/README.md
@@ -27,7 +27,7 @@ Please follow bellow steps to setup GPU environment.
 1. Source oneAPI environment variables:  ``` $source $HOME/intel/oneapi/intelpython/bin/activate  ```
 2. Create conda env:  ```$conda create --name user-tensorflow-gpu --clone tensorflow-gpu ```
 3. Activate the created conda env:  ```$source activate user-tensorflow-gpu ```
-4. Install the required packages:  ```(user-tensorflow-gpu) $pip install -r requirements.txt ```
+4. Install the required packages:  ```(user-tensorflow-gpu) $pip install -r requirements.txt --no-deps```
 5. Deactivate conda env:  ```(user-tensorflow-gpu)$conda deactivate ```
 6. Register the kernel to Jupyter NB: ``` $~/.conda/envs/user-tensorflow-gpu/bin/python  -m ipykernel install --user --name=user-tensorflow-gpu ```  
 

--- a/AI-and-Analytics/Getting-Started-Samples/Intel_Extension_For_TensorFlow_GettingStarted/ResNet50_Inference.ipynb
+++ b/AI-and-Analytics/Getting-Started-Samples/Intel_Extension_For_TensorFlow_GettingStarted/ResNet50_Inference.ipynb
@@ -216,7 +216,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!wget https://raw.githubusercontent.com/oneapi-src/oneAPI-samples/master/Libraries/oneDNN/tutorials/profiling/profile_utils.py"
+    "!wget https://raw.githubusercontent.com/oneapi-src/oneAPI-samples/development/Libraries/oneDNN/tutorials/profiling/profile_utils.py"
    ]
   },
   {

--- a/AI-and-Analytics/Getting-Started-Samples/Intel_Extension_For_TensorFlow_GettingStarted/sample.json
+++ b/AI-and-Analytics/Getting-Started-Samples/Intel_Extension_For_TensorFlow_GettingStarted/sample.json
@@ -15,12 +15,12 @@
 			"env": [
 				"source /intel/oneapi/intelpython/bin/activate",
 				"conda activate tensorflow",
-				"pip install -r requirements.txt",
+				"pip install -r requirements.txt --no-deps",
 				"pip install jupyter ipykernel",
 				"python -m ipykernel install --user --name=tensorflow",
 				"conda deactivate",
 				"conda activate tensorflow-gpu",
-				"pip install -r requirements.txt",
+				"pip install -r requirements.txt --no-deps",
 				"pip install jupyter ipykernel",
 				"python -m ipykernel install --user --name=tensorflow-gpu",
 				"conda deactivate"


### PR DESCRIPTION
# Existing Sample Changes
## Description

TensorFlow-hub dependency will install newer TF version and overwrite one in AI Kit.
remove the installation dependency 

Fixes Issue#  ONSAM-1856

## External Dependencies
NA

## Type of change

Please delete options that are not relevant. Add a 'X' to the one that is applicable. 

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Implement fixes for ONSAM Jiras

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Command Line
- [ ] oneapi-cli
- [ ] Visual Studio
- [ ] Eclipse IDE
- [ ] VSCode
- [ ] When compiling the compliler flag "-Wall -Wformat-security -Werror=format-security" was used

