### PR TITLE
FPGA: Add a note for race condition to the pipelined kernel sample

### DIFF
--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/hls_flow_interfaces/invocation_interfaces/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/hls_flow_interfaces/invocation_interfaces/README.md
@@ -192,7 +192,7 @@ q.wait();
 
 > **Note**: As per the SYCL language semantics, separate invocations of a kernel are **independent**. This means that you can't make assumptions about memory ordering or memory dependences between kernel invocations. Make sure you use synchronization mechanisms such as the `.wait()` function or *atomic operations* to avoid race conditions. \
 If you want to guarantee sequential equivalence, you can also write your kernel with a `while(1)` loop in the kernel body instead of using a pipelined kernel. \
-In particular, a repeatedly-invoked kernel that would have worked correctly in legacy HLS may result in undefined behavior in SYCL and may not function as you expect. 
+In particular, a repeatedly-invoked kernel with memory dependence will result in undefined behavior in SYCL and may not function as you expect. 
 
 For an example of a pipelined streaming kernel, see `src/stream_pipelined.cpp`.
 


### PR DESCRIPTION
# Existing Sample Changes
## Description

Adding a note about race condition when using pipelined kernel invocation.

Result of case [14022435931](https://hsdes.intel.com/appstore/article/#/14022435931)