### PR TITLE
FPGA: Fix ambiguity of math function calls

### DIFF
--- a/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/anr/src/anr.hpp
+++ b/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/anr/src/anr.hpp
@@ -14,6 +14,7 @@
 #include <type_traits>
 #include <utility>
 #include <vector>
+#include <math.h>
 
 #include "anr_params.hpp"
 #include "column_stencil.hpp"

--- a/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/matmul/src/matmul_demo.cpp
+++ b/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/matmul/src/matmul_demo.cpp
@@ -41,7 +41,7 @@ bool EqualMat(std::vector<float> &c_matrix, std::vector<float> &c_reference,
                     << c_reference[idx] << std::endl;
 #endif
         }
-        if (!std::isfinite(c_matrix[idx])) {
+        if (!sycl::isfinite(c_matrix[idx])) {
           passed = false;
 #if DEBUG
           std::cout << "C[" << col << "][" << row << "] = " << c_matrix[idx]

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/ac_fixed/src/ac_fixed.cpp
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/ac_fixed/src/ac_fixed.cpp
@@ -4,6 +4,7 @@
 #include <sycl/ext/intel/fpga_extensions.hpp>
 
 #include <iomanip>  // for std::setprecision
+#include <math.h>
 
 #include "exception_handler.hpp"
 

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/optimization_targets/src/optimization_targets.cpp
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/optimization_targets/src/optimization_targets.cpp
@@ -125,7 +125,7 @@ int main() {
   // validate results
   for (size_t i = 0; i < kInputSize; i++) {
     GreyType golden = Compute(r[i], g[i], b[i]);
-    if (std::fabs(out[i] - golden) > 1e-4) {
+    if (sycl::fabs(out[i] - golden) > 1e-4) {
       std::cout << "Result mismatch:\n"
                 << "out[" << i << "] = " << out[i] << "; golden = " << golden
                 << '\n';

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/speculated_iterations/src/speculated_iterations.cpp
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/speculated_iterations/src/speculated_iterations.cpp
@@ -10,6 +10,7 @@
 #include <iostream>
 #include <string>
 #include <type_traits>
+#include <math.h>
 
 #include "exception_handler.hpp"
 


### PR DESCRIPTION
Upstream LLVM removed the auto-included `math.h`, making some samples fail to compile without explicitly including `math.h` or using the `sycl::` equivalent.