### PR TITLE
FPGA: fix namespaces for `host_ptr` and `device_ptr`

### DIFF
--- a/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/board_test/src/usm_speed.hpp
+++ b/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/board_test/src/usm_speed.hpp
@@ -19,8 +19,8 @@ enum USMTest { MEMCOPY, READ, WRITE };
 sycl::event memcopy_kernel(sycl::queue &q, sycl::ulong8 *in, sycl::ulong8 *out,
                            size_t num_items) {
   return q.single_task<USMMemCopy>([=]() [[intel::kernel_args_restrict]] {
-    sycl::host_ptr<sycl::ulong8> in_h(in);
-    sycl::host_ptr<sycl::ulong8> out_h(out);
+    sycl::ext::intel::host_ptr<sycl::ulong8> in_h(in);
+    sycl::ext::intel::host_ptr<sycl::ulong8> out_h(out);
     for (size_t i = 0; i < num_items; i++) {
       out_h[i] = in_h[i];
     }
@@ -32,8 +32,8 @@ sycl::event memcopy_kernel(sycl::queue &q, sycl::ulong8 *in, sycl::ulong8 *out,
 sycl::event read_kernel(sycl::queue &q, sycl::ulong8 *in, sycl::ulong8 *out,
                         size_t num_items) {
   return q.single_task<USMMemRead>([=]() {
-    sycl::host_ptr<sycl::ulong8> in_h(in);
-    sycl::host_ptr<sycl::ulong8> out_h(out);
+    sycl::ext::intel::host_ptr<sycl::ulong8> in_h(in);
+    sycl::ext::intel::host_ptr<sycl::ulong8> out_h(out);
     sycl::ulong8 sum{0};
     for (size_t i = 0; i < num_items; i++) {
       sum += in_h[i];
@@ -47,7 +47,7 @@ sycl::event read_kernel(sycl::queue &q, sycl::ulong8 *in, sycl::ulong8 *out,
 sycl::event write_kernel(sycl::queue &q, sycl::ulong8 *in, sycl::ulong8 *out,
                          size_t num_items) {
   return q.single_task<USMMemWrite>([=]() {
-    sycl::host_ptr<sycl::ulong8> out_h(out);
+    sycl::ext::intel::host_ptr<sycl::ulong8> out_h(out);
     sycl::ulong8 answer{TEST_VAL};
     for (size_t i = 0; i < num_items; i++) {
       out_h[i] = answer;

--- a/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/cholesky/src/cholesky.hpp
+++ b/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/cholesky/src/cholesky.hpp
@@ -114,7 +114,7 @@ void CholeskyDecompositionImpl(
           // lives on the device.
           // Knowing this, the compiler won't generate hardware to
           // potentially get data from the host.
-          sycl::device_ptr<TT> vector_ptr(l_device);
+          sycl::ext::intel::device_ptr<TT> vector_ptr(l_device);
 #else
           // Device pointers are not supported when targeting an FPGA 
           // family/part

--- a/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/cholesky/src/memory_transfers.hpp
+++ b/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/cholesky/src/memory_transfers.hpp
@@ -50,7 +50,7 @@ void MatrixReadFromDDRToPipe(
           // lives on the device.
           // Knowing this, the compiler won't generate hardware to
           // potentially get data from the host.
-          sycl::device_ptr<TT> matrix_ptr_located(matrix_ptr);
+          sycl::ext::intel::device_ptr<TT> matrix_ptr_located(matrix_ptr);
 #else
           // Device pointers are not supported when targeting an FPGA 
           // family/part

--- a/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/cholesky_inversion/src/memory_transfers.hpp
+++ b/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/cholesky_inversion/src/memory_transfers.hpp
@@ -43,7 +43,7 @@ void MatrixReadFromDDRToPipe(
           // lives on the device.
           // Knowing this, the compiler won't generate hardware to
           // potentially get data from the host.
-          sycl::device_ptr<TT> matrix_ptr_located(matrix_ptr);
+          sycl::ext::intel::device_ptr<TT> matrix_ptr_located(matrix_ptr);
 #else
           // Device pointers are not supported when targeting an FPGA 
           // family/part
@@ -133,7 +133,7 @@ void VectorReadFromPipeToDDR(
           // lives on the device.
           // Knowing this, the compiler won't generate hardware to
           // potentially get data from the host.
-          sycl::device_ptr<TT> vector_ptr_located(vector_ptr);
+          sycl::ext::intel::device_ptr<TT> vector_ptr_located(vector_ptr);
 #else
           // Device pointers are not supported when targeting an FPGA 
           // family/part

--- a/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/decompress/src/common/common.hpp
+++ b/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/decompress/src/common/common.hpp
@@ -326,7 +326,7 @@ sycl::event SubmitProducer(sycl::queue& q, unsigned in_count_padded,
     // lives on the device.
     // Knowing this, the compiler won't generate hardware to
     // potentially get data from the host.
-    sycl::device_ptr<unsigned char> in(in_ptr);
+    sycl::ext::intel::device_ptr<unsigned char> in(in_ptr);
 #else
     // Device pointers are not supported when targeting an FPGA 
     // family/part
@@ -371,7 +371,7 @@ sycl::event SubmitConsumer(sycl::queue& q, unsigned out_count_padded,
     // lives on the device.
     // Knowing this, the compiler won't generate hardware to
     // potentially get data from the host.
-    sycl::device_ptr<unsigned char> out(out_ptr);
+    sycl::ext::intel::device_ptr<unsigned char> out(out_ptr);
 #else
     // Device pointers are not supported when targeting an FPGA 
     // family/part

--- a/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/decompress/src/gzip/gzip_metadata_reader.hpp
+++ b/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/decompress/src/gzip/gzip_metadata_reader.hpp
@@ -290,9 +290,9 @@ sycl::event SubmitGzipMetadataReader(sycl::queue& q, int in_count,
     // lives on the device.
     // Knowing this, the compiler won't generate hardware to
     // potentially get data from the host.
-    sycl::device_ptr<GzipHeaderData> hdr_data(hdr_data_ptr);
-    sycl::device_ptr<int> crc(crc_ptr);
-    sycl::device_ptr<int> out_count(out_count_ptr);
+    sycl::ext::intel::device_ptr<GzipHeaderData> hdr_data(hdr_data_ptr);
+    sycl::ext::intel::device_ptr<int> crc(crc_ptr);
+    sycl::ext::intel::device_ptr<int> out_count(out_count_ptr);
 #else
     // Device pointers are not supported when targeting an FPGA 
     // family/part

--- a/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/decompress/src/snappy/snappy_reader.hpp
+++ b/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/decompress/src/snappy/snappy_reader.hpp
@@ -390,7 +390,7 @@ sycl::event SubmitSnappyReader(sycl::queue& q, unsigned in_count,
     // lives on the device.
     // Knowing this, the compiler won't generate hardware to
     // potentially get data from the host.
-    sycl::device_ptr<unsigned> preamble_count(preamble_count_ptr);
+    sycl::ext::intel::device_ptr<unsigned> preamble_count(preamble_count_ptr);
 #else
     // Device pointers are not supported when targeting an FPGA 
     // family/part

--- a/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/gzip/src/gzipkernel_ll.cpp
+++ b/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/gzip/src/gzipkernel_ll.cpp
@@ -794,7 +794,7 @@ event SubmitCRC(queue &q, size_t block_size, uint32_t *result_crc,
     h.single_task<CRC<engineID>>([=]() [[intel::kernel_args_restrict]] {
       auto accessor_isz = block_size;
 
-      host_ptr<uint32_t> accresult_crc(result_crc);
+      sycl::ext::intel::host_ptr<uint32_t> accresult_crc(result_crc);
 
       // See comments at top of file, regarding batching.
       [[intel::disable_loop_pipelining]]
@@ -2094,9 +2094,9 @@ event SubmitLZReduction(queue &q, size_t block_size, bool last_block,
       // SubmitGzipTasksHelper(); everything to the left of '...' is expanded
       // for each value in ptrs.
 
-      host_ptr<char> host_pibuf[BatchSize];
+      sycl::ext::intel::host_ptr<char> host_pibuf[BatchSize];
       Unroller<0, BatchSize>::step(
-          [&](auto i) { host_pibuf[i] = host_ptr<char>(get<i>(ptrs...)); });
+          [&](auto i) { host_pibuf[i] = sycl::ext::intel::host_ptr<char>(get<i>(ptrs...)); });
 
       // See comments at top of file, regarding batching
       [[intel::disable_loop_pipelining]] for (int iter = 0;
@@ -2104,7 +2104,7 @@ event SubmitLZReduction(queue &q, size_t block_size, bool last_block,
         const int iter_masked =
             iter % BatchSize;  // Hint to the compiler that the access to
                                // host_pibuf is bounded.
-        host_ptr<char> acc_pibuf =
+        sycl::ext::intel::host_ptr<char> acc_pibuf =
             host_pibuf[iter_masked];  // Grab new host pointer on each iteration
                                       // of the batch loop
 
@@ -2465,20 +2465,20 @@ event SubmitStaticHuffman(queue &q, size_t block_size,
 
       // See comments in SubmitLZReduction, where the same parameter unpacking
       // is done.
-      host_ptr<char> host_pobuf[BatchSize];
+      sycl::ext::intel::host_ptr<char> host_pobuf[BatchSize];
       Unroller<0, BatchSize>::step(
-          [&](auto i) { host_pobuf[i] = host_ptr<char>(get<i>(ptrs...)); });
+          [&](auto i) { host_pobuf[i] = sycl::ext::intel::host_ptr<char>(get<i>(ptrs...)); });
 
       auto accessor_isz = block_size;
 
-      host_ptr<GzipOutInfo> acc_gzip_out(gzip_out_buf);
+      sycl::ext::intel::host_ptr<GzipOutInfo> acc_gzip_out(gzip_out_buf);
 
       auto acc_eof = last_block ? 1 : 0;
 
       // See comments at top of file regarding batching.
       [[intel::disable_loop_pipelining]]
       for (int iter=0; iter < BatchSize; iter++) {
-        host_ptr<char> accessor_output = host_pobuf[iter % BatchSize];
+        sycl::ext::intel::host_ptr<char> accessor_output = host_pobuf[iter % BatchSize];
 
         unsigned int leftover[kVec] = {0};
         Unroller<0, kVec>::step([&](int i) { leftover[i] = 0; });

--- a/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/matmul/src/memory_transfers.hpp
+++ b/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/matmul/src/memory_transfers.hpp
@@ -80,7 +80,7 @@ public:
     // the device.
     // Knowing this, the compiler won't generate hardware to potentially get
     // data from the host.
-    sycl::device_ptr<TT> a_ptr_located(a_ptr);
+    sycl::ext::intel::device_ptr<TT> a_ptr_located(a_ptr);
 #else
     // Device pointers are not supported when targeting an FPGA family/part
     TT *a_ptr_located(a_ptr);
@@ -236,7 +236,7 @@ public:
     // the device.
     // Knowing this, the compiler won't generate hardware to potentially get
     // data from the host.
-    sycl::device_ptr<TT> b_ptr_located(b_ptr);
+    sycl::ext::intel::device_ptr<TT> b_ptr_located(b_ptr);
 #else
     // Device pointers are not supported when targeting an FPGA family/part
     TT *b_ptr_located(b_ptr);
@@ -384,7 +384,7 @@ public:
     // the device.
     // Knowing this, the compiler won't generate hardware to potentially get
     // data from the host.
-    sycl::device_ptr<TT> c_ptr_located(c_ptr);
+    sycl::ext::intel::device_ptr<TT> c_ptr_located(c_ptr);
 #else
     // Device pointers are not supported when targeting an FPGA family/part
     TT *c_ptr_located(c_ptr);

--- a/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/pca/src/memory_transfers.hpp
+++ b/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/pca/src/memory_transfers.hpp
@@ -150,7 +150,7 @@ void VectorReadPipeToDDR(
   // lives on the device.
   // Knowing this, the compiler won't generate hardware to
   // potentially get data from the host.
-  sycl::device_ptr<TT> vector_ptr_located(vector_ptr);
+  sycl::ext::intel::device_ptr<TT> vector_ptr_located(vector_ptr);
 #else
   // Device pointers are not supported when targeting an FPGA
   // family/part

--- a/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/qri/src/memory_transfers.hpp
+++ b/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/qri/src/memory_transfers.hpp
@@ -42,7 +42,7 @@ void MatrixReadFromDDRToPipe(
   // lives on the device.
   // Knowing this, the compiler won't generate hardware to
   // potentially get data from the host.
-  sycl::device_ptr<TT> matrix_ptr_located(matrix_ptr);
+  sycl::ext::intel::device_ptr<TT> matrix_ptr_located(matrix_ptr);
 #else
   // Device pointers are not supported when targeting an FPGA 
   // family/part
@@ -143,7 +143,7 @@ void MatrixReadPipeToDDR(
   // lives on the device.
   // Knowing this, the compiler won't generate hardware to
   // potentially get data from the host.
-  sycl::device_ptr<TT> matrix_ptr_located(matrix_ptr);
+  sycl::ext::intel::device_ptr<TT> matrix_ptr_located(matrix_ptr);
 #else
   // Device pointers are not supported when targeting an FPGA 
   // family/part

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/explicit_data_movement/src/explicit_data_movement.cpp
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/explicit_data_movement/src/explicit_data_movement.cpp
@@ -143,8 +143,8 @@ double SubmitExplicitKernel(sycl::queue &q, std::vector<T> &in,
 #if defined(IS_BSP)
       // Explicitly create device pointers to inform the compiler that these
       // pointers point to device memory
-      sycl::device_ptr<T> in_ptr_d(in_ptr);
-      sycl::device_ptr<T> out_ptr_d(out_ptr);
+      sycl::ext::intel::device_ptr<T> in_ptr_d(in_ptr);
+      sycl::ext::intel::device_ptr<T> out_ptr_d(out_ptr);
 #endif
 
       for (size_t i = 0; i < size; i++) {

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/zero_copy_data_transfer/src/zero_copy_kernel.hpp
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/zero_copy_data_transfer/src/zero_copy_kernel.hpp
@@ -74,9 +74,9 @@ event SubmitProducer(queue& q, T* in_data, size_t size) {
 
   return q.single_task<Producer>([=]() [[intel::kernel_args_restrict]] {
 #if defined(IS_BSP)
-    // using a host_ptr tells the compiler that this pointer lives in the
+    // using a sycl::ext::intel::host_ptr tells the compiler that this pointer lives in the
     // hosts address space
-    host_ptr<T> h_in_data(in_data);
+    sycl::ext::intel::host_ptr<T> h_in_data(in_data);
 #endif
 
     for (size_t i = 0; i < size; i++) {
@@ -123,9 +123,9 @@ event SubmitConsumer(queue& q, T* out_data, size_t size) {
 
   return q.single_task<Consumer>([=]() [[intel::kernel_args_restrict]] {
 #if defined(IS_BSP)
-    // using a host_ptr tells the compiler that this pointer lives in the
+    // using a sycl::ext::intel::host_ptr tells the compiler that this pointer lives in the
     // hosts address space
-    host_ptr<T> h_out_data(out_data);
+    sycl::ext::intel::host_ptr<T> h_out_data(out_data);
 #endif
 
     for (size_t i = 0; i < size; i++) {


### PR DESCRIPTION
The `host_ptr` and `device_ptr` constructs have been moved to the `sycl::ext:intel::` namespace.