### PR TITLE
2024.2 install changes for conda forge 

### DIFF
--- a/AI-and-Analytics/Features-and-Functionality/IntelTensorFlow_ModelZoo_Inference_with_FP32_Int8/README.md
+++ b/AI-and-Analytics/Features-and-Functionality/IntelTensorFlow_ModelZoo_Inference_with_FP32_Int8/README.md
@@ -86,7 +86,7 @@ Navigate to the Intel® AI Reference models source directory. By default, it is 
 #### Install Jupyter Notebook
 
 ```
-conda install jupyter nb_conda_kernels
+conda install -c conda-forge jupyter nb_conda_kernels
 ```
 
 #### Open Jupyter Notebook

--- a/AI-and-Analytics/Features-and-Functionality/IntelTensorFlow_Transformer_AMX_bfloat16_MixedPrecision/sample.json
+++ b/AI-and-Analytics/Features-and-Functionality/IntelTensorFlow_Transformer_AMX_bfloat16_MixedPrecision/sample.json
@@ -16,7 +16,7 @@
   		"steps": [
       "source /root/intel/oneapi/intelpython/bin/activate",
 			"conda activate tensorflow",
-			"conda install -y jupyter",
+			"conda install -c conda-forge -y jupyter",
 			"jupyter nbconvert --execute --to notebook IntelTensorFlow_Transformer_AMX_bfloat16_MixedPrecision.ipynb"
   		]
   	}

--- a/AI-and-Analytics/Getting-Started-Samples/INC-Sample-for-Tensorflow/sample.json
+++ b/AI-and-Analytics/Getting-Started-Samples/INC-Sample-for-Tensorflow/sample.json
@@ -13,8 +13,8 @@
 	{
 		"env": ["source /opt/intel/oneapi/setvars.sh --force",
 				"conda activate tensorflow",
-				"conda install -n tensorflow python-flatbuffers -y",
-				"conda install -n tensorflow -c intel neural-compressor -y",
+				"conda install -n tensorflow -c conda-forge python-flatbuffers -y",
+				"conda install -n tensorflow -c https://software.repos.intel.com/python/conda/ -c conda-forge neural-compressor -y",
 				"conda install -n tensorflow -y",
 				"pip install jupyter ipykernel",
 				"python -m ipykernel install --user --name=tensorflow"


### PR DESCRIPTION
# Existing Sample Changes
## Description

intel uses conda forge channel instead of default channel, so instructions needed to be updated.

Fixes Issue# 
ONSAM-1973, 1972, 1970
## External Dependencies
NA

## Type of change

Please delete options that are not relevant. Add a 'X' to the one that is applicable. 

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Implement fixes for ONSAM Jiras

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Command Line
- [ ] oneapi-cli
- [ ] Visual Studio
- [ ] Eclipse IDE
- [ ] VSCode
- [ ] When compiling the compliler flag "-Wall -Wformat-security -Werror=format-security" was used

