### PR TITLE
[GPU opt guide][SYCL][joint matrix] Add explicit std <cmath> to math function

### DIFF
--- a/Publications/GPU-Opt-Guide/joint-matrix/joint-matrix.cpp
+++ b/Publications/GPU-Opt-Guide/joint-matrix/joint-matrix.cpp
@@ -4,6 +4,7 @@
 // SPDX-License-Identifier: MIT
 // =============================================================
 
+#include <cmath>
 #include <iostream>
 #include <sycl/sycl.hpp>
 
@@ -136,7 +137,7 @@ int test() {
   for (int i = 0; i < M; i++) {
     for (int j = 0; j < N; j++) {
       if constexpr (std::is_same_v<Tc, float>) {
-        if (fabs(C[i * N + j] - D[i * N + j]) > BF16_EPSILON) {
+        if (std::fabs(C[i * N + j] - D[i * N + j]) > BF16_EPSILON) {
           res = false;
           std::cout << "Incorrect result in matrix. "
                     << "i: " << i << ", j: " << j << ", Ref: " << D[i * N + j]


### PR DESCRIPTION
# Existing Sample Changes
Updated oneAPI-samples/Publications/GPU-Opt-Guide/joint-matrix/joint-matrix.cpp
## Description
Add explicit std to the math function used in the test and include <cmath>

Fixes Issue# 
https://jira.devtools.intel.com/browse/ONSAM-1933

## Type of change

- [x ] Bug fix (non-breaking change which fixes an issue)
- [x ] Implement fixes for ONSAM Jiras

## How Has This Been Tested?
tested on PVC machine
icpx -fsycl joint-matrix.cpp
./a.out

