### PR TITLE
Fix SYCL math builtin ambiguity

### DIFF
--- a/DirectProgramming/C++SYCL/DenseLinearAlgebra/guided_jacobi_iterative_gpu_optimization/src/2_guided_jacobi_iterative_solver_gpu.cpp
+++ b/DirectProgramming/C++SYCL/DenseLinearAlgebra/guided_jacobi_iterative_gpu_optimization/src/2_guided_jacobi_iterative_solver_gpu.cpp
@@ -55,8 +55,8 @@ void GenerateMatrix(std::vector<float> &input_matrix,
 
       for (int j = i * kSize; j < kSize * (i + 1); ++j) {
         in_mat_acc[j] = distr(engine);
-        in_mat_acc[j] = round(100. * in_mat_acc[j]) / 100.;
-        sum += fabs(in_mat_acc[j]);
+        in_mat_acc[j] = sycl::round(100. * in_mat_acc[j]) / 100.;
+        sum += sycl::fabs(in_mat_acc[j]);
       }
 
       oneapi::dpl::uniform_int_distribution<int> distr2(0, 100);
@@ -68,7 +68,7 @@ void GenerateMatrix(std::vector<float> &input_matrix,
         in_mat_acc[i * kSize + i] = -1 * (sum + 1);
 
       in_res_acc[i] = distr(engine);
-      in_res_acc[i] = round(100. * in_res_acc[i]) / 100.;
+      in_res_acc[i] = sycl::round(100. * in_res_acc[i]) / 100.;
     });
   });
 }
@@ -108,7 +108,7 @@ bool CheckIfEqual(Real *output_data, Real *old_output_data) {
   int correct_result = 0;
 
   for (int i = 0; i < kSize; ++i) {
-    if (fabs(output_data[i] - old_output_data[i]) < kCheckError)
+    if (std::fabs(output_data[i] - old_output_data[i]) < kCheckError)
       correct_result++;
   }
 
@@ -221,7 +221,7 @@ int main(int argc, char *argv[]) {
       accessor R{bufin_res, h, read_only};
       accessor NR{bufout_res, h, read_only};
       h.parallel_for(range<1>(kSize), [=](id<1> id) {
-        Real diff = fabs(NR[id] - R[id]);
+        Real diff = sycl::fabs(NR[id] - R[id]);
         if (diff > kCalculationError) all_eq[0] = false;
       });
     });

--- a/DirectProgramming/C++SYCL/DenseLinearAlgebra/guided_jacobi_iterative_gpu_optimization/src/3_guided_jacobi_iterative_solver_multi_gpu.cpp
+++ b/DirectProgramming/C++SYCL/DenseLinearAlgebra/guided_jacobi_iterative_gpu_optimization/src/3_guided_jacobi_iterative_solver_multi_gpu.cpp
@@ -68,8 +68,8 @@ void GenerateMatrix(std::vector<float> &input_matrix,
 
       for (int j = i * kSize; j < kSize * (i + 1); ++j) {
         in_mat_acc[j] = distr(engine);
-        in_mat_acc[j] = round(100. * in_mat_acc[j]) / 100.;
-        sum += fabs(in_mat_acc[j]);
+        in_mat_acc[j] = sycl::round(100. * in_mat_acc[j]) / 100.;
+        sum += sycl::fabs(in_mat_acc[j]);
       }
 
       oneapi::dpl::uniform_int_distribution<int> distr2(0, 100);
@@ -99,8 +99,8 @@ void GenerateMatrix(std::vector<float> &input_matrix,
 
       for (int j = i * kSize; j < kSize * (i + 1); ++j) {
         in_mat_acc[j] = distr(engine);
-        in_mat_acc[j] = round(100. * in_mat_acc[j]) / 100.;
-        sum += fabs(in_mat_acc[j]);
+        in_mat_acc[j] = sycl::round(100. * in_mat_acc[j]) / 100.;
+        sum += sycl::fabs(in_mat_acc[j]);
       }
 
       oneapi::dpl::uniform_int_distribution<int> distr2(0, 100);
@@ -112,7 +112,7 @@ void GenerateMatrix(std::vector<float> &input_matrix,
         in_mat_acc[i * kSize + i] = -1 * (sum + 1);
 
       in_res_acc[i] = distr(engine);
-      in_res_acc[i] = round(100. * in_res_acc[i]) / 100.;
+      in_res_acc[i] = sycl::round(100. * in_res_acc[i]) / 100.;
     });
   });
 }
@@ -153,7 +153,7 @@ bool CheckIfEqual(const std::vector<Real> &data,
   int correct_result = 0;
 
   for (int i = 0; i < kSize; ++i) {
-    if (fabs(data[i] - old_output_data[i]) < kCheckError) correct_result++;
+    if (std::fabs(data[i] - old_output_data[i]) < kCheckError) correct_result++;
   }
 
   return correct_result == kSize;
@@ -313,7 +313,7 @@ int main(int argc, char *argv[]) {
       accessor R{bufin_res, h, read_only};
       accessor NR{bufout_res, h, read_only};
       h.parallel_for(range<1>(kSize), [=](id<1> id) {
-        Real diff = fabs(NR[id] - R[id]);
+        Real diff = sycl::fabs(NR[id] - R[id]);
         if (diff > kCalculationError) all_eq[0] = false;
       });
     });

--- a/DirectProgramming/C++SYCL/MapReduce/MonteCarloPi/src/monte_carlo_pi.cpp
+++ b/DirectProgramming/C++SYCL/MapReduce/MonteCarloPi/src/monte_carlo_pi.cpp
@@ -20,7 +20,7 @@ constexpr int size_n = 10000;  // Must be greater than size_wg
 // Size of parallel work groups
 constexpr int size_wg = 32;
 // Number of parallel work groups
-const int num_wg = (int)ceil((float)size_n / (float)size_wg);
+const int num_wg = (int)sycl::ceil((float)size_n / (float)size_wg);
 
 // Output image dimensions
 constexpr int img_dimensions = 1024;

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/experimental/hostpipes/src/hostpipes.cpp
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/experimental/hostpipes/src/hostpipes.cpp
@@ -40,7 +40,9 @@ void AlternatingTest(sycl::queue&, ValueT*, ValueT*, size_t, size_t);
 void LaunchCollectTest(sycl::queue&, ValueT*, ValueT*, size_t, size_t);
 
 // offloaded computation
-ValueT SomethingComplicated(ValueT val) { return (ValueT)(val * sqrt(val)); }
+ValueT SomethingComplicated(ValueT val) {
+  return (ValueT)(val * sycl::sqrt(float(val)));
+}
 
 /////////////////////////////////////////
 


### PR DESCRIPTION
# Existing Sample Changes
## Description

SYCL math builtins may cause ambiguity issues with std versions of the same builtins if it is not qualified by its namespace. This commit addresses this issue in select samples.

Replaces https://github.com/oneapi-src/oneAPI-samples/pull/2289.

## External Dependencies

None

## Type of change

Please delete options that are not relevant. Add a 'X' to the one that is applicable. 

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Implement fixes for ONSAM Jiras

## How Has This Been Tested?

As specified in the sample directories.

- [X] Command Line
- [ ] oneapi-cli
- [ ] Visual Studio
- [ ] Eclipse IDE
- [ ] VSCode
- [ ] When compiling the compliler flag "-Wall -Wformat-security -Werror=format-security" was used
