### PR TITLE
reworked samples to split it by fp64 support

### DIFF
--- a/Libraries/oneMKL/binomial/src/binomial.hpp
+++ b/Libraries/oneMKL/binomial/src/binomial.hpp
@@ -9,10 +9,6 @@
 
 #include <chrono>
 
-#ifndef DATA_TYPE
-#define DATA_TYPE double
-#endif
-
 #ifndef VERBOSE
 #define VERBOSE 0
 #endif
@@ -45,6 +41,7 @@ constexpr int opt_n =
 #define __VERSION__ __clang_major__
 #endif
 
+template<typename DATA_TYPE>
 class Binomial {
  public:
   Binomial();
@@ -72,5 +69,7 @@ class timer {
  private:
   std::chrono::steady_clock::time_point t1_, t2_;
 };
+
+bool is_fp64();
 
 #endif  // __Binomial_HPP__

--- a/Libraries/oneMKL/binomial/src/binomial_main.cpp
+++ b/Libraries/oneMKL/binomial/src/binomial_main.cpp
@@ -7,6 +7,7 @@
 #include <cmath>
 #include <cstdio>
 #include <vector>
+#include <iostream>
 
 #include "binomial.hpp"
 
@@ -34,7 +35,8 @@ void BlackScholesRefImpl(double& callResult,
   callResult = (S * N_d1 - L * std::exp(-r * t) * N_d2);
 }
 
-void Binomial::check() {
+template<typename DATA_TYPE>
+void Binomial<DATA_TYPE>::check() {
   if (VERBOSE) {
     std::printf("Creating the reference result...\n");
     std::vector<double> h_call_result_host(opt_n);
@@ -64,8 +66,16 @@ void Binomial::check() {
 }
 
 int main(int argc, char** argv) {
-  Binomial test;
-  test.run();
-  test.check();
+  if(is_fp64()){
+    Binomial<double> test;
+    test.run();
+    test.check();
+  }
+  else{
+    std::cout<<"Warning: could not find a device with double precision support. Single precision is used."<<std::endl;
+    Binomial<float> test;
+    test.run();
+    test.check();
+  }
   return 0;
 }

--- a/Libraries/oneMKL/black_scholes/src/black_scholes.hpp
+++ b/Libraries/oneMKL/black_scholes/src/black_scholes.hpp
@@ -15,9 +15,9 @@
 #define MINOR 6
 /******* VERSION *******/
 
-#ifndef DATA_TYPE
-#define DATA_TYPE double
-#endif
+// #ifndef DATA_TYPE
+// #define DATA_TYPE double
+// #endif
 
 #ifndef VERBOSE
 #define VERBOSE 1
@@ -47,6 +47,7 @@ constexpr size_t opt_n =
 #define __VERSION__ __clang_major__
 #endif
 
+template<typename DATA_TYPE>
 class BlackScholes {
 public:
     BlackScholes();
@@ -80,7 +81,8 @@ void BlackScholesRefImpl(
     call_result = (S * N_d1 - L * std::exp(-r * t) * N_d2);
 }
 
-void BlackScholes::check()
+template<typename DATA_TYPE>
+void BlackScholes<DATA_TYPE>::check()
 {
     if (VERBOSE) {
         std::printf("Creating the reference result...\n");

--- a/Libraries/oneMKL/monte_carlo_european_opt/src/montecarlo.hpp
+++ b/Libraries/oneMKL/monte_carlo_european_opt/src/montecarlo.hpp
@@ -13,10 +13,6 @@
 #include <vector>
 #include <sycl/sycl.hpp>
 
-#ifndef DATA_TYPE
-#define DATA_TYPE double
-#endif
-
 #ifndef ITEMS_PER_WORK_ITEM
 #define ITEMS_PER_WORK_ITEM 4
 #endif
@@ -25,8 +21,6 @@
 #define VEC_SIZE 8
 #endif
 
-using DataType = DATA_TYPE;
-
 //Should be > 1
 constexpr int num_options = 384000;
 //Should be > 16
@@ -34,17 +28,18 @@ constexpr int path_length = 262144;
 //Test iterations
 constexpr int num_iterations = 5;
 
-constexpr DataType risk_free  = 0.06f;
-constexpr DataType volatility = 0.10f;
+constexpr float risk_free  = 0.06f;
+constexpr float volatility = 0.10f;
 
-constexpr DataType RLog2E = -risk_free * M_LOG2E;
-constexpr DataType MuLog2E = M_LOG2E * (risk_free - 0.5 * volatility * volatility);
-constexpr DataType VLog2E = M_LOG2E * volatility;
+constexpr float RLog2E = -risk_free * M_LOG2E;
+constexpr float MuLog2E = M_LOG2E * (risk_free - 0.5 * volatility * volatility);
+constexpr float VLog2E = M_LOG2E * volatility;
 
 template<typename MonteCarlo_vector>
 void check(const MonteCarlo_vector& h_CallResult, const MonteCarlo_vector& h_CallConfidence,
 const MonteCarlo_vector& h_StockPrice, const MonteCarlo_vector& h_OptionStrike, const MonteCarlo_vector& h_OptionYears)
 {
+    using DataType = typename MonteCarlo_vector::value_type;
     std::vector<DataType> h_CallResultRef(num_options);
 
     auto BlackScholesRefImpl = [](


### PR DESCRIPTION
# Existing Sample Changes
## Description

Change sources to switch to `float` if device doesn't support `fp64`. Following samples are affected by changes:
* black scholes
* binomial
* european monte-carlo

## External Dependencies

List any external dependencies created as a result of this change.

## Type of change

Please delete options that are not relevant. Add a 'X' to the one that is applicable. 

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Implement fixes for ONSAM Jiras

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Command Line
- [ ] oneapi-cli
- [x] Visual Studio
- [ ] Eclipse IDE
- [ ] VSCode
- [ ] When compiling the compliler flag "-Wall -Wformat-security -Werror=format-security" was used
