### PR TITLE
Fix namespace of host_ptr

### DIFF
--- a/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/anr/src/dma_kernels.hpp
+++ b/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/anr/src/dma_kernels.hpp
@@ -45,7 +45,7 @@ event SubmitInputDMA(queue &q, T *in_ptr, int rows, int cols, int frames) {
   return q.single_task<KernelId>([=]() [[intel::kernel_args_restrict]] {
 
 #if defined (IS_BSP)
-    device_ptr<T> in(in_ptr);
+    ext::intel::device_ptr<T> in(in_ptr);
 #else 
     T* in(in_ptr);
 #endif  
@@ -90,7 +90,7 @@ event SubmitOutputDMA(queue &q, T *out_ptr, int rows, int cols, int frames) {
   return q.single_task<KernelId>([=]() [[intel::kernel_args_restrict]] {
 
 #if defined (IS_BSP)
-    device_ptr<T> out(out_ptr);
+    ext::intel::device_ptr<T> out(out_ptr);
 #else 
     T* out(out_ptr);
 #endif      

--- a/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/anr/src/intensity_sigma_lut.hpp
+++ b/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/anr/src/intensity_sigma_lut.hpp
@@ -18,7 +18,7 @@ class IntensitySigmaLUT {
 
 #if defined (IS_BSP)
   // construct from a device_ptr (for constructing from device memory)
-  IntensitySigmaLUT(device_ptr<float> ptr) {
+  IntensitySigmaLUT(ext::intel::device_ptr<float> ptr) {
     // use a pipelined LSU to load from device memory since we don't
     // care about the performance of the copy.
     using PipelinedLSU = ext::intel::lsu<>;

--- a/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/board_test/src/usm_speed.hpp
+++ b/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/board_test/src/usm_speed.hpp
@@ -19,8 +19,8 @@ enum USMTest { MEMCOPY, READ, WRITE };
 sycl::event memcopy_kernel(sycl::queue &q, sycl::ulong8 *in, sycl::ulong8 *out,
                            size_t num_items) {
   return q.single_task<USMMemCopy>([=]() [[intel::kernel_args_restrict]] {
-    sycl::host_ptr<sycl::ulong8> in_h(in);
-    sycl::host_ptr<sycl::ulong8> out_h(out);
+    sycl::ext::intel::host_ptr<sycl::ulong8> in_h(in);
+    sycl::ext::intel::host_ptr<sycl::ulong8> out_h(out);
     for (size_t i = 0; i < num_items; i++) {
       out_h[i] = in_h[i];
     }
@@ -32,8 +32,8 @@ sycl::event memcopy_kernel(sycl::queue &q, sycl::ulong8 *in, sycl::ulong8 *out,
 sycl::event read_kernel(sycl::queue &q, sycl::ulong8 *in, sycl::ulong8 *out,
                         size_t num_items) {
   return q.single_task<USMMemRead>([=]() {
-    sycl::host_ptr<sycl::ulong8> in_h(in);
-    sycl::host_ptr<sycl::ulong8> out_h(out);
+    sycl::ext::intel::host_ptr<sycl::ulong8> in_h(in);
+    sycl::ext::intel::host_ptr<sycl::ulong8> out_h(out);
     sycl::ulong8 sum{0};
     for (size_t i = 0; i < num_items; i++) {
       sum += in_h[i];
@@ -47,7 +47,7 @@ sycl::event read_kernel(sycl::queue &q, sycl::ulong8 *in, sycl::ulong8 *out,
 sycl::event write_kernel(sycl::queue &q, sycl::ulong8 *in, sycl::ulong8 *out,
                          size_t num_items) {
   return q.single_task<USMMemWrite>([=]() {
-    sycl::host_ptr<sycl::ulong8> out_h(out);
+    sycl::ext::intel::host_ptr<sycl::ulong8> out_h(out);
     sycl::ulong8 answer{TEST_VAL};
     for (size_t i = 0; i < num_items; i++) {
       out_h[i] = answer;

--- a/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/cholesky/src/cholesky.hpp
+++ b/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/cholesky/src/cholesky.hpp
@@ -114,7 +114,7 @@ void CholeskyDecompositionImpl(
           // lives on the device.
           // Knowing this, the compiler won't generate hardware to
           // potentially get data from the host.
-          sycl::device_ptr<TT> vector_ptr(l_device);
+          sycl::ext::intel::device_ptr<TT> vector_ptr(l_device);
 #else
           // Device pointers are not supported when targeting an FPGA 
           // family/part

--- a/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/cholesky/src/memory_transfers.hpp
+++ b/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/cholesky/src/memory_transfers.hpp
@@ -50,7 +50,7 @@ void MatrixReadFromDDRToPipe(
           // lives on the device.
           // Knowing this, the compiler won't generate hardware to
           // potentially get data from the host.
-          sycl::device_ptr<TT> matrix_ptr_located(matrix_ptr);
+          sycl::ext::intel::device_ptr<TT> matrix_ptr_located(matrix_ptr);
 #else
           // Device pointers are not supported when targeting an FPGA 
           // family/part

--- a/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/cholesky_inversion/src/memory_transfers.hpp
+++ b/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/cholesky_inversion/src/memory_transfers.hpp
@@ -43,7 +43,7 @@ void MatrixReadFromDDRToPipe(
           // lives on the device.
           // Knowing this, the compiler won't generate hardware to
           // potentially get data from the host.
-          sycl::device_ptr<TT> matrix_ptr_located(matrix_ptr);
+          sycl::ext::intel::device_ptr<TT> matrix_ptr_located(matrix_ptr);
 #else
           // Device pointers are not supported when targeting an FPGA 
           // family/part
@@ -133,7 +133,7 @@ void VectorReadFromPipeToDDR(
           // lives on the device.
           // Knowing this, the compiler won't generate hardware to
           // potentially get data from the host.
-          sycl::device_ptr<TT> vector_ptr_located(vector_ptr);
+          sycl::ext::intel::device_ptr<TT> vector_ptr_located(vector_ptr);
 #else
           // Device pointers are not supported when targeting an FPGA 
           // family/part

--- a/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/decompress/src/common/common.hpp
+++ b/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/decompress/src/common/common.hpp
@@ -326,7 +326,7 @@ sycl::event SubmitProducer(sycl::queue& q, unsigned in_count_padded,
     // lives on the device.
     // Knowing this, the compiler won't generate hardware to
     // potentially get data from the host.
-    sycl::device_ptr<unsigned char> in(in_ptr);
+    sycl::ext::intel::device_ptr<unsigned char> in(in_ptr);
 #else
     // Device pointers are not supported when targeting an FPGA 
     // family/part
@@ -371,7 +371,7 @@ sycl::event SubmitConsumer(sycl::queue& q, unsigned out_count_padded,
     // lives on the device.
     // Knowing this, the compiler won't generate hardware to
     // potentially get data from the host.
-    sycl::device_ptr<unsigned char> out(out_ptr);
+    sycl::ext::intel::device_ptr<unsigned char> out(out_ptr);
 #else
     // Device pointers are not supported when targeting an FPGA 
     // family/part

--- a/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/decompress/src/gzip/gzip_metadata_reader.hpp
+++ b/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/decompress/src/gzip/gzip_metadata_reader.hpp
@@ -290,9 +290,9 @@ sycl::event SubmitGzipMetadataReader(sycl::queue& q, int in_count,
     // lives on the device.
     // Knowing this, the compiler won't generate hardware to
     // potentially get data from the host.
-    sycl::device_ptr<GzipHeaderData> hdr_data(hdr_data_ptr);
-    sycl::device_ptr<int> crc(crc_ptr);
-    sycl::device_ptr<int> out_count(out_count_ptr);
+    sycl::ext::intel::device_ptr<GzipHeaderData> hdr_data(hdr_data_ptr);
+    sycl::ext::intel::device_ptr<int> crc(crc_ptr);
+    sycl::ext::intel::device_ptr<int> out_count(out_count_ptr);
 #else
     // Device pointers are not supported when targeting an FPGA 
     // family/part

--- a/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/decompress/src/snappy/snappy_reader.hpp
+++ b/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/decompress/src/snappy/snappy_reader.hpp
@@ -390,7 +390,7 @@ sycl::event SubmitSnappyReader(sycl::queue& q, unsigned in_count,
     // lives on the device.
     // Knowing this, the compiler won't generate hardware to
     // potentially get data from the host.
-    sycl::device_ptr<unsigned> preamble_count(preamble_count_ptr);
+    sycl::ext::intel::device_ptr<unsigned> preamble_count(preamble_count_ptr);
 #else
     // Device pointers are not supported when targeting an FPGA 
     // family/part

--- a/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/gzip/src/gzipkernel_ll.cpp
+++ b/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/gzip/src/gzipkernel_ll.cpp
@@ -790,7 +790,7 @@ event SubmitCRC(queue &q, size_t block_size, uint32_t *result_crc,
     h.single_task<CRC<engineID>>([=]() [[intel::kernel_args_restrict]] {
       auto accessor_isz = block_size;
 
-      host_ptr<uint32_t> accresult_crc(result_crc);
+      ext::intel::host_ptr<uint32_t> accresult_crc(result_crc);
 
       // See comments at top of file, regarding batching.
       [[intel::disable_loop_pipelining]]
@@ -2086,9 +2086,10 @@ event SubmitLZReduction(queue &q, size_t block_size, bool last_block,
       // SubmitGzipTasksHelper(); everything to the left of '...' is expanded
       // for each value in ptrs.
 
-      host_ptr<char> host_pibuf[BatchSize];
-      Unroller<0, BatchSize>::step(
-          [&](auto i) { host_pibuf[i] = host_ptr<char>(get<i>(ptrs...)); });
+      ext::intel::host_ptr<char> host_pibuf[BatchSize];
+      Unroller<0, BatchSize>::step([&](auto i) {
+        host_pibuf[i] = ext::intel::host_ptr<char>(get<i>(ptrs...));
+      });
 
       // See comments at top of file, regarding batching
       [[intel::disable_loop_pipelining]] for (int iter = 0;
@@ -2096,7 +2097,7 @@ event SubmitLZReduction(queue &q, size_t block_size, bool last_block,
         const int iter_masked =
             iter % BatchSize;  // Hint to the compiler that the access to
                                // host_pibuf is bounded.
-        host_ptr<char> acc_pibuf =
+        ext::intel::host_ptr<char> acc_pibuf =
             host_pibuf[iter_masked];  // Grab new host pointer on each iteration
                                       // of the batch loop
 
@@ -2453,20 +2454,22 @@ event SubmitStaticHuffman(queue &q, size_t block_size,
 
       // See comments in SubmitLZReduction, where the same parameter unpacking
       // is done.
-      host_ptr<char> host_pobuf[BatchSize];
-      Unroller<0, BatchSize>::step(
-          [&](auto i) { host_pobuf[i] = host_ptr<char>(get<i>(ptrs...)); });
+      ext::intel::host_ptr<char> host_pobuf[BatchSize];
+      Unroller<0, BatchSize>::step([&](auto i) {
+        host_pobuf[i] = ext::intel::host_ptr<char>(get<i>(ptrs...));
+      });
 
       auto accessor_isz = block_size;
 
-      host_ptr<GzipOutInfo> acc_gzip_out(gzip_out_buf);
+      ext::intel::host_ptr<GzipOutInfo> acc_gzip_out(gzip_out_buf);
 
       auto acc_eof = last_block ? 1 : 0;
 
       // See comments at top of file regarding batching.
       [[intel::disable_loop_pipelining]]
       for (int iter=0; iter < BatchSize; iter++) {
-        host_ptr<char> accessor_output = host_pobuf[iter % BatchSize];
+        ext::intel::host_ptr<char> accessor_output =
+            host_pobuf[iter % BatchSize];
 
         unsigned int leftover[kVec] = {0};
         Unroller<0, kVec>::step([&](int i) { leftover[i] = 0; });

--- a/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/matmul/src/memory_transfers.hpp
+++ b/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/matmul/src/memory_transfers.hpp
@@ -80,7 +80,7 @@ public:
     // the device.
     // Knowing this, the compiler won't generate hardware to potentially get
     // data from the host.
-    sycl::device_ptr<TT> a_ptr_located(a_ptr);
+    sycl::ext::intel::device_ptr<TT> a_ptr_located(a_ptr);
 #else
     // Device pointers are not supported when targeting an FPGA family/part
     TT *a_ptr_located(a_ptr);
@@ -236,7 +236,7 @@ public:
     // the device.
     // Knowing this, the compiler won't generate hardware to potentially get
     // data from the host.
-    sycl::device_ptr<TT> b_ptr_located(b_ptr);
+    sycl::ext::intel::device_ptr<TT> b_ptr_located(b_ptr);
 #else
     // Device pointers are not supported when targeting an FPGA family/part
     TT *b_ptr_located(b_ptr);
@@ -384,7 +384,7 @@ public:
     // the device.
     // Knowing this, the compiler won't generate hardware to potentially get
     // data from the host.
-    sycl::device_ptr<TT> c_ptr_located(c_ptr);
+    sycl::ext::intel::device_ptr<TT> c_ptr_located(c_ptr);
 #else
     // Device pointers are not supported when targeting an FPGA family/part
     TT *c_ptr_located(c_ptr);

--- a/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/merge_sort/src/consume.hpp
+++ b/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/merge_sort/src/consume.hpp
@@ -25,7 +25,7 @@ event Consume(queue& q, ValueT* out_ptr, IndexT total_count, IndexT offset,
     // This is only done in the case where we target a BSP as device 
     // pointers are not supported when targeting an FPGA family/part
 #if defined(IS_BSP)
-    device_ptr<ValueT> out(out_ptr);
+    ext::intel::device_ptr<ValueT> out(out_ptr);
 #else
     ValueT* out(out_ptr);
 #endif

--- a/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/merge_sort/src/main.cpp
+++ b/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/merge_sort/src/main.cpp
@@ -233,8 +233,9 @@ int main(int argc, char *argv[]) {
     // the pointer type for the kernel depends on whether data is coming from
     // USM host or device allocations
     using KernelPtrType =
-        typename std::conditional_t<kUseUSMHostAllocation, host_ptr<ValueT>,
-                                    device_ptr<ValueT>>;
+        typename std::conditional_t<kUseUSMHostAllocation,
+                                    ext::intel::host_ptr<ValueT>,
+                                    ext::intel::device_ptr<ValueT>>;
 
     // run the sort multiple times to increase the accuracy of the timing
     for (int i = 0; i < runs; i++) {

--- a/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/merge_sort/src/produce.hpp
+++ b/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/merge_sort/src/produce.hpp
@@ -27,7 +27,7 @@ event Produce(queue& q, ValueT *in_ptr, IndexT count, IndexT in_block_count,
       // This is only done in the case where we target a BSP as device 
       // pointers are not supported when targeting an FPGA family/part
 #if defined(IS_BSP)
-      device_ptr<ValueT> in(in_ptr);
+      ext::intel::device_ptr<ValueT> in(in_ptr);
 #else
       ValueT* in(in_ptr);
 #endif

--- a/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/merge_sort/src/sorting_networks.hpp
+++ b/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/merge_sort/src/sorting_networks.hpp
@@ -110,7 +110,7 @@ event SortNetworkKernel(queue& q, ValueT* out_ptr, IndexT total_count,
     // This is only done in the case where we target a BSP as device 
     // pointers are not supported when targeting an FPGA family/part
 #if defined(IS_BSP)
-    device_ptr<ValueT> out(out_ptr);
+    ext::intel::device_ptr<ValueT> out(out_ptr);
 #else
     ValueT* out(out_ptr);
 #endif

--- a/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/mvdr_beamforming/src/FakeIOPipes.hpp
+++ b/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/mvdr_beamforming/src/FakeIOPipes.hpp
@@ -29,9 +29,9 @@ class ProducerConsumerBaseImpl {
 
   // use some fancy C++ metaprogramming to get the correct pointer type
   // based on the template variable
-  typedef
-      typename std::conditional_t<use_host_alloc, host_ptr<T>, device_ptr<T>>
-          kernel_ptr_type;
+  typedef typename std::conditional_t<use_host_alloc, ext::intel::host_ptr<T>,
+                                      ext::intel::device_ptr<T>>
+      kernel_ptr_type;
 
   // private constructor so users cannot make an object
   ProducerConsumerBaseImpl(){};

--- a/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/pca/src/memory_transfers.hpp
+++ b/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/pca/src/memory_transfers.hpp
@@ -150,7 +150,7 @@ void VectorReadPipeToDDR(
   // lives on the device.
   // Knowing this, the compiler won't generate hardware to
   // potentially get data from the host.
-  sycl::device_ptr<TT> vector_ptr_located(vector_ptr);
+  sycl::ext::intel::device_ptr<TT> vector_ptr_located(vector_ptr);
 #else
   // Device pointers are not supported when targeting an FPGA
   // family/part

--- a/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/qrd/src/memory_transfers.hpp
+++ b/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/qrd/src/memory_transfers.hpp
@@ -42,7 +42,7 @@ void MatrixReadFromDDRToPipe(
   // lives on the device.
   // Knowing this, the compiler won't generate hardware to
   // potentially get data from the host.
-  sycl::device_ptr<TT> matrix_ptr_located(matrix_ptr);
+  sycl::ext::intel::device_ptr<TT> matrix_ptr_located(matrix_ptr);
 #else
   // Device pointers are not supported when targeting an FPGA 
   // family/part
@@ -143,7 +143,7 @@ void MatrixReadPipeToDDR(
   // lives on the device.
   // Knowing this, the compiler won't generate hardware to
   // potentially get data from the host.
-  sycl::device_ptr<TT> matrix_ptr_located(matrix_ptr);
+  sycl::ext::intel::device_ptr<TT> matrix_ptr_located(matrix_ptr);
 #else
   // Device pointers are not supported when targeting an FPGA 
   // family/part

--- a/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/qrd/src/qrd.hpp
+++ b/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/qrd/src/qrd.hpp
@@ -109,7 +109,7 @@ void QRDecompositionImpl(
     // lives on the device.
     // Knowing this, the compiler won't generate hardware to
     // potentially get data from the host.
-    sycl::device_ptr<TT> vector_ptr_located(r_device);
+    sycl::ext::intel::device_ptr<TT> vector_ptr_located(r_device);
 #else
     // Device pointers are not supported when targeting an FPGA 
     // family/part

--- a/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/qri/src/memory_transfers.hpp
+++ b/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/qri/src/memory_transfers.hpp
@@ -42,7 +42,7 @@ void MatrixReadFromDDRToPipe(
   // lives on the device.
   // Knowing this, the compiler won't generate hardware to
   // potentially get data from the host.
-  sycl::device_ptr<TT> matrix_ptr_located(matrix_ptr);
+  sycl::ext::intel::device_ptr<TT> matrix_ptr_located(matrix_ptr);
 #else
   // Device pointers are not supported when targeting an FPGA 
   // family/part
@@ -143,7 +143,7 @@ void MatrixReadPipeToDDR(
   // lives on the device.
   // Knowing this, the compiler won't generate hardware to
   // potentially get data from the host.
-  sycl::device_ptr<TT> matrix_ptr_located(matrix_ptr);
+  sycl::ext::intel::device_ptr<TT> matrix_ptr_located(matrix_ptr);
 #else
   // Device pointers are not supported when targeting an FPGA 
   // family/part

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/buffered_host_streaming/src/HostStreamer.hpp
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/buffered_host_streaming/src/HostStreamer.hpp
@@ -667,7 +667,7 @@ public:
   // synthesized into FPGA kernels.
   static event LaunchProducerKernel(ProducerType *usm_ptr, size_t count) {
     return sycl_q_->single_task<ProducerKernelId<Id>>([=] {
-      host_ptr<ProducerType> ptr(usm_ptr);
+      ext::intel::host_ptr<ProducerType> ptr(usm_ptr);
       for (size_t i = 0; i < count; i++) {
         // host->device: read from USM and write to the ProducerPipe
         auto val = *(ptr + i);
@@ -678,7 +678,7 @@ public:
 
   static event LaunchConsumerKernel(ConsumerType *usm_ptr, size_t count) {
     return sycl_q_->single_task<ConsumerKernelId<Id>>([=] {
-      host_ptr<ConsumerType> ptr(usm_ptr);
+      ext::intel::host_ptr<ConsumerType> ptr(usm_ptr);
       for (size_t i = 0; i < count; i++) {
         // device->host: read from the ConsumerPipe and write to USM
         auto val = ConsumerPipe::read();

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/buffered_host_streaming/src/streaming_without_api.hpp
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/buffered_host_streaming/src/streaming_without_api.hpp
@@ -328,8 +328,8 @@ event SubmitKernel(queue &q, T *in_ptr, size_t count, T *out_ptr) {
   return q.single_task<Kernel>([=]() [[intel::kernel_args_restrict]] {
     // using a host_ptr class tells the compiler that this pointer lives in
     // the host's address space
-    host_ptr<T> in(in_ptr);
-    host_ptr<T> out(out_ptr);
+    ext::intel::host_ptr<T> in(in_ptr);
+    ext::intel::host_ptr<T> out(out_ptr);
 
     for (size_t i = 0; i < count; i++) {
       T data = *(in + i);

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/explicit_data_movement/src/explicit_data_movement.cpp
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/explicit_data_movement/src/explicit_data_movement.cpp
@@ -143,8 +143,8 @@ double SubmitExplicitKernel(sycl::queue &q, std::vector<T> &in,
 #if defined(IS_BSP)
       // Explicitly create device pointers to inform the compiler that these
       // pointers point to device memory
-      sycl::device_ptr<T> in_ptr_d(in_ptr);
-      sycl::device_ptr<T> out_ptr_d(out_ptr);
+      sycl::ext::intel::device_ptr<T> in_ptr_d(in_ptr);
+      sycl::ext::intel::device_ptr<T> out_ptr_d(out_ptr);
 #endif
 
       for (size_t i = 0; i < size; i++) {

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/io_streaming/src/FakeIOPipes.hpp
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/io_streaming/src/FakeIOPipes.hpp
@@ -29,9 +29,9 @@ class ProducerConsumerBaseImpl {
 
   // use some fancy C++ metaprogramming to get the correct pointer type
   // based on the template variable
-  typedef
-      typename std::conditional_t<use_host_alloc, host_ptr<T>, device_ptr<T>>
-          kernel_ptr_type;
+  typedef typename std::conditional_t<use_host_alloc, ext::intel::host_ptr<T>,
+                                      ext::intel::device_ptr<T>>
+      kernel_ptr_type;
 
   // private constructor so users cannot make an object
   ProducerConsumerBaseImpl(){};

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/simple_host_streaming/src/multi_kernel.hpp
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/simple_host_streaming/src/multi_kernel.hpp
@@ -31,7 +31,7 @@ class C;
 template<typename T, typename InPipe>
 event SubmitProducer(queue &q, T* in_ptr, size_t size) {
   return q.single_task<P>([=]() [[intel::kernel_args_restrict]] {
-    host_ptr<T> in(in_ptr);
+    ext::intel::host_ptr<T> in(in_ptr);
     for (size_t i = 0; i < size; i++) {
       auto data = in[i];
       InPipe::write(data);
@@ -53,7 +53,7 @@ event SubmitProducer(queue &q, T* in_ptr, size_t size) {
 template<typename T, typename OutPipe>
 event SubmitConsumer(queue &q, T* out_ptr, size_t size) {
   return q.single_task<C>([=]() [[intel::kernel_args_restrict]] {
-    host_ptr<T> out(out_ptr);
+    ext::intel::host_ptr<T> out(out_ptr);
     for (size_t i = 0; i < size; i++) {
       auto data = OutPipe::read();
       *(out + i) = data;

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/simple_host_streaming/src/single_kernel.hpp
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/simple_host_streaming/src/single_kernel.hpp
@@ -19,8 +19,8 @@ event SubmitSingleWorker(queue &q, T *in_ptr, T *out_ptr, size_t count) {
   return q.single_task<K>([=]() [[intel::kernel_args_restrict]] {
     // using a host_ptr class tells the compiler that this pointer lives in
     // the hosts address space
-    host_ptr<T> in(in_ptr);
-    host_ptr<T> out(out_ptr);
+    ext::intel::host_ptr<T> in(in_ptr);
+    ext::intel::host_ptr<T> out(out_ptr);
 
     for (size_t i = 0; i < count; i++) {
       // do a simple copy - more complex computation can go here

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/zero_copy_data_transfer/src/zero_copy_kernel.hpp
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/zero_copy_data_transfer/src/zero_copy_kernel.hpp
@@ -76,7 +76,7 @@ event SubmitProducer(queue& q, T* in_data, size_t size) {
 #if defined(IS_BSP)
     // using a host_ptr tells the compiler that this pointer lives in the
     // hosts address space
-    host_ptr<T> h_in_data(in_data);
+    ext::intel::host_ptr<T> h_in_data(in_data);
 #endif
 
     for (size_t i = 0; i < size; i++) {
@@ -125,7 +125,7 @@ event SubmitConsumer(queue& q, T* out_data, size_t size) {
 #if defined(IS_BSP)
     // using a host_ptr tells the compiler that this pointer lives in the
     // hosts address space
-    host_ptr<T> h_out_data(out_data);
+    ext::intel::host_ptr<T> h_out_data(out_data);
 #endif
 
     for (size_t i = 0; i < size; i++) {


### PR DESCRIPTION

# Existing Sample Changes
## Description

The device_ptr and host_ptr aliases in DPC++ is from the [sycl_ext_intel_usm_address_spaces](sycl/doc/extensions/supported/sycl_ext_intel_usm_address_spaces.asciidoc) and as such is under the sycl::ext::intel namespace, rather than the sycl namespace. This commit fixes the namespaces of all uses of these aliases.

## External Dependencies

None.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Implement fixes for ONSAM Jiras

## How Has This Been Tested?

Following the build instructions in each of the respective sample directories.

- [X] Command Line
- [ ] oneapi-cli
- [ ] Visual Studio
- [ ] Eclipse IDE
- [ ] VSCode
- [ ] When compiling the compliler flag "-Wall -Wformat-security -Werror=format-security" was used
