### PR TITLE
[release/2024.2_AITools] Remove TF Serving

### DIFF
--- a/AI-and-Analytics/Features-and-Functionality/IntelTensorFlow_Enabling_Auto_Mixed_Precision_for_TransferLearning/enabling_automixed_precision_for_transfer_learning_with_tensorflow.ipynb
+++ b/AI-and-Analytics/Features-and-Functionality/IntelTensorFlow_Enabling_Auto_Mixed_Precision_for_TransferLearning/enabling_automixed_precision_for_transfer_learning_with_tensorflow.ipynb
@@ -32,7 +32,6 @@
     "import tensorflow_hub as hub\n",
     "from datetime import datetime\n",
     "import requests\n",
-    "import tf_keras\n",
     "print(\"We are using Tensorflow version: \", tf.__version__)"
    ]
   },
@@ -99,7 +98,7 @@
    "outputs": [],
    "source": [
     "tf.compat.v1.logging.set_verbosity(tf.compat.v1.logging.ERROR)\n",
-    "data_root = tf_keras.utils.get_file(\n",
+    "data_root = tf.keras.utils.get_file(\n",
     "  'flower_photos',\n",
     "  'https://storage.googleapis.com/download.tensorflow.org/example_images/flower_photos.tgz',\n",
     "   untar=True)\n",
@@ -108,7 +107,7 @@
     "img_height = 224\n",
     "img_width = 224\n",
     "\n",
-    "train_ds = tf_keras.utils.image_dataset_from_directory(\n",
+    "train_ds = tf.keras.utils.image_dataset_from_directory(\n",
     "  str(data_root),\n",
     "  validation_split=0.2,\n",
     "  subset=\"training\",\n",
@@ -117,7 +116,7 @@
     "  batch_size=batch_size\n",
     ")\n",
     "\n",
-    "val_ds = tf_keras.utils.image_dataset_from_directory(\n",
+    "val_ds = tf.keras.utils.image_dataset_from_directory(\n",
     "  str(data_root),\n",
     "  validation_split=0.2,\n",
     "  subset=\"validation\",\n",
@@ -147,7 +146,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "normalization_layer = tf_keras.layers.Rescaling(1./255)\n",
+    "normalization_layer = tf.keras.layers.Rescaling(1./255)\n",
     "train_ds = train_ds.map(lambda x, y: (normalization_layer(x), y)) # Where x—images, y—labels.\n",
     "val_ds = val_ds.map(lambda x, y: (normalization_layer(x), y)) # Where x—images, y—labels.\n",
     "\n",
@@ -221,7 +220,7 @@
    "id": "70b3eb9b",
    "metadata": {},
    "source": [
-    "Attach the last fully connected classification layer in a **tf_keras.Sequential** model."
+    "Attach the last fully connected classification layer in a **tf.keras.Sequential** model."
    ]
   },
   {
@@ -233,14 +232,14 @@
    "source": [
     "num_classes = len(class_names)\n",
     "\n",
-    "fp32_model = tf_keras.Sequential([\n",
+    "fp32_model = tf.keras.Sequential([\n",
     "  feature_extractor_layer,\n",
-    "  tf_keras.layers.Dense(num_classes)\n",
+    "  tf.keras.layers.Dense(num_classes)\n",
     "])\n",
     "\n",
     "if arch == 'SPR':\n",
     "    # Create a deep copy of the model to train the bf16 model separately to compare accuracy\n",
-    "    bf16_model = tf_keras.models.clone_model(fp32_model)\n",
+    "    bf16_model = tf.keras.models.clone_model(fp32_model)\n",
     "\n",
     "fp32_model.summary()"
    ]
@@ -260,7 +259,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "class TimeHistory(tf_keras.callbacks.Callback):\n",
+    "class TimeHistory(tf.keras.callbacks.Callback):\n",
     "    def on_train_begin(self, logs={}):\n",
     "        self.times = []\n",
     "        self.throughput = []\n",
@@ -290,8 +289,8 @@
    "outputs": [],
    "source": [
     "fp32_model.compile(\n",
-    "  optimizer=tf_keras.optimizers.SGD(),\n",
-    "  loss=tf_keras.losses.SparseCategoricalCrossentropy(from_logits=True),\n",
+    "  optimizer=tf.keras.optimizers.SGD(),\n",
+    "  loss=tf.keras.losses.SparseCategoricalCrossentropy(from_logits=True),\n",
     "  metrics=['acc'])"
    ]
   },
@@ -374,8 +373,8 @@
     "if arch == 'SPR':\n",
     "    # Compile\n",
     "    bf16_model.compile(\n",
-    "      optimizer=tf_keras.optimizers.SGD(),\n",
-    "      loss=tf_keras.losses.SparseCategoricalCrossentropy(from_logits=True),\n",
+    "      optimizer=tf.keras.optimizers.SGD(),\n",
+    "      loss=tf.keras.losses.SparseCategoricalCrossentropy(from_logits=True),\n",
     "      metrics=['acc'])\n",
     "    \n",
     "    # Train\n",

--- a/AI-and-Analytics/Features-and-Functionality/IntelTensorFlow_Enabling_Auto_Mixed_Precision_for_TransferLearning/enabling_automixed_precision_for_transfer_learning_with_tensorflow.ipynb
+++ b/AI-and-Analytics/Features-and-Functionality/IntelTensorFlow_Enabling_Auto_Mixed_Precision_for_TransferLearning/enabling_automixed_precision_for_transfer_learning_with_tensorflow.ipynb
@@ -32,7 +32,7 @@
     "import tensorflow_hub as hub\n",
     "from datetime import datetime\n",
     "import requests\n",
-    "from copy import deepcopy\n",
+    "import tf_keras\n",
     "print(\"We are using Tensorflow version: \", tf.__version__)"
    ]
   },
@@ -99,7 +99,7 @@
    "outputs": [],
    "source": [
     "tf.compat.v1.logging.set_verbosity(tf.compat.v1.logging.ERROR)\n",
-    "data_root = tf.keras.utils.get_file(\n",
+    "data_root = tf_keras.utils.get_file(\n",
     "  'flower_photos',\n",
     "  'https://storage.googleapis.com/download.tensorflow.org/example_images/flower_photos.tgz',\n",
     "   untar=True)\n",
@@ -108,7 +108,7 @@
     "img_height = 224\n",
     "img_width = 224\n",
     "\n",
-    "train_ds = tf.keras.utils.image_dataset_from_directory(\n",
+    "train_ds = tf_keras.utils.image_dataset_from_directory(\n",
     "  str(data_root),\n",
     "  validation_split=0.2,\n",
     "  subset=\"training\",\n",
@@ -117,7 +117,7 @@
     "  batch_size=batch_size\n",
     ")\n",
     "\n",
-    "val_ds = tf.keras.utils.image_dataset_from_directory(\n",
+    "val_ds = tf_keras.utils.image_dataset_from_directory(\n",
     "  str(data_root),\n",
     "  validation_split=0.2,\n",
     "  subset=\"validation\",\n",
@@ -147,7 +147,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "normalization_layer = tf.keras.layers.Rescaling(1./255)\n",
+    "normalization_layer = tf_keras.layers.Rescaling(1./255)\n",
     "train_ds = train_ds.map(lambda x, y: (normalization_layer(x), y)) # Where x—images, y—labels.\n",
     "val_ds = val_ds.map(lambda x, y: (normalization_layer(x), y)) # Where x—images, y—labels.\n",
     "\n",
@@ -221,7 +221,7 @@
    "id": "70b3eb9b",
    "metadata": {},
    "source": [
-    "Attach the last fully connected classification layer in a **tf.keras.Sequential** model."
+    "Attach the last fully connected classification layer in a **tf_keras.Sequential** model."
    ]
   },
   {
@@ -233,14 +233,14 @@
    "source": [
     "num_classes = len(class_names)\n",
     "\n",
-    "fp32_model = tf.keras.Sequential([\n",
+    "fp32_model = tf_keras.Sequential([\n",
     "  feature_extractor_layer,\n",
-    "  tf.keras.layers.Dense(num_classes)\n",
+    "  tf_keras.layers.Dense(num_classes)\n",
     "])\n",
     "\n",
     "if arch == 'SPR':\n",
     "    # Create a deep copy of the model to train the bf16 model separately to compare accuracy\n",
-    "    bf16_model = tf.keras.models.clone_model(fp32_model)\n",
+    "    bf16_model = tf_keras.models.clone_model(fp32_model)\n",
     "\n",
     "fp32_model.summary()"
    ]
@@ -260,7 +260,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "class TimeHistory(tf.keras.callbacks.Callback):\n",
+    "class TimeHistory(tf_keras.callbacks.Callback):\n",
     "    def on_train_begin(self, logs={}):\n",
     "        self.times = []\n",
     "        self.throughput = []\n",
@@ -290,8 +290,8 @@
    "outputs": [],
    "source": [
     "fp32_model.compile(\n",
-    "  optimizer=tf.keras.optimizers.SGD(),\n",
-    "  loss=tf.keras.losses.SparseCategoricalCrossentropy(from_logits=True),\n",
+    "  optimizer=tf_keras.optimizers.SGD(),\n",
+    "  loss=tf_keras.losses.SparseCategoricalCrossentropy(from_logits=True),\n",
     "  metrics=['acc'])"
    ]
   },
@@ -374,8 +374,8 @@
     "if arch == 'SPR':\n",
     "    # Compile\n",
     "    bf16_model.compile(\n",
-    "      optimizer=tf.keras.optimizers.SGD(),\n",
-    "      loss=tf.keras.losses.SparseCategoricalCrossentropy(from_logits=True),\n",
+    "      optimizer=tf_keras.optimizers.SGD(),\n",
+    "      loss=tf_keras.losses.SparseCategoricalCrossentropy(from_logits=True),\n",
     "      metrics=['acc'])\n",
     "    \n",
     "    # Train\n",
@@ -443,19 +443,33 @@
    "id": "8a03faef",
    "metadata": {},
    "source": [
-    "Let's measure the performance of the model we just saved using the `tf_benchmark.py` script that runs inference on dummy data."
+    "Let's measure the performance of the model we just saved using the `tf_benchmark.py` script that runs inference on dummy data.\n",
+    "\n",
+    "_Note: We only use the auto-mixed precision policy if the underlying system is the 4th Gen Intel® Xeon® scalable processor (codenamed Sapphire Rapids)_"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "db6aa4b4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "if arch == 'SPR':\n",
+    "    PRECISION = \"bfloat16\"\n",
+    "else:\n",
+    "    PRECISION = \"float32\"\n",
+    "print(\"Precision for inference: \", PRECISION)"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "id": "fd855747",
-   "metadata": {
-    "scrolled": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
-    "run scripts/tf_benchmark.py --model_path models/my_saved_model --num_warmup 5 --num_iter 50 --precision float32 --batch_size 32 --disable_optimize"
+    "run scripts/tf_benchmark.py --model_path models/my_saved_model --num_warmup 5 --num_iter 50 --precision PRECISION --batch_size 32 --disable_optimize"
    ]
   },
   {
@@ -501,12 +515,10 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "480dddda",
-   "metadata": {
-    "scrolled": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
-    "run scripts/tf_benchmark.py --model_path models/my_optimized_model --num_warmup 5 --num_iter 50 --precision float32 --batch_size 32"
+    "run scripts/tf_benchmark.py --model_path models/my_optimized_model --num_warmup 5 --num_iter 50 --precision PRECISION --batch_size 32"
    ]
   },
   {
@@ -530,170 +542,20 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "id": "8157a5ec",
-   "metadata": {},
-   "source": [
-    "### TensorFlow Serving\n",
-    "\n",
-    "In this section, we will initialize and run TensorFlow Serving natively to serve our retrained model."
-   ]
-  },
-  {
    "cell_type": "code",
    "execution_count": null,
-   "id": "6a00c32d",
+   "id": "7c1bd119-ffc1-4761-a614-c2ffd83e6b4c",
    "metadata": {},
    "outputs": [],
-   "source": [
-    "!mkdir serving\n",
-    "!cp -r models/my_optimized_model serving/1"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "a45b5438",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "os.environ[\"MODEL_DIR\"] = os.getcwd() + \"/serving\""
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "edcd77c4",
-   "metadata": {},
-   "source": [
-    "This is where we start running TensorFlow Serving and load our model. After it loads we can start making inference requests using REST. There are some important parameters:\n",
-    "- **rest_api_port**: The port that you'll use for REST requests.\n",
-    "- **model_name**: You'll use this in the URL of REST requests. It can be anything.\n",
-    "- **model_base_path**: This is the path to the directory where you've saved your model."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "34aee14f",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "%%bash --bg\n",
-    "nohup tensorflow_model_server --rest_api_port=8501 --model_name=rn50 --model_base_path=${MODEL_DIR} > server.log 2>&1"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "e486894a",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "!tail server.log"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "7dc7606d",
-   "metadata": {},
-   "source": [
-    "**Prepare the testing data for prediction**"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "c9dfa9d8",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "for image_batch, labels_batch in val_ds:\n",
-    "    print(image_batch.shape)\n",
-    "    print(labels_batch.shape)\n",
-    "    break\n",
-    "test_data, test_labels = image_batch.numpy(), labels_batch.numpy()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "5d4e5f62",
-   "metadata": {},
-   "source": [
-    "First, let's take a look at a random example from our test data."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "e2761dcf",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "import matplotlib.pyplot as plt\n",
-    "\n",
-    "def show(idx, title):\n",
-    "    plt.figure()\n",
-    "    plt.imshow(test_data[idx])\n",
-    "    plt.axis('off')\n",
-    "    plt.title('\\n\\n{}'.format(title), fontdict={'size': 16})\n",
-    "\n",
-    "import random\n",
-    "rando = random.randint(0,test_data.shape[0]-1)\n",
-    "show(rando, 'An Example Image:')"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "3b362658",
-   "metadata": {},
-   "source": [
-    "#### Make a request to your model in TensorFlow Serving\n",
-    "\n",
-    "Now let's create the JSON object for a batch of three inference requests, and see how well our model recognizes things:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "831bf2d1",
-   "metadata": {
-    "scrolled": true
-   },
-   "outputs": [],
-   "source": [
-    "import json\n",
-    "data = json.dumps({\"signature_name\": \"serving_default\", \"instances\": test_data[0:3].tolist()})\n",
-    "print('Data: {} ... {}'.format(data[:50], data[len(data)-52:]))"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "427f3c8b",
-   "metadata": {},
-   "source": [
-    "#### Make REST requests\n",
-    "\n",
-    "We'll send a predict request as a POST to our server's REST endpoint, and pass it three examples."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "3d7f5e5e",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "headers = {\"content-type\": \"application/json\"}\n",
-    "json_response = requests.post('http://localhost:8501/v1/models/rn50:predict', data=data, headers=headers)\n",
-    "predictions = json.loads(json_response.text)['predictions']\n",
-    "\n",
-    "for i in range(0,3):\n",
-    "    show(i, 'The model thought this was a {} (class {}), and it was actually a {} (class {})'.format(\n",
-    "        class_names[np.argmax(predictions[i])], np.argmax(predictions[i]), class_names[test_labels[i]], test_labels[i]))"
-   ]
+   "source": []
   }
  ],
  "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
@@ -704,7 +566,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.12"
+   "version": "3.10.12"
   }
  },
  "nbformat": 4,

--- a/AI-and-Analytics/Features-and-Functionality/IntelTensorFlow_Enabling_Auto_Mixed_Precision_for_TransferLearning/enabling_automixed_precision_for_transfer_learning_with_tensorflow.ipynb
+++ b/AI-and-Analytics/Features-and-Functionality/IntelTensorFlow_Enabling_Auto_Mixed_Precision_for_TransferLearning/enabling_automixed_precision_for_transfer_learning_with_tensorflow.ipynb
@@ -468,7 +468,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "run scripts/tf_benchmark.py --model_path models/my_saved_model --num_warmup 5 --num_iter 50 --precision PRECISION --batch_size 32 --disable_optimize"
+    "!python scripts/tf_benchmark.py --model_path models/my_saved_model --num_warmup 5 --num_iter 50 --precision PRECISION --batch_size 32 --disable_optimize"
    ]
   },
   {
@@ -499,7 +499,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "run scripts/freeze_optimize_v2.py --input_saved_model_dir=models/my_saved_model --output_saved_model_dir=models/my_optimized_model"
+    "!python scripts/freeze_optimize_v2.py --input_saved_model_dir=models/my_saved_model --output_saved_model_dir=models/my_optimized_model"
    ]
   },
   {
@@ -517,7 +517,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "run scripts/tf_benchmark.py --model_path models/my_optimized_model --num_warmup 5 --num_iter 50 --precision PRECISION --batch_size 32"
+    "!python scripts/tf_benchmark.py --model_path models/my_optimized_model --num_warmup 5 --num_iter 50 --precision PRECISION --batch_size 32"
    ]
   },
   {
@@ -537,7 +537,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "run scripts/plot.py"
+    "!python scripts/plot.py"
    ]
   },
   {

--- a/AI-and-Analytics/Features-and-Functionality/IntelTensorFlow_Enabling_Auto_Mixed_Precision_for_TransferLearning/requirements.txt
+++ b/AI-and-Analytics/Features-and-Functionality/IntelTensorFlow_Enabling_Auto_Mixed_Precision_for_TransferLearning/requirements.txt
@@ -1,6 +1,5 @@
-notebook
-neural_compressor
+neural_compressor==2.4.1
 Pillow
 py-cpuinfo
 requests
-tensorflow_hub
+tensorflow_hub==0.16.0

--- a/AI-and-Analytics/Features-and-Functionality/IntelTensorFlow_Enabling_Auto_Mixed_Precision_for_TransferLearning/requirements.txt
+++ b/AI-and-Analytics/Features-and-Functionality/IntelTensorFlow_Enabling_Auto_Mixed_Precision_for_TransferLearning/requirements.txt
@@ -1,4 +1,6 @@
 notebook
+neural_compressor
 Pillow
-tensorflow_hub
+py-cpuinfo
 requests
+tensorflow_hub

--- a/AI-and-Analytics/Features-and-Functionality/IntelTensorFlow_Enabling_Auto_Mixed_Precision_for_TransferLearning/scripts/tf_benchmark.py
+++ b/AI-and-Analytics/Features-and-Functionality/IntelTensorFlow_Enabling_Auto_Mixed_Precision_for_TransferLearning/scripts/tf_benchmark.py
@@ -190,7 +190,7 @@ def run_benchmark(model_details, args, find_graph_def):
         throughput = 1.0 / avg_time * args.batch_size
         print('Batch size = %d' % args.batch_size)
         print("Latency: {:.3f} ms".format(latency))
-        print("Throughput: {:.2f} fps".format(throughput))
+        print("Throughput: {:.2f} images per sec".format(throughput))
 
         # Logging to a file
         log_file = open("log.txt", "a")


### PR DESCRIPTION
# Existing Sample Changes
## Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

- Remove TF Serving from the jupyter notebook and add it to the README for user's reference.
- Choose precision for inference based on the underlying architecture.
- Update `requirements.txt` to include `neural_compressor` (used to load the model for inference) and `py-cpuinfo`.

Fixes Issue# 

- CI was failing as the port for TF Serving was not exposed to the public.

## External Dependencies

List any external dependencies created as a result of this change.

## Type of change

Please delete options that are not relevant. Add a 'X' to the one that is applicable. 

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Implement fixes for ONSAM Jiras

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [X] Command Line
- [ ] oneapi-cli
- [ ] Visual Studio
- [ ] Eclipse IDE
- [ ] VSCode
- [ ] When compiling the compliler flag "-Wall -Wformat-security -Werror=format-security" was used