### PR TITLE
FPGA: Remove detail::empty_properties_t and add std::log10

### DIFF
--- a/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/anr/src/main.cpp
+++ b/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/anr/src/main.cpp
@@ -444,7 +444,7 @@ bool Validate(PixelT* val, PixelT* ref, int rows, int cols,
   mse /= count;
 
   // compute the PSNR
-  double psnr = (20 * log10(max_i)) - (10 * log10(mse));
+  double psnr = (20 * std::log10(max_i)) - (10 * std::log10(mse));
 
   // check PSNR and maximum pixel difference
   bool passed = true;

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/experimental/annotated_class_clean_coding/src/annotated_class_util.hpp
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/experimental/annotated_class_clean_coding/src/annotated_class_util.hpp
@@ -128,8 +128,8 @@ struct remove_align_from {};
 
 template <>
 struct remove_align_from<
-    sycl::ext::oneapi::experimental::detail::empty_properties_t> {
-  using type = sycl::ext::oneapi::experimental::detail::empty_properties_t;
+    sycl::ext::oneapi::experimental::empty_properties_t> {
+  using type = sycl::ext::oneapi::experimental::empty_properties_t;
 };
 
 template <typename Prop, typename... Props>


### PR DESCRIPTION
# Existing Sample Changes
## Description

Remove redundant sycl::ext::oneapi::experimental::detail::empty_properties_t and replace it with sycl::ext::oneapi::experimental::empty_properties_t https://jira.devtools.intel.com/browse/ONSAM-1938

Specify std::log10 to avoid ambiguity. Issue was introduced with sycl/trunk/20240502 https://psg-sc-arc.sc.intel.com/arc/dashboard/reports/show_job/1727201571


## External Dependencies

List any external dependencies created as a result of this change.

## Type of change

Please delete options that are not relevant. Add a 'X' to the one that is applicable. 

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Implement fixes for ONSAM Jiras

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Command Line
- [ ] oneapi-cli
- [ ] Visual Studio
- [ ] Eclipse IDE
- [ ] VSCode
- [ ] When compiling the compliler flag "-Wall -Wformat-security -Werror=format-security" was used