### PR TITLE
Add missing headers to introduce math functions needed by sample.

### DIFF
--- a/DirectProgramming/C++SYCL/ParallelPatterns/PrefixSum/src/PrefixSum.cpp
+++ b/DirectProgramming/C++SYCL/ParallelPatterns/PrefixSum/src/PrefixSum.cpp
@@ -34,6 +34,8 @@
 
 #include <iostream>
 #include <string>
+#include <cmath>
+#include <complex>
 // dpc_common.hpp can be found in the dev-utilities include folder.
 // e.g., $ONEAPI_ROOT/dev-utilities/<version>/include/dpc_common.hpp
 #include "dpc_common.hpp"


### PR DESCRIPTION
# Existing Sample Changes
## Description

A recent change in the DPC++ compiler has removed an implicit inclusion of cmath and complex header files.  This change adds those explicitly to the same to resolve compile errors that otherwise are encountered with the new DPC++ compiler.

Fixes Issue# 

## External Dependencies

None

## Type of change

Please delete options that are not relevant. Add a 'X' to the one that is applicable. 

- [ X ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Implement fixes for ONSAM Jiras

## How Has This Been Tested?

Confirmed the sample would not compile on my local system as-is, and that adding the header files as suggested resolved the issue.

- [ ] Command Line
- [X ] oneapi-cli
- [ ] Visual Studio
- [ ] Eclipse IDE
- [ ] VSCode
- [ ] When compiling the compliler flag "-Wall -Wformat-security -Werror=format-security" was used
