### PR TITLE
krzeszew/ONSAM-1897 enable testing command

### DIFF
--- a/Publications/GPU-Opt-Guide/CMakeLists.txt
+++ b/Publications/GPU-Opt-Guide/CMakeLists.txt
@@ -9,6 +9,7 @@ if (BUILD_FORTRAN_EXAMPLES)
   set(CMAKE_Fortran_COMPILER ifx)
 endif()
 
+enable_testing()
 
 project(GPUOptGuide
   LANGUAGES ${_languages}


### PR DESCRIPTION
# Existing Sample Changes
## Description

Add enable_testing() command to CMakeLists.txt in Publications/GPU-Opt-Guide. Command was removed with the last commit changing IntelDPCPP to IntelSYCL compiler and needs to be reintroduced. 

Fixes Issue #ONSAM-1897 

## External Dependencies

List any external dependencies created as a result of this change.

## Type of change

Please delete options that are not relevant. Add a 'X' to the one that is applicable. 

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] Implement fixes for ONSAM Jiras

## How Has This Been Tested?

- [X] Command Line
