### PR TITLE
FPGA: Bug fixes for the `fft2d` sample

### DIFF
--- a/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/fft2d/src/fft2d.hpp
+++ b/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/fft2d/src/fft2d.hpp
@@ -122,7 +122,7 @@ std::array<ac_complex<T>, points> ReorderData(
   // the contents of the entire buffer is shifted by 1 element
 
 #pragma unroll
-  for (int k = 0; k < points; k++) {
+  for (int k = 0; k < points / 2; k++) {
     data[k * 2 + 1] = Delay(data[k * 2 + 1], depth,
                             shift_reg + (k * 2 + 1 - 1) / 2 * (depth + 1));
   }
@@ -469,6 +469,11 @@ struct FFT {
      */
 
     ac_complex<T> fft_delay_elements[kN + kPoints * (logn - 2)];
+
+#pragma unroll
+    for (unsigned i = 0; i < kN + kPoints * (logn - 2); i++) {
+      fft_delay_elements[i] = {0.0f, 0.0f};
+    }
 
     // needs to run "kN / kPoints - 1" additional iterations to drain the last
     // outputs


### PR DESCRIPTION
# Existing Sample Changes
## Description

1. Fix array index out of bound in function `ReorderData`
2. Fix use of uninitialized array `fft_delay_elements`

## Type of change

Please delete options that are not relevant. Add a 'X' to the one that is applicable. 

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Implement fixes for ONSAM Jiras

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Command Line
- [ ] oneapi-cli
- [ ] Visual Studio
- [ ] Eclipse IDE
- [ ] VSCode
- [ ] When compiling the compliler flag "-Wall -Wformat-security -Werror=format-security" was used
