### PR TITLE
FPGA: Move all samples from the DE10 to the N6001 board

### DIFF
--- a/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/board_test/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/board_test/README.md
@@ -264,7 +264,7 @@ The tests listed above check the following interfaces in a platform:
 
 ## Example Output
 
-Running on FPGA device (Terasic’s DE10-Agilex Development Board). Performance results are based on testing as of August 30, 2023.
+Running on FPGA device (Intel® FPGA SmartNIC N6001-PL). Performance results are based on testing as of May 10, 2024.
 
 > **Note**: Refer to the [Performance Disclaimers](/DirectProgramming/C++SYCL_FPGA/README.md#performance-disclaimers) section for important performance information.
 
@@ -287,21 +287,21 @@ The tests are:
 Note: Kernel Clock Frequency is run along with all tests except 1 (Host Speed and Host Read Write test)
 
 Running all tests 
-Running on device: de10_agilex : Agilex Reference Platform (aclde10_agilex0)
+Running on device: ofs_n6001 : Intel OFS Platform (ofs_ee00000)
 
-clGetDeviceInfo CL_DEVICE_GLOBAL_MEM_SIZE = 34359737344
-clGetDeviceInfo CL_DEVICE_MAX_MEM_ALLOC_SIZE = 34359737344
-Device buffer size available for allocation = 34359737344 bytes
+clGetDeviceInfo CL_DEVICE_GLOBAL_MEM_SIZE = 17179869184
+clGetDeviceInfo CL_DEVICE_MAX_MEM_ALLOC_SIZE = 17179868160
+Device buffer size available for allocation = 17179868160 bytes
 
 *****************************************************************
 *********************** Host Speed Test *************************
 *****************************************************************
 
-Size of buffer created = 34359737344 bytes
-Writing 32767 MB to device global memory ... 8776.42 MB/s
-Reading 32767 MB from device global memory ... 9743.93 MB/s
+Size of buffer created = 17179868160 bytes
+Writing 16383 MiB to device global memory ... 7592.7 MB/s
+Reading 16383 MiB from device global memory ... 7628.8 MB/s
 Verifying data ...
-Successfully wrote and readback 32767 MB buffer
+Successfully wrote and readback 16383 MB buffer
 
 Transferring 8192 KBs in 256 32 KB blocks ...
 Transferring 8192 KBs in 128 64 KB blocks ...
@@ -316,34 +316,34 @@ Transferring 8192 KBs in 1 8192 KB blocks ...
 Writing 8192 KBs with block size (in bytes) below:
 
 Block_Size Avg Max Min End-End (MB/s)
-   32768 428.07 435.44 382.82 395.97 
-   65536 783.64 793.81 665.47 730.92 
-  131072 1325.34 1343.33 1165.79 1250.47 
-  262144 1984.22 2016.88 1776.27 1903.43 
-  524288 3507.84 3588.65 3165.04 3385.12 
- 1048576 4845.12 4982.59 4533.71 4730.02 
- 2097152 5741.51 5758.96 5719.79 5656.95 
- 4194304 6695.96 6869.04 6531.39 6652.06 
- 8388608 7585.54 7585.54 7585.54 7585.54 
+   32768 381.23 426.21 249.94 4775.26 
+   65536 510.22 546.47 406.00 7332.94 
+  131072 757.51 1073.87 701.72 13826.89 
+  262144 977.82 1954.74 869.33 16369.93 
+  524288 1272.50 3282.34 1037.37 14452.23 
+ 1048576 1746.77 4678.85 1083.52 8202.39 
+ 2097152 5797.93 5983.74 5546.83 20416.05 
+ 4194304 6436.09 6557.66 6318.95 12325.60 
+ 8388608 6919.11 6919.11 6919.11 6919.11 
 
 Reading 8192 KBs with block size (in bytes) below:
 
 Block_Size Avg Max Min End-End (MB/s)
-   32768 477.89 492.37 430.08 436.84 
-   65536 869.03 896.61 814.20 799.03 
-  131072 1464.26 1504.16 1384.23 1363.57 
-  262144 2201.40 2237.72 2136.42 2090.72 
-  524288 3869.46 3966.81 3728.03 3697.54 
- 1048576 5318.21 5457.59 5197.05 5171.01 
- 2097152 6325.13 6432.15 6175.55 6217.27 
- 4194304 7577.67 7609.52 7546.07 7526.88 
- 8388608 8441.18 8441.18 8441.18 8441.18 
+   32768 416.23 463.80 149.57 4051.34 
+   65536 588.92 634.71 261.48 6861.12 
+  131072 769.07 1089.64 397.59 12046.73 
+  262144 1017.03 2195.03 654.95 16790.08 
+  524288 1204.36 3581.23 815.31 13943.92 
+ 1048576 1512.05 4862.33 953.71 8371.75 
+ 2097152 2775.19 6196.34 1046.06 4133.37 
+ 4194304 2893.07 6699.52 1844.87 3673.20 
+ 8388608 2977.26 2977.26 2977.26 2977.26 
 
-Host write top speed = 7585.54 MB/s
-Host read top speed = 8441.18 MB/s
+Host write top speed = 20416.05 MB/s
+Host read top speed = 16790.08 MB/s
 
 
-HOST-TO-MEMORY BANDWIDTH = 8013 MB/s
+HOST-TO-MEMORY BANDWIDTH = 18603 MB/s
 
 
 *****************************************************************
@@ -351,13 +351,7 @@ HOST-TO-MEMORY BANDWIDTH = 8013 MB/s
 *****************************************************************
 
 --- Running host read write test with device offset 0
-** WARNING: [aclde10_agilex0] NOT using DMA to transfer 1024 bytes from host to device because of lack of alignment
-**                 host ptr (0x1688a3f5) and/or dev offset (0x400) is not aligned to 4 bytes
 --- Running host read write test with device offset 3
-** WARNING: [aclde10_agilex0] NOT using DMA to transfer 1024 bytes from host to device because of lack of alignment
-**                 host ptr (0x1688a3f5) and/or dev offset (0x403) is not aligned to 4 bytes
-** WARNING: [aclde10_agilex0] NOT using DMA to transfer 1024 bytes from device to host because of lack of alignment
-**                 host ptr (0x16893cb8) and/or dev offset (0x403) is not aligned to 4 bytes
 
 HOST READ-WRITE TEST PASSED!
 
@@ -365,8 +359,8 @@ HOST READ-WRITE TEST PASSED!
 *******************  Kernel Clock Frequency Test  ***************
 *****************************************************************
 
-Measured Frequency    =   598.905 MHz 
-Quartus Compiled Frequency  =   600 MHz 
+Measured Frequency    =   511.062 MHz 
+Quartus Compiled Frequency  =   512 MHz 
 
 Measured Clock frequency is within 2 percent of Quartus compiled frequency. 
 
@@ -386,16 +380,16 @@ KERNEL_LAUNCH_TEST PASSED
 ********************  Kernel Latency  **************************
 *****************************************************************
 
-Processed 10000 kernels in 217.0312 ms
-Single kernel round trip time = 21.7031 us
-Throughput = 46.0763 kernels/ms
+Processed 10000 kernels in 118.6319 ms
+Single kernel round trip time = 11.8632 us
+Throughput = 84.2943 kernels/ms
 Kernel execution is complete
 
 *****************************************************************
 *************  Kernel-to-Memory Read Write Test  ***************
 *****************************************************************
 
-Maximum device global memory allocation size is 34359737344 bytes 
+Maximum device global memory allocation size is 17179868160 bytes 
 Finished host memory allocation for input and output data
 Creating device buffer
 Finished writing to device buffers 
@@ -404,10 +398,6 @@ Launching kernel with global offset : 0
 Launching kernel with global offset : 1073741824
 Launching kernel with global offset : 2147483648
 Launching kernel with global offset : 3221225472
-Launching kernel with global offset : 4294967296
-Launching kernel with global offset : 5368709120
-Launching kernel with global offset : 6442450944
-Launching kernel with global offset : 7516192768
 ... kernel finished execution. 
 Finished Verification
 KERNEL TO MEMORY READ WRITE TEST PASSED 
@@ -419,17 +409,17 @@ KERNEL TO MEMORY READ WRITE TEST PASSED
 Note: This test assumes that design was compiled with -Xsno-interleaving option
 
 
-Performing kernel transfers of 4096 MBs on the default global memory (address starting at 0)
+Performing kernel transfers of 4096 MiBs on the default global memory (address starting at 0)
 Launching kernel MemWriteStream ... 
 Launching kernel MemReadStream ... 
 Launching kernel MemReadWriteStream ... 
 
 Summarizing bandwidth in MB/s/bank for banks 1 to 8
- 19307.6  19312.5  19309.3  19309.4  19309.2  19309.4  19311.3  19309.2  MemWriteStream
- 19337.7  19339.8  19337.7  19341.4  19340.3  19338.3  19337.7  19339.3  MemReadStream
- 17657.3  17657.1  17657.5  17657.4  17656.7  17657.7  17657.6  17657.5  MemReadWriteStream
+ 8765.24  8765.28  8765.26  8765.29  8765.27  8765.24  8765.3  8765.28  MemWriteStream
+ 8786.28  8786.28  8786.27  8786.26  8786.27  8786.26  8786.3  8786.26  MemReadStream
+ 8059.25  8062.61  8061.29  8054.25  8058.78  8061.35  8062.6  8058.39  MemReadWriteStream
 
-KERNEL-TO-MEMORY BANDWIDTH = 18768.7 MB/s/bank
+KERNEL-TO-MEMORY BANDWIDTH = 8537.12 MB/s/bank
 
 *****************************************************************
 ***********************  USM Bandwidth  *************************

--- a/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/cholesky/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/cholesky/README.md
@@ -66,7 +66,7 @@ Performance results are based on testing as of August 30, 2023.
 
 | Device                                            | Throughput
 |:---                                               |:---
-| Terasic’s DE10-Agilex Development Board           | 378k matrices/s for real matrices of size 32x32
+| Intel® FPGA SmartNIC N6001-PL                     | 338k matrices/s for real matrices of size 32x32
 
 ## Key Implementation Details
 
@@ -294,11 +294,11 @@ You can apply the Cholesky decomposition to a number of matrices, as shown below
 ## Example Output
 
 ```
-Running on device: de10_agilex : Agilex Reference Platform (aclde10_agilex0)
+Running on device: ofs_n6001 : Intel OFS Platform (ofs_ee00000)
 Generating 8 random real matrices of size 32x32 
 Computing the Cholesky decomposition of 8 matrices 819200 times
-   Total duration:   17.3307 s
-Throughput: 378.15k matrices/s
+   Total duration:   19.366 s
+Throughput: 338.407k matrices/s
 Verifying results...
 
 PASSED

--- a/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/cholesky_inversion/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/cholesky_inversion/README.md
@@ -79,11 +79,10 @@ Performance results are based on testing as of April 26, 2022.
 
 | Device                                            | Throughput
 |:---                                               |:---
-| Terasic’s DE10-Agilex Development Board           | 415k matrices/s for real matrices of size 32x32
+| Intel® FPGA SmartNIC N6001-PL                     | 389k matrices/s for real matrices of size 32x32
 
 ## Key Implementation Details
 
-In this reference design, the Cholesky decomposition algorithm is used to factor a real _n_ × _n_ matrix. The algorithm computes the vector dot product of two rows of the matrix. In our FPGA implementation, the dot product is computed in a loop over the row's _n_ elements. The loop is fully unrolled to maximize throughput. As a result, *n* real multiplication operations are performed in parallel on the FPGA, followed by sequential additions to compute the dot product result.
 
 With this optimization, our FPGA implementation requires _n_ DSPs to compute the real floating point dot product. The input matrix is also replicated two times in order to be able to read two full rows per cycle. The matrix size is constrained by the total FPGA DSP and RAM resources available.
 
@@ -320,11 +319,11 @@ You can apply the Cholesky-based inversion to 8 matrices repeated a number of ti
 ## Example Output
 
 ```
-Running on device: de10_agilex : Agilex Reference Platform (aclde10_agilex0)
+Running on device: ofs_n6001 : Intel OFS Platform (ofs_ee00000)
 Generating 8 random real matrices of size 32x32 
 Computing the Cholesky-based inversion of 8 matrices 819200 times
-   Total duration:   15.7619 s
-Throughput: 415.789k matrices/s
+   Total duration:   16.8337 s
+Throughput: 389.315k matrices/s
 Verifying results...
 
 PASSED

--- a/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/crr/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/crr/README.md
@@ -61,9 +61,9 @@ Performance results are based on testing as of August 30, 2023.
 
 > **Note**: Refer to the [Performance Disclaimers](/DirectProgramming/C++SYCL_FPGA/README.md#performance-disclaimers) section for important performance information.
 
-| Device                                              | Throughput
-|:---                                                 |:---
-| Terasic’s DE10-Agilex Development Board             | 653 assets/s
+| Device                                          | Congifuration                         | Throughput
+|:---                                             |:---                                   |:---
+| Intel® FPGA SmartNIC N6001-PL                   | Outer unroll: 1; Inner unroll: 64     | 329 assets/s
 
 
 ## Key Implementation Details
@@ -296,14 +296,14 @@ This design measures the FPGA performance to determine how many assets can be pr
 ## Example Output
 
 ```
-Running on device: de10_agilex : Agilex Reference Platform (aclde10_agilex0)
+Running on device: ofs_n6001 : Intel OFS Platform (ofs_ec00000)
 
 ============= Correctness Test ============= 
 Running analytical correctness checks... 
 CPU-FPGA Equivalence: PASS
 
 ============= Throughput Test =============
-   Avg throughput:   653.9 assets/s
+   Avg throughput:   329.5 assets/s
 ```
 
 ## License

--- a/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/fft2d/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/fft2d/README.md
@@ -265,36 +265,36 @@ Additionally, the `cmake` build system can be configured using the following par
 ## Example Output
 
 
-Example Output when running on the **Terasic DE10-Agilex Development Board**.
+Example Output when running on the **Intel® FPGA SmartNIC N6001-PL**.
 
 ```
 No program argument was passed, running all fft2d variants
-Running on device: de10_agilex : Agilex Reference Platform (aclde10_agilex0)
+Running on device: ofs_n6001 : Intel OFS Platform (ofs_ee00000)
 Using USM device allocations
 Launching a 1048576 points 8-parallel FFT transform (ordered data layout)
-Processing time = 0.00296994s
-Throughput = 0.353063 Gpoints / sec (35.3063 Gflops)
+Processing time = 0.00187981s
+Throughput = 0.55781 Gpoints / sec (55.781 Gflops)
 Signal to noise ratio on output sample: 137.231
  --> PASSED
-Running on device: de10_agilex : Agilex Reference Platform (aclde10_agilex0)
+Running on device: ofs_n6001 : Intel OFS Platform (ofs_ee00000)
 Using USM device allocations
 Launching a 1048576 points 8-parallel inverse FFT transform (ordered data layout)
-Processing time = 0.00277858s
-Throughput = 0.377378 Gpoints / sec (37.7378 Gflops)
+Processing time = 0.00184986s
+Throughput = 0.566842 Gpoints / sec (56.6842 Gflops)
 Signal to noise ratio on output sample: 136.861
  --> PASSED
-Running on device: de10_agilex : Agilex Reference Platform (aclde10_agilex0)
+Running on device: ofs_n6001 : Intel OFS Platform (ofs_ee00000)
 Using USM device allocations
 Launching a 1048576 points 8-parallel FFT transform (alternative data layout)
-Processing time = 0.0027715s
-Throughput = 0.378343 Gpoints / sec (37.8343 Gflops)
+Processing time = 0.00185805s
+Throughput = 0.564343 Gpoints / sec (56.4343 Gflops)
 Signal to noise ratio on output sample: 137.436
  --> PASSED
-Running on device: de10_agilex : Agilex Reference Platform (aclde10_agilex0)
+Running on device: ofs_n6001 : Intel OFS Platform (ofs_ee00000)
 Using USM device allocations
 Launching a 1048576 points 8-parallel inverse FFT transform (alternative data layout)
-Processing time = 0.00277509s
-Throughput = 0.377852 Gpoints / sec (37.7852 Gflops)
+Processing time = 0.00185293s
+Throughput = 0.565902 Gpoints / sec (56.5902 Gflops)
 Signal to noise ratio on output sample: 136.689
  --> PASSED
 ```

--- a/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/gzip/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/gzip/README.md
@@ -118,7 +118,7 @@ Performance results are based on testing as of August 30, 2023.
 
 | Device                                                                              | Throughput
 |:---                                                                                 |:---
-| Terasic’s DE10-Agilex Development Board                                             | 2 engines @ 4.6 GB/s
+| Intel® FPGA SmartNIC N6001-PL                                                       | 2 engines @ 7 GB/s
 
 ## Build the `GZIP` Design
 
@@ -307,7 +307,7 @@ Performance results are based on testing as of August 30, 2023.
 ## Example Output
 
 ```
-Running on device: de10_agilex : Agilex Reference Platform (aclde10_agilex0)
+Running on device: ofs_n6001 : Intel OFS Platform (ofs_ee00000)
 Launching High-Bandwidth DMA GZIP application with 2 engines
 outputSize: 145706366 Prepin: 0
 kMinBufferSize: 16384 isz: 145706110 kInOutPadding: 256
@@ -325,21 +325,21 @@ outputSize: 145706366 Prepin: 0
 kMinBufferSize: 16384 isz: 145706110 kInOutPadding: 256
 outputSize: 145706366 Prepin: 0
 kMinBufferSize: 16384 isz: 145706110 kInOutPadding: 256
-Throughput: 4.62197 GB/s
+Throughput: 6.99 GB/s
 
 TP breakdown for engine #0 (GB/s)
-CRC = 9.58499
-LZ77 = 9.22334
-Huffman Encoding = 4.51518
-DMA host-to-device = 8.92087
-DMA device-to-host = 9.85465
+CRC = 5.75029
+LZ77 = 3.51912
+Huffman Encoding = 3.5107
+DMA host-to-device = 9.26423
+DMA device-to-host = 7.4516
 
 TP breakdown for engine #1 (GB/s)
-CRC = 9.58543
-LZ77 = 9.23241
-Huffman Encoding = 4.50995
-DMA host-to-device = 8.93201
-DMA device-to-host = 9.86107
+CRC = 5.75794
+LZ77 = 3.52021
+Huffman Encoding = 3.50743
+DMA host-to-device = 9.36199
+DMA device-to-host = 8.74803
 
 Compression Ratio 43.9262%
 PASSED

--- a/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/matmul/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/matmul/README.md
@@ -60,7 +60,7 @@ Performance results are based on testing as of March 6, 2023.
 
 | Device                                            | Throughput
 |:---                                               |:---
-| Terasic’s DE10-Agilex Development Board           | 144k matrices/s for single-precision floating-point matrices of size 64 * 64, computed using a systolic array of 8 * 8 PEs (64 DSPs)
+| Intel® FPGA SmartNIC N6001-PL                     | 142k matrices/s for single-precision floating-point matrices of size 64 * 64, computed using a systolic array of 8 * 8 PEs (64 DSPs)
 
 ## Key Implementation Details
 
@@ -354,16 +354,16 @@ You can perform the multiplication of the set of matrices repeatedly. This step 
 
 ## Example Output
 
-Example output when running on **Terasic’s DE10-Agilex Development Board** for the multiplication of 8 matrices 819200 times (each matrix consisting of 64x64 single-precision floating point numbers, computed using a systolic array of 8x8 PEs).
+Example output when running on **Intel® FPGA SmartNIC N6001-PL** for the multiplication of 8 matrices 819200 times (each matrix consisting of 64x64 single-precision floating point numbers, computed using a systolic array of 8x8 PEs).
 
 ```
-Running on device: de10_agilex : Agilex Reference Platform (aclde10_agilex0)
+Running on device: ofs_n6001 : Intel OFS Platform (ofs_ee00000)
  Matrix A size: 64 x 64 (tile: 8 x 64)
  Matrix B size: 64 x 64 (tile: 64 x 8)
  Systolic array size: 8 x 8 PEs
 Running matrix multiplication of 2 matrices 819200 times
-   Total duration:   11.3746 s
-Throughput: 144.04k matrices/s
+   Total duration:   11.4577 s
+Throughput: 142.995k matrices/s
 
 PASSED
 ```

--- a/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/merge_sort/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/merge_sort/README.md
@@ -190,14 +190,14 @@ For `constexpr_math.hpp`, `pipe_utils.hpp`, and `unrolled_loop.hpp` see the READ
 >**Note**: When running on the FPGA emulator, the *Execution time* and *Throughput* values do not reflect the design's actual hardware performance.
 
 ```
-Running on device: de10_agilex : Agilex Reference Platform (aclde10_agilex0)
+Running on device: ofs_n6001 : Intel OFS Platform (ofs_ee00000)
 Running sort 17 times for an input size of 16777216 using 8 4-way merge units
 Streaming data from device memory
-Execution time: 21.3643 ms
-Throughput: 748.914 Melements/s
+Execution time: 33.7713 ms
+Throughput: 473.775 Melements/s
 PASSED
 ```
->**Note**: The performance numbers above were achieved using Terasic’s DE10-Agilex Development Board; your results may vary.
+>**Note**: The performance numbers above were achieved using the Intel® FPGA SmartNIC N6001-PL; your results may vary.
 
 ## License
 

--- a/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/mvdr_beamforming/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/mvdr_beamforming/README.md
@@ -346,7 +346,7 @@ Matrices:         1024
 Input Directory:  '../data'
 Output Directory: '.'
 
-Running on device: de10_agilex : Agilex Reference Platform (aclde10_agilex0)
+Running on device: ofs_n6001 : Intel OFS Platform (ofs_ee00000)
 Reading training data from '../data/A_real.txt and ../data/A_imag.txt
 Reading input data from ../data/X_real.txt and ../data/X_imag.txt
 Launched MVDR kernels
@@ -357,7 +357,7 @@ Training matrix rows          : 48
 Data rows per training matrix : 48
 Steering vectors              : 25
 Streaming pipe width          : 4
-Throughput: 357351 matrices/second
+Throughput: 324173 matrices/second
 Checking output data against ../data/small_expected_out_real.txt and ../data/small_expected_out_imag.txt
 Output data check succeeded
 PASSED

--- a/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/pca/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/pca/README.md
@@ -67,7 +67,7 @@ Performance results are based on testing as of June 1st, 2023.
 
 | Device                                            | Throughput
 |:---                                               |:---
-| Terasic DE10-Agilex Development Board             | 16k matrices/s for matrices of size 8 features * 4176 samples
+| Intel® FPGA SmartNIC N6001-PL                     | 14k matrices/s for matrices of size 8 features * 4176 samples
 
 ## Key Implementation Details
 
@@ -475,17 +475,17 @@ Additionally, the `cmake` build system can be configured using the following par
 
 ## Example Output
 
-Example Output when running on the **Terasic DE10-Agilex Development Board**.
+Example Output when running on the **Intel® FPGA SmartNIC N6001-PL**.
 
 ```
-Running on device: de10_agilex : Agilex Reference Platform (aclde10_agilex0)
+Running on device: ofs_n6001 : Intel OFS Platform (ofs_ee00000)
 Reading the input data from file.
 Features count: 8
 Samples count: 4176
 Running Principal Component analysis of 1 matrix 4096 times
 Using device allocations
-   Total duration:   0.250902 s
-Throughput: 16.3251k matrices/s
+   Total duration:   0.290521 s
+Throughput: 14.0988k matrices/s
 Verifying results...
 All the tests passed.
 ```

--- a/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/qri/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/qri/README.md
@@ -296,14 +296,14 @@ You can perform the QR-based inversion of the set of matrices repeatedly, as sho
 
 ## Example Output
 
-Example output when running on **Terasic’s DE10-Agilex Development Board** for 8 matrices (each consisting of 32 x 32 real numbers).
+Example output when running on **Intel® FPGA SmartNIC N6001-PL** for 8 matrices (each consisting of 32 x 32 real numbers).
 
 ```
-Running on device: de10_agilex : Agilex Reference Platform (aclde10_agilex0)
+Running on device: ofs_n6001 : Intel OFS Platform (ofs_ee00000)
 Generating 8 random real matrices of size 32x32 
 Running QR inversion of 8 matrices 6553600 times
-   Total duration:   170.299 s
-Throughput: 307.864k matrices/s
+   Total duration:   166.892 s
+Throughput: 314.149k matrices/s
 Verifying results... 
 PASSED
 ```

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/double_buffering/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/double_buffering/README.md
@@ -228,7 +228,7 @@ The key concepts discussed in this sample are as followed:
 
 ```
 Platform name: Intel(R) FPGA SDK for OpenCL(TM)
-Running on device: de10_agilex : Agilex Reference Platform (aclde10_agilex0)
+Running on device: ofs_n6001 : Intel OFS Platform (ofs_ee00000)
 Executing kernel 100 times in each round.
 
 *** Beginning execution, without double buffering
@@ -243,9 +243,9 @@ Launching kernel #70
 Launching kernel #80
 Launching kernel #90
 
-Overall execution time without double buffering = 12715 ms
-Total kernel-only execution time without double buffering = 8310 ms
-Throughput = 82.465027 MB/s
+Overall execution time without double buffering = 13343 ms
+Total kernel-only execution time without double buffering = 12878 ms
+Throughput = 78.583199 MB/s
 
 
 *** Beginning execution, with double buffering.
@@ -260,9 +260,9 @@ Launching kernel #70
 Launching kernel #80
 Launching kernel #90
 
-Overall execution time with double buffering = 8309 ms
-Total kernel-only execution time with double buffering = 8303 ms
-Throughput = 126.18566 MB/s
+Overall execution time with double buffering = 12929 ms
+Total kernel-only execution time with double buffering = 12924 ms
+Throughput = 81.101379 MB/s
 
 
 Verification PASSED
@@ -344,12 +344,12 @@ The basic implementation flow is as follows:
 
 ### Impact of Double Buffering
 
-A test compile of this tutorial design achieved a maximum frequency (f<sub>MAX</sub>) of approximately 602 MHz on Terasic’s DE10-Agilex Development Board. The results with and without double buffering are shown in the following table:
+A test compile of this tutorial design achieved a maximum frequency (f<sub>MAX</sub>) of approximately 600 MHz on Intel® FPGA SmartNIC N6001-PL. The results with and without double buffering are shown in the following table:
 
 | Configuration             | Overall Execution Time (ms)  | Total Kernel Execution time (ms)
 |:--                        |:--                           |:--
-| Without double buffering  | 56                           | 3
-| With double buffering     | 6                            | 2
+| Without double buffering  | 13343                        | 12878
+| With double buffering     | 12929                        | 12924
 
 In both runs, the total kernel execution time is similar as expected; however, without double buffering, the overall execution time exceeds the total kernel execution time, implying there is downtime between kernel executions. With double buffering, the overall execution time is close to the total kernel execution time.
 

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/loop_carried_dependency/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/loop_carried_dependency/README.md
@@ -270,11 +270,11 @@ Look at the _Compiler Report > Throughput Analysis > Loop Analysis_ section in t
 
 ```
 Number of elements: 150
-Running on device: de10_agilex : Agilex Reference Platform (aclde10_agilex0)
+Running on device: ofs_n6001 : Intel OFS Platform (ofs_ee00000)
 Run: Unoptimized:
-kernel time : 0.441344 ms
+kernel time : 0.637952 ms
 Run: Optimized:
-kernel time : 0.368128 ms
+kernel time : 0.5056 ms
 PASSED
 ```
 

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/n_way_buffering/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/n_way_buffering/README.md
@@ -308,20 +308,20 @@ After each kernel is launched, the host-side operations (that occur *after* the 
 
 ### Example Output on FPGA Device
 
-> **Note**: A test compile of this tutorial design achieved an f<sub>MAX</sub> of approximately 602 MHz on Terasic’s DE10-Agilex Development Board. The table shows the results.
+> **Note**: A test compile of this tutorial design achieved an f<sub>MAX</sub> of approximately 602 MHz on the Intel® FPGA SmartNIC N6001-PL. The table shows the results.
 >
 >Configuration                     | Overall Execution Time (ms) | Total Kernel Execution time (ms)
 >|:--                              |:--                          |:--
->|1-way buffering, single-threaded | 14157                       | 8312
->|1-way buffering, multi-threaded  | 9698                        | 8308
->|2-way buffering, multi-threaded  | 8608                        | 8312
->|5-way buffering, multi-threaded  | 8530                        | 8309
+>|1-way buffering, single-threaded | 14257                       | 13008
+>|1-way buffering, multi-threaded  | 14001                       | 13008
+>|2-way buffering, multi-threaded  | 13401                       | 13008
+>|5-way buffering, multi-threaded  | 13182                       | 13039
 >
 >In all runs, the total kernel execution time is similar as expected. In the first three configurations, the overall execution time exceeds the total kernel execution time, implying there is downtime between kernel executions. However, as we switch from single-threaded to multi-threaded host operations and increase the number of buffer sets used, the overall execution time approaches the kernel execution time.
 
 ```
 Platform name: Intel(R) FPGA SDK for OpenCL(TM)
-Running on device: de10_agilex : Agilex Reference Platform (aclde10_agilex0)
+Running on device: ofs_n6001 : Intel OFS Platform (ofs_ee00000)
 Executing kernel 100 times in each round.
 
 *** Beginning execution, 1-way buffering, single-threaded host operations
@@ -336,9 +336,9 @@ Launching kernel #70
 Launching kernel #80
 Launching kernel #90
 
-Overall execution time = 14157 ms
-Total kernel-only execution time = 8312 ms
-Throughput = 74.063652 MB/s
+Overall execution time = 14257 ms
+Total kernel-only execution time = 13008 ms
+Throughput = 73.54554 MB/s
 
 
 *** Beginning execution, 1-way buffering, multi-threaded host operations.
@@ -353,9 +353,9 @@ Launching kernel #70
 Launching kernel #80
 Launching kernel #90
 
-Overall execution time = 9698 ms
-Total kernel-only execution time = 8308 ms
-Throughput = 108.11652 MB/s
+Overall execution time = 14001 ms
+Total kernel-only execution time = 13008 ms
+Throughput = 74.89061 MB/s
 
 
 *** Beginning execution, 2-way buffering, multi-threaded host operationss
@@ -370,9 +370,9 @@ Launching kernel #70
 Launching kernel #80
 Launching kernel #90
 
-Overall execution time = 8608 ms
-Total kernel-only execution time = 8312 ms
-Throughput = 121.80763 MB/s
+Overall execution time = 13401 ms
+Total kernel-only execution time = 13008 ms
+Throughput = 78.243797 MB/s
 
 
 *** Beginning execution, N=5-way buffering, multi-threaded host operations
@@ -387,9 +387,9 @@ Launching kernel #70
 Launching kernel #80
 Launching kernel #90
 
-Overall execution time with N-way buffering = 8530 ms
-Total kernel-only execution time with N-way buffering = 8309 ms
-Throughput = 122.91462 MB/s
+Overall execution time with N-way buffering = 13182 ms
+Total kernel-only execution time with N-way buffering = 13039 ms
+Throughput = 79.542877 MB/s
 
 
 Verification PASSED

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/onchip_memory_cache/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/onchip_memory_cache/README.md
@@ -257,55 +257,55 @@ This tutorial creates multiple kernels sweeping across different cache depths wi
 
 ```
 Platform name: Intel(R) FPGA SDK for OpenCL(TM)
-Running on device: de10_agilex : Agilex Reference Platform (aclde10_agilex0)
+Running on device: ofs_n6001 : Intel OFS Platform (ofs_ee00000)
 
 Number of inputs: 16777216
 Number of outputs: 64
 
 Beginning run with cache depth 0 (no cache)
 Data check succeeded for cache depth 0
-Kernel execution time: 0.091634 seconds
-Kernel throughput for cache depth 0: 698.429967 MB/s
+Kernel execution time: 0.094196 seconds
+Kernel throughput for cache depth 0: 679.434782 MB/s
 
 Beginning run with cache depth 1
 Data check succeeded for cache depth 1
-Kernel execution time: 0.045878 seconds
-Kernel throughput for cache depth 1: 1394.991736 MB/s
+Kernel execution time: 0.047102 seconds
+Kernel throughput for cache depth 1: 1358.746969 MB/s
 
 Beginning run with cache depth 2
 Data check succeeded for cache depth 2
-Kernel execution time: 0.045879 seconds
-Kernel throughput for cache depth 2: 1394.963914 MB/s
+Kernel execution time: 0.047099 seconds
+Kernel throughput for cache depth 2: 1358.830543 MB/s
 
 Beginning run with cache depth 3
 Data check succeeded for cache depth 3
-Kernel execution time: 0.045877 seconds
-Kernel throughput for cache depth 3: 1395.036069 MB/s
+Kernel execution time: 0.047101 seconds
+Kernel throughput for cache depth 3: 1358.772354 MB/s
 
 Beginning run with cache depth 4
 Data check succeeded for cache depth 4
-Kernel execution time: 0.045875 seconds
-Kernel throughput for cache depth 4: 1395.100751 MB/s
+Kernel execution time: 0.047099 seconds
+Kernel throughput for cache depth 4: 1358.828466 MB/s
 
 Beginning run with cache depth 5
 Data check succeeded for cache depth 5
-Kernel execution time: 0.045881 seconds
-Kernel throughput for cache depth 5: 1394.918977 MB/s
+Kernel execution time: 0.047101 seconds
+Kernel throughput for cache depth 5: 1358.768344 MB/s
 
 Beginning run with cache depth 6
 Data check succeeded for cache depth 6
-Kernel execution time: 0.045877 seconds
-Kernel throughput for cache depth 6: 1395.038928 MB/s
+Kernel execution time: 0.047101 seconds
+Kernel throughput for cache depth 6: 1358.772758 MB/s
 
 Beginning run with cache depth 7
 Data check succeeded for cache depth 7
-Kernel execution time: 0.045881 seconds
-Kernel throughput for cache depth 7: 1394.920680 MB/s
+Kernel execution time: 0.047102 seconds
+Kernel throughput for cache depth 7: 1358.766383 MB/s
 
 Beginning run with cache depth 8
 Data check succeeded for cache depth 8
-Kernel execution time: 0.045876 seconds
-Kernel throughput for cache depth 8: 1395.054588 MB/s
+Kernel execution time: 0.047102 seconds
+Kernel throughput for cache depth 8: 1358.767191 MB/s
 
 Verification PASSED
 ```

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/optimize_inner_loop/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/optimize_inner_loop/README.md
@@ -309,14 +309,14 @@ Examine the loop attributes for the three different versions of the `Producer` k
     ```
 generating 5000000 random numbers in the range [0,3]
 Running kernel 0
-Running on device: de10_agilex : Agilex Reference Platform (aclde10_agilex0)
+Running on device: ofs_n6001 : Intel OFS Platform (ofs_ee00000)
 Running kernel 1
-Running on device: de10_agilex : Agilex Reference Platform (aclde10_agilex0)
+Running on device: ofs_n6001 : Intel OFS Platform (ofs_ee00000)
 Running kernel 2
-Running on device: de10_agilex : Agilex Reference Platform (aclde10_agilex0)
-Kernel 0 throughput: 745.57 MB/s 
-Kernel 1 throughput: 750.70 MB/s 
-Kernel 2 throughput: 1328.99 MB/s 
+Running on device: ofs_n6001 : Intel OFS Platform (ofs_ee00000)
+Kernel 0 throughput: 938.08 MB/s 
+Kernel 1 throughput: 787.41 MB/s 
+Kernel 2 throughput: 1131.16 MB/s 
 PASSED
     ```
 

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/shannonization/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/shannonization/README.md
@@ -422,13 +422,13 @@ PASSED
 ```
 Generating input data
 Computing golden result
-Running on device: de10_agilex : Agilex Reference Platform (aclde10_agilex0)
+Running on device: ofs_n6001 : Intel OFS Platform (ofs_ee00000)
 Running 5 iterations of kernel 0 with |A|=16384 and |B|=32768
-Kernel 0 average throughput: 338.588 MB/s
+Kernel 0 average throughput: 182.521 MB/s
 Running 5 iterations of kernel 1 with |A|=16384 and |B|=32768
-Kernel 1 average throughput: 445.205 MB/s
+Kernel 1 average throughput: 221.232 MB/s
 Running 5 iterations of kernel 2 with |A|=16384 and |B|=32768
-Kernel 2 average throughput: 388.668 MB/s
+Kernel 2 average throughput: 226.728 MB/s
 PASSED
 ```
 

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/triangular_loop/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/triangular_loop/README.md
@@ -363,30 +363,30 @@ Summing the number of real and dummy iterations gives the total iterations of th
 
 ```
 Platform name: Intel(R) FPGA SDK for OpenCL(TM)
-Running on device: de10_agilex : Agilex Reference Platform (aclde10_agilex0)
+Running on device: ofs_n6001 : Intel OFS Platform (ofs_ee00000)
 Length of input array: 8192
 
 Beginning run without triangular loop optimization.
 
 Verification PASSED
 
-Execution time: 0.217014 seconds
-Throughput without optimization: 589.823554 MB/s
+Execution time: 0.217675 seconds
+Throughput without optimization: 588.033603 MB/s
 
 Beginning run with triangular loop optimization.
 
 Verification PASSED
 
-Execution time: 0.108002 seconds
-Throughput with optimization: 1185.163666 MB/s
+Execution time: 0.108317 seconds
+Throughput with optimization: 1181.717294 MB/s
 ```
 
-A test compile of this tutorial design achieved an f<sub>MAX</sub> of approximately 311 MHz on Terasic's DE10-Agilex Development Board. The results with and without the optimization are shown in the following table:
+A test compile of this tutorial design achieved an f<sub>MAX</sub> of approximately 310 MHz on Intel® FPGA SmartNIC N6001-PL. The results with and without the optimization are shown in the following table:
 
 Configuration         | Overall Execution Time (s)  | Throughput (MB/s)
 |:---                 |:---                         |:---
-|Without optimization | 0.217                       | 589.8
-|With optimization    | 0.108                       | 1185.1
+|Without optimization | 0.217                       | 588
+|With optimization    | 0.108                       | 1181
 
 Without optimization, the compiler achieved an II of 30 on the inner-loop. With the optimization, the compiler achieves an II of 1, and the throughput increased by approximately 30x.
 

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/kernel_args_restrict/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/kernel_args_restrict/README.md
@@ -319,23 +319,23 @@ Next, look at the loop details of the *IDKernelArgsRestrict_Lambda* kernel (simi
 ## Example Output
 
 ```
-Running on device: de10_agilex : Agilex Reference Platform (aclde10_agilex0)
+Running on device: ofs_n6001 : Intel OFS Platform (ofs_ee00000)
 Size of vector: 5000000 elements
-Lambda kernel throughput without attribute: 12.6131 MB/s
-Lambda kernel throughput with attribute: 2272.19 MB/s
-Functor kernel throughput without attribute: 12.6173 MB/s
-Functor kernel throughput with attribute: 2274.7 MB/s
+Lambda kernel throughput without attribute: 5.35162 MB/s
+Lambda kernel throughput with attribute: 2088.2 MB/s
+Functor kernel throughput without attribute: 5.35199 MB/s
+Functor kernel throughput with attribute: 2087.85 MB/s
 PASSED
 ```
 
 ### Results Explained
 
-The throughput observed when running the kernels with and without the `kernel_args_restrict` attribute should reflect the difference in loop II seen in the reports. The ratios will not exactly match because the loop IIs are estimates. An example ratio (compiled and run on Terasic's DE10-Agilex Development Board) is shown.
+The throughput observed when running the kernels with and without the `kernel_args_restrict` attribute should reflect the difference in loop II seen in the reports. The ratios will not exactly match because the loop IIs are estimates. An example ratio (compiled and run on the Intel® FPGA SmartNIC N6001-PL) is shown.
 
 |Attribute used?  | II    | Kernel Throughput (MB/s)
 |:---             |:---   |:---
-|No               | ~64   | 12.6
-|Yes              | ~1    | 2272.2
+|No               | ~854  | 5.35
+|Yes              | ~1    | 2088
 
 > **Note**: This performance difference will be apparent only when running on FPGA hardware. The emulator and simulator, while useful for verifying functionality, will generally not reflect differences in performance of the memory system.
 

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/loop_unroll/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/loop_unroll/README.md
@@ -109,10 +109,10 @@ In an FPGA design, unrolling loops is a common strategy to directly trade-off on
 
 This tutorial demonstrates this trade off with a simple vector add kernel. The tutorial shows how increasing the unroll factor on a loop increases throughput until another bottleneck is encountered. This example is constructed to run up against global memory bandwidth constraints.
 
-For this example, let us consider the Terasic's DE10-Agilex Development Board. 
+For this example, let us consider the Intel® FPGA SmartNIC N6001-PL. 
 The tutorial design will likely run at around 600 MHz when targeting this BSP. 
-The memory bandwidth of this FPGA board is about 21 GB/second per DDR bank.
-It is reasonable to assume that one can reach about 90% of the peak theoretical throughput value (21 * 90% = 18.9 GB/s) 
+The memory bandwidth of this FPGA board is about 19 GB/second per DDR bank.
+It is reasonable to assume that one can reach about 90% of the peak theoretical throughput value (19 * 90% = 17 GB/s) 
 In this design, the FPGA design processes a new iteration every cycle in a pipeline-parallel fashion. 
 The theoretical computation limit for one adder is:
 
@@ -123,13 +123,13 @@ You repeat this back-of-the-envelope calculation for different unroll factors:
 
 |Unroll Factor  | GFlops (GB/s) | Computation Bandwidth (GB/s)
 |:---           |:---           |:---
-|1              | 0.6           | 2.4
-|2              | 1.2           | 4.8
-|4              | 2.4           | 9.6
-|8              | 4.8           | 19.2
-|16             | 9.6           | 38.4
+|1              | 0.5           | 2.4
+|2              | 1.0           | 4.8
+|4              | 1.7           | 9.6
+|8              | 2.2           | 19.2
+|16             | 2.3           | 38.4
 
-On a Terasic's DE10-Agilex Development Board, one can reasonably predict that the program will become memory-bandwidth limited when the unroll factor grows between 4 and 8. If you have access to such an FPGA board, check this prediction by running the design following the instructions below (providing the appropriate BSP when running `cmake`).
+On the Intel® FPGA SmartNIC N6001-PL, one can reasonably predict that the program will become memory-bandwidth limited when the unroll factor grows between 4 and 8. If you have access to such an FPGA board, check this prediction by running the design following the instructions below (providing the appropriate BSP when running `cmake`).
 
 ## Build the `Loop Unroll` Tutorial
 
@@ -293,21 +293,21 @@ You can also check the achieved system f<sub>MAX</sub> to verify the earlier cal
 
 ```
 Input Array Size:  67108864
-Running on device: de10_agilex : Agilex Reference Platform (aclde10_agilex0)
-unroll_factor 1 kernel time : 111.944 ms
-Throughput for kernel with unroll_factor 1: 0.599 GFlops
-Running on device: de10_agilex : Agilex Reference Platform (aclde10_agilex0)
-unroll_factor 2 kernel time : 56.939 ms
-Throughput for kernel with unroll_factor 2: 1.179 GFlops
-Running on device: de10_agilex : Agilex Reference Platform (aclde10_agilex0)
-unroll_factor 4 kernel time : 30.151 ms
-Throughput for kernel with unroll_factor 4: 2.226 GFlops
-Running on device: de10_agilex : Agilex Reference Platform (aclde10_agilex0)
-unroll_factor 8 kernel time : 16.637 ms
-Throughput for kernel with unroll_factor 8: 4.034 GFlops
-Running on device: de10_agilex : Agilex Reference Platform (aclde10_agilex0)
-unroll_factor 16 kernel time : 14.954 ms
-Throughput for kernel with unroll_factor 16: 4.488 GFlops
+Running on device: ofs_n6001 : Intel OFS Platform (ofs_ee00000)
+unroll_factor 1 kernel time : 127.557 ms
+Throughput for kernel with unroll_factor 1: 0.526 GFlops
+Running on device: ofs_n6001 : Intel OFS Platform (ofs_ee00000)
+unroll_factor 2 kernel time : 63.962 ms
+Throughput for kernel with unroll_factor 2: 1.049 GFlops
+Running on device: ofs_n6001 : Intel OFS Platform (ofs_ee00000)
+unroll_factor 4 kernel time : 39.041 ms
+Throughput for kernel with unroll_factor 4: 1.719 GFlops
+Running on device: ofs_n6001 : Intel OFS Platform (ofs_ee00000)
+unroll_factor 8 kernel time : 30.084 ms
+Throughput for kernel with unroll_factor 8: 2.231 GFlops
+Running on device: ofs_n6001 : Intel OFS Platform (ofs_ee00000)
+unroll_factor 16 kernel time : 28.105 ms
+Throughput for kernel with unroll_factor 16: 2.388 GFlops
 PASSED: The results are correct
 Checking realtive throughput
 UNROLL_FACTOR2 PASSED
@@ -316,15 +316,15 @@ UNROLL_FACTOR8 PASSED
 UNROLL_FACTOR16 PASSED
 ```
 
-The following table summarizes the execution time (in ms), throughput (in GFlops), and number of DSPs used for unroll factors of 1, 2, 4, 8, and 16 for a default input array size of 64M floats (2 ^ 26 floats) on Terasic's DE10-Agilex Development Board:
+The following table summarizes the execution time (in ms), throughput (in GFlops), and number of DSPs used for unroll factors of 1, 2, 4, 8, and 16 for a default input array size of 64M floats (2 ^ 26 floats) on the Intel® FPGA SmartNIC N6001-PL:
 
 Unroll Factor  | Kernel Time (ms) | Throughput (GFlops) | Num of DSPs
 |:---          |:---              |:---                 |:---
-|1             | 111              | 0.599               | 1
-|2             | 56               | 1.179               | 2
-|4             | 30               | 2.226               | 4
-|8             | 16               | 4.034               | 8
-|16            | 14               | 4.488               | 16
+|1             | 127              | 0.526               | 1
+|2             | 63               | 1.049               | 2
+|4             | 39               | 1.719               | 4
+|8             | 30               | 2.231               | 8
+|16            | 28               | 2.388               | 16
 
 Notice that when the unroll factor increases from 1 to 2 and from 2 to 4, the kernel execution time decreases by a factor of two. Correspondingly, the kernel throughput doubles. However, when the unroll factor is increased from 4 to 8 or from 8 to 16, the throughput no longer scales by a factor of two at each step. The design is now bound by memory bandwidth limitations instead of compute unit limitations, even though the hardware is replicated.
 

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/max_interleaving/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/max_interleaving/README.md
@@ -256,12 +256,12 @@ Locate `report.html` in the `max_interleaving.report.prj/reports/` directory.
 #### View the Hardware Area Savings
 **NOTE**: For the most accurate numbers, you must compile to hardware so that `Quartus®` can decide where to place each hardware unit on the board.
 1. Go to `Summary` (top navigation bar). In the `Summary` pane, go to `Quartus® Fitter Resource Utilization Summary`. For less accurate estimates (but you can obtain these numbers after compiling to report instead of the full hardware flow), go to `Compile Estimated Kernel Resource Utilization Summary`.
-2. Verify that `KernelCompute<1>` (interleaving disabled) uses slightly fewer resources (ALMs, ALUTs, REGs, etc.) than `KernelCompute<0>` (interleaving enabled). For example, at the time of writing this tutorial, this is the final resource usage when compiling for the Terasic DE10-Agilex Development Board:
+2. Verify that `KernelCompute<1>` (interleaving disabled) uses slightly fewer resources (ALMs, ALUTs, REGs, etc.) than `KernelCompute<0>` (interleaving enabled). For example, at the time of writing this tutorial, this is the final resource usage when compiling for the Intel® FPGA SmartNIC N6001-PL:
 
 |                 | ALM  | ALUT | REG   | MLAB | RAM | DSP |
 | ---             | ---  | ---  | ---   | ---  | --- | --- |
-| KernelCompute_0 | 3506 | 3940 | 11393 | 37   | 66  | 6   |
-| KernelCompute_1 | 3318 | 3743 | 11028 | 34   | 66  | 6   | 
+| KernelCompute_0 | 1703 | 3406 | 7769  | 34   | 100 | 6   |
+| KernelCompute_1 | 1653 | 3307 | 6741  | 33   | 100 | 6   | 
 
 ## Run the `max_interleaving` Sample
 
@@ -300,18 +300,18 @@ Locate `report.html` in the `max_interleaving.report.prj/reports/` directory.
 ## Example Output On FPGA Hardware
 
 ```
-Running on device: de10_agilex : Agilex Reference Platform (aclde10_agilex0)
-Max interleaving 0 kernel time : 0.10368 ms
-Throughput for kernel with max_interleaving 0: 0.632 GFlops
-Running on device: de10_agilex : Agilex Reference Platform (aclde10_agilex0)
-Max interleaving 1 kernel time : 0.922 ms
-Throughput for kernel with max_interleaving 1: 0.071 GFlops
+Running on device: ofs_n6001 : Intel OFS Platform (ofs_ee00000)
+Max interleaving 0 kernel time : 0.062976 ms
+Throughput for kernel with max_interleaving 0: 1.041 GFlops
+Running on device: ofs_n6001 : Intel OFS Platform (ofs_ee00000)
+Max interleaving 1 kernel time : 0.909 ms
+Throughput for kernel with max_interleaving 1: 0.072 GFlops
 PASSED: The results are correct
 ```
 
 The stdout output shows the giga-floating point operations per second (GFlops) for each kernel.
 
-When run on Terasic's DE10-Agilex Development Board, we see that the throughput is significantly higher for `max_interleaving(0)` (interleaving enabled) than `max_interleaving(1)`, showing the effectiveness of interleaving. However, the kernel using `max_interleaving(1)` uses slightly fewer hardware resources, as shown in the reports. 
+When run on the Intel® FPGA SmartNIC N6001-PL, we see that the throughput is significantly higher for `max_interleaving(0)` (interleaving enabled) than `max_interleaving(1)`, showing the effectiveness of interleaving. However, the kernel using `max_interleaving(1)` uses slightly fewer hardware resources, as shown in the reports. 
 
 While the throughput differences are substantial, if the interleaving loops were a small part of a kernel whose total runtime was an order of magnitude greater than these loops, it may be worth it to disable interleaving for hardware savings.
 

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/mem_channel/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/mem_channel/README.md
@@ -328,36 +328,35 @@ significantly lower than the case where burst-interleaving is enabled.
 
 Running `./mem_channel.fpga` when compiled with `-DPART=INTERLEAVING`:
 ```
-Running on device: de10_agilex : Agilex Reference Platform (aclde10_agilex0)
+Running on device: ofs_n6001 : Intel OFS Platform (ofs_ec00000)
 
 Vector size: 1000000
 Verification PASSED
 
-Kernel execution time: 0.001760 seconds
-Kernel throughput: 1704.945536 MB/s
+Kernel execution time: 0.001674 seconds
+Kernel throughput: 1791.987308 MB/s
 ```
 
 Running `./mem_channel.fpga` when compiled with `-DPART=NO_INTERLEAVING`:
 ```
-Running on device: de10_agilex : Agilex Reference Platform (aclde10_agilex0)
+Running on device: ofs_n6001 : Intel OFS Platform (ofs_ec00000)
 
 Vector size: 1000000
 Verification PASSED
 
-Kernel execution time: 0.001692 seconds
-Kernel throughput without burst-interleaving: 1772.869425 MB/s
+Kernel execution time: 0.001673 seconds
+Kernel throughput without burst-interleaving: 1793.003700 MB/s
 ```
 
 ### Discussion of Results
 
-A test compile of this tutorial design achieved the following results on Terasic's 
-DE10-Agilex Development Board. The table
-below shows the performance of the design as well as the resources consumed by
+A test compile of this tutorial design achieved the following results on the Intel® FPGA SmartNIC N6001-PL. 
+The table below shows the performance of the design as well as the resources consumed by
 the kernel system.
 Configuration | Execution Time (ms) | Throughput (MB/s) | ALM | REG | MLAB | RAM | DSP
 |:--- |:--- |:--- |:--- |:--- |:--- |:--- |:--- 
-|Without `-Xsno-interleaving` | 1.760 | 1704 | 9795 | 50875  | 10 | 245 | 0
-|With `-Xsno-interleaving` | 1.692 | 1772 | 6745  | 29592  | 10 | 186  | 0
+|Without `-Xsno-interleaving` | 1.674 | 1791 | 3192 | 14198 | 6  | 345 | 0 
+|With `-Xsno-interleaving` | 1.673 | 1793 | 1997  | 12458  | 6 | 186  | 0
 
 Notice that the throughput of the design when burst-interleaving is disabled is
 equal or better than when burst-interleaving is enabled. However, the resource

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/private_copies/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/private_copies/README.md
@@ -255,23 +255,23 @@ On the main report page, scroll down to the section titled "Estimated Resource U
 ## Example Output
 
 ```
-Running on device: de10_agilex : Agilex Reference Platform (aclde10_agilex0)
-Kernel time when private_copies is set to 0: 682.802 ms
+Running on device: ofs_n6001 : Intel OFS Platform (ofs_ee00000)
+Kernel time when private_copies is set to 0: 682.683 ms
 Kernel throughput when private_copies is set to 0: 1.200 GFlops
-Kernel time when private_copies is set to 1: 1069.627 ms
-Kernel throughput when private_copies is set to 1: 0.766 GFlops
-Kernel time when private_copies is set to 2: 682.735 ms
+Kernel time when private_copies is set to 1: 1080.958 ms
+Kernel throughput when private_copies is set to 1: 0.758 GFlops
+Kernel time when private_copies is set to 2: 682.684 ms
 Kernel throughput when private_copies is set to 2: 1.200 GFlops
-Kernel time when private_copies is set to 3: 682.800 ms
+Kernel time when private_copies is set to 3: 682.684 ms
 Kernel throughput when private_copies is set to 3: 1.200 GFlops
-Kernel time when private_copies is set to 4: 682.751 ms
+Kernel time when private_copies is set to 4: 682.684 ms
 Kernel throughput when private_copies is set to 4: 1.200 GFlops
 PASSED: The results are correct
 ```
 
 The stdout output shows the throughput (GFlops) for each kernel.
 
-When run on Terasic's DE10-Agilex Development Board, we see that the throughput of the kernel approximately doubles when going from 1 to 2 private copies for array `a`. Increasing to 3 private copies has a very small effect, and further increasing the number of private copies does not increase the throughput achieved. This means that increasing private copies beyond 2 will incur an area penalty for little or no throughput gain. As such, for this tutorial design, optimal throughput/area tradeoff is achieved when using 2 private copies. This is as expected based on an analysis of the code, as there are two inner loops which are able to run in parallel if they each have their own private copy of the array. The small jump in throughput observed from using 3 private copies instead of 2 can be attributed to the third private copy allowing subsequent outer loop iterations to launch slightly sooner than they would with 2 private copies due to internal delays in tracking the use of each private copy.
+When run on the Intel® FPGA SmartNIC N6001-PL, we see that the throughput of the kernel approximately doubles when going from 1 to 2 private copies for array `a`. Increasing to 3 private copies has a very small effect, and further increasing the number of private copies does not increase the throughput achieved. This means that increasing private copies beyond 2 will incur an area penalty for little or no throughput gain. As such, for this tutorial design, optimal throughput/area tradeoff is achieved when using 2 private copies. This is as expected based on an analysis of the code, as there are two inner loops which are able to run in parallel if they each have their own private copy of the array. The small jump in throughput observed from using 3 private copies instead of 2 can be attributed to the third private copy allowing subsequent outer loop iterations to launch slightly sooner than they would with 2 private copies due to internal delays in tracking the use of each private copy.
 
 Setting the `private_copies` attribute to 0 (or equivalently omitting the attribute entirely) produced good throughput, and the reports show us that the compiler selected 3 private copies. This does produce the optimal throughput, but in this case it probably makes sense to save some area in exchange for a very small throughput loss by specifying 2 private copies instead.
 

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/read_only_cache/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/read_only_cache/README.md
@@ -283,35 +283,35 @@ cache has been created.
 ### Example Output for `./read_only_cache.fpga` with `-DPART=CACHE_DISABLED`
 
 ```
-Running on device: de10_agilex : Agilex Reference Platform (aclde10_agilex0)
+Running on device: ofs_n6001 : Intel OFS Platform (ofs_ee00000)
 
 SQRT LUT size: 512
 Number of outputs: 131072
 Verification PASSED
 
-Kernel execution time: 0.001677 seconds
-Kernel throughput: 298.184355 MB/s
+Kernel execution time: 0.006714 seconds
+Kernel throughput: 74.469202 MB/s
 ```
 
 ### Example Output for `./read_only_cache.fpga` with `-DPART=CACHE_ENABLED`
 
 ```
-Running on device: de10_agilex : Agilex Reference Platform (aclde10_agilex0)
+Running on device: ofs_n6001 : Intel OFS Platform (ofs_ee00000)
 
 SQRT LUT size: 512
 Number of outputs: 131072
 Verification PASSED
 
-Kernel execution time: 0.000849 seconds
-Kernel throughput with the read-only cache: 589.155069 MB/s
+Kernel execution time: 0.000860 seconds
+Kernel throughput with the read-only cache: 581.580643 MB/s
 ```
 
-A test compile of this tutorial design achieved the following results on Terasic's DE10-Agilex Development Board:
+A test compile of this tutorial design achieved the following results on the Intel® FPGA SmartNIC N6001-PL:
 
 |Configuration    | Execution Time (ms) | Throughput (MB/s)
 |:---             |:---                 |:---
-|Without caching  | 1.677               | 298.18
-|With caching     | 0.849               | 589.15
+|Without caching  | 6.714               | 74.46
+|With caching     | 0.860               | 581.58
 
 When the read-only cache is enabled, performance notably increases. As
 previously mentioned, when the global memory accesses are random (for example, non-contiguous), enabling the read-only cache and sizing it correctly may allow

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/speculated_iterations/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/speculated_iterations/README.md
@@ -270,13 +270,13 @@ These results make sense when you recall that the loop exit computation has a la
 ## Example of Output
 
 ```
-Running on device: de10_agilex : Agilex Reference Platform (aclde10_agilex0)
-Speculated Iterations: 0 -- kernel time: 6333.5 ms
-Performance for kernel with 0 speculated iterations: 15789 MFLOPs
-Speculated Iterations: 10 -- kernel time: 667 ms
-Performance for kernel with 10 speculated iterations: 149973 MFLOPs
-Speculated Iterations: 50 -- kernel time: 167 ms
-Performance for kernel with 50 speculated iterations: 599893 MFLOPs
+Running on device: ofs_n6001 : Intel OFS Platform (ofs_ee00000)
+Speculated Iterations: 0 -- kernel time: 6050.43 ms
+Performance for kernel with 0 speculated iterations: 16528 MFLOPs
+Speculated Iterations: 10 -- kernel time: 504 ms
+Performance for kernel with 10 speculated iterations: 198331 MFLOPs
+Speculated Iterations: 50 -- kernel time: 168 ms
+Performance for kernel with 50 speculated iterations: 594977 MFLOPs
 PASSED: The results are correct
 ```
 

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/stall_enable/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/stall_enable/README.md
@@ -248,18 +248,18 @@ On the main report page, scroll down to the section titled `Compile Estimated Ke
 ### Example Output for `stall_enable.fpga_emu` compiled with `-DPART=STALL_FREE`
 
 ```
-Running on device: de10_agilex : Agilex Reference Platform (aclde10_agilex0)
-Stall free Kernel -- kernel time : 23.552 microseconds
-Throughput for kernel: 8491848KB/s
+Running on device: ofs_n6001 : Intel OFS Platform (ofs_ee00000)
+Stall free Kernel -- kernel time : 12.8 microseconds
+Throughput for kernel: 15625001KB/s
 PASSED: The results are correct
 ```
 
 ### Example Output for `stall_enable.fpga_emu` compiled with `-DPART=STALL_ENABLE`
 
 ```
-Running on device: de10_agilex : Agilex Reference Platform (aclde10_agilex0)
-Stall enable Kernel -- kernel time : 23.04 microseconds
-Throughput for kernel: 8680556KB/s
+Running on device: ofs_n6001 : Intel OFS Platform (ofs_ee00000)
+Stall enable Kernel -- kernel time : 7.936 microseconds
+Throughput for kernel: 25201614KB/s
 PASSED: The results are correct
 ```
 

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Tools/system_profiling/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Tools/system_profiling/README.md
@@ -316,23 +316,23 @@ __Command line `stdout`:__
 When run without `cliloader`, the tutorial output should resemble the result below.
 ```
 Platform name: Intel(R) FPGA SDK for OpenCL(TM)
-Running on device: de10_agilex : Agilex Reference Platform (aclde10_agilex0)
+Running on device: ofs_n6001 : Intel OFS Platform (ofs_ee00000)
 Executing kernel 3 times in each round.
 
 *** Beginning execution, without double buffering
 Launching kernel #0
 
-Overall execution time without double buffering = 4085 ms
-Total kernel-only execution time without double buffering = 25 ms
-Throughput = 0.7699827 MB/s
+Overall execution time without double buffering = 48 ms
+Total kernel-only execution time without double buffering = 38 ms
+Throughput = 64.228554 MB/s
 
 
 *** Beginning execution, with double buffering.
 Launching kernel #0
 
-Overall execution time with double buffering = 25 ms
-Total kernel-only execution time with double buffering = 25 ms
-Throughput = 121.66745 MB/s
+Overall execution time with double buffering = 40 ms
+Total kernel-only execution time with double buffering = 38 ms
+Throughput = 77.011658 MB/s
 
 
 Verification PASSED


### PR DESCRIPTION
This PR moves all the code samples HW references from the Terasic DE10 board to the N6001 board.