### PR TITLE
[release/2024.2_AITools] added missing argument in numba_dpex kernel call

### DIFF
--- a/AI-and-Analytics/Features-and-Functionality/IntelPython_Numpy_Numba_dpex_kNN/IntelPython_Numpy_Numba_dpex_kNN.ipynb
+++ b/AI-and-Analytics/Features-and-Functionality/IntelPython_Numpy_Numba_dpex_kNN/IntelPython_Numpy_Numba_dpex_kNN.ipynb
@@ -439,6 +439,7 @@
     "\n",
     "numba_dpex.call_kernel(\n",
     "    knn_numba_dpex,\n",
+    "    numba_dpex.Range(len(X_test.values)),\n",
     "    X_train_dpt,\n",
     "    y_train_dpt,\n",
     "    X_test_dpt,\n",


### PR DESCRIPTION
added missing argument when calling numba_dpex kernel.