### PR TITLE
Update host pipe tests for FPGA emulator

### DIFF
--- a/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/convolution2d/src/convolution_kernel.hpp
+++ b/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/convolution2d/src/convolution_kernel.hpp
@@ -21,6 +21,12 @@ constexpr int kKernelVersion = 1;
 // Define input/output streaming interfaces
 /////////////////////////////////////////////
 
+#if defined(FPGA_SIMULATOR) || defined(FPGA_HARDWARE)
+constexpr size_t kPipeMinCapacity = 0;
+#else  // #if defined(FPGA_EMULATOR)
+constexpr size_t kPipeMinCapacity = 15000;
+#endif
+
 class ID_InStr;
 using InputImgStreamProperties =
     decltype(sycl::ext::oneapi::experimental::properties(
@@ -29,12 +35,14 @@ using InputImgStreamProperties =
         sycl::ext::intel::experimental::ready_latency<0>,
         sycl::ext::intel::experimental::first_symbol_in_high_order_bits<true>));
 using InputImageStream =
-    sycl::ext::intel::experimental::pipe<ID_InStr, conv2d::RGBBeat, 0,
+    sycl::ext::intel::experimental::pipe<ID_InStr, conv2d::RGBBeat,
+                                         kPipeMinCapacity,
                                          InputImgStreamProperties>;
 
 class ID_InStrGrey;
 using InputImageStreamGrey =
-    sycl::ext::intel::experimental::pipe<ID_InStrGrey, conv2d::GreyScaleBeat, 0,
+    sycl::ext::intel::experimental::pipe<ID_InStrGrey, conv2d::GreyScaleBeat,
+                                         kPipeMinCapacity,
                                          InputImgStreamProperties>;
 
 class ID_OutStr;
@@ -45,11 +53,13 @@ using OutputImgStreamProperties =
         sycl::ext::intel::experimental::ready_latency<0>,
         sycl::ext::intel::experimental::first_symbol_in_high_order_bits<true>));
 using OutputImageStreamGrey =
-    sycl::ext::intel::experimental::pipe<ID_OutStr, conv2d::GreyScaleBeat, 0,
+    sycl::ext::intel::experimental::pipe<ID_OutStr, conv2d::GreyScaleBeat,
+                                         kPipeMinCapacity,
                                          OutputImgStreamProperties>;
 
 using OutputImageStream =
-    sycl::ext::intel::experimental::pipe<ID_OutStr, conv2d::RGBBeat, 0,
+    sycl::ext::intel::experimental::pipe<ID_OutStr, conv2d::RGBBeat,
+                                         kPipeMinCapacity,
                                          OutputImgStreamProperties>;
 
 /////////////////////////////////////////////

--- a/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/convolution2d/src/convolution_kernel.hpp
+++ b/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/convolution2d/src/convolution_kernel.hpp
@@ -21,10 +21,11 @@ constexpr int kKernelVersion = 1;
 // Define input/output streaming interfaces
 /////////////////////////////////////////////
 
-#if defined(FPGA_SIMULATOR) || defined(FPGA_HARDWARE)
-constexpr size_t kPipeMinCapacity = 0;
-#else  // #if defined(FPGA_EMULATOR)
+// Pipe capacity
+#if FPGA_EMULATOR
 constexpr size_t kPipeMinCapacity = 15000;
+#else
+constexpr size_t kPipeMinCapacity = 0;
 #endif
 
 class ID_InStr;

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/experimental/hostpipes/src/hostpipes.cpp
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/experimental/hostpipes/src/hostpipes.cpp
@@ -177,7 +177,6 @@ void LaunchCollectTest(sycl::queue& q, ValueT* in, ValueT* out, size_t count,
                        size_t repeats) {
   std::cout << "\t Run Loopback Kernel on FPGA" << std::endl;
 
-#if defined(FPGA_SIMULATOR) || defined(FPGA_HARDWARE)
   for (size_t r = 0; r < repeats; r++) {
     std::cout << "\t " << r << ": "
               << "Doing " << count << " writes" << std::endl;
@@ -185,39 +184,24 @@ void LaunchCollectTest(sycl::queue& q, ValueT* in, ValueT* out, size_t count,
       // write data in host-to-device hostpipe
       H2DPipe::write(q, in[i]);
     }
+#if FPGA_EMULATOR
+  auto e = SubmitLoopBackKernel<LoopBackKernelID, H2DPipe, D2HPipe>(
+      q, count);
+#else
   }
 
   auto e = SubmitLoopBackKernel<LoopBackKernelID, H2DPipe, D2HPipe>(
       q, count * repeats);
 
   for (size_t r = 0; r < repeats; r++) {
-    std::cout << "\t " << r << ": "
-              << "Doing " << count << " reads" << std::endl;
-    for (size_t i = 0; i < count; i++) {
-      // read data from device-to-host hostpipe
-      out[i] = D2HPipe::read(q);
-    }
-  }
-#else  // #if defined(FPGA_EMULATOR)
-  for (size_t r = 0; r < repeats; r++) {
-    std::cout << "\t " << r << ": "
-              << "Doing " << count << " writes" << std::endl;
-    for (size_t i = 0; i < count; i++) {
-      // write data in host-to-device hostpipe
-      H2DPipe::write(q, in[i]);
-    }
-
-    auto e = SubmitLoopBackKernel<LoopBackKernelID, H2DPipe, D2HPipe>(
-        q, count);
-
-    std::cout << "\t " << r << ": "
-              << "Doing " << count << " reads" << std::endl;
-    for (size_t i = 0; i < count; i++) {
-      // read data from device-to-host hostpipe
-      out[i] = D2HPipe::read(q);
-    }
-  }
 #endif
+    std::cout << "\t " << r << ": "
+              << "Doing " << count << " reads" << std::endl;
+    for (size_t i = 0; i < count; i++) {
+      // read data from device-to-host hostpipe
+      out[i] = D2HPipe::read(q);
+    }
+  }
 
   // No need to wait on kernel to finish as the pipe reads are blocking
 

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/hls_flow_interfaces/streaming_data_interfaces/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/hls_flow_interfaces/streaming_data_interfaces/README.md
@@ -66,7 +66,7 @@ Each pipe is a class declaration of the templated `pipe` class. A pipe declarati
 | ---                                     | ---
 | `name`                                  | A user-defined type that uniquely identifies this pipe. The name of this type is also used to identify the interface in the generated RTL.
 | `dataT`                                 | The type of data that passes through the pipe*. This is the data type that is read during a successful pipe read() operation, or written during a successful pipe write() operation. The type must have a standard layout and be trivially copyable.
-| `min_capacity`                          | User-defined minimum number of words (in units of `dataT`) that the pipe must be able to store without any being read out. This parameter is optional, and defaults to 0.
+| `min_capacity`                          | User-defined minimum number of words (in units of `dataT`) that the pipe must be able to store without any being read out. This parameter is optional, and defaults to 0. For FPGA emulator, when `min_capacity` is 0, the pipe depth defaults to 1. If the pipe is expected to store `N` (N > 1) words without any being read out, `min_capacity` should be set to a number greater than or equal to `N`.
 | `properties`                            | An unordered list of SYCL properties that define additional semantic properties for a pipe. This parameter is optional.**
 
 > **Note**: Omitting a single property from the properties class instructs the compiler to assume the default value for that property, so you can just define the properties you would like to change from the default. Omitting the properties template parameter entirely instructs the compiler to assume the default values for all properties.

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/hls_flow_interfaces/streaming_data_interfaces/src/streaming_data_interfaces.cpp
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/hls_flow_interfaces/streaming_data_interfaces/src/streaming_data_interfaces.cpp
@@ -29,18 +29,25 @@ using PipePropertiesT = decltype(sycl::ext::oneapi::experimental::properties(
     sycl::ext::intel::experimental::first_symbol_in_high_order_bits<true>,
     sycl::ext::intel::experimental::protocol_avalon_streaming_uses_ready));
 
+// Pipe capacity
+#if FPGA_EMULATOR
+constexpr size_t kPipeMinCapacity = 256;
+#else
+constexpr size_t kPipeMinCapacity = 0;
+#endif
+
 // Image streams
 using InPixelPipe = sycl::ext::intel::experimental::pipe<
-    InStream,        // An identifier for the pipe
-    StreamingBeatT,  // The type of data in the pipe
-    0,               // The capacity of the pipe
-    PipePropertiesT  // Customizable pipe properties
+    InStream,          // An identifier for the pipe
+    StreamingBeatT,    // The type of data in the pipe
+    kPipeMinCapacity,  // The capacity of the pipe
+    PipePropertiesT    // Customizable pipe properties
     >;
 using OutPixelPipe = sycl::ext::intel::experimental::pipe<
-    OutStream,       // An identifier for the pipe
-    StreamingBeatT,  // The type of data in the pipe
-    0,               // The capacity of the pipe
-    PipePropertiesT  // Customizable pipe properties
+    OutStream,         // An identifier for the pipe
+    StreamingBeatT,    // The type of data in the pipe
+    kPipeMinCapacity,  // The capacity of the pipe
+    PipePropertiesT    // Customizable pipe properties
     >;
 
 // A kernel that thresholds pixel values in an image over a stream. Uses start


### PR DESCRIPTION
# Existing Sample Changes
## Description

When a host pipe on FPGA emulator does not specify the depth, the depth will be 1 by default. For tests that write a number of data packets to a pipe, the pipe needs to specify its depth large enough to store data packets without any being read out.

## Type of change

Please delete options that are not relevant. Add a 'X' to the one that is applicable. 

- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [X] Command Line
- [ ] oneapi-cli
- [ ] Visual Studio
- [ ] Eclipse IDE
- [ ] VSCode
- [ ] When compiling the compliler flag "-Wall -Wformat-security -Werror=format-security" was used
