### PR TITLE
ci: Enable faster execution on CI

### DIFF
--- a/AI-and-Analytics/Features-and-Functionality/IntelTensorFlow_TextGeneration_with_LSTM/TextGenerationModelTraining.ipynb
+++ b/AI-and-Analytics/Features-and-Functionality/IntelTensorFlow_TextGeneration_with_LSTM/TextGenerationModelTraining.ipynb
@@ -47,6 +47,7 @@
    "source": [
     "import string\n",
     "import requests\n",
+    "import os\n",
     "\n",
     "response = requests.get('https://www.gutenberg.org/cache/epub/1497/pg1497.txt')\n",
     "data = response.text.split('\\n')\n",
@@ -253,6 +254,11 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "num_epochs = 200\n",
+    "# For custom epochs numbers from the environment\n",
+    "if \"ITEX_NUM_EPOCHS\" in os.environ:\n",
+    "    num_epochs = int(os.environ.get('ITEX_NUM_EPOCHS'))\n",
+    "\n",
     "neuron_coef = 4\n",
     "itex_lstm_model = Sequential()\n",
     "itex_lstm_model.add(Embedding(input_dim=vocab_size, output_dim=seq_length, input_length=seq_length))\n",
@@ -262,7 +268,7 @@
     "itex_lstm_model.add(Dense(units=vocab_size, activation='softmax'))\n",
     "itex_lstm_model.summary()\n",
     "itex_lstm_model.compile(optimizer='adam', loss='categorical_crossentropy', metrics=['accuracy'])\n",
-    "itex_lstm_model.fit(x,y, batch_size=256, epochs=200)"
+    "itex_lstm_model.fit(x,y, batch_size=256, epochs=num_epochs)"
    ]
   },
   {
@@ -296,6 +302,11 @@
     "seq_length = x.shape[1]\n",
     "vocab_size = y.shape[1]\n",
     "\n",
+    "num_epochs = 20\n",
+    "# For custom epochs numbers\n",
+    "if \"KERAS_NUM_EPOCHS\" in os.environ:\n",
+    "    num_epochs = int(os.environ.get('KERAS_NUM_EPOCHS'))\n",
+    "\n",
     "neuron_coef = 1\n",
     "keras_lstm_model = Sequential()\n",
     "keras_lstm_model.add(Embedding(input_dim=vocab_size, output_dim=seq_length, input_length=seq_length))\n",
@@ -305,7 +316,7 @@
     "keras_lstm_model.add(Dense(units=vocab_size, activation='softmax'))\n",
     "keras_lstm_model.summary()\n",
     "keras_lstm_model.compile(optimizer='adam', loss='categorical_crossentropy', metrics=['accuracy'])\n",
-    "keras_lstm_model.fit(x,y, batch_size=256, epochs=20)"
+    "keras_lstm_model.fit(x,y, batch_size=256, epochs=num_epochs)"
    ]
   },
   {

--- a/AI-and-Analytics/Features-and-Functionality/IntelTensorFlow_TextGeneration_with_LSTM/TextGenerationModelTraining.py
+++ b/AI-and-Analytics/Features-and-Functionality/IntelTensorFlow_TextGeneration_with_LSTM/TextGenerationModelTraining.py
@@ -28,6 +28,7 @@
 
 import string
 import requests
+import os
 
 response = requests.get('https://www.gutenberg.org/cache/epub/1497/pg1497.txt')
 data = response.text.split('\n')
@@ -168,6 +169,11 @@ import intel_extension_for_tensorflow as itex
 # In[ ]:
 
 
+num_epochs = 200
+# For custom epochs numbers from the environment
+if "ITEX_NUM_EPOCHS" in os.environ:
+    num_epochs = int(os.environ.get('ITEX_NUM_EPOCHS'))
+
 neuron_coef = 4
 itex_lstm_model = Sequential()
 itex_lstm_model.add(Embedding(input_dim=vocab_size, output_dim=seq_length, input_length=seq_length))
@@ -177,7 +183,7 @@ itex_lstm_model.add(Dense(units=seq_length * neuron_coef, activation='relu'))
 itex_lstm_model.add(Dense(units=vocab_size, activation='softmax'))
 itex_lstm_model.summary()
 itex_lstm_model.compile(optimizer='adam', loss='categorical_crossentropy', metrics=['accuracy'])
-itex_lstm_model.fit(x,y, batch_size=256, epochs=200)
+itex_lstm_model.fit(x,y, batch_size=256, epochs=num_epochs)
 
 
 # ## Compared to LSTM from Keras
@@ -201,6 +207,11 @@ x, y, keras_tokenizer = tokenize_prepare_dataset(lines)
 seq_length = x.shape[1]
 vocab_size = y.shape[1]
 
+num_epochs = 20
+# For custom epochs numbers
+if "KERAS_NUM_EPOCHS" in os.environ:
+    num_epochs = int(os.environ.get('KERAS_NUM_EPOCHS'))
+
 neuron_coef = 1
 keras_lstm_model = Sequential()
 keras_lstm_model.add(Embedding(input_dim=vocab_size, output_dim=seq_length, input_length=seq_length))
@@ -210,7 +221,7 @@ keras_lstm_model.add(Dense(units=seq_length * neuron_coef, activation='relu'))
 keras_lstm_model.add(Dense(units=vocab_size, activation='softmax'))
 keras_lstm_model.summary()
 keras_lstm_model.compile(optimizer='adam', loss='categorical_crossentropy', metrics=['accuracy'])
-keras_lstm_model.fit(x,y, batch_size=256, epochs=20)
+keras_lstm_model.fit(x,y, batch_size=256, epochs=num_epochs)
 
 
 # ## Generating text based on the input

--- a/AI-and-Analytics/Features-and-Functionality/IntelTensorFlow_TextGeneration_with_LSTM/sample.json
+++ b/AI-and-Analytics/Features-and-Functionality/IntelTensorFlow_TextGeneration_with_LSTM/sample.json
@@ -23,7 +23,7 @@
             "id": "inc_text_generation_lstm_py",
             "steps": [
                 "export ITEX_ENABLE_NEXTPLUGGABLE_DEVICE=0",
-                "python TextGenerationModelTraining.py"
+                "ITEX_NUM_EPOCHS=5 KERAS_NUM_EPOCHS=5 python TextGenerationModelTraining.py"
              ]
         }
       ]


### PR DESCRIPTION
# Existing Sample Changes
## Description

Running training with 200 epoch is too long for CI.  Add env variable to control number of epochs.

## Type of change

Please delete options that are not relevant. Add a 'X' to the one that is applicable. 

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Implement fixes for ONSAM Jiras

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Command Line
- [ ] oneapi-cli
- [ ] Visual Studio
- [ ] Eclipse IDE
- [ ] VSCode
- [ ] When compiling the compliler flag "-Wall -Wformat-security -Werror=format-security" was used

