### PR TITLE
FPGA: Replace CL/sycl.hpp with sycl/sycl.hpp for fpga_compile

### DIFF
--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/GettingStarted/fpga_compile/part3_dpcpp_lambda_usm/src/vector_add.cpp
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/GettingStarted/fpga_compile/part3_dpcpp_lambda_usm/src/vector_add.cpp
@@ -2,7 +2,7 @@
 #include <vector>
 
 // oneAPI headers
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 #include <sycl/ext/intel/fpga_extensions.hpp>
 
 using namespace sycl;


### PR DESCRIPTION
# Existing Sample Changes
## Description

Replace CL/sycl.hpp with sycl/sycl.hpp for fpga_compile because it is deprecated

## Type of change

Please delete options that are not relevant. Add a 'X' to the one that is applicable. 

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Implement fixes for ONSAM Jiras

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [X] Command Line
- [ ] oneapi-cli
- [ ] Visual Studio
- [ ] Eclipse IDE
- [ ] VSCode
- [ ] When compiling the compliler flag "-Wall -Wformat-security -Werror=format-security" was used