### PR TITLE
Remove mention of Windows support

### DIFF
--- a/Tools/ApplicationDebugger/guided_matrix_mult_RaceCondition/README.md
+++ b/Tools/ApplicationDebugger/guided_matrix_mult_RaceCondition/README.md
@@ -29,7 +29,7 @@ The sample includes different versions of a simple matrix multiplication program
 
 | Optimized for           | Description
 |:---                     |:---
-| OS                      | Ubuntu* 20.04 <br> Windows* 10
+| OS                      | Ubuntu* 20.04
 | Hardware                | GEN9 or newer
 | Software                | Intel® oneAPI DPC++/C++ Compiler <br> Intel® Distribution for GDB* <br> [Tracing and Profiling Tool](https://github.com/intel/pti-gpu/tree/master/tools/onetrace), which is available from the [onetrace](https://github.com/intel/pti-gpu/tree/master/tools/onetrace) GitHub repository.
 


### PR DESCRIPTION
# Existing Sample Changes
## Description

This change removes mention of Windows support for the Guided Matrix Multiplication Race Condition sample README. Only Linux is supported.

Fixes Issue# ONSAM-1984

## External Dependencies

None

## Type of change

Please delete options that are not relevant. Add a 'X' to the one that is applicable. 

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] Implement fixes for ONSAM Jiras

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [X] Command Line
- [ ] oneapi-cli
- [ ] Visual Studio
- [ ] Eclipse IDE
- [ ] VSCode
- [ ] When compiling the compliler flag "-Wall -Wformat-security -Werror=format-security" was used