### PR TITLE
fix out-of-bounds bug in loop_bounds and map examples

### DIFF
--- a/Publications/GPU-Opt-Guide/OpenMP/07_loop_bounds/test_loop_bounds_fp.cpp
+++ b/Publications/GPU-Opt-Guide/OpenMP/07_loop_bounds/test_loop_bounds_fp.cpp
@@ -19,7 +19,7 @@
 #define scaled_rand() ((rand() % MAX) / (1.0 * MAX))
 
 #define IDX2(i, j) (i * P + j)
-#define IDX4(b, i, j, k) (b * P * P * P + i * P * P + j * P + k)
+#define IDX4(b, i, j, k) ((b * P * P * P + i * P * P + j * P + k) % SIZE)
 
 int main(void) {
   double w[SIZE];            /* output */

--- a/Publications/GPU-Opt-Guide/OpenMP/07_loop_bounds/test_loop_bounds_map.cpp
+++ b/Publications/GPU-Opt-Guide/OpenMP/07_loop_bounds/test_loop_bounds_map.cpp
@@ -19,7 +19,7 @@
 #define scaled_rand() ((rand() % MAX) / (1.0 * MAX))
 
 #define IDX2(i, j) (i * P + j)
-#define IDX4(b, i, j, k) (b * P * P * P + i * P * P + j * P + k)
+#define IDX4(b, i, j, k) ((b * P * P * P + i * P * P + j * P + k) % SIZE)
 
 int main(void) {
   double w[SIZE];            /* output */

--- a/Publications/GPU-Opt-Guide/OpenMP/07_loop_bounds/test_loop_bounds_nofp_nomap.cpp
+++ b/Publications/GPU-Opt-Guide/OpenMP/07_loop_bounds/test_loop_bounds_nofp_nomap.cpp
@@ -19,7 +19,7 @@
 #define scaled_rand() ((rand() % MAX) / (1.0 * MAX))
 
 #define IDX2(i, j) (i * P + j)
-#define IDX4(b, i, j, k) (b * P * P * P + i * P * P + j * P + k)
+#define IDX4(b, i, j, k) ((b * P * P * P + i * P * P + j * P + k) % SIZE)
 
 int main(void) {
   double w[SIZE];            /* output */

--- a/Publications/GPU-Opt-Guide/OpenMP/10_map/test_map_to_or_from.cpp
+++ b/Publications/GPU-Opt-Guide/OpenMP/10_map/test_map_to_or_from.cpp
@@ -19,7 +19,7 @@
 #define scaled_rand() ((rand() % MAX) / (1.0 * MAX))
 
 #define IDX2(i, j) (i * P + j)
-#define IDX4(b, i, j, k) (b * P * P * P + i * P * P + j * P + k)
+#define IDX4(b, i, j, k) ((b * P * P * P + i * P * P + j * P + k) % SIZE)
 
 int main(void) {
   double w[SIZE];            /* output */

--- a/Publications/GPU-Opt-Guide/OpenMP/10_map/test_map_tofrom.cpp
+++ b/Publications/GPU-Opt-Guide/OpenMP/10_map/test_map_tofrom.cpp
@@ -19,7 +19,7 @@
 #define scaled_rand() ((rand() % MAX) / (1.0 * MAX))
 
 #define IDX2(i, j) (i * P + j)
-#define IDX4(b, i, j, k) (b * P * P * P + i * P * P + j * P + k)
+#define IDX4(b, i, j, k) ((b * P * P * P + i * P * P + j * P + k) % SIZE)
 
 int main(void) {
   double w[SIZE];            /* output */


### PR DESCRIPTION
# Existing Sample Changes
## Description

This change fixes bug in loop_bounds and map examples for access to index of array which is out of bounds.

Fixes Issue:  ONSAM-2016

## External Dependencies

None

## Type of change

Please delete options that are not relevant. Add a 'X' to the one that is applicable. 

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Implement fixes for ONSAM Jiras

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [X] Command Line
- [ ] oneapi-cli
- [ ] Visual Studio
- [ ] Eclipse IDE
- [ ] VSCode
- [ ] When compiling the compliler flag "-Wall -Wformat-security -Werror=format-security" was used

Local validation of impacted tests with printf's added to verify oob accesses were resolved.