### PR TITLE
FPGA: add caveat for running the `build_system.tcl` script in the `platform_designer` code sample

### DIFF
--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Tools/platform_designer/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Tools/platform_designer/README.md
@@ -279,7 +279,7 @@ Follow these steps to compile and test the design:
    > xcopy add_quartus\output_files\add.sof system_console /Y
    ```
 
-You may also build the SOF using the pre-generated Intel® Qupartus® Prime project in the `add_quartus_sln` directory by executing the included `build_system.tcl` script.
+You may also build the SOF using the pre-generated Intel® Qupartus® Prime project in the `add_quartus_sln` directory by executing the included `build_system.tcl` script. This script has been verified against the latest version of Quartus® Prime Pro Edition software available at the time of writing (24.1). The script and pre-generated project may not work with other versions of Quartus® Prime.
 
    Linux:
 


### PR DESCRIPTION
# Existing Sample Changes
## Description

Add a disclaimer for the Platform Designer code sample, since the pre-generated quartus project definitely doesn't work with Quartus® Prime 21.2. Confirm that re-building the project as shown in directions works though.

Fixes Issue# 

## External Dependencies

List any external dependencies created as a result of this change.

## Type of change

Please delete options that are not relevant. Add a 'X' to the one that is applicable. 

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Implement fixes for ONSAM Jiras

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Command Line
- [ ] oneapi-cli
- [ ] Visual Studio
- [ ] Eclipse IDE
- [ ] VSCode
- [ ] When compiling the compliler flag "-Wall -Wformat-security -Werror=format-security" was used
