### PR TITLE
FPGA: Add in template argument list after template keyword

### DIFF
--- a/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/decompress/CMakeLists.txt
+++ b/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/decompress/CMakeLists.txt
@@ -63,6 +63,8 @@ if(NOT DEFINED DEVICE_FLAG)
                          -DDEVICE_FLAG=Agilex7.")
 endif()
 
+message("\tDEVICE_FLAG set to ${DEVICE_FLAG}")
+
 # Select between SNAPPY and GZIP decompression
 if(DEFINED SNAPPY AND DEFINED GZIP)
   message(FATAL_ERROR "Cannot compile for both SNAPPY and GZIP compression. You must define exactly one of -DSNAPPY=1 and -DGZIP=1")

--- a/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/decompress/src/gzip/byte_bit_stream.hpp
+++ b/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/decompress/src/gzip/byte_bit_stream.hpp
@@ -92,7 +92,7 @@ class ByteBitStream {
   //
   void NewByte(unsigned char b) {
     ac_int<8, false> b_ac_int(b);
-    buf_.template set_slc(size_, b_ac_int);
+    buf_.template set_slc<>(size_, b_ac_int);
 
     size_ += decltype(size_)(8);
     space_ -= decltype(space_)(8);

--- a/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/decompress/src/snappy/snappy_reader.hpp
+++ b/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/decompress/src/snappy/snappy_reader.hpp
@@ -82,7 +82,7 @@ unsigned SnappyReader(unsigned in_count) {
       bool valid_read;
       auto pipe_data = InPipe::read(valid_read);
       if (valid_read) {
-        byte_stream.template Write(pipe_data);
+        byte_stream.template Write<>(pipe_data);
         data_read_in_preamble += literals_per_cycle;
       }
     }
@@ -180,7 +180,7 @@ unsigned SnappyReader(unsigned in_count) {
       bool valid_read;
       auto pipe_data = InPipe::read(valid_read);
       if (valid_read) {
-        byte_stream.template Write(pipe_data);
+        byte_stream.template Write<>(pipe_data);
         data_read += literals_per_cycle;
         all_data_read = all_data_read_next;
         all_data_read_next = data_read >= (in_count - literals_per_cycle);


### PR DESCRIPTION
## Description

This PR adds a template argument list after the template keyword. This is now required with newer versions of SYCL.

This change also adds a print message for the DEVICE_FLAG variable so that we are not getting any CMake unused variable warnings when running this design.

## Type of change 

- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [X] Command Line

* Manually compiled the design with `make report` to make sure that there is no longer a CMake warning, and that the SYCL error is gone.

