### PR TITLE
Add links to Cookbook recipes for oneMKL Samples

### DIFF
--- a/Libraries/oneMKL/black_scholes/README.md
+++ b/Libraries/oneMKL/black_scholes/README.md
@@ -30,7 +30,7 @@ the `SYCL_DEVICE_FILTER` environment variable to `cpu` or `gpu` to select the de
 
 This article explains in detail how oneMKL functions speed up Black-Scholes
 computation of European options pricing:
-https://www.intel.com/content/www/us/en/docs/onemkl/cookbook/2024-0/black-scholes-formula-european-options-pricing.html.
+https://www.intel.com/content/www/us/en/docs/onemkl/cookbook/current/black-scholes-formula-european-options-pricing.html.
 
 ## Key Implementation Details
 

--- a/Libraries/oneMKL/black_scholes/README.md
+++ b/Libraries/oneMKL/black_scholes/README.md
@@ -28,6 +28,10 @@ distribution and a Philox-type generator provided by the oneMKL RNG API.
 This sample performs its computations on the default SYCL* device. You can set
 the `SYCL_DEVICE_FILTER` environment variable to `cpu` or `gpu` to select the device to use.
 
+This article explains in detail how oneMKL functions speed up Black-Scholes
+computation of European options pricing:
+https://www.intel.com/content/www/us/en/docs/onemkl/cookbook/2024-0/black-scholes-formula-european-options-pricing.html.
+
 ## Key Implementation Details
 
 This sample illustrates how to create an RNG engine object (the source of

--- a/Libraries/oneMKL/block_cholesky_decomposition/README.md
+++ b/Libraries/oneMKL/block_cholesky_decomposition/README.md
@@ -20,7 +20,7 @@ The sample code shows how to inform oneMKL of the dependencies between routines 
 
 This sample will use the default SYCL device. You can set the `SYCL_DEVICE_TYPE` environment variable to `cpu` or `gpu` to select the device to use.
 
-This article explains in detail how to solve a system of linear equations with a Cholesky-factored symmetric positive definite block tridiagonal coefficient matrix: https://www.intel.com/content/www/us/en/docs/onemkl/cookbook/2024-0/slve-lin-eqs-blck-tridag-symm-pos-def-coeff-mtrx.html.
+This article explains in detail how to solve a system of linear equations with a Cholesky-factored symmetric positive definite block tridiagonal coefficient matrix: https://www.intel.com/content/www/us/en/docs/onemkl/cookbook/current/slve-lin-eqs-blck-tridag-symm-pos-def-coeff-mtrx.html.
 
 ## Key Implementation Details
 

--- a/Libraries/oneMKL/block_cholesky_decomposition/README.md
+++ b/Libraries/oneMKL/block_cholesky_decomposition/README.md
@@ -6,7 +6,7 @@ Block Cholesky Decomposition shows how to use the Intel® oneAPI Math Kernel Lib
 |:---                               |:---
 | OS                                | Linux* Ubuntu* 18.04 <br> Windows* 10
 | Hardware                          | Skylake with Gen9 or newer
-| Software                          | Intel® oneAPI Math Kernel Library (oneMKL) 
+| Software                          | Intel® oneAPI Math Kernel Library (oneMKL)
 | What you will learn               | How to use oneMKL BLAS and LAPACK routines with pointer-based (USM) programming
 | Time to complete                  | 15 minutes
 
@@ -20,6 +20,7 @@ The sample code shows how to inform oneMKL of the dependencies between routines 
 
 This sample will use the default SYCL device. You can set the `SYCL_DEVICE_TYPE` environment variable to `cpu` or `gpu` to select the device to use.
 
+This article explains in detail how to solve a system of linear equations with a Cholesky-factored symmetric positive definite block tridiagonal coefficient matrix: https://www.intel.com/content/www/us/en/docs/onemkl/cookbook/2024-0/slve-lin-eqs-blck-tridag-symm-pos-def-coeff-mtrx.html.
 
 ## Key Implementation Details
 

--- a/Libraries/oneMKL/block_lu_decomposition/README.md
+++ b/Libraries/oneMKL/block_lu_decomposition/README.md
@@ -18,6 +18,8 @@ Both factoring and solving require several oneMKL routines. Some steps can be pa
 
 This sample will use the default SYCL device. You can set the `SYCL_DEVICE_TYPE` environment variable to `cpu` or `gpu` to select the device to use.
 
+This article explains in detail how oneMKL LAPACK routines can be used to solve a system of linear equations with an LU-factored block tridiagonal coefficient matrix: https://www.intel.com/content/www/us/en/docs/onemkl/cookbook/2024-0/slv-sys-lin-eq-lu-factor-blk-tridiag-coeff-mat.html.
+
 ## Key Implementation Details
 This sample illustrates several important oneMKL routines: matrix multiplication, triangular solves from BLAS (`gemm`, `trsm`), and LU factorization (`getrf`) from LAPACK, as well as several other utility routines.
 

--- a/Libraries/oneMKL/block_lu_decomposition/README.md
+++ b/Libraries/oneMKL/block_lu_decomposition/README.md
@@ -18,7 +18,7 @@ Both factoring and solving require several oneMKL routines. Some steps can be pa
 
 This sample will use the default SYCL device. You can set the `SYCL_DEVICE_TYPE` environment variable to `cpu` or `gpu` to select the device to use.
 
-This article explains in detail how oneMKL LAPACK routines can be used to solve a system of linear equations with an LU-factored block tridiagonal coefficient matrix: https://www.intel.com/content/www/us/en/docs/onemkl/cookbook/2024-0/slv-sys-lin-eq-lu-factor-blk-tridiag-coeff-mat.html.
+This article explains in detail how oneMKL LAPACK routines can be used to solve a system of linear equations with an LU-factored block tridiagonal coefficient matrix: https://www.intel.com/content/www/us/en/docs/onemkl/cookbook/current/slv-sys-lin-eq-lu-factor-blk-tridiag-coeff-mat.html.
 
 ## Key Implementation Details
 This sample illustrates several important oneMKL routines: matrix multiplication, triangular solves from BLAS (`gemm`, `trsm`), and LU factorization (`getrf`) from LAPACK, as well as several other utility routines.

--- a/Libraries/oneMKL/computed_tomography/README.md
+++ b/Libraries/oneMKL/computed_tomography/README.md
@@ -20,7 +20,7 @@ In computed tomography, the raw imaging data is a set of line integrals over the
 
 This sample performs its computations on the default SYCL* device. You can set the `SYCL_DEVICE_TYPE` environment variable to `cpu` or `gpu` to select the device to use.
 
-This article explains in detail how oneMKL fast Fourier transform (FFT) functions can be used to reconstruct the original image from the Computer Tomography (CT) data: https://www.intel.com/content/www/us/en/docs/onemkl/cookbook/2024-0/ffts-for-computer-tomography-image-reconstruction.html.
+This article explains in detail how oneMKL fast Fourier transform (FFT) functions can be used to reconstruct the original image from the Computer Tomography (CT) data: https://www.intel.com/content/www/us/en/docs/onemkl/cookbook/current/ffts-for-computer-tomography-image-reconstruction.html.
 
 ## Key Implementation Details
 

--- a/Libraries/oneMKL/computed_tomography/README.md
+++ b/Libraries/oneMKL/computed_tomography/README.md
@@ -20,6 +20,8 @@ In computed tomography, the raw imaging data is a set of line integrals over the
 
 This sample performs its computations on the default SYCL* device. You can set the `SYCL_DEVICE_TYPE` environment variable to `cpu` or `gpu` to select the device to use.
 
+This article explains in detail how oneMKL fast Fourier transform (FFT) functions can be used to reconstruct the original image from the Computer Tomography (CT) data: https://www.intel.com/content/www/us/en/docs/onemkl/cookbook/2024-0/ffts-for-computer-tomography-image-reconstruction.html.
+
 ## Key Implementation Details
 
 To use oneMKL DFT routines, the sample creates a descriptor object for the given precision and domain (real-to-complex or complex-to-complex), calls the `commit` method, and provides a `sycl::queue` object to define the device and context. The `compute_*` routines are then called to perform the actual computation with the appropriate descriptor object and input/output buffers.

--- a/Libraries/oneMKL/monte_carlo_european_opt/README.md
+++ b/Libraries/oneMKL/monte_carlo_european_opt/README.md
@@ -26,7 +26,7 @@ the `SYCL_DEVICE_TYPE` environment variable to `cpu` or `gpu` to select the devi
 
 This article explains in detail how oneMKL random number generators can be used
 for parallel computation of European options pricing, based on Monte-Carlo method:
-https://www.intel.com/content/www/us/en/docs/onemkl/cookbook/2024-0/monte-carlo-simulating-european-options-pricing.html.
+https://www.intel.com/content/www/us/en/docs/onemkl/cookbook/current/monte-carlo-simulating-european-options-pricing.html.
 
 ## Key Implementation Details
 

--- a/Libraries/oneMKL/monte_carlo_european_opt/README.md
+++ b/Libraries/oneMKL/monte_carlo_european_opt/README.md
@@ -24,6 +24,10 @@ their values in each realization.
 This sample performs its computations on the default SYCL* device. You can set
 the `SYCL_DEVICE_TYPE` environment variable to `cpu` or `gpu` to select the device to use.
 
+This article explains in detail how oneMKL random number generators can be used
+for parallel computation of European options pricing, based on Monte-Carlo method:
+https://www.intel.com/content/www/us/en/docs/onemkl/cookbook/2024-0/monte-carlo-simulating-european-options-pricing.html.
+
 ## Key Implementation Details
 
 This sample illustrates how to create an RNG engine object (the source of pseudo-randomness),


### PR DESCRIPTION
# Existing Sample Changes
## Description

It's useful to link oneMKL Samples with [oneMKL cookbook recipes](https://www.intel.com/content/www/us/en/docs/onemkl/cookbook/current/overview.html). Following samples have been changed:
* Black-Scholes
* Block Cholesky Decomposition
* Block LU Decomposition
* Computed Tomography Reconstruction
* Monte Carlo European Options

## External Dependencies

List any external dependencies created as a result of this change:
* Links to https://www.intel.com/content/www/us/en/docs/onemkl/cookbook/current/overview.html

## Type of change

Please delete options that are not relevant. Add a 'X' to the one that is applicable. 

- [X] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

N/A