### PR TITLE
[oneMKL] Fix batched linear solver sample page fault

### DIFF
--- a/Libraries/oneMKL/batched_linear_solver/lu_solve_omp_offload_optimized.F90
+++ b/Libraries/oneMKL/batched_linear_solver/lu_solve_omp_offload_optimized.F90
@@ -97,9 +97,7 @@ program solve_batched_linear_systems
 
     ! Allocate memory for linear algebra computations
     allocate (a(stride_a, batch_size), b(n, batch_size*nrhs), &
-#if !defined(_OPENMP)
               ipiv(stride_ipiv, batch_size),                  &
-#endif
               info_rf(batch_size), info_rs(batch_size),       &
               stat = allocstat, errmsg = allocmsg)
     if (allocstat > 0) stop trim(allocmsg)
@@ -188,9 +186,5 @@ program solve_batched_linear_systems
     print *, 'Total time:', total_time, 'seconds'
 
     ! Clean up
-#if defined(_OPENMP)
-    deallocate (a, b, a_orig, b_orig, x, info_rf, info_rs)
-#else
     deallocate (a, b, a_orig, b_orig, x, ipiv, info_rf, info_rs)
-#endif
 end program solve_batched_linear_systems


### PR DESCRIPTION
# Existing Sample Changes
## Description

Fixes a page fault that is visible when looking at dmesg output. The ipiv array must still be allocated on the host even when using the OpenMP "map" with alloc attribute. Thanks and credit goes to Sergey Kiselev for rootcausing the issue and providing a fix!

## External Dependencies

List any external dependencies created as a result of this change.
None

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [X] Command Line

Tested locally that the page fault is visible with the sample code as written and that the page fault disappears with the change in this PR.