### PR TITLE
Fix compilation failures after math builtin API updates (ONSAM-1948).

### DIFF
--- a/DirectProgramming/C++SYCL/StructuredGrids/iso2dfd_dpcpp/src/iso2dfd.cpp
+++ b/DirectProgramming/C++SYCL/StructuredGrids/iso2dfd_dpcpp/src/iso2dfd.cpp
@@ -149,7 +149,7 @@ bool WithinEpsilon(float* output, float* reference, const size_t dim_x,
   }
 
   err_file.close();
-  norm2 = sqrt(norm2);
+  norm2 = 1/rsqrt(norm2);
   if (error) printf("error (Euclidean norm): %.9e\n", norm2);
   return error;
 }

--- a/DirectProgramming/C++SYCL/StructuredGrids/iso3dfd_dpcpp/src/utils.cpp
+++ b/DirectProgramming/C++SYCL/StructuredGrids/iso3dfd_dpcpp/src/utils.cpp
@@ -159,7 +159,7 @@ bool WithinEpsilon(float* output, float* reference, const size_t dim_x,
   }
 
   error_file.close();
-  norm2 = sqrt(norm2);
+  norm2 = 1/rsqrt(norm2);
   if (error) std::cout << "error (Euclidean norm): " << norm2 << "\n";
   return error;
 }


### PR DESCRIPTION
# Existing Sample Changes

## Description:
Fix compilation failures after math builtin API updates 

Fixes Issue#:
(ONSAM-1948)

## External Dependencies:
None

## Type of change

Please delete options that are not relevant. Add a 'X' to the one that is applicable. 

- [X ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Implement fixes for ONSAM Jiras

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ X] Command Line
- [ ] oneapi-cli
- [ ] Visual Studio
- [ ] Eclipse IDE
- [ ] VSCode
- [ ] When compiling the compliler flag "-Wall -Wformat-security -Werror=format-security" was used
