### PR TITLE
removed notebook execution command

### DIFF
--- a/AI-and-Analytics/Features-and-Functionality/IntelTransformers_Quantization/sample.json
+++ b/AI-and-Analytics/Features-and-Functionality/IntelTransformers_Quantization/sample.json
@@ -13,16 +13,12 @@
 		"linux": [{
 			"env": [
 				"source /intel/oneapi/intelpython/bin/activate",
-				"apt-get install -y numactl",
 				"conda activate pytorch",
-				"pip install -r requirements.txt",
-				"pip install jupyter ipykernel",
-				"python -m ipykernel install --user --name=pytorch"	
+				"pip install -r requirements.txt"
             ],
 			"id": "itrex_quantize_transformer_models",
 			"steps": [
-				"jupyter nbconvert --ExecutePreprocessor.enabled=True --ExecutePreprocessor.kernel_name=pytorch --to notebook quantize_transformer_models_with_itrex.ipynb",
-				"numactl -m 0 -C all python quantize_transformer_models_with_itrex.py --model_name \"Intel/neural-chat-7b-v3-1\" --quantize \"int8\" --max_new_tokens 50"
+				"python quantize_transformer_models_with_itrex.py --model_name \"Intel/neural-chat-7b-v3-1\" --quantize \"int4\" --max_new_tokens 50"
 			]
 		}]
 	},


### PR DESCRIPTION
# Existing Sample Changes
## Description

sample.json file used `jupyter nbconvert` command to execute the notebook. But since the notebook required manual restart after loading each model, it was not possible to run it in CI. So, replace notebook execution command with python script. 

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [X] Command Line
- [ ] oneapi-cli
- [ ] Visual Studio
- [ ] Eclipse IDE
- [ ] VSCode
- [ ] When compiling the compliler flag "-Wall -Wformat-security -Werror=format-security" was used
