### PR TITLE
Fix Matrix Multiply Sample filename in README

### DIFF
--- a/DirectProgramming/Fortran/guided_matrix_mul_OpenMP/README.md
+++ b/DirectProgramming/Fortran/guided_matrix_mul_OpenMP/README.md
@@ -106,7 +106,7 @@ Note that:
    ```
 4. Run the program.
    ```
-   01_mm_sequential.exe
+   01_mm_CPU_sequential.exe
    ```
 
 ### Example Sequential Program Output


### PR DESCRIPTION
# Existing Sample Changes
## Description

This change fixes an error in the Matrix Multiply Sample README. The filename for working sequential version should be `01_mm_CPU_sequential.exe`, not `01_mm_sequential.exe`

Fixes Issue# ONSAM-1982

## External Dependencies

None

## Type of change

Please delete options that are not relevant. Add a 'X' to the one that is applicable. 

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Implement fixes for ONSAM Jiras

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Command Line
- [ ] oneapi-cli
- [ ] Visual Studio
- [ ] Eclipse IDE
- [ ] VSCode
- [ ] When compiling the compliler flag "-Wall -Wformat-security -Werror=format-security" was used