### PR TITLE
FPGA: Add print statement to mem_channel tutorial to avoid cmake warning

### DIFF
--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/mem_channel/CMakeLists.txt
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/mem_channel/CMakeLists.txt
@@ -57,6 +57,8 @@ if(NOT DEFINED DEVICE_FLAG)
                          -DDEVICE_FLAG=Agilex7.")
 endif()
 
+message("\tDEVICE_FLAG set to ${DEVICE_FLAG}")
+
 if (NOT DEFINED PART)
     set (PART " ")
 endif()


### PR DESCRIPTION
## Description

This change adds a print statement of the `DEVICE_FLAG` so that a CMake "unused variable" warning is not emitted.

## External Dependencies

* N/A

## Type of change

Please delete options that are not relevant. Add a 'X' to the one that is applicable. 

- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Manually compiled the design to reports to make sure that the cmake warning is no longer displayed to users and that the proper flags are still being passed to the design. When users run cmake they will now see output that looks something like the following:

```
-- The CXX compiler identification is IntelLLVM 2024.2.0
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: /p/psg/swip/hld/r/sycl/rel/20240417/linux64/compiler/latest/bin/icpx - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Configuring the design with the following target: ofs_n6001
	DEVICE_FLAG set to Agilex7
-- Additional USER_FPGA_FLAGS=
-- Additional USER_FLAGS=
-- Additional USER_INCLUDE_PATHS=../../../include
-- Additional USER_LIB_PATHS=
-- Additional USER_LIBS=
-- Configuring done
-- Generating done
-- Build files have been written to: /tmp/jrosner/stella/external/oneapi-src/oneAPI-samples/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/mem_channel/build
```
* Note the DEVICE_FLAG message
