### PR TITLE
FPGA: fix `zero_copy_data_transfers` `CMakelist.txt` to add the appropriate `-DIS_BSP` flags

### DIFF
--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/zero_copy_data_transfer/CMakeLists.txt
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/zero_copy_data_transfer/CMakeLists.txt
@@ -54,8 +54,10 @@ else()
     # Check if the target is a BSP
     if(IS_BSP MATCHES "1")
         set(IS_BSP "1")
+        set(BSP_FLAG "-DIS_BSP")
     else()
         set(IS_BSP "0")
+        set(BSP_FLAG "")
         message(STATUS "The selected target ${FPGA_DEVICE} is assumed to be an FPGA part number, so USM will be enabled by default.")
         message(STATUS "If the target is actually a BSP that does not support USM, run cmake with -DIS_BSP=1.")
     endif()
@@ -88,7 +90,7 @@ endif()
 set(USER_FPGA_FLAGS ${USER_FPGA_FLAGS})
 
 # Use cmake -DUSER_FLAGS=<flags> to set extra flags for general compilation.
-set(USER_FLAGS ${USER_FLAGS};-D${DEVICE_FLAG};${HYPER_FLAG})
+set(USER_FLAGS ${USER_FLAGS};-D${DEVICE_FLAG};${HYPER_FLAG};${BSP_FLAG})
 
 # Use cmake -DUSER_INCLUDE_PATHS=<paths> to set extra paths for general
 # compilation.


### PR DESCRIPTION
# Existing Sample Changes
## Description

This change fixes the CMakeLists.txt for zero_copy_data_transfer so that it adds the -DIS_BSP flag to the compile flags.

## External Dependencies

N/A

## Type of change

Please delete options that are not relevant. Add a 'X' to the one that is applicable. 

- [x] Bug fix (non-breaking change which fixes an issue)


## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Command Line
- [ ] oneapi-cli
- [ ] Visual Studio
- [ ] Eclipse IDE
- [ ] VSCode
- [ ] When compiling the compliler flag "-Wall -Wformat-security -Werror=format-security" was used
