### PR TITLE
Fix onsam 1926

### DIFF
--- a/DirectProgramming/C++SYCL/CombinationalLogic/sepia-filter/src/sepia_sycl.cpp
+++ b/DirectProgramming/C++SYCL/CombinationalLogic/sepia-filter/src/sepia_sycl.cpp
@@ -48,7 +48,7 @@ static void ReportTime(const string &msg, event e) {
 // - SYCL compiler will automatically deduce the address space for the two
 //   pointers; sycl::multi_ptr specialization for particular address space
 //   can used for more control
-__attribute__((always_inline)) static void ApplyFilter(uint8_t *src_image,
+__attribute__((always_inline)) static void ApplyFilter(multi_ptr<const unsigned char, access::address_space::global_space, (sycl::access::decorated)2> src_image,
                                                        uint8_t *dst_image,
                                                        int i) {
   i *= 3;

--- a/DirectProgramming/C++SYCL/SpectralMethods/DiscreteCosineTransform/src/DCT.cpp
+++ b/DirectProgramming/C++SYCL/SpectralMethods/DiscreteCosineTransform/src/DCT.cpp
@@ -47,7 +47,8 @@ void MatrixTranspose(float x[block_size], float xinv[block_size]) {
 }
 
 // Multiply two matrices x and y and write output to xy
-SYCL_EXTERNAL void MatrixMultiply(float x[block_size], float y[block_size],
+SYCL_EXTERNAL void MatrixMultiply(multi_ptr<const float, access::address_space::global_space, (sycl::access::decorated)2> x, 
+                                  multi_ptr<const float, access::address_space::global_space, (sycl::access::decorated)2> y,
                                   float xy[block_size]) {
   for (int i = 0; i < block_dims; ++i) {
     for (int j = 0; j < block_dims; ++j) {
@@ -60,8 +61,9 @@ SYCL_EXTERNAL void MatrixMultiply(float x[block_size], float y[block_size],
 }
 
 // Processes an individual 8x8 subset of image data
-SYCL_EXTERNAL void ProcessBlock(rgb* indataset, rgb* outdataset,
-                                float dct[block_size], float dctinv[block_size],
+SYCL_EXTERNAL void ProcessBlock(multi_ptr<const rgb, access::address_space::global_space, (sycl::access::decorated)2> indataset, rgb* outdataset,
+                                multi_ptr<const float, access::address_space::global_space, (sycl::access::decorated)2> dct,
+                                multi_ptr<const float, access::address_space::global_space, (sycl::access::decorated)2> dctinv,
                                 int start_index, int width) {
   float interim[block_size], product[block_size], red_input[block_size],
       blue_input[block_size], green_input[block_size], temp[block_size];


### PR DESCRIPTION
# Existing Sample Changes
## Description

Fix for ONSAM 1926.

Fixes Issue#  ONSAM1926

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Implement fixes for ONSAM Jiras

## How Has This Been Tested?

Tested locally with the 2025.0 version of the compiler.

- [x] Command Line
- [ ] oneapi-cli
- [ ] Visual Studio
- [ ] Eclipse IDE
- [x] VSCode
- [x] When compiling the compliler flag "-Wall -Wformat-security -Werror=format-security" was used
