### PR TITLE
FPGA: Update `host_ptr` and `device_ptr` to appropriate namespace

### DIFF
--- a/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/merge_sort/src/main.cpp
+++ b/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/merge_sort/src/main.cpp
@@ -233,8 +233,9 @@ int main(int argc, char *argv[]) {
     // the pointer type for the kernel depends on whether data is coming from
     // USM host or device allocations
     using KernelPtrType =
-        typename std::conditional_t<kUseUSMHostAllocation, host_ptr<ValueT>,
-                                    device_ptr<ValueT>>;
+        typename std::conditional_t<kUseUSMHostAllocation, 
+                                    sycl::ext::intel::host_ptr<ValueT>,
+                                    sycl::ext::intel::device_ptr<ValueT>>;
 
     // run the sort multiple times to increase the accuracy of the timing
     for (int i = 0; i < runs; i++) {

--- a/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/mvdr_beamforming/src/FakeIOPipes.hpp
+++ b/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/mvdr_beamforming/src/FakeIOPipes.hpp
@@ -30,7 +30,7 @@ class ProducerConsumerBaseImpl {
   // use some fancy C++ metaprogramming to get the correct pointer type
   // based on the template variable
   typedef
-      typename std::conditional_t<use_host_alloc, host_ptr<T>, device_ptr<T>>
+      typename std::conditional_t<use_host_alloc, sycl::ext::intel::host_ptr<T>, sycl::ext::intel::device_ptr<T>>
           kernel_ptr_type;
 
   // private constructor so users cannot make an object

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/buffered_host_streaming/src/HostStreamer.hpp
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/buffered_host_streaming/src/HostStreamer.hpp
@@ -667,7 +667,7 @@ public:
   // synthesized into FPGA kernels.
   static event LaunchProducerKernel(ProducerType *usm_ptr, size_t count) {
     return sycl_q_->single_task<ProducerKernelId<Id>>([=] {
-      host_ptr<ProducerType> ptr(usm_ptr);
+      sycl::ext::intel::host_ptr<ProducerType> ptr(usm_ptr);
       for (size_t i = 0; i < count; i++) {
         // host->device: read from USM and write to the ProducerPipe
         auto val = *(ptr + i);
@@ -678,7 +678,7 @@ public:
 
   static event LaunchConsumerKernel(ConsumerType *usm_ptr, size_t count) {
     return sycl_q_->single_task<ConsumerKernelId<Id>>([=] {
-      host_ptr<ConsumerType> ptr(usm_ptr);
+      sycl::ext::intel::host_ptr<ConsumerType> ptr(usm_ptr);
       for (size_t i = 0; i < count; i++) {
         // device->host: read from the ConsumerPipe and write to USM
         auto val = ConsumerPipe::read();

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/buffered_host_streaming/src/streaming_without_api.hpp
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/buffered_host_streaming/src/streaming_without_api.hpp
@@ -328,8 +328,8 @@ event SubmitKernel(queue &q, T *in_ptr, size_t count, T *out_ptr) {
   return q.single_task<Kernel>([=]() [[intel::kernel_args_restrict]] {
     // using a host_ptr class tells the compiler that this pointer lives in
     // the host's address space
-    host_ptr<T> in(in_ptr);
-    host_ptr<T> out(out_ptr);
+    sycl::ext::intel::host_ptr<T> in(in_ptr);
+    sycl::ext::intel::host_ptr<T> out(out_ptr);
 
     for (size_t i = 0; i < count; i++) {
       T data = *(in + i);

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/io_streaming/src/FakeIOPipes.hpp
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/io_streaming/src/FakeIOPipes.hpp
@@ -30,7 +30,8 @@ class ProducerConsumerBaseImpl {
   // use some fancy C++ metaprogramming to get the correct pointer type
   // based on the template variable
   typedef
-      typename std::conditional_t<use_host_alloc, host_ptr<T>, device_ptr<T>>
+      typename std::conditional_t<use_host_alloc, sycl::ext::intel::host_ptr<T>, 
+                                  sycl::ext::intel::device_ptr<T>>
           kernel_ptr_type;
 
   // private constructor so users cannot make an object

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/simple_host_streaming/src/multi_kernel.hpp
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/simple_host_streaming/src/multi_kernel.hpp
@@ -31,7 +31,7 @@ class C;
 template<typename T, typename InPipe>
 event SubmitProducer(queue &q, T* in_ptr, size_t size) {
   return q.single_task<P>([=]() [[intel::kernel_args_restrict]] {
-    host_ptr<T> in(in_ptr);
+    sycl::ext::intel::host_ptr<T> in(in_ptr);
     for (size_t i = 0; i < size; i++) {
       auto data = in[i];
       InPipe::write(data);
@@ -53,7 +53,7 @@ event SubmitProducer(queue &q, T* in_ptr, size_t size) {
 template<typename T, typename OutPipe>
 event SubmitConsumer(queue &q, T* out_ptr, size_t size) {
   return q.single_task<C>([=]() [[intel::kernel_args_restrict]] {
-    host_ptr<T> out(out_ptr);
+    sycl::ext::intel::host_ptr<T> out(out_ptr);
     for (size_t i = 0; i < size; i++) {
       auto data = OutPipe::read();
       *(out + i) = data;

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/simple_host_streaming/src/single_kernel.hpp
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/simple_host_streaming/src/single_kernel.hpp
@@ -19,8 +19,8 @@ event SubmitSingleWorker(queue &q, T *in_ptr, T *out_ptr, size_t count) {
   return q.single_task<K>([=]() [[intel::kernel_args_restrict]] {
     // using a host_ptr class tells the compiler that this pointer lives in
     // the hosts address space
-    host_ptr<T> in(in_ptr);
-    host_ptr<T> out(out_ptr);
+    sycl::ext::intel::host_ptr<T> in(in_ptr);
+    sycl::ext::intel::host_ptr<T> out(out_ptr);
 
     for (size_t i = 0; i < count; i++) {
       // do a simple copy - more complex computation can go here


### PR DESCRIPTION
Raw `host_prt` and `device_ptr` are to be deprecated.
Their replacements are `sycl::ext::intel::host_ptr` and `sycl::ext::intel::device_ptr`.
This PR updates the code samples that relied on these constructs.