### PR TITLE
FPGA: correct 'categories' for hls flow/interfaces code samples

### DIFF
--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/hls_flow_interfaces/component_interfaces_comparison/sample.json
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/hls_flow_interfaces/component_interfaces_comparison/sample.json
@@ -1,7 +1,7 @@
 {
     "guid": "7d8482f5-39f1-4cf1-aa2e-a1f72cfc47cb",
     "name": "Component Interfaces Comparison",
-    "categories": ["Toolkit/oneAPI Direct Programming/C++SYCL FPGA/Getting Started Tutorials"],
+    "categories": ["Toolkit/oneAPI Direct Programming/C++SYCL FPGA/Getting Started Tutorials", "Toolkit/oneAPI Direct Programming/C++SYCL FPGA/Tutorials/Features/HLS Flow: Interfaces"],
     "description": "Intel® FPGA tutorial introducing different invocation/data interfaces that can be used for IP components",
     "toolchain": ["icpx"],
     "os": ["linux", "windows"],

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/hls_flow_interfaces/mmhost/sample.json
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/hls_flow_interfaces/mmhost/sample.json
@@ -1,7 +1,7 @@
 {
   "guid": "CE509751-B84A-44D1-A391-2007937F3A7F",
   "name": "Avalon Memory-Mapped Host Interfaces",
-  "categories": ["Toolkit/oneAPI Direct Programming/C++SYCL FPGA/Tutorials/Features/HLS FLow: Interfaces"],
+  "categories": ["Toolkit/oneAPI Direct Programming/C++SYCL FPGA/Tutorials/Features/HLS Flow: Interfaces"],
   "description": "An Intel® FPGA tutorial demonstrating how to annotate pointer arguments to customize Avalon memory-mapped host interfaces",
   "toolchain": ["icpx"],
   "os": ["linux", "windows"],

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/hls_flow_interfaces/streaming_data_interfaces/sample.json
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/hls_flow_interfaces/streaming_data_interfaces/sample.json
@@ -1,7 +1,7 @@
 {
   "guid": "aeaca2ce-126e-452b-a6e3-2a3d5b1dbf55",
   "name": "Streaming Data Interfaces",
-  "categories": ["Toolkit/oneAPI Direct Programming/C++SYCL FPGA/Tutorials/HLS Flow: Interfaces"],
+  "categories": ["Toolkit/oneAPI Direct Programming/C++SYCL FPGA/Tutorials/Features/HLS Flow: Interfaces"],
   "description": "An Intel® FPGA tutorial demonstrating how to use pipes to implement streaming interfaces on IP Components",
   "toolchain": ["icpx"],
   "os": ["linux", "windows"],


### PR DESCRIPTION
# Existing Sample Changes
## Description

Correct 'categories' for hls flow/interfaces code samples so they group together nicely in the sample browser

## Type of change

Please delete options that are not relevant. Add a 'X' to the one that is applicable. 

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Implement fixes for ONSAM Jiras

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Command Line
- [ ] oneapi-cli
- [ ] Visual Studio
- [ ] Eclipse IDE
- [ ] VSCode
- [ ] When compiling the compliler flag "-Wall -Wformat-security -Werror=format-security" was used

No tests as this is a metadata change to group items correctly in the sample browser.