### PR TITLE
FPGA: Update README to include note about emulator environment variables

### DIFF
--- a/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/convolution2d/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/convolution2d/README.md
@@ -363,6 +363,8 @@ This design uses CMake to generate a build script for GNU/make.
    | FPGA Simulator      | `make fpga_sim`
    | FPGA Hardware       | `nmake fpga`
 
+>**Note**: Since this design uses host pipes, make sure that the emulator pipe depth behaviour is as intended. Set the environment variable `CL_CONFIG_CHANNEL_DEPTH_EMULATION_MODE` to `ignore-depth` for this design so that multiple writes can happen to the pipe without first having the contents read.
+
 ### On a Windows* System
 This design uses CMake to generate a build script for  `nmake`.
 
@@ -395,6 +397,8 @@ This design uses CMake to generate a build script for  `nmake`.
    | FPGA Hardware       | `nmake fpga`
 
    > **Note**: If you encounter any issues with long paths when compiling under Windows*, you may have to create your 'build' directory in a shorter path, for example c:\samples\build.  You can then run cmake from that directory, and provide cmake with the full path to your sample directory, for example:
+  
+   >**Note**: Since this design uses host pipes, make sure that the emulator pipe depth behaviour is as intended. Set the environment variable `CL_CONFIG_CHANNEL_DEPTH_EMULATION_MODE` to `ignore-depth` for this design so that multiple writes can happen to the pipe without first having the contents read.
 >
 >  ```
   > C:\samples\build> cmake -G "NMake Makefiles" C:\long\path\to\code\sample\CMakeLists.txt

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/experimental/hostpipes/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/experimental/hostpipes/README.md
@@ -292,6 +292,7 @@ In the latter launch-collect test, the entire contents of the `in` vector are wr
       ```
       make fpga_emu
       ```
+      >**Note**: Since this design uses host pipes, make sure that the emulator pipe depth behaviour is as intended. Set the environment variable `CL_CONFIG_CHANNEL_DEPTH_EMULATION_MODE` to `ignore-depth` for this design so that multiple writes can happen to the pipe without first having the contents read.
    2. Generate the HTML optimization reports. (See [Read the Reports](#read-the-reports) below for information on finding and understanding the reports.)
       ```
       make report
@@ -327,6 +328,7 @@ In the latter launch-collect test, the entire contents of the `in` vector are wr
       ```
       nmake fpga_emu
       ```
+      >**Note**: Since this design uses host pipes, make sure that the emulator pipe depth behaviour is as intended. Set the environment variable `CL_CONFIG_CHANNEL_DEPTH_EMULATION_MODE` to `ignore-depth` for this design so that multiple writes can happen to the pipe without first having the contents read.
    2. Generate the optimization report. (See [Read the Reports](#read-the-reports) below for information on finding and understanding the reports.)
       ```
       nmake report

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/hls_flow_interfaces/component_interfaces_comparison/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/hls_flow_interfaces/component_interfaces_comparison/README.md
@@ -157,6 +157,8 @@ Use the appropriate TYPE parameter when running CMake to config which design to 
       ```
       make fpga_emu
       ```
+      >**Note**: Since this design uses host pipes, make sure that the emulator pipe depth behaviour is as intended. Set the environment variable `CL_CONFIG_CHANNEL_DEPTH_EMULATION_MODE` to `ignore-depth` for this design so that multiple writes can happen to the pipe without first having the contents read.
+
 
    2. Compile for simulation (fast compile time, targets simulator FPGA device):
       ```
@@ -195,6 +197,7 @@ Use the appropriate TYPE parameter when running CMake to config which design to 
       ```
       nmake fpga_emu
       ```
+      >**Note**: Since this design uses host pipes, make sure that the emulator pipe depth behaviour is as intended. Set the environment variable `CL_CONFIG_CHANNEL_DEPTH_EMULATION_MODE` to `ignore-depth` for this design so that multiple writes can happen to the pipe without first having the contents read.
    2. Compile for simulation (fast compile time, targets simulator FPGA device):
       ```
       nmake fpga_sim

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/hls_flow_interfaces/streaming_data_interfaces/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/hls_flow_interfaces/streaming_data_interfaces/README.md
@@ -186,6 +186,7 @@ See the [Host Pipes](/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/experime
       ```
       make fpga_emu
       ```
+      >**Note**: Since this design uses host pipes, make sure that the emulator pipe depth behaviour is as intended. Set the environment variable `CL_CONFIG_CHANNEL_DEPTH_EMULATION_MODE` to `ignore-depth` for this design so that multiple writes can happen to the pipe without first having the contents read.
    2. Generate the optimization report.
       ```
       make report
@@ -221,6 +222,7 @@ See the [Host Pipes](/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/experime
       ```
       nmake fpga_emu
       ```
+      >**Note**: Since this design uses host pipes, make sure that the emulator pipe depth behaviour is as intended. Set the environment variable `CL_CONFIG_CHANNEL_DEPTH_EMULATION_MODE` to `ignore-depth` for this design so that multiple writes can happen to the pipe without first having the contents read.
    2. Generate the optimization report.
       ```
       nmake report

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/task_sequence/hardware_reuse/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/task_sequence/hardware_reuse/README.md
@@ -213,6 +213,7 @@ Use these commands to run the design, depending on your OS.
       ```
       make fpga_emu
       ```
+      >**Note**: Since this design uses host pipes, make sure that the emulator pipe depth behaviour is as intended. Set the environment variable `CL_CONFIG_CHANNEL_DEPTH_EMULATION_MODE` to `ignore-depth` for this design so that multiple writes can happen to the pipe without first having the contents read.
    2. Generate the HTML optimization reports.
       ```
       make report
@@ -253,6 +254,7 @@ Use these commands to run the design, depending on your OS.
       ```
       nmake fpga_emu
       ```
+      >**Note**: Since this design uses host pipes, make sure that the emulator pipe depth behaviour is as intended. Set the environment variable `CL_CONFIG_CHANNEL_DEPTH_EMULATION_MODE` to `ignore-depth` for this design so that multiple writes can happen to the pipe without first having the contents read.
    2. Generate the optimization report. 
       ```
       nmake report

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/task_sequence/parallel_loops/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/task_sequence/parallel_loops/README.md
@@ -249,6 +249,7 @@ The 2 different example designs in this sample perform similar operations. You m
       ```
       make fpga_emu
       ```
+      >**Note**: Since this design uses host pipes, make sure that the emulator pipe depth behaviour is as intended. Set the environment variable `CL_CONFIG_CHANNEL_DEPTH_EMULATION_MODE` to `ignore-depth` for this design so that multiple writes can happen to the pipe without first having the contents read.
    2. Generate the HTML optimization reports.
       ```
       make report
@@ -289,6 +290,7 @@ The 2 different example designs in this sample perform similar operations. You m
       ```
       nmake fpga_emu
       ```
+      >**Note**: Since this design uses host pipes, make sure that the emulator pipe depth behaviour is as intended. Set the environment variable `CL_CONFIG_CHANNEL_DEPTH_EMULATION_MODE` to `ignore-depth` for this design so that multiple writes can happen to the pipe without first having the contents read.
    2. Generate the optimization report. 
       ```
       nmake report


### PR DESCRIPTION
## Description

The FPGA Emulator has modified how pipe depth is emulated. If a design wishes to increase the host buffer capacity (in emulation) of a host pipe to larger than the buffer on the device, `CL_CONFIG_CHANNEL_DEPTH_EMULATION_MODE` will have to be set to `ignore-depth`.

This change updates the README's of designs that do exactly that, and were previously relying on the emulator defaulting to this behaviour.

## External Dependencies

* N/A

## Type of change

Please delete options that are not relevant. Add a 'X' to the one that is applicable. 

- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- These are just changes to the README. No code was touched.

