### PR TITLE
[ONSAM-1813] fix a tensorflow-hub dependency issue

### DIFF
--- a/AI-and-Analytics/Features-and-Functionality/IntelTensorFlow_Enabling_Auto_Mixed_Precision_for_TransferLearning/README.md
+++ b/AI-and-Analytics/Features-and-Functionality/IntelTensorFlow_Enabling_Auto_Mixed_Precision_for_TransferLearning/README.md
@@ -43,7 +43,7 @@ You will need to download and install the following toolkits, tools, and compone
 
 - **Other dependencies**
 
-  Install using PIP and the `requirements.txt` file supplied with the sample: `$pip install -r requirements.txt`. <br> The `requirements.txt` file contains the necessary dependencies to run the Notebook.
+  Install using PIP and the `requirements.txt` file supplied with the sample: `$pip install -r requirements.txt --no-deps`. <br> The `requirements.txt` file contains the necessary dependencies to run the Notebook.
 
 ### For Intel® DevCloud
 

--- a/AI-and-Analytics/Features-and-Functionality/IntelTensorFlow_Enabling_Auto_Mixed_Precision_for_TransferLearning/sample.json
+++ b/AI-and-Analytics/Features-and-Functionality/IntelTensorFlow_Enabling_Auto_Mixed_Precision_for_TransferLearning/sample.json
@@ -14,7 +14,7 @@
 			"env": [
 				"source /intel/oneapi/intelpython/bin/activate",
 				"conda activate tensorflow",
-				"pip install -r requirements.txt",
+				"pip install -r requirements.txt --no-deps",
 				"pip install jupyter ipykernel",
 				"python -m ipykernel install --user --name=tensorflow"
 			],


### PR DESCRIPTION
# Existing Sample Changes
## Description
TensorFlow-hub dependency will install newer TF version and overwrite one in AI Kit.
remove the installation dependency

Fixes Issue# ONSAM-1813

## External Dependencies
NA

## Type of change

Please delete options that are not relevant. Add a 'X' to the one that is applicable. 

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Implement fixes for ONSAM Jiras

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Command Line
- [ ] oneapi-cli
- [ ] Visual Studio
- [ ] Eclipse IDE
- [ ] VSCode
- [ ] When compiling the compliler flag "-Wall -Wformat-security -Werror=format-security" was used

