### PR TITLE
FPGA: fix syntax of `reqd_work_group_size`

### DIFF
--- a/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/board_test/src/board_test.hpp
+++ b/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/board_test/src/board_test.hpp
@@ -732,7 +732,7 @@ int ShimMetrics::KernelClkFreq(sycl::queue &q, bool report_chk) {
     constexpr size_t kReqdWgSize = 32 * kKiB;  // 32 KB
     h.parallel_for<NopNDRange>(
         sycl::nd_range<1>(sycl::range<1>(kN), sycl::range<1>(kReqdWgSize)), [=
-    ](auto id) [[sycl::reqd_work_group_size(1, 1, kReqdWgSize)]]{});
+    ](auto id) [[sycl::reqd_work_group_size(kReqdWgSize)]]{});
   });
   // Wait for operation to complete
   e.wait();
@@ -1389,7 +1389,7 @@ int ShimMetrics::KernelMemBW(sycl::queue &q) {
                 sycl::nd_range<1>(sycl::range<1>(N), sycl::range<1>(kWGSize)),
                 [=](sycl::nd_item<1> it)
                     [[intel::num_simd_work_items(kSimdItems),
-                      sycl::reqd_work_group_size(1, 1, kWGSize)]] {
+                      sycl::reqd_work_group_size(kWGSize)]] {
                       // Write global ID to memory
                       auto gid = it.get_global_id(0);
                       mem[gid] = gid;
@@ -1400,7 +1400,7 @@ int ShimMetrics::KernelMemBW(sycl::queue &q) {
                 sycl::nd_range<1>(sycl::range<1>(N), sycl::range<1>(kWGSize)),
                 [=](sycl::nd_item<1> it)
                     [[intel::num_simd_work_items(kSimdItems),
-                      sycl::reqd_work_group_size(1, 1, kWGSize)]] {
+                      sycl::reqd_work_group_size(kWGSize)]] {
                       // Read memory
                       auto gid = it.get_global_id();
                       unsigned val = mem[gid];
@@ -1416,7 +1416,7 @@ int ShimMetrics::KernelMemBW(sycl::queue &q) {
                 sycl::nd_range<1>(sycl::range<1>(N), sycl::range<1>(kWGSize)),
                 [=](sycl::nd_item<1> it)
                     [[intel::num_simd_work_items(kSimdItems),
-                      sycl::reqd_work_group_size(1, 1, kWGSize)]] {
+                      sycl::reqd_work_group_size(kWGSize)]] {
                       // Read, modify and write to memory
                       auto gid = it.get_global_id(0);
                       mem[gid] = mem[gid] + 2;


### PR DESCRIPTION
# Existing Sample Changes
## Description

Update the board_test code sample to adhere to the new reqd_work_group_size syntax.

## Type of change

Please delete options that are not relevant. Add a 'X' to the one that is applicable. 

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Implement fixes for ONSAM Jiras

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [X] Command Line
- [ ] oneapi-cli
- [ ] Visual Studio
- [ ] Eclipse IDE
- [ ] VSCode
- [ ] When compiling the compliler flag "-Wall -Wformat-security -Werror=format-security" was used
