### PR TITLE
Bug fix, infinite recursion. Mandel.hpp

### DIFF
--- a/DirectProgramming/C++SYCL/VisualizedSamples/VisualMandlebrot/Mandel.hpp
+++ b/DirectProgramming/C++SYCL/VisualizedSamples/VisualMandlebrot/Mandel.hpp
@@ -137,7 +137,7 @@ void Mandelbrot::Calculate(uint32_t* pixels) {
 	if (singlePrecision)
 		CalculateSP(pixels);
 	else
-		Calculate(pixels);
+		CalculateDP(pixels);
 }
 
 void Mandelbrot::CalculateSP(uint32_t* pixels) {


### PR DESCRIPTION
@bjodom @MoushumiMaria @pmpeter1 @yuguen-intel
Can you please review this change (DPC++) 

**Description**
A new routine had been created to handle double precision numbers. Mandelbrot::CalculateDP 

The Method Mandelbrot::Calculate did not call this new method, for some reason, it seems it called itself and recursed into a stack overflow.

```
void Mandelbrot::Calculate(uint32_t* pixels) {
	if (singlePrecision)
		CalculateSP(pixels);
	else
		Calculate(pixels);  //<--- Should be CalculateDP(pixels);
}
```
**Fixes Issue#** 
[ISSUE 2263](https://github.com/oneapi-src/oneAPI-samples/issues/2263)

**External Dependencies**

None

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)

**How** Has This Been Tested?

Term coverage analysis was done for the lines changed.
- [x] Visual Studio
