### PR TITLE
Update Genetic Algorithm code sample according to new numba-dpex API syntax

### DIFF
--- a/AI-and-Analytics/Features-and-Functionality/IntelPython_GPU_numba-dpex_Genetic_Algorithm/IntelPython_GPU_numba-dpex_Genetic_Algorithm.ipynb
+++ b/AI-and-Analytics/Features-and-Functionality/IntelPython_GPU_numba-dpex_Genetic_Algorithm/IntelPython_GPU_numba-dpex_Genetic_Algorithm.ipynb
@@ -348,7 +348,7 @@
     "\n",
     "The only par that differs form the standard implementation is the evaluation function.\n",
     "\n",
-    "The most important part is to specify the global index of the computation. This is the current index of the computed chromosomes. This serves as a loop function across all chromosomes."
+    "The most important part is to specify the index of the computation. This is the current index of the computed chromosomes. This serves as a loop function across all chromosomes."
    ]
   },
   {
@@ -365,10 +365,11 @@
    "outputs": [],
    "source": [
     "import numba_dpex\n",
+    "from numba_dpex import kernel_api\n",
     "\n",
     "@numba_dpex.kernel\n",
-    "def eval_genomes_sycl_kernel(chromosomes, fitnesses, chrom_length):\n",
-    "  pos = numba_dpex.get_global_id(0)\n",
+    "def eval_genomes_sycl_kernel(item: kernel_api.Item, chromosomes, fitnesses, chrom_length):\n",
+    "  pos = item.get_id(0)\n",
     "  num_loops = 3000\n",
     "  for i in range(num_loops):\n",
     "    fitnesses[pos] += chromosomes[pos*chrom_length + 1]\n",
@@ -409,8 +410,9 @@
     "  chromosomes_flat = chromosomes.flatten()\n",
     "  chromosomes_flat_dpctl = dpnp.asarray(chromosomes_flat, device=\"gpu\")\n",
     "  fitnesses_dpctl = dpnp.asarray(fitnesses, device=\"gpu\")\n",
-    "\n",
-    "  eval_genomes_sycl_kernel[numba_dpex.Range(pop_size)](chromosomes_flat_dpctl, fitnesses_dpctl, chrom_size)\n",
+    "  \n",
+    "  exec_range = kernel_api.Range(pop_size)\n",
+    "  numba_dpex.call_kernel(eval_genomes_sycl_kernel, exec_range, chromosomes_flat_dpctl, fitnesses_dpctl, chrom_size)\n",
     "  fitnesses = dpnp.asnumpy(fitnesses_dpctl)\n",
     "  chromosomes = next_generation(chromosomes, fitnesses)\n",
     "  fitnesses = np.zeros(pop_size, dtype=np.float32)\n",
@@ -544,7 +546,7 @@
     "\n",
     "The evaluate created generation we are calculating the full distance of the given path (chromosome). In this example, the lower the fitness value is, the better the chromosome. That's different from the general GA that we implemented.\n",
     "\n",
-    "As in this example we are also using numba-dpex, we are using a global index like before."
+    "As in this example we are also using numba-dpex, we are using an index like before."
    ]
   },
   {
@@ -554,8 +556,8 @@
    "outputs": [],
    "source": [
     "@numba_dpex.kernel\n",
-    "def eval_genomes_plain_TSP_SYCL(chromosomes, fitnesses, distances, pop_length):\n",
-    "  pos = numba_dpex.get_global_id(0)\n",
+    "def eval_genomes_plain_TSP_SYCL(item: kernel_api.Item, chromosomes, fitnesses, distances, pop_length):\n",
+    "  pos = item.get_id(1)\n",
     "  for j in range(pop_length-1):\n",
     "    fitnesses[pos] += distances[int(chromosomes[pos, j]), int(chromosomes[pos, j+1])]\n"
    ]
@@ -708,7 +710,8 @@
     "  chromosomes_flat_dpctl = dpnp.asarray(chromosomes, device=\"gpu\")\n",
     "  fitnesses_dpctl = dpnp.asarray(fitnesses.copy(), device=\"gpu\")\n",
     "\n",
-    "  eval_genomes_plain_TSP_SYCL[numba_dpex.Range(pop_size)](chromosomes_flat_dpctl, fitnesses_dpctl, distances_dpctl, pop_size)\n",
+    "  exec_range = kernel_api.Range(pop_size)\n",
+    "  numba_dpex.call_kernel(eval_genomes_plain_TSP_SYCL, exec_range, chromosomes_flat_dpctl, fitnesses_dpctl, distances_dpctl, pop_size)\n",
     "  fitnesses = dpnp.asnumpy(fitnesses_dpctl)\n",
     "  chromosomes = next_generation_TSP(chromosomes, fitnesses)\n",
     "  fitnesses = np.zeros(pop_size, dtype=np.float32)\n",

--- a/AI-and-Analytics/Features-and-Functionality/IntelPython_GPU_numba-dpex_Genetic_Algorithm/IntelPython_GPU_numba-dpex_Genetic_Algorithm.py
+++ b/AI-and-Analytics/Features-and-Functionality/IntelPython_GPU_numba-dpex_Genetic_Algorithm/IntelPython_GPU_numba-dpex_Genetic_Algorithm.py
@@ -260,16 +260,17 @@ for i in range(pop_size):
 # 
 # The only par that differs form the standard implementation is the evaluation function.
 # 
-# The most important part is to specify the global index of the computation. This is the current index of the computed chromosomes. This serves as a loop function across all chromosomes.
+# The most important part is to specify the index of the computation. This is the current index of the computed chromosomes. This serves as a loop function across all chromosomes.
 
 # In[ ]:
 
 
 import numba_dpex
+from numba_dpex import kernel_api
 
 @numba_dpex.kernel
-def eval_genomes_sycl_kernel(chromosomes, fitnesses, chrom_length):
-  pos = numba_dpex.get_global_id(0)
+def eval_genomes_sycl_kernel(item: kernel_api.Item, chromosomes, fitnesses, chrom_length):
+  pos = item.get_id(0)
   num_loops = 3000
   for i in range(num_loops):
     fitnesses[pos] += chromosomes[pos*chrom_length + 1]
@@ -300,7 +301,8 @@ for i in range(num_generations):
   chromosomes_flat_dpctl = dpnp.asarray(chromosomes_flat, device="gpu")
   fitnesses_dpctl = dpnp.asarray(fitnesses, device="gpu")
 
-  eval_genomes_sycl_kernel[numba_dpex.Range(pop_size)](chromosomes_flat_dpctl, fitnesses_dpctl, chrom_size)
+  exec_range = kernel_api.Range(pop_size)
+  numba_dpex.call_kernel(eval_genomes_sycl_kernel, exec_range, chromosomes_flat_dpctl, fitnesses_dpctl, chrom_size)
   fitnesses = dpnp.asnumpy(fitnesses_dpctl)
   chromosomes = next_generation(chromosomes, fitnesses)
   fitnesses = np.zeros(pop_size, dtype=np.float32)
@@ -398,14 +400,14 @@ for i in range(pop_size):
 # 
 # The evaluate created generation we are calculating the full distance of the given path (chromosome). In this example, the lower the fitness value is, the better the chromosome. That's different from the general GA that we implemented.
 # 
-# As in this example we are also using numba-dpex, we are using a global index like before.
+# As in this example we are also using numba-dpex, we are using an index like before.
 
 # In[ ]:
 
 
 @numba_dpex.kernel
-def eval_genomes_plain_TSP_SYCL(chromosomes, fitnesses, distances, pop_length):
-  pos = numba_dpex.get_global_id(0)
+def eval_genomes_plain_TSP_SYCL(item: kernel_api.Item, chromosomes, fitnesses, distances, pop_length):
+  pos = item.get_id(1)
   for j in range(pop_length-1):
     fitnesses[pos] += distances[int(chromosomes[pos, j]), int(chromosomes[pos, j+1])]
 
@@ -526,7 +528,8 @@ for i in range(num_generations):
   chromosomes_flat_dpctl = dpnp.asarray(chromosomes, device="gpu")
   fitnesses_dpctl = dpnp.asarray(fitnesses.copy(), device="gpu")
 
-  eval_genomes_plain_TSP_SYCL[numba_dpex.Range(pop_size)](chromosomes_flat_dpctl, fitnesses_dpctl, distances_dpctl, pop_size)
+  exec_range = kernel_api.Range(pop_size)
+  numba_dpex.call_kernel(eval_genomes_plain_TSP_SYCL, exec_range, chromosomes_flat_dpctl, fitnesses_dpctl, distances_dpctl, pop_size)
   fitnesses = dpnp.asnumpy(fitnesses_dpctl)
   chromosomes = next_generation_TSP(chromosomes, fitnesses)
   fitnesses = np.zeros(pop_size, dtype=np.float32)


### PR DESCRIPTION
# Existing Sample Changes
## Description

Updated kernel signature as well as kernel call in Genetic Algorithm code sample to use the new syntax.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Python script was generated based on the jupyter notebook and tested using command line on GTA machine with 2024.2.0 Intel Distribution of Python release (installed using offline installer).

- [X] Command Line - using GTA machine
- [ ] oneapi-cli
- [ ] Visual Studio
- [ ] Eclipse IDE
- [ ] VSCode
- [ ] When compiling the compliler flag "-Wall -Wformat-security -Werror=format-security" was used
