### PR TITLE
FPGA: Worked around runtime bug with event dependences between invocations of the same kernel

### DIFF
--- a/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/gzip/src/gzipkernel_ll.cpp
+++ b/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/gzip/src/gzipkernel_ll.cpp
@@ -783,9 +783,13 @@ template <int engineID, int BatchSize>
 event SubmitCRC(queue &q, size_t block_size, uint32_t *result_crc,
                 std::vector<event> &depend_on) {
   event e = q.submit([&](handler &h) {
-    if (!depend_on.empty()) {
-      h.depends_on(depend_on[kCRCIndex]);
-    }
+    // Temporarily remove event dependences to work around a bug in 2024.2
+    // This is safe on FPGA because invocations of the same kernel are 
+    // serialized for non-pipelined kernels
+    // Note: this is not portable
+    //if (!depend_on.empty()) {
+    //  h.depends_on(depend_on[kCRCIndex]);
+    //}
 
     h.single_task<CRC<engineID>>([=]() [[intel::kernel_args_restrict]] {
       auto accessor_isz = block_size;
@@ -2073,9 +2077,13 @@ event SubmitLZReduction(queue &q, size_t block_size, bool last_block,
   event e = q.submit([&](handler &h) {
     auto accessor_isz = block_size;
 
-    if (!depend_on.empty()) {
-      h.depends_on(depend_on[kLZReductionIndex]);
-    }
+    // Temporarily remove event dependences to work around a bug in 2024.2
+    // This is safe on FPGA because invocations of the same kernel are 
+    // serialized for non-pipelined kernels
+    // Note: this is not portable
+    //if (!depend_on.empty()) {
+    //  h.depends_on(depend_on[kLZReductionIndex]);
+    //}
 
     h.single_task<LZReduction<engineID>>([=]() [[intel::kernel_args_restrict]] {
       // Unpack the ptrs parameter pack and grab all of the pointers, annotating
@@ -2445,9 +2453,13 @@ event SubmitStaticHuffman(queue &q, size_t block_size,
                           std::vector<event> &depend_on,
                           PtrTypes... ptrs) {
   event e = q.submit([&](handler &h) {
-    if (!depend_on.empty()) {
-      h.depends_on(depend_on[kStaticHuffmanIndex]);
-    }
+    // Temporarily remove event dependences to work around a bug in 2024.2
+    // This is safe on FPGA because invocations of the same kernel are 
+    // serialized for non-pipelined kernels
+    // Note: this is not portable
+    //if (!depend_on.empty()) {
+    //  h.depends_on(depend_on[kStaticHuffmanIndex]);
+    //}
 
     h.single_task<StaticHuffman<engineID>>([=]() [[intel::kernel_args_restrict]] {
 


### PR DESCRIPTION
## Description

This change implements a workaround for a bug affecting FPGA targets.  The bug and workaround will be documented in the upcoming 2024.2 release notes.  This workaround can be removed when the underlying bug is fixed (presumably in 2025.0).  

Specifically, when kernels are explicitly made dependent on other invocations of the same kernel through events, the FPGA runtime can occasionally hang.  The hang is rare, but since the gzip_ll code sample attempts to enqueue kernels in this way hundreds of times it has a good chance of hitting it on any given run.  

Unfortunately, this code sample seems to be affected by a second, unrelated hang though because while this fix allows the program to complete some of the time, it still hangs periodically.  Runtime traces of those remaining hangs indicate that they are a different issue.  I still think it's worth submitting this as it reduces the frequency with which the design hangs.  

## External Dependencies

No new external dependencies

## Type of change

- [X ] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [X] Command Line
- [ ] oneapi-cli
- [ ] Visual Studio
- [ ] Eclipse IDE
- [ ] VSCode
- [] When compiling the compiler flag "-Wall -Wformat-security -Werror=format-security" was used

I tested by compiling the sample for FPGA (make fpga) and running it on a Silicom N6010 Agilex 7 board.  