### PR TITLE
Updated simpleCudaGraphs migration sample for oneAPI 2024.2 release. 

### DIFF
--- a/DirectProgramming/C++SYCL/SYCLMigration/guided_simpleCudaGraphs_SYCLMigration/02_sycl_migrated_option1/Samples/3_CUDA_Features/simpleCudaGraphs/simpleCudaGraphs.dp.cpp
+++ b/DirectProgramming/C++SYCL/SYCLMigration/guided_simpleCudaGraphs_SYCLMigration/02_sycl_migrated_option1/Samples/3_CUDA_Features/simpleCudaGraphs/simpleCudaGraphs.dp.cpp
@@ -81,8 +81,7 @@ void reduce(float *inputVec, double *outputVec, size_t inputSize,
       beta += temp;
       tmp[item_ct1.get_local_linear_id()] = beta;
     }
-    tile32.barrier();
-  }
+   }
   
   item_ct1.barrier();
 
@@ -262,7 +261,7 @@ tmp.get_multi_ptr<sycl::access::decorated::no>()
       "%zu\n",
       sf_Task + tf_Task);
 
-  printf("Cloned Graph Output.. \n");
+ printf("Cloned Graph Output.. \n");
   tf::Taskflow tflow_clone(std::move(tflow));
   exe.run_n(tflow_clone, GRAPH_LAUNCH_ITERATIONS).wait();
 }

--- a/DirectProgramming/C++SYCL/SYCLMigration/guided_simpleCudaGraphs_SYCLMigration/README.md
+++ b/DirectProgramming/C++SYCL/SYCLMigration/guided_simpleCudaGraphs_SYCLMigration/README.md
@@ -41,7 +41,7 @@ This sample contains two versions in the following folders:
 | OS                                                 | Ubuntu* 22.04
 | Hardware (for 02_sycl_migrated__option1)           | Intel® Gen9 <br> Intel® Gen11 <br> Intel® Xeon CPU <br> Intel® Data Center GPU Max <br> Nvidia Testla P100 <br> Nvidia A100 <br> Nvidia H100
 | Hardware (for 02_sycl_migrated__option2)           | Intel® Data Center GPU Max <br> 
-| Software                                           | SYCLomatic (Tag - 20240403) <br> Intel® oneAPI Base Toolkit (Base Kit) version 2024.1 <br> oneAPI for NVIDIA GPUs plugin (version 2024.1) from Codeplay
+| Software                                           | SYCLomatic (Tag - 20240403) <br> Intel® oneAPI Base Toolkit (Base Kit) version 2024.2 <br> oneAPI for NVIDIA GPUs plugin (version 2024.1) from Codeplay
 
 For more information on how to install Syclomatic Tool, visit [Migrate from CUDA* to C++ with SYCL*](https://www.intel.com/content/www/us/en/developer/tools/oneapi/training/migrate-from-cuda-to-cpp-with-sycl.html#gs.v354cy) <br>
 Refer to [oneAPI for NVIDIA GPUs plugin](https://developer.codeplay.com/products/oneapi/nvidia/) from Codeplay to execute a sample on NVIDIA GPU.


### PR DESCRIPTION
# Existing Sample Changes
## Description

Updated/bug fix for guided_simpleCudaGraph_SYCLMigration sample in SYCLMigration and Jupyter/cuda-to-sycl-migration-training folder.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Implement fixes for ONSAM Jiras

## How Has This Been Tested?

- [X] Command Line
- [ ] oneapi-cli
- [ ] Visual Studio
- [ ] Eclipse IDE
- [ ] VSCode
- [X] When compiling the compliler flag "-Wall -Wformat-security -Werror=format-security" was used

