### PR TITLE
FPGA: Remove unused memory allocation in the gzip sample

### DIFF
--- a/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/gzip/src/gzip.cpp
+++ b/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/gzip/src/gzip.cpp
@@ -196,7 +196,6 @@ struct KernelInfo {
   buffer<unsigned, 1> *current_crc;
   buffer<char, 1> *pobuf;
   buffer<char, 1> *pibuf;
-  char *pobuf_decompress;
 
   uint32_t buffer_crc[kMinBufferSize];
   uint32_t refcrc;
@@ -319,7 +318,6 @@ int CompressFile(queue &q, std::string &input_file, std::vector<std::string> out
                                 : new buffer<char, 1>(input_alloc_size);
       kinfo[eng][i].pobuf =
           i >= 3 ? kinfo[eng][i - 3].pobuf : new buffer<char, 1>(outputSize);
-      kinfo[eng][i].pobuf_decompress = (char *)malloc(kinfo[eng][i].file_size);
     }
   }
 
@@ -527,7 +525,6 @@ int CompressFile(queue &q, std::string &input_file, std::vector<std::string> out
           free(kinfo[eng][i].poutput_buffer);
         }
       }
-      free(kinfo[eng][i].pobuf_decompress);
     }
     free(kinfo[eng]);
   }


### PR DESCRIPTION
The gzip code sample included a memory allocation of the size of the file to be compressed, which was issued for every repeated iteration of the kernel.
This led to increasingly large host memory allocation when the file to compress was increasing in size.
However, the allocated memory was never used.
This change therefore removes the unneeded allocation.