### PR TITLE
Fix wrong folder specified in cuBLAS Migration README

### DIFF
--- a/Libraries/oneMKL/guided_cuBLAS_examples_SYCL_Migration/README.md
+++ b/Libraries/oneMKL/guided_cuBLAS_examples_SYCL_Migration/README.md
@@ -92,7 +92,7 @@ Run the programs on a CPU or GPU. Each sample uses a default device, which in mo
 > line in the code.
 
 
-1. Run the samples in the `02_sycl_dpct_migrated` folder.
+1. Run the samples in the `build` folder.
    ```
    make run_amax
    ```


### PR DESCRIPTION
# Existing Sample Changes
## Description

This change fixes a wrong folder specified in the cuBLAS Migration README. Running `make run_amax` in `02_sycl_dpct_migrated` folder instead of `build` folder previously resulted in a make error.

Fixes Issue# ONSAM-1991

## External Dependencies

None.

## Type of change

Please delete options that are not relevant. Add a 'X' to the one that is applicable. 

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] Implement fixes for ONSAM Jiras

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [X] Command Line
- [ ] oneapi-cli
- [ ] Visual Studio
- [ ] Eclipse IDE
- [ ] VSCode
- [ ] When compiling the compliler flag "-Wall -Wformat-security -Werror=format-security" was used