### PR TITLE
Update Tachyon build instructions for Linux

### DIFF
--- a/Tools/VTuneProfiler/tachyon/README.md
+++ b/Tools/VTuneProfiler/tachyon/README.md
@@ -90,6 +90,7 @@ To learn more about the extensions and how to configure the oneAPI environment, 
 1. Change to the sample directory.
 2. Build the program.
    ```
+   cd linux
    mkdir build
    cd build
    cmake ..


### PR DESCRIPTION
# Existing Sample Changes
## Description

This change explicitly instructs the user to run `cd linux` in the Tachyon README. Not changing the working directory previously resulted in a make error.

Fixes Issue# ONSAM-1999

## External Dependencies

None.

## Type of change

Please delete options that are not relevant. Add a 'X' to the one that is applicable. 

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] Implement fixes for ONSAM Jiras

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [X] Command Line
- [ ] oneapi-cli
- [ ] Visual Studio
- [ ] Eclipse IDE
- [ ] VSCode
- [ ] When compiling the compliler flag "-Wall -Wformat-security -Werror=format-security" was used