### PR TITLE
Add exit if MKL matrix mul sample fails verification

### DIFF
--- a/Libraries/oneMKL/matrix_mul_mkl/matrix_mul_mkl.cpp
+++ b/Libraries/oneMKL/matrix_mul_mkl/matrix_mul_mkl.cpp
@@ -75,6 +75,9 @@ void test(queue &Q, int M, int N, int K)
         if (linear_id >= elems) break;
     }
     std::cout << (ok ? " passes." : " FAILS!") << std::endl;
+    if (!ok) {
+        exit(1);
+    }
 
     /* Fill A/B with random data */
     generate_random_data(rd_size, host_data);


### PR DESCRIPTION
# Existing Sample Changes
## Description

Update #2512 by adding an exit if verification fails.

## External Dependencies

No external dependencies.

## Type of change

Please delete options that are not relevant. Add a 'X' to the one that is applicable. 

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Tested locally on linux.

- [x] Command Line
- [ ] oneapi-cli
- [ ] Visual Studio
- [ ] Eclipse IDE
- [ ] VSCode
- [x] When compiling the compliler flag "-Wall -Wformat-security -Werror=format-security" was used
