### PR TITLE
Update quantize_with_inc.ipynb

### DIFF
--- a/AI-and-Analytics/Getting-Started-Samples/INC-Quantization-Sample-for-PyTorch/quantize_with_inc.ipynb
+++ b/AI-and-Analytics/Getting-Started-Samples/INC-Quantization-Sample-for-PyTorch/quantize_with_inc.ipynb
@@ -52,7 +52,8 @@
     "version = version.split('.') # ['x','y','z']\n",
     "version = float(version[0]) + sum([float(x)*10**(-(y+1)) for y, x in enumerate(version[1:])])\n",
     "print(version)\n",
-    "assert float(version) >= 2.0, "The below APIs work with Intel® Neural Compressor (INC) 2.0 and above\" 
+    "assert float(version) >= 2.0\n",
+    "The below APIs work with Intel® Neural Compressor (INC) 2.0 and above\" 
    ]
   },
   {

--- a/AI-and-Analytics/Getting-Started-Samples/INC-Quantization-Sample-for-PyTorch/quantize_with_inc.ipynb
+++ b/AI-and-Analytics/Getting-Started-Samples/INC-Quantization-Sample-for-PyTorch/quantize_with_inc.ipynb
@@ -48,7 +48,11 @@
     "#######################################################################################################################################\n",
     "\n",
     "# check if Intel® Neural Compressor (INC) is above v2.0\n",
-    "assert float(neural_compressor.__version__) >= 2.0, \"The below APIs work with Intel® Neural Compressor (INC) 2.0 and above\" "
+    "version = neural_compressor.__version__\n",
+    "version = version.split('.') # ['x','y','z']\n",
+    "version = float(version[0]) + sum([float(x)*10**(-(y+1)) for y, x in enumerate(version[1:])])\n",
+    "print(version)\n",
+    "assert float(version) >= 2.0, "The below APIs work with Intel® Neural Compressor (INC) 2.0 and above\" 
    ]
   },
   {


### PR DESCRIPTION
There was an error when the version was in the format x.y.z

In my case :
```
ValueError: could not convert string to float: '2.5.1'
```
# Existing Sample Changes
## Description
So I made a quick fix, but I am sure that there is a much more elegant way of doing it!

```Python
version = neural_compressor.__version__
version = version.split('.') # ['x','y','z']
version = float(version[0]) + sum([float(x)*10**(-(y+1)) for y, x in enumerate(version[1:])])
print(version)
```

Fixes Issue# 

## External Dependencies

List any external dependencies created as a result of this change.

## Type of change

- [ X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [X ] Command Line
