### PR TITLE
FPGA: fix incorrectly placed event wait when using REAL_IO_PIPES in mvdr

### DIFF
--- a/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/mvdr_beamforming/src/mvdr_beamforming.cpp
+++ b/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/mvdr_beamforming/src/mvdr_beamforming.cpp
@@ -382,12 +382,13 @@ int main(int argc, char *argv[]) {
         DataOutConsumer::Start(q, kDataOutSize * num_matrix_copies);
     std::tie(produce_dma_event, produce_kernel_event) =
         DataProducer::Start(q, kInputDataSize * num_matrix_copies);
-#endif
+
     ////////////////////////////////////////////////////////////////////////////
 
     // Wait for the DMA event to finish for the producer before starting the
     // timer. If USM host allocations are used, this is a noop.
     produce_dma_event.wait();
+#endif
 
     auto start_time = high_resolution_clock::now();
 


### PR DESCRIPTION
This PR moved a dma wait event inside the appropriate if statement it is attached to, fixing a compile error when using REAL_IO_PIPES.

Addresses https://github.com/oneapi-src/oneAPI-samples/issues/2201