### PR TITLE
ApplicationDebugger: Replace get_pointer with get_multi_ptr in jacobi.

### DIFF
--- a/Tools/ApplicationDebugger/jacobi/src/bugged.cpp
+++ b/Tools/ApplicationDebugger/jacobi/src/bugged.cpp
@@ -12,8 +12,8 @@
 
 // Compute x_k1 and write the result to its accessor.
 
-void compute_x_k1_kernel (id<1> &index, float *b, 
-                          float *x_k, float *x_k1) {
+void compute_x_k1_kernel (id<1> &index, const float *b,
+                          const float *x_k, float *x_k1) {
   // Current index.
   int i = index[0];
 
@@ -54,8 +54,10 @@ void compute_x_k1 (queue &q, buffer_args &buffers) {
     accessor acc_x_k1(buffers.x_k1, h, write_only);
 
     h.parallel_for(range{n}, [=](id<1> index) {
-      compute_x_k1_kernel (index, acc_b.get_pointer(), acc_x_k.get_pointer(), 
-                           acc_x_k1.get_pointer());
+      compute_x_k1_kernel (index,
+                           acc_b.template get_multi_ptr<access::decorated::no>().get(),
+                           acc_x_k.template get_multi_ptr<access::decorated::no>().get(),
+                           acc_x_k1.template get_multi_ptr<access::decorated::no>().get());
     });
   });
 }

--- a/Tools/ApplicationDebugger/jacobi/src/fixed.cpp
+++ b/Tools/ApplicationDebugger/jacobi/src/fixed.cpp
@@ -11,8 +11,8 @@
 
 // Compute x_k1 and write the result to its accessor.
 
-void compute_x_k1_kernel (id<1> &index, float *b, 
-                          float *x_k, float *x_k1) {
+void compute_x_k1_kernel (id<1> &index, const float *b,
+                          const float *x_k, float *x_k1) {
   // Current index.
   int i = index[0];
 
@@ -61,8 +61,10 @@ void compute_x_k1 (queue &q, buffer_args &buffers) {
     accessor acc_x_k1(buffers.x_k1, h, write_only);
 
     h.parallel_for(range{n}, [=](id<1> index) {
-      compute_x_k1_kernel (index, acc_b.get_pointer(), acc_x_k.get_pointer(), 
-                           acc_x_k1.get_pointer());
+      compute_x_k1_kernel (index,
+                           acc_b.template get_multi_ptr<access::decorated::no>().get(),
+                           acc_x_k.template get_multi_ptr<access::decorated::no>().get(),
+                           acc_x_k1.template get_multi_ptr<access::decorated::no>().get());
     });
   });
 }


### PR DESCRIPTION
… sample.

# Existing Sample Changes
## Description

The "get_pointer" function is deprecated so it is replaced with the new function "get_multi_ptr". This function returns multi_ptr with the "const" qualifier for the READ_ONLY accessor.  So, "const" is added to the "compute_x_k1_kernel" function arguments of this type.


Fixes Issue#  https://jira.devtools.intel.com/browse/IGDB-5200

## External Dependencies

None

## Type of change

Please delete options that are not relevant. Add a 'X' to the one that is applicable. 

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Implement fixes for ONSAM Jiras

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [X] Command Line
- [ ] oneapi-cli
- [ ] Visual Studio
- [ ] Eclipse IDE
- [ ] VSCode
- [ ] When compiling the compliler flag "-Wall -Wformat-security -Werror=format-security" was used

Follow steps mentioned here to compile jacobi application. This changes fixes the compilation error seen with latest 2025.0 compiler.
https://github.com/oneapi-src/oneAPI-samples/blob/master/Tools/ApplicationDebugger/jacobi/README.md
