### PR TITLE
Fixed oneapi env var path in trainings

### DIFF
--- a/DirectProgramming/C++SYCL/Jupyter/oneapi-essentials-training/06_Intel_VTune_Profiler/vtune_collect.sh
+++ b/DirectProgramming/C++SYCL/Jupyter/oneapi-essentials-training/06_Intel_VTune_Profiler/vtune_collect.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-source /opt/intel/inteloneapi/setvars.sh
+source /opt/intel/oneapi/setvars.sh
 /bin/echo "##" $(whoami) is compiling SYCL_Essentials Module6 -- Intel Vtune profiler - 1 of 1 Vtune_Profiler
 #vtune
 #type=hotspots

--- a/DirectProgramming/C++SYCL/Jupyter/oneapi-essentials-training/07_oneDPL_Library/run_binary_search.sh
+++ b/DirectProgramming/C++SYCL/Jupyter/oneapi-essentials-training/07_oneDPL_Library/run_binary_search.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-source /opt/intel/inteloneapi/setvars.sh > /dev/null 2>&1
+source /opt/intel/oneapi/setvars.sh > /dev/null 2>&1
 /bin/echo "##" $(whoami) is compiling SYCL_Essentials Module7 -- oneDPL Extension APIs - 4 of 12 binary_search.cpp
 icpx -fsycl lab/binary_search.cpp -w -o bin/binary_search
 bin/binary_search

--- a/DirectProgramming/C++SYCL/Jupyter/oneapi-essentials-training/07_oneDPL_Library/run_counting_iterator.sh
+++ b/DirectProgramming/C++SYCL/Jupyter/oneapi-essentials-training/07_oneDPL_Library/run_counting_iterator.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-source /opt/intel/inteloneapi/setvars.sh > /dev/null 2>&1
+source /opt/intel/oneapi/setvars.sh > /dev/null 2>&1
 /bin/echo "##" $(whoami) is compiling SYCL_Essentials Module7 -- oneDPL Extension APIs - 7 of 12 counting_iterator.cpp
 icpx -fsycl lab/counting_iterator.cpp -w -o bin/counting_iterator
 bin/counting_iterator

--- a/DirectProgramming/C++SYCL/Jupyter/oneapi-essentials-training/07_oneDPL_Library/run_discard_iterator.sh
+++ b/DirectProgramming/C++SYCL/Jupyter/oneapi-essentials-training/07_oneDPL_Library/run_discard_iterator.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-source /opt/intel/inteloneapi/setvars.sh > /dev/null 2>&1
+source /opt/intel/oneapi/setvars.sh > /dev/null 2>&1
 /bin/echo "##" $(whoami) is compiling SYCL_Essentials Module7 -- oneDPL Extension APIs - 8 of 12 discard_iterator.cpp
 icpx -fsycl lab/discard_iterator.cpp -w -o bin/discard_iterator
 bin/discard_iterator

--- a/DirectProgramming/C++SYCL/Jupyter/oneapi-essentials-training/07_oneDPL_Library/run_ex_scan.sh
+++ b/DirectProgramming/C++SYCL/Jupyter/oneapi-essentials-training/07_oneDPL_Library/run_ex_scan.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-source /opt/intel/inteloneapi/setvars.sh > /dev/null 2>&1
+source /opt/intel/oneapi/setvars.sh > /dev/null 2>&1
 /bin/echo "##" $(whoami) is compiling SYCL_Essentials Module7 -- oneDPL Extension APIs - 3 of 12 exclusive_scan.cpp
 icpx -fsycl lab/exclusive_scan.cpp -std=c++17 -w -o bin/exclusive_scan
 bin/exclusive_scan

--- a/DirectProgramming/C++SYCL/Jupyter/oneapi-essentials-training/07_oneDPL_Library/run_in_scan.sh
+++ b/DirectProgramming/C++SYCL/Jupyter/oneapi-essentials-training/07_oneDPL_Library/run_in_scan.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-source /opt/intel/inteloneapi/setvars.sh > /dev/null 2>&1
+source /opt/intel/oneapi/setvars.sh > /dev/null 2>&1
 /bin/echo "##" $(whoami) is compiling SYCL_Essentials Module7 -- oneDPL Extension APIs - 2 of 12 inclusive_scan.cpp
 icpx -fsycl lab/inclusive_scan.cpp -w -o bin/inclusive_scan
 bin/inclusive_scan

--- a/DirectProgramming/C++SYCL/Jupyter/oneapi-essentials-training/07_oneDPL_Library/run_lower_bound.sh
+++ b/DirectProgramming/C++SYCL/Jupyter/oneapi-essentials-training/07_oneDPL_Library/run_lower_bound.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-source /opt/intel/inteloneapi/setvars.sh > /dev/null 2>&1
+source /opt/intel/oneapi/setvars.sh > /dev/null 2>&1
 /bin/echo "##" $(whoami) is compiling SYCL_Essentials Module7 -- oneDPL Extension APIs - 5 of 12 lower_bound.cpp
 icpx -fsycl lab/lower_bound.cpp -std=c++17 -w -o bin/lower_bound
 bin/lower_bound

--- a/DirectProgramming/C++SYCL/Jupyter/oneapi-essentials-training/07_oneDPL_Library/run_max.sh
+++ b/DirectProgramming/C++SYCL/Jupyter/oneapi-essentials-training/07_oneDPL_Library/run_max.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-source /opt/intel/inteloneapi/setvars.sh > /dev/null 2>&1
+source /opt/intel/oneapi/setvars.sh > /dev/null 2>&1
 /bin/echo "##" $(whoami) is compiling SYCL_Essentials Module7 -- oneDPL Extension APIs - 10 of 12 maximum_function.cpp
 icpx -fsycl lab/maximum_function.cpp -w -o bin/maximum_function
 bin/maximum_function

--- a/DirectProgramming/C++SYCL/Jupyter/oneapi-essentials-training/07_oneDPL_Library/run_min.sh
+++ b/DirectProgramming/C++SYCL/Jupyter/oneapi-essentials-training/07_oneDPL_Library/run_min.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-source /opt/intel/inteloneapi/setvars.sh > /dev/null 2>&1
+source /opt/intel/oneapi/setvars.sh > /dev/null 2>&1
 /bin/echo "##" $(whoami) is compiling SYCL_Essentials Module7 -- oneDPL Extension APIs - 9 of 12 minimum_function.cpp
 icpx -fsycl lab/minimum_function.cpp -w -o bin/minimum_function
 bin/minimum_function

--- a/DirectProgramming/C++SYCL/Jupyter/oneapi-essentials-training/07_oneDPL_Library/run_permutation_iterator.sh
+++ b/DirectProgramming/C++SYCL/Jupyter/oneapi-essentials-training/07_oneDPL_Library/run_permutation_iterator.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-source /opt/intel/inteloneapi/setvars.sh > /dev/null 2>&1
+source /opt/intel/oneapi/setvars.sh > /dev/null 2>&1
 /bin/echo "##" $(whoami) is compiling SYCL_Essentials Module7 -- oneDPL Extension APIs - 9 of 12 permutation_iterator.cpp
 icpx -fsycl lab/permutation_iterator.cpp -w -o bin/permutation_iterator
 bin/permutation_iterator

--- a/DirectProgramming/C++SYCL/Jupyter/oneapi-essentials-training/07_oneDPL_Library/run_ranges.sh
+++ b/DirectProgramming/C++SYCL/Jupyter/oneapi-essentials-training/07_oneDPL_Library/run_ranges.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-source /opt/intel/inteloneapi/setvars.sh > /dev/null 2>&1
+source /opt/intel/oneapi/setvars.sh > /dev/null 2>&1
 /bin/echo "##" $(whoami) is compiling SYCL_Essentials Module7 -- DPC++ Libraries - 12 of 13 ranges.cpp
 icpx -fsycl lab/ranges.cpp -std=c++17 -o bin/ranges -w
 bin/ranges

--- a/DirectProgramming/C++SYCL/Jupyter/oneapi-essentials-training/07_oneDPL_Library/run_reduce_segment.sh
+++ b/DirectProgramming/C++SYCL/Jupyter/oneapi-essentials-training/07_oneDPL_Library/run_reduce_segment.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-source /opt/intel/inteloneapi/setvars.sh > /dev/null 2>&1
+source /opt/intel/oneapi/setvars.sh > /dev/null 2>&1
 /bin/echo "##" $(whoami) is compiling SYCL_Essentials Module7 -- oneDPL Extension APIs - 1 of 12 reduce_segment.cpp
 icpx -fsycl lab/reduce_segment.cpp -w -o bin/reduce_segment
 bin/reduce_segment

--- a/DirectProgramming/C++SYCL/Jupyter/oneapi-essentials-training/07_oneDPL_Library/run_stable_sort.sh
+++ b/DirectProgramming/C++SYCL/Jupyter/oneapi-essentials-training/07_oneDPL_Library/run_stable_sort.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-source /opt/intel/inteloneapi/setvars.sh > /dev/null 2>&1
+source /opt/intel/oneapi/setvars.sh > /dev/null 2>&1
 /bin/echo "##" $(whoami) is compiling SYCL_Essentials Module7 -- oneDPL Extension APIs - 12 of stable_sort_bykey.cpp
 rm -rf stable_sort_by_key/build
 cd stable_sort_by_key &&

--- a/DirectProgramming/C++SYCL/Jupyter/oneapi-essentials-training/07_oneDPL_Library/run_transform_iterator.sh
+++ b/DirectProgramming/C++SYCL/Jupyter/oneapi-essentials-training/07_oneDPL_Library/run_transform_iterator.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-source /opt/intel/inteloneapi/setvars.sh > /dev/null 2>&1
+source /opt/intel/oneapi/setvars.sh > /dev/null 2>&1
 /bin/echo "##" $(whoami) is compiling SYCL_Essentials Module7 -- oneDPL Extension APIs - 8 of 12 transform_iterator.cpp
 icpx -fsycl lab/transform_iterator.cpp -w -o bin/transform_iterator
 bin/transform_iterator

--- a/DirectProgramming/C++SYCL/Jupyter/oneapi-essentials-training/07_oneDPL_Library/run_upper_bound.sh
+++ b/DirectProgramming/C++SYCL/Jupyter/oneapi-essentials-training/07_oneDPL_Library/run_upper_bound.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-source /opt/intel/inteloneapi/setvars.sh > /dev/null 2>&1
+source /opt/intel/oneapi/setvars.sh > /dev/null 2>&1
 /bin/echo "##" $(whoami) is compiling SYCL_Essentials Module7 -- oneDPL Extension APIs - 6 of 12 upper_bound.cpp
 icpx -fsycl lab/upper_bound.cpp -w -o bin/upper_bound
 bin/upper_bound

--- a/DirectProgramming/C++SYCL/Jupyter/oneapi-essentials-training/07_oneDPL_Library/run_zip_iterator.sh
+++ b/DirectProgramming/C++SYCL/Jupyter/oneapi-essentials-training/07_oneDPL_Library/run_zip_iterator.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-source /opt/intel/inteloneapi/setvars.sh > /dev/null 2>&1
+source /opt/intel/oneapi/setvars.sh > /dev/null 2>&1
 /bin/echo "##" $(whoami) is compiling SYCL_Essentials Module7 -- oneDPL Extension APIs - 7 of 12 zip_iterator.cpp
 icpx -fsycl lab/zip_iterator.cpp -w -o bin/zip_iterator
 bin/zip_iterator

--- a/DirectProgramming/C++SYCL/Jupyter/sycl-performance-portability-training/run_all.sh
+++ b/DirectProgramming/C++SYCL/Jupyter/sycl-performance-portability-training/run_all.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-source /opt/intel/inteloneapi/setvars.sh > /dev/null 2>&1
+source /opt/intel/oneapi/setvars.sh > /dev/null 2>&1
 
 #Command Line Arguments
 arg=" -n 1024" # set matrix  size

--- a/DirectProgramming/C++SYCL/Jupyter/sycl-performance-portability-training/run_mm_basic.sh
+++ b/DirectProgramming/C++SYCL/Jupyter/sycl-performance-portability-training/run_mm_basic.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-source /opt/intel/inteloneapi/setvars.sh > /dev/null 2>&1
+source /opt/intel/oneapi/setvars.sh > /dev/null 2>&1
 
 #Command Line Arguments
 arg=" -n 1024" # set matrix size

--- a/DirectProgramming/C++SYCL/Jupyter/sycl-performance-portability-training/run_mm_basic_full.sh
+++ b/DirectProgramming/C++SYCL/Jupyter/sycl-performance-portability-training/run_mm_basic_full.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-source /opt/intel/inteloneapi/setvars.sh > /dev/null 2>&1
+source /opt/intel/oneapi/setvars.sh > /dev/null 2>&1
 
 #Command Line Arguments
 arg=" -n 1024" # set matrix size

--- a/DirectProgramming/C++SYCL/Jupyter/sycl-performance-portability-training/run_mm_localmem.sh
+++ b/DirectProgramming/C++SYCL/Jupyter/sycl-performance-portability-training/run_mm_localmem.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-source /opt/intel/inteloneapi/setvars.sh > /dev/null 2>&1
+source /opt/intel/oneapi/setvars.sh > /dev/null 2>&1
 
 #Command Line Arguments
 arg=" -n 1024 -m 16" # set matrix size

--- a/DirectProgramming/C++SYCL/Jupyter/sycl-performance-portability-training/run_mm_localmem_wg.sh
+++ b/DirectProgramming/C++SYCL/Jupyter/sycl-performance-portability-training/run_mm_localmem_wg.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-source /opt/intel/inteloneapi/setvars.sh > /dev/null 2>&1
+source /opt/intel/oneapi/setvars.sh > /dev/null 2>&1
 
 #Command Line Arguments
 arg=" -n 5120" # set matrix size

--- a/DirectProgramming/C++SYCL/Jupyter/sycl-performance-portability-training/run_mm_mkl.sh
+++ b/DirectProgramming/C++SYCL/Jupyter/sycl-performance-portability-training/run_mm_mkl.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-source /opt/intel/inteloneapi/setvars.sh > /dev/null 2>&1
+source /opt/intel/oneapi/setvars.sh > /dev/null 2>&1
 
 #Command Line Arguments
 arg=" -n 1024" # set matrix  size

--- a/DirectProgramming/C++SYCL/Jupyter/sycl-performance-portability-training/run_mm_ndrange.sh
+++ b/DirectProgramming/C++SYCL/Jupyter/sycl-performance-portability-training/run_mm_ndrange.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-source /opt/intel/inteloneapi/setvars.sh > /dev/null 2>&1
+source /opt/intel/oneapi/setvars.sh > /dev/null 2>&1
 
 #Command Line Arguments
 arg=" -n 1024 -m 16" # set matrix size

--- a/DirectProgramming/C++SYCL/Jupyter/sycl-performance-portability-training/run_mm_ndrange_var.sh
+++ b/DirectProgramming/C++SYCL/Jupyter/sycl-performance-portability-training/run_mm_ndrange_var.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-source /opt/intel/inteloneapi/setvars.sh > /dev/null 2>&1
+source /opt/intel/oneapi/setvars.sh > /dev/null 2>&1
 
 #Command Line Arguments
 arg=" -n 1024 -m 16" # set matrix size


### PR DESCRIPTION
# Existing Sample Changes
## Description

Fixed oneapi env var path in trainings from old IDC path to current


## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
- [X] Command Line

