### PR TITLE
Fix ONSAM-1905

### DIFF
--- a/Publications/GPU-Opt-Guide/explicit-scaling/07_explicit_subdevice/explicit_subdevice.cpp
+++ b/Publications/GPU-Opt-Guide/explicit-scaling/07_explicit_subdevice/explicit_subdevice.cpp
@@ -7,7 +7,7 @@
 // Copyright (C) 2020 Intel Corporation
 // SPDX-License-Identifier: MIT
 
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 #include <algorithm>
 #include <cassert>
 #include <cfloat>
@@ -24,6 +24,13 @@ cl_ulong triad(size_t array_size) {
   cl_ulong min_time_ns1 = DBL_MAX;
 
   device dev = device(gpu_selector_v);
+
+  auto part_prop =
+        dev.get_info<sycl::info::device::partition_properties>();
+  if (part_prop.empty()) {
+    std::cout << "Device cannot be partitioned to subdevices\n";
+    exit(1);
+  }
 
   std::vector<device> subdev = {};
   subdev = dev.create_sub_devices<sycl::info::partition_property::
@@ -113,8 +120,8 @@ int main(int argc, char *argv[]) {
     array_size =  std::stoi(argv[1]);
   }
   else {
-    std::cout << "Run as ./<progname> <arraysize in elements>\n";
-    return 1;
+    array_size = 128;
+    std::cout << "Use default array size 128" << std::endl;
   }
   std::cout << "Running with stream size of " << array_size
     << " elements (" << (array_size * sizeof(double))/(double)1024/1024 << "MB)\n";


### PR DESCRIPTION
# Existing Sample Changes
## Description

Use default array size 128 if no array size is specified
Gracefully exit if a device does not have subdevices
Remove compilation warnings with the latest compiler

Fixes Issue# ONSAM-1905

## External Dependencies

None

## Type of change

Please delete options that are not relevant. Add a 'X' to the one that is applicable. 

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Implement fixes for ONSAM Jiras

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [X] Command Line
- [ ] oneapi-cli
- [ ] Visual Studio
- [ ] Eclipse IDE
- [ ] VSCode
- [ ] When compiling the compliler flag "-Wall -Wformat-security -Werror=format-security" was used
