### PR TITLE
[oneMKL] Updated oneMKL API for Sparse Conjugate Gradient 

### DIFF
--- a/Libraries/oneMKL/sparse_conjugate_gradient/sparse_cg.cpp
+++ b/Libraries/oneMKL/sparse_conjugate_gradient/sparse_cg.cpp
@@ -138,7 +138,7 @@ void run_sparse_cg_example(const sycl::device &dev)
     try {
         mkl::sparse::init_matrix_handle(&handle);
 
-        mkl::sparse::set_csr_data(handle, nrows, nrows, mkl::index_base::zero,
+        mkl::sparse::set_csr_data(main_queue, handle, nrows, nrows, mkl::index_base::zero,
                                           ia_buffer, ja_buffer, a_buffer);
 
         mkl::sparse::set_matrix_property(handle, mkl::sparse::property::symmetric);
@@ -272,7 +272,8 @@ void run_sparse_cg_example(const sycl::device &dev)
         std::cout << "\t\tCaught exception:\n" << e.what() << std::endl;
     }
     
-    mkl::sparse::release_matrix_handle(&handle);
+    mkl::sparse::release_matrix_handle(main_queue, &handle);
+    main_queue.wait();
 }
 
 //

--- a/Libraries/oneMKL/sparse_conjugate_gradient/sparse_cg.cpp
+++ b/Libraries/oneMKL/sparse_conjugate_gradient/sparse_cg.cpp
@@ -174,13 +174,14 @@ void run_sparse_cg_example(const sycl::device &dev)
 
         // Calculation B^{-1}r_0
         {
+            fp alpha = 1.0;
             mkl::sparse::trsv(main_queue, mkl::uplo::lower,
-                                      mkl::transpose::nontrans, mkl::diag::nonunit,
-                                      handle, r_buffer, t_buffer);
+                                        mkl::transpose::nontrans,
+                                        mkl::diag::nonunit, alpha, handle, r_buffer, t_buffer);
             diagonal_mv<fp, intType>(main_queue, nrows, d_buffer, t_buffer);
             mkl::sparse::trsv(main_queue, mkl::uplo::upper,
-                                      mkl::transpose::nontrans, mkl::diag::nonunit,
-                                      handle, t_buffer, w_buffer);
+                                        mkl::transpose::nontrans,
+                                        mkl::diag::nonunit, alpha, handle, t_buffer, w_buffer);
         }
 
         mkl::blas::copy(main_queue, nrows, w_buffer, 1, p_buffer, 1);
@@ -225,13 +226,14 @@ void run_sparse_cg_example(const sycl::device &dev)
 
             // Calculate w_k = B^{-1}r_k
             {
+                fp alpha = 1.0;
                 mkl::sparse::trsv(main_queue, mkl::uplo::lower,
                                           mkl::transpose::nontrans,
-                                          mkl::diag::nonunit, handle, r_buffer, t_buffer);
+                                          mkl::diag::nonunit, alpha, handle, r_buffer, t_buffer);
                 diagonal_mv<fp, intType>(main_queue, nrows, d_buffer, t_buffer);
                 mkl::sparse::trsv(main_queue, mkl::uplo::upper,
                                           mkl::transpose::nontrans,
-                                          mkl::diag::nonunit, handle, t_buffer, w_buffer);
+                                          mkl::diag::nonunit, alpha, handle, t_buffer, w_buffer);
             }
 
             // Calculate current norm of correction
@@ -271,7 +273,7 @@ void run_sparse_cg_example(const sycl::device &dev)
     catch (std::exception const &e) {
         std::cout << "\t\tCaught exception:\n" << e.what() << std::endl;
     }
-    
+
     mkl::sparse::release_matrix_handle(main_queue, &handle);
     main_queue.wait();
 }


### PR DESCRIPTION
# Existing Sample Changes
## Description

Updated oneMKL API for the Sparse Conjugate Gradient sample

## Type of change

Please delete options that are not relevant. Add a 'X' to the one that is applicable. 

- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [X] Command Line
- [ ] oneapi-cli
- [ ] Visual Studio
- [ ] Eclipse IDE
- [ ] VSCode
- [ ] When compiling the compliler flag "-Wall -Wformat-security -Werror=format-security" was used
