### PR TITLE
Fix Tachyon filename in README (dev)

### DIFF
--- a/Tools/VTuneProfiler/tachyon/README.md
+++ b/Tools/VTuneProfiler/tachyon/README.md
@@ -196,14 +196,15 @@ Compare the code in `tachyon.openmp.cpp` to `tachyon.serial.cpp`. `tachyon.openm
 3. Run optimized OpenMP version. 
 
    ```
-   ./tachyon.openmp_solution ../dat/balls.dat 
+   ./tachyon.openmp_optimized ../dat/balls.dat
    ```
    
    You will see the following output: 
 
    ```
    Scene contains 7386 bounded objects. 
-   tachyon.openmp_solution ../dat/balls.dat: 0.153 seconds    ```
+   tachyon.openmp_optimized ../dat/balls.dat: 0.153 seconds
+   ```
 
 4. Compare the render time between the basic OpenMP and optimized OpenMP versions. The optimized version shows an improvement in render time. 
 


### PR DESCRIPTION
# Existing Sample Changes
## Description

This change fixes an error in the Taychon Sample README. The filename for the optimized OpenMP executable should be `tachyon.openmp_optimized`, not `tachyon.openmp_solution`.

Fixes Issue# ONSAM-2000

## External Dependencies

None.

## Type of change

Please delete options that are not relevant. Add a 'X' to the one that is applicable. 

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Implement fixes for ONSAM Jiras

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [X] Command Line
- [ ] oneapi-cli
- [ ] Visual Studio
- [ ] Eclipse IDE
- [ ] VSCode
- [ ] When compiling the compliler flag "-Wall -Wformat-security -Werror=format-security" was used