### PR TITLE
Update github-pages.yml

### DIFF
--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -8,12 +8,18 @@ on:
  workflow_dispatch: 
 
 #  schedule:
-#    - cron: '55 13 * * *' 
+#    - cron: '55 13 * * *'
+
+# Top-level default; empty/no permissions 
+permissions: {}  
 
 jobs:
   pages:
     name: Build GitHub Pages
-    runs-on: ubuntu-latest 
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      # Above required for publishing to gh-pages; see auth on Ln 67-68
 
     steps:
     - name: Set up Python


### PR DESCRIPTION
- Update permissions to publish to gh-pages 
- Top-level lockdown uses empty/no permissions; whereas job-level uses write permissions with token
- Refer to app/dev CI job with successfull publishing job 19/03/2024
