### PR TITLE
[FPGA] Remove reference to hardware runs on Windows

### DIFF
--- a/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/anr/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/anr/README.md
@@ -286,10 +286,7 @@ The design uses the following generic header files.
    anr.fpga_sim.exe
    set CL_CONTEXT_MPSIM_DEVICE_INTELFPGA=
    ```
-3. Alternatively, run the sample on the FPGA device (only if you ran `cmake` with `-DFPGA_DEVICE=<board-support-package>:<board-variant>`).
-   ```
-   anr.fpga.exe
-   ```
+> **Note**: Hardware runs are not supported on Windows.
 
 ## Example Output
 

--- a/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/board_test/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/board_test/README.md
@@ -253,14 +253,7 @@ The tests listed above check the following interfaces in a platform:
     ```
     board_test.exe -test=<test_number>
     ```
- 2. Run the sample on the FPGA device.
-    ```
-    board_test.fpga.exe
-    ```
-    By default the program runs all tests. To run a specific test, enter the test number as an argument to the `-test` option:
-    ```
-    board_test.fpga.exe -test=<test_number>
-    ```
+> **Note**: Hardware runs are not supported on Windows.
 
 ## Example Output
 
@@ -274,7 +267,6 @@ Command to run board_test using generated binary:
   > To run all tests (default): run board_test.fpga
   > To run a specific test (see list below); pass the test number as argument to "-test" option: 
   Linux: ./board_test.fpga -test=<test_number>
-  Windows: board_test.exe -test=<test_number>
   > To see more details on what each test does use -help option
 The tests are:
   1. Host Speed and Host Read Write Test

--- a/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/cholesky/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/cholesky/README.md
@@ -286,10 +286,7 @@ You can apply the Cholesky decomposition to a number of matrices, as shown below
    cholesky.fpga_sim.exe
    set CL_CONTEXT_MPSIM_DEVICE_INTELFPGA=
    ```
-3. Run the sample on the FPGA device (only if you ran `cmake` with `-DFPGA_DEVICE=<board-support-package>:<board-variant>`).
-   ```
-   cholesky.fpga.exe
-   ```
+> **Note**: Hardware runs are not supported on Windows.
 
 ## Example Output
 

--- a/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/cholesky_inversion/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/cholesky_inversion/README.md
@@ -311,10 +311,7 @@ You can apply the Cholesky-based inversion to 8 matrices repeated a number of ti
    cholesky_inversion.fpga_sim.exe
    set CL_CONTEXT_MPSIM_DEVICE_INTELFPGA=
    ```
-3. Run on the FPGA device (only if you ran `cmake` with `-DFPGA_DEVICE=<board-support-package>:<board-variant>`).
-   ```
-   cholesky_inversion.fpga.exe
-   ```
+> **Note**: Hardware runs are not supported on Windows.
 
 ## Example Output
 

--- a/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/crr/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/crr/README.md
@@ -288,10 +288,7 @@ This design measures the FPGA performance to determine how many assets can be pr
    set CL_CONTEXT_MPSIM_DEVICE_INTELFPGA=
    ```
 
-3. Run the sample on the FPGA device (only if you ran `cmake` with `-DFPGA_DEVICE=<board-support-package>:<board-variant>`).
-   ```
-   crr.fpga.exe <input_file> [-o=<output_file>]
-   ```
+> **Note**: Hardware runs are not supported on Windows.
 
 ## Example Output
 

--- a/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/db/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/db/README.md
@@ -305,10 +305,7 @@ Query 12 showcases the `MergeJoin` database operator. The block diagram of the d
    db.fpga_sim.exe --dbroot=../data/sf0.01 --test
    set CL_CONTEXT_MPSIM_DEVICE_INTELFPGA=
    ```
-3. Run the sample on an FPGA device (only if you ran `cmake` with `-DFPGA_DEVICE=<board-support-package>:<board-variant>`).
-   ```
-   db.fpga.exe --dbroot=../data/sf1 --test
-   ```
+> **Note**: Hardware runs are not supported on Windows.
 
 ## Example Output
 

--- a/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/decompress/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/decompress/README.md
@@ -450,10 +450,7 @@ For `constexpr_math.hpp`, `memory_utils.hpp`, `metaprogramming_utils.hpp`, `tupl
     decompress.fpga_sim.exe
     set CL_CONTEXT_MPSIM_DEVICE_INTELFPGA=
     ```
-3. Run the sample on the FPGA device (only if you ran `cmake` with `-DFPGA_DEVICE=<board-support-package>:<board-variant>`).
-    ```
-    decompress.fpga.exe
-    ```
+> **Note**: Hardware runs are not supported on Windows.
 
 ## Example Output
 

--- a/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/fft2d/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/fft2d/README.md
@@ -216,39 +216,29 @@ Additionally, the `cmake` build system can be configured using the following par
 
 ### On Linux
 
-#### Run on FPGA Emulator
-
 1. Run the sample on the FPGA emulator (the kernel executes on the CPU).
    ```
    ./fft2d.fpga_emu
    ```
 
-#### Run on FPGA Simulator
-
-1. Run the sample on the FPGA simulator.
+2. Run the sample on the FPGA simulator.
    ```
    CL_CONTEXT_MPSIM_DEVICE_INTELFPGA=1 ./fft2d.fpga_sim
    ```
 
-#### Run on FPGA
-
-1. Run the sample on the FPGA device (only if you ran `cmake` with `-DFPGA_DEVICE=<board-support-package>:<board-variant>`).
+3. Run the sample on the FPGA device (only if you ran `cmake` with `-DFPGA_DEVICE=<board-support-package>:<board-variant>`).
    ```
    ./fft2d.fpga
    ```
 
 ### On Windows
 
-#### Run on FPGA Emulator
-
 1. Run the sample on the FPGA emulator (the kernel executes on the CPU).
    ```
    fft2d.fpga_emu.exe
    ```
 
-#### Run on FPGA Simulator
-
-1. Run the sample on the FPGA simulator.
+2. Run the sample on the FPGA simulator.
    ```
    set CL_CONTEXT_MPSIM_DEVICE_INTELFPGA=1
    fft2d.fpga_sim.exe

--- a/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/fft2d/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/fft2d/README.md
@@ -255,12 +255,7 @@ Additionally, the `cmake` build system can be configured using the following par
    set CL_CONTEXT_MPSIM_DEVICE_INTELFPGA=
    ```
 
-#### Run on FPGA
-
-1. Run the sample on the FPGA device (only if you ran `cmake` with `-DFPGA_DEVICE=<board-support-package>:<board-variant>`).
-   ```
-   fft2d.fpga.exe
-   ```
+> **Note**: Hardware runs are not supported on Windows.
 
 ## Example Output
 

--- a/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/gzip/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/gzip/README.md
@@ -299,10 +299,7 @@ Performance results are based on testing as of August 30, 2023.
     gzip.fpga_sim.exe ../data/100b.txt -o=<output_file>
     set CL_CONTEXT_MPSIM_DEVICE_INTELFPGA=
     ```
- 3. Run the sample on the FPGA device (only if you ran `cmake` with `-DFPGA_DEVICE=<board-support-package>:<board-variant>`).
-    ```
-    gzip.fpga.exe <input_file> -o=<output_file>
-    ```
+> **Note**: Hardware runs are not supported on Windows.
 
 ## Example Output
 

--- a/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/matmul/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/matmul/README.md
@@ -345,12 +345,7 @@ You can perform the multiplication of the set of matrices repeatedly. This step 
    matmul.fpga_sim.exe
    set CL_CONTEXT_MPSIM_DEVICE_INTELFPGA=
    ```
-#### Run on FPGA
-
-1. Run the sample on the FPGA device (only if you ran `cmake` with `-DFPGA_DEVICE=<board-support-package>:<board-variant>`).
-   ```
-   matmul.fpga.exe
-   ```
+> **Note**: Hardware runs are not supported on Windows.
 
 ## Example Output
 

--- a/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/matmul/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/matmul/README.md
@@ -307,39 +307,29 @@ You can perform the multiplication of the set of matrices repeatedly. This step 
 
 ### On Linux
 
-#### Run on FPGA Emulator
-
 1. Run the sample on the FPGA emulator (the kernel executes on the CPU).
    ```
    ./matmul.fpga_emu
    ```
 
-#### Run on FPGA Simulator
-
-1. Run the sample on the FPGA simulator.
+2. Run the sample on the FPGA simulator.
    ```
    CL_CONTEXT_MPSIM_DEVICE_INTELFPGA=1 ./matmul.fpga_sim
    ```
 
-#### Run on FPGA
-
-1. Run the sample on the FPGA device (only if you ran `cmake` with `-DFPGA_DEVICE=<board-support-package>:<board-variant>`).
+3. Run the sample on the FPGA device (only if you ran `cmake` with `-DFPGA_DEVICE=<board-support-package>:<board-variant>`).
    ```
    ./matmul.fpga
    ```
 
 ### On Windows
 
-#### Run on FPGA Emulator
-
 1. Run the sample on the FPGA emulator (the kernel executes on the CPU).
    ```
    matmul.fpga_emu.exe
    ```
 
-#### Run on FPGA Simulator
-
-1. Run the sample on the FPGA simulator.
+2. Run the sample on the FPGA simulator.
    ```
    set CL_CONTEXT_MPSIM_DEVICE_INTELFPGA=1
    matmul.fpga_sim.exe

--- a/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/mvdr_beamforming/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/mvdr_beamforming/README.md
@@ -266,10 +266,7 @@ The general syntax for running the program is shown below and the table describe
    mvdr_beamforming.fpga_sim.exe ../data .
    set CL_CONTEXT_MPSIM_DEVICE_INTELFPGA=
    ```
-3. Run the sample on the FPGA device (only if you ran `cmake` with `-DFPGA_DEVICE=<board-support-package>:<board-variant>`).
-   ```
-   mvdr_beamforming.fpga.exe 1024 ../data .
-   ```
+> **Note**: Hardware runs are not supported on Windows.
 
 ## Build and Run the Design Using Real IO-pipes
 

--- a/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/pca/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/pca/README.md
@@ -466,12 +466,7 @@ Additionally, the `cmake` build system can be configured using the following par
    set CL_CONTEXT_MPSIM_DEVICE_INTELFPGA=
    ```
 
-#### Run on FPGA
-
-1. Run the sample on the FPGA device (only if you ran `cmake` with `-DFPGA_DEVICE=<board-support-package>:<board-variant>`).
-   ```
-   pca.fpga.exe <path to data/abalone.csv>
-   ```
+> **Note**: Hardware runs are not supported on Windows.
 
 ## Example Output
 

--- a/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/pca/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/pca/README.md
@@ -427,39 +427,29 @@ Additionally, the `cmake` build system can be configured using the following par
 
 ### On Linux
 
-#### Run on FPGA Emulator
-
 1. Run the sample on the FPGA emulator (the kernel executes on the CPU).
    ```
    ./pca.fpga_emu <path to data/abalone.csv>
    ```
 
-#### Run on FPGA Simulator
-
-1. Run the sample on the FPGA simulator.
+2. Run the sample on the FPGA simulator.
    ```
    CL_CONTEXT_MPSIM_DEVICE_INTELFPGA=1 ./pca.fpga_sim <path to data/abalone.csv>
    ```
 
-#### Run on FPGA
-
-1. Run the sample on the FPGA device (only if you ran `cmake` with `-DFPGA_DEVICE=<board-support-package>:<board-variant>`).
+3. Run the sample on the FPGA device (only if you ran `cmake` with `-DFPGA_DEVICE=<board-support-package>:<board-variant>`).
    ```
    ./pca.fpga <path to data/abalone.csv>
    ```
 
 ### On Windows
 
-#### Run on FPGA Emulator
-
 1. Run the sample on the FPGA emulator (the kernel executes on the CPU).
    ```
    pca.fpga_emu.exe <path to data/abalone.csv>
    ```
 
-#### Run on FPGA Simulator
-
-1. Run the sample on the FPGA simulator.
+2. Run the sample on the FPGA simulator.
    ```
    set CL_CONTEXT_MPSIM_DEVICE_INTELFPGA=1
    pca.fpga_sim.exe <path to data/abalone.csv>

--- a/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/qrd/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/qrd/README.md
@@ -253,43 +253,33 @@ You can perform the QR decomposition of the set of matrices repeatedly. This ste
 
 ### On Linux
 
-#### Run on FPGA Emulator
-
-1. Increase the amount of memory that the emulator runtime is permitted to allocate by exporting the `CL_CONFIG_CPU_FORCE_PRIVATE_MEM_SIZE` environment variable before running the executable.
-2. Run the sample on the FPGA emulator (the kernel executes on the CPU).
+1. Run the sample on the FPGA emulator (the kernel executes on the CPU).
    ```
    export CL_CONFIG_CPU_FORCE_PRIVATE_MEM_SIZE=32MB
    ./qrd.fpga_emu
    ```
+   * Increase the amount of memory that the emulator runtime is permitted to allocate by exporting the `CL_CONFIG_CPU_FORCE_PRIVATE_MEM_SIZE` environment variable before running the executable.
 
-#### Run on FPGA Simulator
-
-1. Run the sample on the FPGA simulator.
+2. Run the sample on the FPGA simulator.
    ```
    CL_CONTEXT_MPSIM_DEVICE_INTELFPGA=1 ./qrd.fpga_sim
    ```
 
-#### Run on FPGA
-
-1. Run the sample on the FPGA device (only if you ran `cmake` with `-DFPGA_DEVICE=<board-support-package>:<board-variant>`).
+3. Run the sample on the FPGA device (only if you ran `cmake` with `-DFPGA_DEVICE=<board-support-package>:<board-variant>`).
    ```
    ./qrd.fpga
    ```
 
 ### On Windows
 
-#### Run on FPGA Emulator
-
-1. Increase the amount of memory that the emulator runtime is permitted to allocate by setting the `CL_CONFIG_CPU_FORCE_PRIVATE_MEM_SIZE` environment variable before running the executable.
-2. Run the sample on the FPGA emulator (the kernel executes on the CPU).
+1. Run the sample on the FPGA emulator (the kernel executes on the CPU).
    ```
    set CL_CONFIG_CPU_FORCE_PRIVATE_MEM_SIZE=32MB
    qrd.fpga_emu.exe
    ```
+   * Increase the amount of memory that the emulator runtime is permitted to allocate by setting the `CL_CONFIG_CPU_FORCE_PRIVATE_MEM_SIZE` environment variable before running the executable.
 
-#### Run on FPGA Simulator
-
-1. Run the sample on the FPGA simulator.
+2. Run the sample on the FPGA simulator.
    ```
    set CL_CONTEXT_MPSIM_DEVICE_INTELFPGA=1
    qrd.fpga_sim.exe

--- a/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/qrd/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/qrd/README.md
@@ -296,12 +296,7 @@ You can perform the QR decomposition of the set of matrices repeatedly. This ste
    set CL_CONTEXT_MPSIM_DEVICE_INTELFPGA=
    ```
 
-#### Run on FPGA
-
-1. Run the sample on the FPGA device (only if you ran `cmake` with `-DFPGA_DEVICE=<board-support-package>:<board-variant>`).
-   ```
-   qrd.fpga.exe
-   ```
+> **Note**: Hardware runs are not supported on Windows.
 
 ## Example Output
 

--- a/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/qri/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/qri/README.md
@@ -287,12 +287,7 @@ You can perform the QR-based inversion of the set of matrices repeatedly, as sho
    set CL_CONTEXT_MPSIM_DEVICE_INTELFPGA=
    ```
 
-#### Run on FPGA
-
-1. Run the sample on the FPGA device (only if you ran `cmake` with `-DFPGA_DEVICE=<board-support-package>:<board-variant>`).
-   ```
-   qri.fpga.exe
-   ```
+> **Note**: Hardware runs are not supported on Windows.
 
 ## Example Output
 

--- a/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/qri/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/qri/README.md
@@ -244,43 +244,33 @@ You can perform the QR-based inversion of the set of matrices repeatedly, as sho
 
 ### On Linux
 
-#### Run on FPGA Emulator
-
-1. Increase the amount of memory that the emulator runtime is permitted to allocate by exporting the `CL_CONFIG_CPU_FORCE_PRIVATE_MEM_SIZE` environment variable before running the executable.
-2. Run the sample on the FPGA emulator (the kernel executes on the CPU).
+1. Run the sample on the FPGA emulator (the kernel executes on the CPU).
    ```
    export CL_CONFIG_CPU_FORCE_PRIVATE_MEM_SIZE=32MB
    ./qri.fpga_emu
    ```
+   * Increase the amount of memory that the emulator runtime is permitted to allocate by exporting the `CL_CONFIG_CPU_FORCE_PRIVATE_MEM_SIZE` environment variable before running the executable.
 
-#### Run on FPGA Simulator
-
-1. Run the sample on the FPGA simulator.
+2. Run the sample on the FPGA simulator.
    ```
    CL_CONTEXT_MPSIM_DEVICE_INTELFPGA=1 ./qri.fpga_sim
    ```
 
-#### Run on FPGA
-
-1. Run the sample on the FPGA device (only if you ran `cmake` with `-DFPGA_DEVICE=<board-support-package>:<board-variant>`).
+3. Run the sample on the FPGA device (only if you ran `cmake` with `-DFPGA_DEVICE=<board-support-package>:<board-variant>`).
    ```
    ./qri.fpga
    ```
 
 ### On Windows
 
-#### Run on FPGA Emulator
-
-1. Increase the amount of memory that the emulator runtime is permitted to allocate by setting the `CL_CONFIG_CPU_FORCE_PRIVATE_MEM_SIZE` environment variable before running the executable.
-2. Run the sample on the FPGA emulator (the kernel executes on the CPU).
+1. Run the sample on the FPGA emulator (the kernel executes on the CPU).
    ```
    set CL_CONFIG_CPU_FORCE_PRIVATE_MEM_SIZE=32MB
    qri.fpga_emu.exe
    ```
+   * Increase the amount of memory that the emulator runtime is permitted to allocate by setting the `CL_CONFIG_CPU_FORCE_PRIVATE_MEM_SIZE` environment variable before running the executable.
 
-#### Run on FPGA Simulator
-
-1. Run the sample on the FPGA simulator.
+2. Run the sample on the FPGA simulator.
    ```
    set CL_CONTEXT_MPSIM_DEVICE_INTELFPGA=1
    qri.fpga_sim.exe

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/autorun/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/autorun/README.md
@@ -224,10 +224,7 @@ Typically, these kernels are meant to run forever, and data is streamed to and f
    autorun.fpga_sim.exe
    set CL_CONTEXT_MPSIM_DEVICE_INTELFPGA=
    ```
-3. Run on an FPGA device (only if you ran `cmake` with `-DFPGA_DEVICE=<board-support-package>:<board-variant>`).
-   ```
-   autorun.fpga.exe
-   ```
+> **Note**: Hardware runs are not supported on Windows.
 
 ## Example Output
 

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/buffered_host_streaming/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/buffered_host_streaming/README.md
@@ -226,10 +226,7 @@ This sample demonstrates the following concepts:
    buffered_host_streaming.fpga_sim.exe
    set CL_CONTEXT_MPSIM_DEVICE_INTELFPGA=
    ```
-3. Run the sample on the FPGA device (only if you ran `cmake` with `-DFPGA_DEVICE=<board-support-package>:<board-variant>`):
-   ```
-   buffered_host_streaming.fpga.exe
-   ```
+> **Note**: Hardware runs are not supported on Windows.
 
 ## Example Output
 

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/compute_units/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/compute_units/README.md
@@ -266,10 +266,7 @@ Each compute unit in the chain from `Source` to `Sink` must read from a unique p
    compute_units.fpga_sim.exe
    set CL_CONTEXT_MPSIM_DEVICE_INTELFPGA=
    ```
-3. Run the sample on the FPGA device (only if you ran `cmake` with `-DFPGA_DEVICE=<board-support-package>:<board-variant>`).
-   ```
-   compute_units.fpga.exe
-   ```
+> **Note**: Hardware runs are not supported on Windows.
 
 ## Example Output
 ```

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/double_buffering/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/double_buffering/README.md
@@ -217,10 +217,7 @@ The key concepts discussed in this sample are as followed:
    double_buffering.fpga_sim.exe
    set CL_CONTEXT_MPSIM_DEVICE_INTELFPGA=
    ```
-3. Run the sample on the FPGA device (only if you ran `cmake` with `-DFPGA_DEVICE=<board-support-package>:<board-variant>`).
-   ```
-   double_buffering.fpga.exe
-   ```
+> **Note**: Hardware runs are not supported on Windows.
 
 ## Example Output
 

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/explicit_data_movement/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/explicit_data_movement/README.md
@@ -249,10 +249,7 @@ Alternatively, in the full stack flow, there is a hybrid approach that uses some
    explicit_data_movement.fpga_sim.exe
    set CL_CONTEXT_MPSIM_DEVICE_INTELFPGA=
    ```
-3. Run the sample on the FPGA device (only if you ran `cmake` with `-DFPGA_DEVICE=<board-support-package>:<board-variant>`).
-   ```
-   explicit_data_movement.fpga.exe
-   ```
+> **Note**: Hardware runs are not supported on Windows.
 
 ## Example Output
 

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/io_streaming/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/io_streaming/README.md
@@ -269,10 +269,7 @@ Notice that the main kernel in the `SubmitSideChannelKernels` function in *src/S
    io_streaming.fpga_sim.exe
    set CL_CONTEXT_MPSIM_DEVICE_INTELFPGA=
    ```
-3. Run the sample on the FPGA device (only if you ran `cmake` with `-DFPGA_DEVICE=<board-support-package>:<board-variant>`).
-   ```
-   io_streaming.fpga.exe
-   ```
+> **Note**: Hardware runs are not supported on Windows.
 
 ## Example Output
 

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/loop_carried_dependency/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/loop_carried_dependency/README.md
@@ -257,10 +257,7 @@ Look at the _Compiler Report > Throughput Analysis > Loop Analysis_ section in t
    loop_carried_dependency.fpga_sim.exe
    set CL_CONTEXT_MPSIM_DEVICE_INTELFPGA=
    ```
-3. Run the sample on the FPGA device (only if you ran `cmake` with `-DFPGA_DEVICE=<board-support-package>:<board-variant>`).
-   ```
-   loop_carried_dependency.fpga.exe
-   ```
+> **Note**: Hardware runs are not supported on Windows.
 
 ## Example Output
 

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/n_way_buffering/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/n_way_buffering/README.md
@@ -282,10 +282,7 @@ After each kernel is launched, the host-side operations (that occur *after* the 
    ```
    CL_CONTEXT_MPSIM_DEVICE_INTELFPGA=1 ./n_way_buffering.fpga_sim
    ```
-3. Run the sample on the FPGA device (only if you ran `cmake` with `-DFPGA_DEVICE=<board-support-package>:<board-variant>`).
-   ```
-   ./n_way_buffering.fpga
-   ```
+> **Note**: Hardware runs are not supported on Windows.
 
 ### On Windows
 

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/onchip_memory_cache/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/onchip_memory_cache/README.md
@@ -248,10 +248,7 @@ This tutorial creates multiple kernels sweeping across different cache depths wi
    onchip_memory_cache.fpga_sim.exe
    set CL_CONTEXT_MPSIM_DEVICE_INTELFPGA=
    ```
-3. Run the sample on the FPGA device (only if you ran `cmake` with `-DFPGA_DEVICE=<board-support-package>:<board-variant>`).
-   ```
-   onchip_memory_cache.fpga.exe
-   ```
+> **Note**: Hardware runs are not supported on Windows.
 
 ## Example Output
 

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/optimize_inner_loop/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/optimize_inner_loop/README.md
@@ -289,10 +289,7 @@ Examine the loop attributes for the three different versions of the `Producer` k
    loop_carried_dependency.fpga_sim.exe
    set CL_CONTEXT_MPSIM_DEVICE_INTELFPGA=
    ```
-3. Run the sample on the FPGA device (only if you ran `cmake` with `-DFPGA_DEVICE=<board-support-package>:<board-variant>`):
-   ```
-   optimize_inner_loop.fpga.exe
-   ```
+> **Note**: Hardware runs are not supported on Windows.
 
 ## Example Output
 

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/pipe_array/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/pipe_array/README.md
@@ -331,10 +331,7 @@ The host must thus enqueue the producer kernel and `kNumRows * kNumCols` separat
    pipe_array.fpga_sim.exe
    set CL_CONTEXT_MPSIM_DEVICE_INTELFPGA=
    ```
-3. Run the sample on the FPGA device (only if you ran `cmake` with `-DFPGA_DEVICE=<board-support-package>:<board-variant>`).
-   ```
-   pipe_array.fpga.exe
-   ```
+> **Note**: Hardware runs are not supported on Windows.
 
 ## Example Output
 

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/shannonization/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/shannonization/README.md
@@ -399,10 +399,7 @@ The following table explains the command-line arguments that can be passed to th
    shannonization.fpga_sim.exe
    set CL_CONTEXT_MPSIM_DEVICE_INTELFPGA=
    ```
-3. Run the sample on the FPGA device (only if you ran `cmake` with `-DFPGA_DEVICE=<board-support-package>:<board-variant>`).
-   ```
-   shannonization.fpga.exe
-   ```
+> **Note**: Hardware runs are not supported on Windows.
 
 ## Example Output
 

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/simple_host_streaming/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/simple_host_streaming/README.md
@@ -277,10 +277,7 @@ We are currently working on an API and tutorial to address both of these drawbac
    simple_host_streaming.fpga_sim.exe
    set CL_CONTEXT_MPSIM_DEVICE_INTELFPGA=
    ```
-3. Run the sample on the FPGA device (only if you ran `cmake` with `-DFPGA_DEVICE=<board-support-package>:<board-variant>`).
-   ```
-   simple_host_streaming.fpga.exe
-   ```
+> **Note**: Hardware runs are not supported on Windows.
 
 ## Example Output
 

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/triangular_loop/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/triangular_loop/README.md
@@ -354,10 +354,7 @@ Summing the number of real and dummy iterations gives the total iterations of th
    triangular_loop.fpga_sim.exe
    set CL_CONTEXT_MPSIM_DEVICE_INTELFPGA=
    ```
-3. Run the sample on the FPGA device (only if you ran `cmake` with `-DFPGA_DEVICE=<board-support-package>:<board-variant>`).
-   ```
-   triangular_loop.fpga.exe
-   ```
+> **Note**: Hardware runs are not supported on Windows.
 
 ## Example Output
 

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/zero_copy_data_transfer/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/zero_copy_data_transfer/README.md
@@ -229,10 +229,7 @@ This approach is not considered host streaming since the CPU and FPGA cannot (re
    zero_copy_data_transfer.fpga_sim.exe
    set CL_CONTEXT_MPSIM_DEVICE_INTELFPGA=
    ```
-3. Run the sample on the FPGA device (only if you ran `cmake` with `-DFPGA_DEVICE=<board-support-package>:<board-variant>`).
-   ```
-   zero_copy_data_transfer.fpga.exe
-   ```
+> **Note**: Hardware runs are not supported on Windows.
 
 ## Example Output
 

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/ac_fixed/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/ac_fixed/README.md
@@ -299,10 +299,7 @@ Scroll down on the Summary page of the report and expand the section titled **Co
    ac_fixed.fpga_sim.exe
    set CL_CONTEXT_MPSIM_DEVICE_INTELFPGA=
    ```
-3. Run the sample on the FPGA device (only if you ran `cmake` with `-DFPGA_DEVICE=<board-support-package>:<board-variant>`).
-   ```bash
-   ac_fixed.fpga.exe
-   ```
+> **Note**: Hardware runs are not supported on Windows.
 
 ## Example Output
 

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/ac_int/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/ac_int/README.md
@@ -283,10 +283,7 @@ Navigate to *System Viewer* (*Views* > *System Viewer*) and find the cluster in 
    ac_int.fpga_sim.exe
    set CL_CONTEXT_MPSIM_DEVICE_INTELFPGA=
    ```
-3. Run the sample on the FPGA device (only if you ran `cmake` with `-DFPGA_DEVICE=<board-support-package>:<board-variant>`).
-   ```
-   ac_int.fpga.exe
-   ```
+> **Note**: Hardware runs are not supported on Windows.
 
 ## Example Output
 

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/dsp_control/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/dsp_control/README.md
@@ -258,10 +258,7 @@ Locate `report.html` in the `dsp_control.report.prj/reports/` directory.
    dsp_control.fpga_sim.exe
    set CL_CONTEXT_MPSIM_DEVICE_INTELFPGA=
    ```
-3. Run the sample on the FPGA device (only if you ran `cmake` with `-DFPGA_DEVICE=<board-support-package>:<board-variant>`).
-   ```
-   dsp_control.fpga.exe
-   ```
+> **Note**: Hardware runs are not supported on Windows.
 
 ## Example Output
 

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/experimental/device_global/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/experimental/device_global/README.md
@@ -208,7 +208,7 @@ int main () {
    device_global.fpga_sim.exe
    set CL_CONTEXT_MPSIM_DEVICE_INTELFPGA=
    ```
-   > **Note**: Running this sample on an actual FPGA device requires a BSP that supports device_globals with host access from a dedicated interface. As there are currently no commercial BSPs with such support, only the SYCL HLS flow is enabled for this code sample.
+   > **Note**: Hardware runs are not supported on Windows.
 
 
 ## Example Output

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/experimental/hostpipes/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/experimental/hostpipes/README.md
@@ -397,7 +397,7 @@ using D2HPipe = cl::sycl::ext::intel::experimental::pipe<
    hostpipes.fpga_sim.exe
    set CL_CONTEXT_MPSIM_DEVICE_INTELFPGA=
    ```
-> **Note**: Running this sample on an actual FPGA device requires a BSP that supports host pipes. As there are currently no commercial BSPs with such support, only the SYCL HLS flow is enabled for this code sample.
+> **Note**: Hardware runs are not supported on Windows.
 
 ## Example Output
 

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/experimental/latency_control/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/experimental/latency_control/README.md
@@ -307,10 +307,7 @@ The compiler tries to achieve the latency constraints, and it errors out if some
    latency_control.fpga_sim.exe
    set CL_CONTEXT_MPSIM_DEVICE_INTELFPGA=
    ```
-3. Run the sample on the FPGA device (only if you ran `cmake` with `-DFPGA_DEVICE=<board-support-package>:<board-variant>`).
-   ```
-   latency_control.fpga.exe
-   ```
+> **Note**: Hardware runs are not supported on Windows.
 
 ### Example Output
 

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/fpga_reg/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/fpga_reg/README.md
@@ -288,10 +288,7 @@ Observe the structure of the design in the optimization report's System Viewer a
    set CL_CONTEXT_MPSIM_DEVICE_INTELFPGA=
    ```
 
-3. Run the sample on the FPGA device (only if you ran `cmake` with `-DFPGA_DEVICE=<board-support-package>:<board-variant>`).
-   ```
-   fpga_reg.fpga.exe
-   ```
+> **Note**: Hardware runs are not supported on Windows.
 
 ## Example Output
 

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/kernel_args_restrict/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/kernel_args_restrict/README.md
@@ -311,10 +311,7 @@ Next, look at the loop details of the *IDKernelArgsRestrict_Lambda* kernel (simi
    set CL_CONTEXT_MPSIM_DEVICE_INTELFPGA=
    ```
 
-3. Run the sample on the FPGA device (only if you ran `cmake` with `-DFPGA_DEVICE=<board-support-package>:<board-variant>`).
-   ```
-   kernel_args_restrict.fpga.exe
-   ```
+> **Note**: Hardware runs are not supported on Windows.
 
 ## Example Output
 

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/loop_coalesce/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/loop_coalesce/README.md
@@ -251,10 +251,7 @@ On the main report page, scroll down to the section titled `Compile Estimated Ke
    loop_coalesce.fpga_sim.exe
    set CL_CONTEXT_MPSIM_DEVICE_INTELFPGA=
    ```
-3. Run the sample on the FPGA device (only if you ran `cmake` with `-DFPGA_DEVICE=<board-support-package>:<board-variant>`).
-   ```
-   loop_coalesce.fpga.exe
-   ```
+> **Note**: Hardware runs are not supported on Windows.
 
 ## License
 

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/loop_fusion/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/loop_fusion/README.md
@@ -266,10 +266,7 @@ Navigate to the Area Analysis of the system under Area Analysis. The Kernel Syst
    loop_fusion.fpga_sim.exe
    set CL_CONTEXT_MPSIM_DEVICE_INTELFPGA=
    ```
-3. Run the sample on the FPGA device (only if you ran `cmake` with `-DFPGA_DEVICE=<board-support-package>:<board-variant>`).
-   ```
-   loop_fusion.fpga.exe
-   ```
+> **Note**: Hardware runs are not supported on Windows.
 
 ## Example Output
 

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/loop_initiation_interval/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/loop_initiation_interval/README.md
@@ -332,10 +332,7 @@ Compare the results to the report for the version of the design using the `intel
    set CL_CONTEXT_MPSIM_DEVICE_INTELFPGA=
    ```
 
-3. Run the sample on the FPGA device (only if you ran `cmake` with `-DFPGA_DEVICE=<board-support-package>:<board-variant>`).
-   ```
-   loop_initiation_interval.fpga.exe
-   ```
+> **Note**: Hardware runs are not supported on Windows.
 
 ## Example Output
 

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/loop_ivdep/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/loop_ivdep/README.md
@@ -345,10 +345,7 @@ You should see a message similar to "Compiler failed to schedule this loop with 
    loop_ivdep.fpga_sim.exe
    set CL_CONTEXT_MPSIM_DEVICE_INTELFPGA=
    ```
-3. Run the sample on the FPGA device (only if you ran `cmake` with `-DFPGA_DEVICE=<board-support-package>:<board-variant>`).
-   ```
-   loop_ivdep.fpga.exe
-   ```
+> **Note**: Hardware runs are not supported on Windows.
 
 ## Example Output
 

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/loop_unroll/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/loop_unroll/README.md
@@ -284,10 +284,7 @@ You can also check the achieved system f<sub>MAX</sub> to verify the earlier cal
    loop_unroll.fpga_sim.exe
    set CL_CONTEXT_MPSIM_DEVICE_INTELFPGA=
    ```
-3. Run the sample on the FPGA device (only if you ran `cmake` with `-DFPGA_DEVICE=<board-support-package>:<board-variant>`).
-   ```
-   loop_unroll.fpga.exe
-   ```
+> **Note**: Hardware runs are not supported on Windows.
 
 ## Example Output
 

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/lsu_control/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/lsu_control/README.md
@@ -327,10 +327,7 @@ For more details on the descriptions of LSU controls, styles, and modifiers, ref
    lsu_control.fpga_sim.exe
    set CL_CONTEXT_MPSIM_DEVICE_INTELFPGA=
    ```
-3. Run the sample on the FPGA device (only if you ran `cmake` with `-DFPGA_DEVICE=<board-support-package>:<board-variant>`).
-   ```
-   lsu_control.fpga.exe
-   ```
+> **Note**: Hardware runs are not supported on Windows.
 
 ### Example Output
 

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/max_interleaving/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/max_interleaving/README.md
@@ -292,10 +292,7 @@ Locate `report.html` in the `max_interleaving.report.prj/reports/` directory.
    max_interleaving.fpga_sim.exe
    set CL_CONTEXT_MPSIM_DEVICE_INTELFPGA=
    ```
-3. Run the sample on the FPGA device (only if you ran `cmake` with `-DFPGA_DEVICE=<board-support-package>:<board-variant>`).
-   ```
-   max_interleaving.fpga.exe
-   ```
+> **Note**: Hardware runs are not supported on Windows.
 
 ## Example Output On FPGA Hardware
 

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/max_reinvocation_delay/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/max_reinvocation_delay/README.md
@@ -206,7 +206,7 @@ Now, the first iteration of the `i+1`th  invocation of the inner loop will launc
    max_reinvocation_delay.fpga_sim.exe
    set CL_CONTEXT_MPSIM_DEVICE_INTELFPGA=
    ```
-> **Note**: Running this sample on an actual FPGA device requires a BSP that supports host pipes. As there are currently no commercial BSPs with such support, only the SYCL HLS flow is enabled for this code sample.
+> **Note**: Hardware runs are not supported on Windows.
 
 ## Example Output
 

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/mem_channel/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/mem_channel/README.md
@@ -318,11 +318,8 @@ significantly lower than the case where burst-interleaving is enabled.
     Note that the `mem_channel` property and the `-Xsno-interleaving` flag have
     no impact on the simulator which is why we only have a single executable for
     this flow.
-3. Run the sample on the FPGA device (only if you ran `cmake` with `-DFPGA_DEVICE=<board-support-package>:<board-variant>`):
-     ```
-     ./mem_channel.fpga         (Linux)
-     mem_channel.fpga.exe       (Windows)
-     ```
+
+> **Note**: Hardware runs are not supported on Windows.
 
 ### Example of Output
 

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/memory_attributes/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/memory_attributes/README.md
@@ -372,10 +372,7 @@ There are often many ways to generate a stall-free memory system. As a programme
    set CL_CONTEXT_MPSIM_DEVICE_INTELFPGA=
    ```
 
-3. Run the sample on the FPGA device (only if you ran `cmake` with `-DFPGA_DEVICE=<board-support-package>:<board-variant> -DIS_BSP`).
-   ```
-   memory_attributes.fpga.exe
-   ```
+> **Note**: Hardware runs are not supported on Windows.
 
 ## Example Output
 

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/optimization_targets/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/optimization_targets/README.md
@@ -255,10 +255,7 @@ Navigate to **Clock Frequency Summary** (**Summary > Clock Frequency Summary**) 
    set CL_CONTEXT_MPSIM_DEVICE_INTELFPGA=
    ```
 
-3. Run the sample on the FPGA device (only if you ran `cmake` with `-DFPGA_DEVICE=<board-support-package>:<board-variant>`).
-   ```
-   optimization_targets.fpga.exe
-   ```
+> **Note**: Hardware runs are not supported on Windows.
 
 ## Example Output
 

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/pipes/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/pipes/README.md
@@ -335,10 +335,7 @@ Navigate to the "System Viewer" to visualize the structure of the kernel system.
    pipes.fpga_sim.exe
    set CL_CONTEXT_MPSIM_DEVICE_INTELFPGA=
    ```
-3. Run the sample on the FPGA device (only if you ran `cmake` with `-DFPGA_DEVICE=<board-support-package>:<board-variant>`).
-   ```
-   pipes.fpga.exe
-   ```
+> **Note**: Hardware runs are not supported on Windows.
 
 ## Example Output
 

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/printf/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/printf/README.md
@@ -252,10 +252,7 @@ From the report, you can find the compilation information of the design and the 
    printf.fpga_sim.exe
    set CL_CONTEXT_MPSIM_DEVICE_INTELFPGA=
    ```
-3. Run the sample on the FPGA device (only if you ran `cmake` with `-DFPGA_DEVICE=<board-support-package>:<board-variant>`).
-   ```
-   printf.fpga.exe
-   ```
+> **Note**: Hardware runs are not supported on Windows.
 
 ## Example Output
 

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/private_copies/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/private_copies/README.md
@@ -247,10 +247,7 @@ On the main report page, scroll down to the section titled "Estimated Resource U
    private_copies.fpga_sim.exe
    set CL_CONTEXT_MPSIM_DEVICE_INTELFPGA=
    ```
-3. Run the sample on the FPGA device (only if you ran `cmake` with `-DFPGA_DEVICE=<board-support-package>:<board-variant>`).
-   ```
-   private_copies.fpga.exe
-   ```
+> **Note**: Hardware runs are not supported on Windows.
 
 ## Example Output
 

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/read_only_cache/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/read_only_cache/README.md
@@ -273,10 +273,7 @@ cache has been created.
    ```
    > **Note**: Although the circuit for the read-only cache is implemented in simulation, one cannot see consistent performance increases with the cache enabled, as each clock cycle in the simulator does not have a consistent latency as it does in the hardware. For this reason here is just a single executable for this flow.
 
-3. Run the sample on the FPGA device (only if you ran `cmake` with `-DFPGA_DEVICE=<board-support-package>:<board-variant>`).
-   ```
-   read_only_cache.fpga.exe
-   ```
+> **Note**: Hardware runs are not supported on Windows.
 
 ## Example Output
 

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/scheduler_target_fmax/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/scheduler_target_fmax/README.md
@@ -248,10 +248,7 @@ Navigate to the Area Analysis of System (Area Analysis > Area Analysis of System
    set CL_CONTEXT_MPSIM_DEVICE_INTELFPGA=
    ```
 
-3. Run the sample on the FPGA device (only if you ran `cmake` with `-DFPGA_DEVICE=<board-support-package>:<board-variant>`).
-   ```
-   scheduler_target_fmax.fpga.exe
-   ```
+> **Note**: Hardware runs are not supported on Windows.
 
 ## Example Output
 

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/speculated_iterations/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/speculated_iterations/README.md
@@ -262,10 +262,7 @@ These results make sense when you recall that the loop exit computation has a la
    speculated_iterations.fpga_sim.exe
    set CL_CONTEXT_MPSIM_DEVICE_INTELFPGA=
    ```
-3. Run the sample on the FPGA device (only if you ran `cmake` with `-DFPGA_DEVICE=<board-support-package>:<board-variant>`).
-   ```
-   speculated_iterations.fpga.exe
-   ```
+> **Note**: Hardware runs are not supported on Windows.
 
 ## Example of Output
 

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/stall_enable/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/stall_enable/README.md
@@ -238,10 +238,7 @@ On the main report page, scroll down to the section titled `Compile Estimated Ke
    stall_enable.fpga_sim.exe
    set CL_CONTEXT_MPSIM_DEVICE_INTELFPGA=
    ```
-3. Run the sample on the FPGA device (only if you ran `cmake` with `-DFPGA_DEVICE=<board-support-package>:<board-variant>`).
-   ```
-   stall_enable.fpga.exe
-   ```
+> **Note**: Hardware runs are not supported on Windows.
 
 ## Example Output
 

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/GettingStarted/fast_recompile/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/GettingStarted/fast_recompile/README.md
@@ -292,10 +292,7 @@ For larger and more complex projects, the device link method has the advantage o
    fast_recompile.fpga_sim.exe
    set CL_CONTEXT_MPSIM_DEVICE_INTELFPGA=
    ```
-3. Run the sample on the FPGA device (only if you ran `cmake` with `-DFPGA_DEVICE=<board-support-package>:<board-variant>`):
-   ```
-   fast_recompile.fpga.exe
-   ```
+> **Note**: Hardware runs are not supported on Windows.
 
 ## Example Output
 

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/GettingStarted/fpga_compile/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/GettingStarted/fpga_compile/README.md
@@ -378,10 +378,7 @@ Browse the reports that were generated for the `VectorAdd` kernel's FPGA early i
    vector_add.fpga_sim.exe
    set CL_CONTEXT_MPSIM_DEVICE_INTELFPGA=
    ```
-3. Run the sample on the FPGA device (only if you ran `cmake` with `-DFPGA_DEVICE=<board-support-package>:<board-variant>`):
-   ```
-   vector_add.fpga.exe
-   ```
+> **Note**: Hardware runs are not supported on Windows.
 
 ## Example Output
 

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/GettingStarted/fpga_template/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/GettingStarted/fpga_template/README.md
@@ -290,10 +290,7 @@ This design uses CMake to generate a build script for  `nmake`.
    fpga_template.fpga_sim.exe
    set CL_CONTEXT_MPSIM_DEVICE_INTELFPGA=
    ```
-3. Alternatively, run the sample on the FPGA device (only if you ran `cmake` with `-DFPGA_DEVICE=<board-support-package>:<board-variant>`).
-   ```
-   fpga_template.fpga.exe
-   ```
+> **Note**: Hardware runs are not supported on Windows.
 
 ## Example Output
 

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Tools/use_library/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Tools/use_library/README.md
@@ -238,6 +238,8 @@ Note that the library files (\*.a) must be included after all of the cpp files i
    CL_CONTEXT_MPSIM_DEVICE_INTELFPGA=1 ./use_library.fpga_sim
    ```
 
+> **Note**: Running this sample on an actual FPGA device requires a BSP that supports host pipes. As there are currently no commercial BSPs with such support, only the SYCL HLS flow is enabled for this code sample.
+
 ### On Windows
 
 1. Run the sample on the FPGA emulator (the kernel executes on the CPU).

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Tools/use_library/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Tools/use_library/README.md
@@ -251,6 +251,8 @@ Note that the library files (\*.a) must be included after all of the cpp files i
    set CL_CONTEXT_MPSIM_DEVICE_INTELFPGA=
    ```
 
+> **Note**: Hardware runs are not supported on Windows.
+
 ### Example of Output
 
 ```bash


### PR DESCRIPTION
## Description

This PR removes reference in the code samples to hardware runs on Windows as this is not something that is supported.

## External Dependencies

* N/A

## Type of change 

- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

* These are just removing references in our code samples to running hardware jobs on windows.


