### PR TITLE
[ONSAM-1856 ]onednn profile util fix for v3.4

### DIFF
--- a/Libraries/oneDNN/tutorials/profiling/profile_utils.py
+++ b/Libraries/oneDNN/tutorials/profiling/profile_utils.py
@@ -83,29 +83,26 @@ class oneDNNLog:
 
     def load_log(self, log):
         self.filename = log
-        self.with_timestamp = True
-        data = self.load_log_dnnl_timestamp_backend(log)
-        count = data['time'].count()
-       
-        if count <= 1:
-            data = self.load_log_dnnl_timestamp(log)
-            count = data['time'].count()
-            self.with_timestamp = True
 
-            if count <= 1:
-                data = self.load_log_dnnl_backend(log)
-                count = data['time'].count()
+        fn_t_list = [self.load_log_dnnl_timestamp_backend, self.load_log_dnnl_timestamp]
+        fn_not_list = [self.load_log_dnnl_backend, self.load_log_dnnl, self.load_log_mkldnn]
+
+        fn_list = fn_not_list
+        self.with_timestamp = False
+
+        data = fn_t_list[0](log)
+        for d in data['timestamp']:
+            if self.is_float(d) is True:
                 self.with_timestamp = False
+                fn_list = fn_t_list
 
-                if count <= 1:
-                    data = self.load_log_dnnl(log)
-                    count = data['time'].count()
-                    self.with_timestamp = False
-                              
-        if count == 0:
-            data = self.load_log_mkldnn(log)
+
+        for index, fn in enumerate(fn_list):
+            data = fn(log)
             count = data['time'].count()
-            self.with_timestamp = False
+            if count > 2:
+                print(index)
+                break
 
         exec_data = data[data['exec'] == 'exec']
         self.data = data
@@ -150,7 +147,7 @@ class oneDNNLog:
       
     def load_log_dnnl_timestamp_backend(self, log):
         import pandas as pd
-        # dnnl_verbose,629411020589.218018,primitive,exec,cpu,convolution,jit:avx2,forward_inference,src_f32::blocked:abcd:f0 wei_f32::blocked:Acdb8a:f0 bia_f32::blocked:a:f0 dst_f32::blocked:aBcd8b:f0,,alg:convolution_direct,mb1_ic3oc96_ih227oh55kh11sh4dh0ph0_iw227ow55kw11sw4dw0pw0,1.21704
+        #dnnl_verbose,629411020589.218018,primitive,exec,cpu,convolution,jit:avx2,forward_inference,src_f32::blocked:abcd:f0 wei_f32::blocked:Acdb8a:f0 bia_f32::blocked:a:f0 dst_f32::blocked:aBcd8b:f0,,alg:convolution_direct,mb1_ic3oc96_ih227oh55kh11sh4dh0ph0_iw227ow55kw11sw4dw0pw0,1.21704
         data = pd.read_csv(log, names=[ 'dnnl_verbose','timestamp','backend','exec','arch','type', 'jit', 'pass', 'fmt', 'opt', 'alg', 'shape', 'time', 'dummy'], engine='python')
         return data
       
@@ -160,6 +157,15 @@ class oneDNNLog:
         print("load_log_mkldnn")
         data = pd.read_csv(log, names=[ 'mkldnn_verbose','exec','type', 'jit', 'pass', 'fmt', 'alg', 'shape', 'time'], engine='python')
         return data
+    def is_float(self, num):
+        if type(num) is not str:
+            return False
+        try:
+            float(num)
+            return True
+        except ValueError:
+            return False
+
 
 
 class oneDNNUtils:


### PR DESCRIPTION
# Existing Sample Changes
## Description

oneDNN verbose log changes since 3.4. change profile_utils.py to parse the new log format

Fixes Issue# [ONSAM-1856](https://jira.devtools.intel.com/browse/ONSAM-1856)

## External Dependencies

NA

## Type of change

Please delete options that are not relevant. Add a 'X' to the one that is applicable. 

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Implement fixes for ONSAM Jiras

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Command Line
- [ ] oneapi-cli
- [ ] Visual Studio
- [ ] Eclipse IDE
- [ ] VSCode
- [ ] When compiling the compliler flag "-Wall -Wformat-security -Werror=format-security" was used

