### PR TITLE
Add explicit headers for iso3dfd

### DIFF
--- a/DirectProgramming/C++SYCL/StructuredGrids/guided_iso3dfd_GPUOptimization/src/Utils.hpp
+++ b/DirectProgramming/C++SYCL/StructuredGrids/guided_iso3dfd_GPUOptimization/src/Utils.hpp
@@ -8,6 +8,8 @@
 
 #include <sycl/sycl.hpp>
 #include <iostream>
+#include <cmath>
+#include <complex>
 
 #include "Iso3dfd.hpp"
 


### PR DESCRIPTION
# Existing Sample Changes
## Description

Fix for ONSAM JIRA 1941. Explicitly adding headers.

Fixes Issue# 

https://jira.devtools.intel.com/browse/ONSAM-1941

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Implement fixes for ONSAM Jiras

## How Has This Been Tested?

Tested in CL and VSCode

- [x] Command Line
- [ ] oneapi-cli
- [ ] Visual Studio
- [ ] Eclipse IDE
- [x] VSCode
- [ ] When compiling the compliler flag "-Wall -Wformat-security -Werror=format-security" was used
