### PR TITLE
FPGA: Update MatrixReadPipeToDDR to use ptr_annotations

### DIFF
--- a/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/pca/src/memory_transfers.hpp
+++ b/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/pca/src/memory_transfers.hpp
@@ -5,6 +5,11 @@
 #include "tuple.hpp"
 #include "unrolled_loop.hpp"
 
+using namespace sycl::ext::intel::experimental;
+using namespace sycl::ext::oneapi::experimental;
+
+constexpr int BL0 = 0;
+
 /*
   Read matrix_count matrices of type TT from DDR by bursts of num_elem_per_bank
   elements, and write the matrices to the "MatrixPipe" pipe num_elem_per_bank by
@@ -66,7 +71,12 @@ template <typename TT,            // Datatype of the elements of the matrix
           typename MatrixPipe     // Input matrix
           >
 void MatrixReadPipeToDDR(
-    TT* matrix_ptr,    // Output matrix pointer
+#if defined (IS_BSP)
+    TT matrix_ptr,  // Output matrix pointer
+# else
+    annotated_ptr<TT, decltype(properties{buffer_location<BL0>,
+                                          dwidth<512>})> matrix_ptr,
+#endif
     int matrix_count,  // Number of matrix to write to DDR
     int repetitions    // Number of time to read the same matrix to the pipe
 ) {

--- a/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/qrd/src/memory_transfers.hpp
+++ b/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/qrd/src/memory_transfers.hpp
@@ -156,7 +156,7 @@ void MatrixReadPipeToDDR(
   sycl::ext::intel::device_ptr<TT> matrix_ptr_located(matrix_ptr);
 #else
   // Device pointers are not supported when targeting an FPGA 
-  // family/part. We want to use the ptr_annotation that was definied in qri.hpp
+  // family/part. We want to use the ptr_annotation that was definied in qrd.hpp
   auto matrix_ptr_located = matrix_ptr;
 #endif  
 

--- a/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/qrd/src/memory_transfers.hpp
+++ b/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/qrd/src/memory_transfers.hpp
@@ -5,6 +5,11 @@
 #include "constexpr_math.hpp"
 #include "unrolled_loop.hpp"
 
+using namespace sycl::ext::intel::experimental;
+using namespace sycl::ext::oneapi::experimental;
+
+constexpr int BL0 = 0;
+
 /*
   Read matrix_count matrices of type TT from DDR by bursts of num_elem_per_bank
   elements, and write the matrices to the "MatrixPipe" pipe num_elem_per_bank by
@@ -120,7 +125,12 @@ template <typename TT,           // Datatype of the elements of the matrix
           typename MatrixPipe    // Input matrix
           >
 void MatrixReadPipeToDDR(
+#if defined (IS_BSP)
     TT* matrix_ptr,  // Output matrix pointer
+# else
+    annotated_ptr<TT, decltype(properties{buffer_location<BL0>,
+                                          dwidth<512>})> matrix_ptr,
+#endif
     int matrix_count,// Number of matrix to write to DDR
     int repetitions  // Number of time to read the same matrix to the pipe
     ) {
@@ -146,8 +156,8 @@ void MatrixReadPipeToDDR(
   sycl::ext::intel::device_ptr<TT> matrix_ptr_located(matrix_ptr);
 #else
   // Device pointers are not supported when targeting an FPGA 
-  // family/part
-  TT* matrix_ptr_located(matrix_ptr);
+  // family/part. We want to use the ptr_annotation that was definied in qri.hpp
+  auto matrix_ptr_located = matrix_ptr;
 #endif  
 
 


### PR DESCRIPTION
## Description

A recent functional change to the compiler means that it will now correctly identify memory dependences. As a side effect, this will now cause for the compiler to emit a message that it is unable to achieve a user specified II for the `MatrixReadPipeToDDR` function in memory_transfers.hpp. 

To regain this performance we can use annotated_ptr's in the SYCL HLS flow to specify a larger interface width which will allow for the compiler to coalesce stores to memory, thus resulting in being able to achieve the user specified II again.

## External Dependencies

* N/A

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [X] Command Line

Ran all of the tests manually in their reports and simulation flows.