### PR TITLE
FPGA: Tidy up Component Interfaces Comparison code sample

### DIFF
--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/hls_flow_interfaces/component_interfaces_comparison/mm-host/src/vector_add.cpp
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/hls_flow_interfaces/component_interfaces_comparison/mm-host/src/vector_add.cpp
@@ -12,7 +12,7 @@ constexpr int kBL3 = 3;
 
 // Forward declare the kernel name in the global scope. This is an FPGA best
 // practice that reduces name mangling in the optimization reports.
-class SimpleVAdd;
+class IDSimpleVAdd;
 
 struct SimpleVAddKernel {
   sycl::ext::oneapi::experimental::annotated_arg<
@@ -108,7 +108,7 @@ int main() {
 
     std::cout << "Add two vectors of size " << count << std::endl;
 
-    q.single_task<SimpleVAdd>(SimpleVAddKernel{a, b, c, count}).wait();
+    q.single_task<IDSimpleVAdd>(SimpleVAddKernel{a, b, c, count}).wait();
 
     // verify that VC is correct
     bool passed = true;

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/hls_flow_interfaces/component_interfaces_comparison/streaming-invocation/src/vector_add.cpp
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/hls_flow_interfaces/component_interfaces_comparison/streaming-invocation/src/vector_add.cpp
@@ -1,8 +1,9 @@
 #include <iostream>
 
 // oneAPI headers
-#include <sycl/sycl.hpp>
 #include <sycl/ext/intel/fpga_extensions.hpp>
+#include <sycl/sycl.hpp>
+
 #include "exception_handler.hpp"
 
 // Forward declare the kernel name in the global scope. This is an FPGA best
@@ -65,9 +66,16 @@ int main() {
     // create the device queue
     sycl::queue q(selector, fpga_tools::exception_handler);
 
-    int count = kVectorSize;  // pass array size by value
+    auto device = q.get_device();
 
-    // Create USM shared allocations in the specified buffer_location. 
+    std::cout << "Running on device: "
+              << device.get_info<sycl::info::device::name>().c_str()
+              << std::endl;
+
+    // Vector size is a constant here, but it could be a run-time variable too.
+    int count = kVectorSize;
+
+    // Create USM shared allocations in the specified buffer_location.
     // You can also use host allocations with malloc_host(...) API
     int *a = sycl::malloc_shared<int>(count, q);
     int *b = sycl::malloc_shared<int>(count, q);
@@ -79,9 +87,10 @@ int main() {
 
     std::cout << "Add two vectors of size " << count << std::endl;
 
-    q.single_task<IDSimpleVAdd>(SimpleVAddKernel{a, b, c, count}).wait();
+    sycl::event e = q.single_task<IDSimpleVAdd>(SimpleVAddKernel{a, b, c, count});
 
-    // verify that VC is correct
+    // Verify that outputs are correct, after the kernel has finished running.
+    e.wait();
     bool passed = true;
     for (int i = 0; i < count; i++) {
       int expected = a[i] + b[i];
@@ -106,9 +115,6 @@ int main() {
     std::cerr << "   If you are targeting an FPGA hardware, "
                  "ensure that your system is plugged to an FPGA board that is "
                  "set up correctly"
-              << std::endl;
-    std::cerr << "   If you are targeting the FPGA emulator, compile with "
-                 "-DFPGA_EMULATOR"
               << std::endl;
     std::terminate();
   }


### PR DESCRIPTION
- improve comparibility across code versions
- remove unnecessary ready signal from csr-pipes version
- re-run clang-format

# Existing Sample Changes
## Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes Issue# 

## External Dependencies

List any external dependencies created as a result of this change.

## Type of change

Please delete options that are not relevant. Add a 'X' to the one that is applicable. 

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Implement fixes for ONSAM Jiras

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [X] Command Line
- [ ] oneapi-cli
- [ ] Visual Studio
- [ ] Eclipse IDE
- [X] VSCode
- [X] When compiling the compiler flag "-Wall -Wformat-security -Werror=format-security" was used
- [X] FPGA Windows regtest: https://spetc.intel.com/testanalysis?trview=0&testRunIds=10210363&tapgsize=20&tasort=testCasePath&tasortdir=asc
- [X] FPGA Linux regtest: https://spetc.intel.com/testanalysis?trview=0&testRunIds=10210357&tapgsize=20&tasort=testCasePath&tasortdir=asc