### PR TITLE
[FPGA] Fix `IS_BSP` flow for pca and qri

### DIFF
--- a/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/pca/src/memory_transfers.hpp
+++ b/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/pca/src/memory_transfers.hpp
@@ -72,7 +72,7 @@ template <typename TT,            // Datatype of the elements of the matrix
           >
 void MatrixReadPipeToDDR(
 #if defined (IS_BSP)
-    TT matrix_ptr,  // Output matrix pointer
+    TT* matrix_ptr,  // Output matrix pointer
 # else
     annotated_ptr<TT, decltype(properties{buffer_location<BL0>,
                                           dwidth<512>})> matrix_ptr,

--- a/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/qri/src/memory_transfers.hpp
+++ b/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/qri/src/memory_transfers.hpp
@@ -126,7 +126,7 @@ template <typename TT,           // Datatype of the elements of the matrix
           >
 void MatrixReadPipeToDDR(
 #if defined (IS_BSP)
-    TT matrix_ptr,  // Output matrix pointer
+    TT* matrix_ptr,  // Output matrix pointer
 # else
     annotated_ptr<TT, decltype(properties{buffer_location<BL0>,
                                           dwidth<512>})> matrix_ptr,


### PR DESCRIPTION
## Description

This change addresses a bug in the full-system flow where a pointer was not being passed into `MatrixReadPipeToDDR`.


## External Dependencies

* N/A

## Type of change 

- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [X] Command Line

Manually compiled to reports and emulation for both of these tests.
