### PR TITLE
Add basic verification to oneMKL matmul sample

### DIFF
--- a/Libraries/oneMKL/matrix_mul_mkl/utilities.hpp
+++ b/Libraries/oneMKL/matrix_mul_mkl/utilities.hpp
@@ -24,6 +24,14 @@ int nice_ld(int x)
     return x;
 }
 
+template <typename T>
+void generate_ones(size_t elems, T *v)
+{
+#pragma omp parallel for
+    for (size_t i = 0; i < elems; i++)
+        v[i] = T(1);
+}
+
 /* Random number generation helpers */
 template <typename T>
 void generate_random_data(size_t elems, T *v)


### PR DESCRIPTION
# Existing Sample Changes
## Description

Adds basic verification to oneMKL sample `matrix_mul_mkl.cpp`. A step is added where we multiply two matrices of all ones and check the resulting values.

## External Dependencies

No external dependencies were added.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Tested locally on linux.

- [x] Command Line
- [ ] oneapi-cli
- [ ] Visual Studio
- [ ] Eclipse IDE
- [ ] VSCode
- [x] When compiling the compliler flag "-Wall -Wformat-security -Werror=format-security" was used
