### PR TITLE
Fix compiler env variable in oneDNN README (rel)

### DIFF
--- a/Libraries/oneDNN/getting_started/README.md
+++ b/Libraries/oneDNN/getting_started/README.md
@@ -87,7 +87,7 @@ and threading runtimes:
 source ${INTEL_ONEAPI_INSTALL_FOLDER}/setvars.sh --dnnl-configuration=cpu_gomp  
 mkdir build  
 cd build  
-CC=GCC CXX=g++ cmake ..  
+CC=gcc CXX=g++ cmake ..  
 make  
 ```
 * Intel® C++ Compiler and Intel OpenMP runtime
@@ -95,7 +95,7 @@ make
 source ${INTEL_ONEAPI_INSTALL_FOLDER}/setvars.sh --dnnl-configuration=cpu_iomp  
 mkdir build  
 cd build  
-CC=icc CXX=icpc cmake ..  
+CC=icx CXX=icpx cmake ..  
 make  
 ```
 * Intel® C++ Compiler and TBB runtime
@@ -103,7 +103,7 @@ make
 source ${INTEL_ONEAPI_INSTALL_FOLDER}/setvars.sh --dnnl-configuration=cpu_tbb  
 mkdir build  
 cd build  
-CC=icc CXX=icpc cmake ..  
+CC=icx CXX=icpx cmake ..  
 make  
 ```
 ### On a Windows* System


### PR DESCRIPTION
# Existing Sample Changes
## Description

This change fixes the compiler environment variables in the oneDNN getting started README.
For GNU C++ Compiler, `CC=GCC CXX=g++ cmake ..` should be `CC=gcc CXX=g++ cmake ..`.
For Intel C++ Compiler, `CC=icc CXX=icpc cmake ..` should be `CC=icx CXX=icpx cmake ..`.

Fixes Issue# ONSAM-1992

## External Dependencies

None.

## Type of change

Please delete options that are not relevant. Add a 'X' to the one that is applicable. 

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Implement fixes for ONSAM Jiras

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [X] Command Line
- [ ] oneapi-cli
- [ ] Visual Studio
- [ ] Eclipse IDE
- [ ] VSCode
- [ ] When compiling the compliler flag "-Wall -Wformat-security -Werror=format-security" was used