### PR TITLE
Updates and revisions to the oneAPI samples involving oneMKL DFT domain

### DIFF
--- a/Libraries/oneMKL/computed_tomography/computed_tomography.cpp
+++ b/Libraries/oneMKL/computed_tomography/computed_tomography.cpp
@@ -288,8 +288,11 @@ sycl::event step3_ifft_2d(matrix_r &fhat,
                           const std::vector<sycl::event> &deps)
 {
     // Configure descriptor
-    std::int64_t strides[3] = {0, (fhat.ldw) / 2, 1}; // fhat.ldw/2, in complex'es
-    ifft2d.set_value(oneapi::mkl::dft::config_param::INPUT_STRIDES, strides);
+    std::vector<std::int64_t> strides = {0, (fhat.ldw) / 2, 1}; // fhat.ldw/2, in complex'es
+    // Strides must be identical in forward and backward domain for in-place
+    // complex transforms
+    ifft2d.set_value(oneapi::mkl::dft::config_param::FWD_STRIDES, strides);
+    ifft2d.set_value(oneapi::mkl::dft::config_param::BWD_STRIDES, strides);
     ifft2d.commit(main_queue);
 
     sycl::event ifft2d_ev = oneapi::mkl::dft::compute_backward(ifft2d, fhat.data, deps);

--- a/Libraries/oneMKL/fourier_correlation/fcorr_1d_buffers.cpp
+++ b/Libraries/oneMKL/fourier_correlation/fcorr_1d_buffers.cpp
@@ -6,97 +6,196 @@
 //
 //  Content:
 //     This code implements the 1D Fourier correlation algorithm
-//     using SYCL, oneMKL, oneDPL, and explicit buffering.
+//     using SYCL, oneMKL, and explicit buffering.
 //
 // =============================================================
 
-#include <oneapi/dpl/algorithm>
-#include <oneapi/dpl/execution>
-#include <oneapi/dpl/iterator>
-
+#include <mkl.h>
 #include <sycl/sycl.hpp>
-#include <oneapi/mkl/dfti.hpp>
+#include <iostream>
+#include <oneapi/mkl/dft.hpp>
 #include <oneapi/mkl/rng.hpp>
 #include <oneapi/mkl/vm.hpp>
-#include <mkl.h>
+#include <oneapi/mkl/blas.hpp>
 
-#include <iostream>
-#include <string>
+static void
+naive_cross_correlation(sycl::queue& Q,
+                        unsigned int N,
+                        sycl::buffer<float>& u,
+                        sycl::buffer<float>& v,
+                        sycl::buffer<float>& w) {
+  const size_t min_byte_size = N * sizeof(float);
+  if (u.byte_size() < min_byte_size ||
+      v.byte_size() < min_byte_size ||
+      w.byte_size() < min_byte_size) {
+    throw std::invalid_argument("All buffers must contain at least N float values");
+  }
+  Q.submit([&](sycl::handler &cgh) {
+    auto u_acc = u.get_access<sycl::access::mode::read>(cgh);
+    auto v_acc = v.get_access<sycl::access::mode::read>(cgh);
+    auto w_acc = w.get_access<sycl::access::mode::write>(cgh);
+    cgh.parallel_for(sycl::range<1>{N}, [=](sycl::id<1> id) {
+      const size_t s = id.get(0);
+      w_acc[s] = 0.0f;
+      for (size_t j = 0; j < N; j++) {
+        w_acc[s] += u_acc[j] * v_acc[(j - s + N) % N];
+      }
+    });
+  });
+}
 
 int main(int argc, char **argv) {
   unsigned int N = (argc == 1) ? 32 : std::stoi(argv[1]);
-  if ((N % 2) != 0) N++;
-  if (N < 32) N = 32;
+  // N >= 8 required for the arbitrary signals as defined herein
+  if (N < 8)
+    throw std::invalid_argument("The input value N must be 8 or greater.");
+
+  // Let s be an integer s.t. 0 <= s < N and let
+  //       corr[s] = \sum_{j = 0}^{N-1} sig1[j] sig2[(j - s + N) mod N]
+  // be the cross-correlation between two real periodic signals sig1 and sig2
+  // of period N. This code shows how to calculate corr using Discrete Fourier
+  // Transforms (DFTs).
+  // 0 (resp. 1) is returned if naive and DFT-based calculations are (resp.
+  // are not) within error tolerance of one another.
+  int return_code = 0;
 
   // Initialize SYCL queue
   sycl::queue Q(sycl::default_selector_v);
   std::cout << "Running on: "
-            << Q.get_device().get_info<sycl::info::device::name>() << "\n";
+            << Q.get_device().get_info<sycl::info::device::name>()
+            << std::endl;
+  // Initialize signal and correlation buffers. The buffers must be large enough
+  // to store the forward and backward domains' data, consisting of N real
+  // values and (N/2 + 1) complex values, respectively (for the DFT-based
+  // calculations).
+  sycl::buffer<float> sig1{2 * (N / 2 + 1)};
+  sycl::buffer<float> sig2{2 * (N / 2 + 1)};
+  sycl::buffer<float> corr{2 * (N / 2 + 1)};
+  // Buffer used for calculating corr without Discrete Fourier Transforms
+  // (for comparison purposes):
+  sycl::buffer<float> naive_corr{N};
 
-  // Create buffers for signal data. This will only be used on the device.
-  sycl::buffer<float> sig1_buf{N + 2};
-  sycl::buffer<float> sig2_buf{N + 2};
-  sycl::buffer<float> corr_buf{N + 2};
-
-  // Initialize the input signals with artificial data
+  // Initialize input signals with artificial "noise" data (random values of
+  // magnitude much smaller than relevant signal data points)
   std::uint32_t seed = (unsigned)time(NULL);  // Get RNG seed value
   oneapi::mkl::rng::mcg31m1 engine(Q, seed);  // Initialize RNG engine
                                               // Set RNG distribution
   oneapi::mkl::rng::uniform<float, oneapi::mkl::rng::uniform_method::standard>
-      rng_distribution(-0.00005, 0.00005);
+      rng_distribution(-0.00005f, 0.00005f);
 
-  oneapi::mkl::rng::generate(rng_distribution, engine, N, sig1_buf);  // Noise
-  oneapi::mkl::rng::generate(rng_distribution, engine, N, sig2_buf);
+  oneapi::mkl::rng::generate(rng_distribution, engine, N, sig1);
+  oneapi::mkl::rng::generate(rng_distribution, engine, N, sig2);
 
-  Q.submit([&](sycl::handler &h) {
-    sycl::accessor sig1_acc{sig1_buf, h, sycl::write_only};
-    sycl::accessor sig2_acc{sig2_buf, h, sycl::write_only};
-    h.single_task<>([=]() {
-      sig1_acc[N - N / 4 - 1] = 1.0;
-      sig1_acc[N - N / 4] = 1.0;
-      sig1_acc[N - N / 4 + 1] = 1.0;  // Signal
-      sig2_acc[N / 4 - 1] = 1.0;
-      sig2_acc[N / 4] = 1.0;
-      sig2_acc[N / 4 + 1] = 1.0;
+  // Set the (relevant) signal data as shifted versions of one another
+  Q.submit([&](sycl::handler &cgh) {
+    sycl::accessor sig1_acc{sig1, cgh, sycl::write_only};
+    sycl::accessor sig2_acc{sig2, cgh, sycl::write_only};
+    cgh.single_task<>([=]() {
+      sig1_acc[N - N / 4 - 1] = 1.0f;
+      sig1_acc[N - N / 4]     = 1.0f;
+      sig1_acc[N - N / 4 + 1] = 1.0f;
+      sig2_acc[N / 4 - 1]     = 1.0f;
+      sig2_acc[N / 4]         = 1.0f;
+      sig2_acc[N / 4 + 1]     = 1.0f;
     });
-  });  // End signal initialization
-
-  // Initialize FFT descriptor
+  });
+  // Calculate L2 norms of both input signals before proceeding (for
+  // normalization purposes and for the definition of error tolerance)
+  float norm_sig1, norm_sig2;
+  {
+    sycl::buffer<float> temp{1};
+    oneapi::mkl::blas::nrm2(Q, N, sig1, 1, temp);
+    norm_sig1 = temp.get_host_access(sycl::read_only)[0];
+    oneapi::mkl::blas::nrm2(Q, N, sig2, 1, temp);
+    norm_sig2 = temp.get_host_access(sycl::read_only)[0];
+  }
+  // 1) Calculate the cross-correlation naively (for verification purposes);
+  naive_cross_correlation(Q, N, sig1, sig2, naive_corr);
+  // 2) Calculate the cross-correlation via Discrete Fourier Transforms (DFTs):
+  //       corr = (1/N) * iDFT(DFT(sig1) * CONJ(DFT(sig2)))
+  // Initialize DFT descriptor
   oneapi::mkl::dft::descriptor<oneapi::mkl::dft::precision::SINGLE,
-                               oneapi::mkl::dft::domain::REAL>
-      transform_plan(N);
-  transform_plan.commit(Q);
+                               oneapi::mkl::dft::domain::REAL> desc(N);
+  desc.set_value(oneapi::mkl::dft::config_param::BACKWARD_SCALE, 1.0f / N);
+  desc.commit(Q);
+  // Compute in-place forward transforms of both signals:
+  // sig1 <- DFT(sig1)
+  oneapi::mkl::dft::compute_forward(desc, sig1);
+  // sig2 <- DFT(sig2)
+  oneapi::mkl::dft::compute_forward(desc, sig2);
+  // Compute the element-wise multipication of (complex) coefficients in
+  // backward domain:
+  // corr <- sig1 * CONJ(sig2) [component-wise]
+  auto sig1_cplx =
+      sig1.template reinterpret<std::complex<float>, 1>(N / 2 + 1);
+  auto sig2_cplx =
+      sig2.template reinterpret<std::complex<float>, 1>(N / 2 + 1);
+  auto corr_cplx =
+      corr.template reinterpret<std::complex<float>, 1>(N / 2 + 1);
+  oneapi::mkl::vm::mulbyconj(Q, N / 2 + 1,
+                             sig1_cplx, sig2_cplx, corr_cplx);
+  // Compute in-place (scaled) backward transform:
+  // corr <- (1/N) * iDFT(corr)
+  oneapi::mkl::dft::compute_backward(desc, corr);
 
-  // Perform forward transforms on real arrays
-  oneapi::mkl::dft::compute_forward(transform_plan, sig1_buf);
-  oneapi::mkl::dft::compute_forward(transform_plan, sig2_buf);
-
-  // Compute: DFT(sig1) * CONJG(DFT(sig2))
-  auto sig1_buf_cplx =
-      sig1_buf.template reinterpret<std::complex<float>, 1>((N + 2) / 2);
-  auto sig2_buf_cplx =
-      sig2_buf.template reinterpret<std::complex<float>, 1>((N + 2) / 2);
-  auto corr_buf_cplx =
-      corr_buf.template reinterpret<std::complex<float>, 1>((N + 2) / 2);
-  oneapi::mkl::vm::mulbyconj(Q, N / 2, sig1_buf_cplx, sig2_buf_cplx,
-                             corr_buf_cplx);
-
-  // Perform backward transform on complex correlation array
-  oneapi::mkl::dft::compute_backward(transform_plan, corr_buf);
-
-  // Find the shift that gives maximum correlation value
-  auto policy = oneapi::dpl::execution::make_device_policy(Q);
-  auto maxloc = oneapi::dpl::max_element(policy,
-                                         oneapi::dpl::begin(corr_buf),
-                                         oneapi::dpl::end(corr_buf));
-  int shift = oneapi::dpl::distance(oneapi::dpl::begin(corr_buf), maxloc);
-  float max_corr = corr_buf.get_host_access()[shift];
-
-  shift =
-      (shift > N / 2) ? shift - N : shift;  // Treat the signals as circularly
-                                            // shifted versions of each other.
-  std::cout << "Shift the second signal " << shift
-            << " elements relative to the first signal to get a maximum, "
-               "normalized correlation score of "
-            << max_corr / N << ".\n";
+  // Error bound for naive calculations:
+  float max_err_threshold =
+    2.0f * std::numeric_limits<float>::epsilon() * norm_sig1 * norm_sig2;
+  // Adding an (empirical) error bound for the DFT-based calculation defined as
+  //           epsilon * O(log(N)) * scaling_factor * nrm2(input data),
+  // wherein (for the last DFT at play)
+  // - scaling_factor = 1.0 / N;
+  // - nrm2(input data) = norm_sig1 * norm_sig2 * N
+  // - O(log(N)) ~ 2 * log(N) [arbitrary choice; implementation-dependent behavior]
+  max_err_threshold +=
+    2.0f * logf(N) * std::numeric_limits<float>::epsilon()
+         * norm_sig1 * norm_sig2;
+  // Verify results by comparing DFT-based and naive calculations to each other,
+  // and fetch optimal shift maximizing correlation (DFT-based calculation).
+  auto naive_corr_acc = naive_corr.get_host_access(sycl::read_only);
+  auto corr_acc = corr.get_host_access(sycl::read_only);
+  float max_err = 0.0f;
+  float max_corr = corr_acc[0];
+  int optimal_shift = 0;
+  for (size_t s = 0; s < N; s++) {
+    const float local_err = fabs(naive_corr_acc[s] - corr_acc[s]);
+    if (local_err > max_err)
+      max_err = local_err;
+    if (max_err > max_err_threshold) {
+      std::cerr << "An error was found when verifying the results." << std::endl;
+      std::cerr << "For shift value s = " << s << ":" << std::endl;
+      std::cerr << "\tNaive calculation results in " << naive_corr_acc[s] << std::endl;
+      std::cerr << "\tFourier-based calculation results in " << corr_acc[s] << std::endl;
+      std::cerr << "The error (" << max_err
+                << ") exceeds the threshold value of "
+                << max_err_threshold <<  std::endl;
+      return_code = 1;
+      break;
+    }
+    if (corr_acc[s] > max_corr) {
+      max_corr = corr_acc[s];
+      optimal_shift = s;
+    }
+  }
+  // Conclude:
+  if (return_code == 0) {
+    // Get average and standard deviation of either signal for normalizing the
+    // correlation "score"
+    const float avg_sig1 = sig1.get_host_access(sycl::read_only)[0] / N;
+    const float avg_sig2 = sig2.get_host_access(sycl::read_only)[0] / N;
+    const float std_dev_sig1 =
+          sqrt((norm_sig1 * norm_sig1 - N * avg_sig1 * avg_sig1) / N);
+    const float std_dev_sig2 =
+          sqrt((norm_sig2 * norm_sig2 - N * avg_sig2 * avg_sig2) / N);
+    const float normalized_corr =
+      (max_corr / N - avg_sig1 * avg_sig2) / (std_dev_sig1 * std_dev_sig2);
+    std::cout << "Right-shift the second signal " << optimal_shift
+              << " elements to get a maximum, normalized correlation score of "
+              << normalized_corr
+              << " (treating the signals as periodic)." << std::endl;
+    std::cout << "Max difference between naive and Fourier-based calculations : "
+              << max_err << " (verification threshold: " << max_err_threshold
+              << ")." << std::endl;
+  }
+  return return_code;
 }

--- a/Libraries/oneMKL/fourier_correlation/fcorr_1d_buffers.cpp
+++ b/Libraries/oneMKL/fourier_correlation/fcorr_1d_buffers.cpp
@@ -148,8 +148,8 @@ int main(int argc, char **argv) {
   // - nrm2(input data) = norm_sig1 * norm_sig2 * N
   // - O(log(N)) ~ 2 * log(N) [arbitrary choice; implementation-dependent behavior]
   max_err_threshold +=
-    2.0f * logf(N) * std::numeric_limits<float>::epsilon()
-         * norm_sig1 * norm_sig2;
+    2.0f * std::log(static_cast<float>(N))
+         * std::numeric_limits<float>::epsilon() * norm_sig1 * norm_sig2;
   // Verify results by comparing DFT-based and naive calculations to each other,
   // and fetch optimal shift maximizing correlation (DFT-based calculation).
   auto naive_corr_acc = naive_corr.get_host_access(sycl::read_only);
@@ -184,9 +184,9 @@ int main(int argc, char **argv) {
     const float avg_sig1 = sig1.get_host_access(sycl::read_only)[0] / N;
     const float avg_sig2 = sig2.get_host_access(sycl::read_only)[0] / N;
     const float std_dev_sig1 =
-          sqrt((norm_sig1 * norm_sig1 - N * avg_sig1 * avg_sig1) / N);
+          std::sqrt((norm_sig1 * norm_sig1 - N * avg_sig1 * avg_sig1) / N);
     const float std_dev_sig2 =
-          sqrt((norm_sig2 * norm_sig2 - N * avg_sig2 * avg_sig2) / N);
+          std::sqrt((norm_sig2 * norm_sig2 - N * avg_sig2 * avg_sig2) / N);
     const float normalized_corr =
       (max_corr / N - avg_sig1 * avg_sig2) / (std_dev_sig1 * std_dev_sig2);
     std::cout << "Right-shift the second signal " << optimal_shift

--- a/Libraries/oneMKL/fourier_correlation/fcorr_1d_buffers.cpp
+++ b/Libraries/oneMKL/fourier_correlation/fcorr_1d_buffers.cpp
@@ -164,7 +164,7 @@ int main(int argc, char **argv) {
   float max_corr = corr_acc[0];
   int optimal_shift = 0;
   for (size_t s = 0; s < N; s++) {
-    const float local_err = fabs(naive_corr_acc[s] - corr_acc[s]);
+    const float local_err = std::fabs(naive_corr_acc[s] - corr_acc[s]);
     if (local_err > max_err)
       max_err = local_err;
     if (max_err > max_err_threshold) {

--- a/Libraries/oneMKL/fourier_correlation/fcorr_1d_buffers.cpp
+++ b/Libraries/oneMKL/fourier_correlation/fcorr_1d_buffers.cpp
@@ -45,10 +45,11 @@ naive_cross_correlation(sycl::queue& Q,
 }
 
 int main(int argc, char **argv) {
-  unsigned int N = (argc == 1) ? 32 : std::stoi(argv[1]);
+  const unsigned int N = (argc > 1) ? std::stoi(argv[1]) : 32;
   // N >= 8 required for the arbitrary signals as defined herein
-  if (N < 8)
-    throw std::invalid_argument("The input value N must be 8 or greater.");
+  if (N < 8 || N > INT_MAX)
+    throw std::invalid_argument("The period of the signal, chosen as input of "
+                                "the program, must be 8 or greater.");
 
   // Let s be an integer s.t. 0 <= s < N and let
   //       corr[s] = \sum_{j = 0}^{N-1} sig1[j] sig2[(j - s + N) mod N]
@@ -67,12 +68,15 @@ int main(int argc, char **argv) {
   // Initialize signal and correlation buffers. The buffers must be large enough
   // to store the forward and backward domains' data, consisting of N real
   // values and (N/2 + 1) complex values, respectively (for the DFT-based
-  // calculations).
+  // calculations). Note: 2 * (N / 2 + 1) > N for all N > 0, since
+  //   2 * (N / 2 + 1) = N + 1 if N is odd
+  //   2 * (N / 2 + 1) = N + 2 if N is even
+  // so max(N, 2 * (N / 2 + 1)) == 2 * (N / 2 + 1)
   sycl::buffer<float> sig1{2 * (N / 2 + 1)};
   sycl::buffer<float> sig2{2 * (N / 2 + 1)};
   sycl::buffer<float> corr{2 * (N / 2 + 1)};
   // Buffer used for calculating corr without Discrete Fourier Transforms
-  // (for comparison purposes):
+  // for comparison purposes (calculations entirely done in forward domain):
   sycl::buffer<float> naive_corr{N};
 
   // Initialize input signals with artificial "noise" data (random values of
@@ -116,6 +120,8 @@ int main(int argc, char **argv) {
   // Initialize DFT descriptor
   oneapi::mkl::dft::descriptor<oneapi::mkl::dft::precision::SINGLE,
                                oneapi::mkl::dft::domain::REAL> desc(N);
+  // oneMKL DFT descriptors use unit scaling factors by default. Explicitly set
+  // the non-default scaling factor for the backward ("inverse") DFT:
   desc.set_value(oneapi::mkl::dft::config_param::BACKWARD_SCALE, 1.0f / N);
   desc.commit(Q);
   // Compute in-place forward transforms of both signals:

--- a/Libraries/oneMKL/fourier_correlation/fcorr_1d_usm.cpp
+++ b/Libraries/oneMKL/fourier_correlation/fcorr_1d_usm.cpp
@@ -142,8 +142,8 @@ int main(int argc, char** argv) {
   // - nrm2(input data) = norm_sig1[0] * norm_sig2[0] * N
   // - O(log(N)) ~ 2 * log(N) [arbitrary choice; implementation-dependent behavior]
   max_err_threshold +=
-    2.0f * logf(N) * std::numeric_limits<float>::epsilon()
-         * norm_sig1[0] * norm_sig2[0];
+    2.0f * std::log(static_cast<float>(N))
+         * std::numeric_limits<float>::epsilon() * norm_sig1[0] * norm_sig2[0];
   // Verify results by comparing DFT-based and naive calculations to each other,
   // and fetch optimal shift maximizing correlation (DFT-based calculation).
   float max_err = 0.0f;
@@ -176,9 +176,9 @@ int main(int argc, char** argv) {
     const float avg_sig1 = sig1[0] / N;
     const float avg_sig2 = sig2[0] / N;
     const float std_dev_sig1 =
-          sqrt((norm_sig1[0] * norm_sig1[0] - N * avg_sig1 * avg_sig1) / N);
+          std::sqrt((norm_sig1[0] * norm_sig1[0] - N * avg_sig1 * avg_sig1) / N);
     const float std_dev_sig2 =
-          sqrt((norm_sig2[0] * norm_sig2[0] - N * avg_sig2 * avg_sig2) / N);
+          std::sqrt((norm_sig2[0] * norm_sig2[0] - N * avg_sig2 * avg_sig2) / N);
     const float normalized_corr =
       (max_corr / N - avg_sig1 * avg_sig2) / (std_dev_sig1 * std_dev_sig2);
     std::cout << "Right-shift the second signal " << optimal_shift

--- a/Libraries/oneMKL/fourier_correlation/fcorr_1d_usm.cpp
+++ b/Libraries/oneMKL/fourier_correlation/fcorr_1d_usm.cpp
@@ -13,103 +13,189 @@
 #include <mkl.h>
 #include <sycl/sycl.hpp>
 #include <iostream>
-#include <string>
-#include <oneapi/mkl/dfti.hpp>
+#include <oneapi/mkl/dft.hpp>
 #include <oneapi/mkl/rng.hpp>
 #include <oneapi/mkl/vm.hpp>
+#include <oneapi/mkl/blas.hpp>
 
-template <typename T, typename I>
-using maxloc = sycl::ext::oneapi::maximum<std::pair<T, I>>;
+template <typename T>
+static bool is_device_accessible(const T* x, const sycl::queue& Q) {
+  sycl::usm::alloc alloc_type = sycl::get_pointer_type(x, Q.get_context());
+  return (alloc_type == sycl::usm::alloc::shared
+          || alloc_type == sycl::usm::alloc::device);
+}
 
-constexpr size_t L = 1;
+static sycl::event
+naive_cross_correlation(sycl::queue& Q,
+                        unsigned int N,
+                        const float* u,
+                        const float* v,
+                        float* w,
+                        const std::vector<sycl::event> deps = {}) {
+  // u, v and w must be USM allocations of (at least) N device-accessible float
+  // values (w must be writable)
+  if (!is_device_accessible(u, Q) ||
+      !is_device_accessible(v, Q) ||
+      !is_device_accessible(w, Q)) {
+    throw std::invalid_argument("Data arrays must be device-accessible");
+  }
+  auto ev = Q.parallel_for(sycl::range<1>{N}, deps, [=](sycl::id<1> item) {
+    size_t s = item.get(0);
+    w[s] = 0.0f;
+    for (size_t j = 0; j < N; j++) {
+      w[s] += u[j] * v[(j - s + N) % N];
+    }
+  });
+  return ev;
+}
 
 int main(int argc, char** argv) {
   unsigned int N = (argc == 1) ? 32 : std::stoi(argv[1]);
-  if ((N % 2) != 0) N++;
-  if (N < 32) N = 32;
+  // N >= 8 required for the arbitrary signals as defined herein
+  if (N < 8)
+    throw std::invalid_argument("The input value N must be 8 or greater.");
+
+  // Let s be an integer s.t. 0 <= s < N and let
+  //       corr[s] = \sum_{j = 0}^{N-1} sig1[j] sig2[(j - s + N) mod N]
+  // be the cross-correlation between two real periodic signals sig1 and sig2
+  // of period N. This code shows how to calculate corr using Discrete Fourier
+  // Transforms (DFTs).
+  // 0 (resp. 1) is returned if naive and DFT-based calculations are (resp.
+  // are not) within error tolerance of one another.
+  int return_code = 0;
 
   // Initialize SYCL queue
   sycl::queue Q(sycl::default_selector_v);
   std::cout << "Running on: "
-            << Q.get_device().get_info<sycl::info::device::name>() << "\n";
+            << Q.get_device().get_info<sycl::info::device::name>()
+            << std::endl;
+  // Initialize signal and correlation arrays. The arrays must be large enough
+  // to store the forward and backward domains' data, consisting of N real
+  // values and (N/2 + 1) complex values, respectively (for the DFT-based
+  // calculations).
+  auto sig1 = sycl::malloc_shared<float>(2 * (N / 2 + 1), Q);
+  auto sig2 = sycl::malloc_shared<float>(2 * (N / 2 + 1), Q);
+  auto corr = sycl::malloc_shared<float>(2 * (N / 2 + 1), Q);
+  // Array used for calculating corr without Discrete Fourier Transforms
+  // (for comparison purposes):
+  auto naive_corr = sycl::malloc_shared<float>(N, Q);
 
-  // Initialize signal and correlation arrays
-  auto sig1 = sycl::malloc_shared<float>(N + 2, Q);
-  auto sig2 = sycl::malloc_shared<float>(N + 2, Q);
-  auto corr = sycl::malloc_shared<float>(N + 2, Q);
-
-  // Initialize input signals with artificial data
+  // Initialize input signals with artificial "noise" data (random values of
+  // magnitude much smaller than relevant signal data points)
   std::uint32_t seed = (unsigned)time(NULL);  // Get RNG seed value
   oneapi::mkl::rng::mcg31m1 engine(Q, seed);  // Initialize RNG engine
                                               // Set RNG distribution
   oneapi::mkl::rng::uniform<float, oneapi::mkl::rng::uniform_method::standard>
-      rng_distribution(-0.00005, 0.00005);
+      rng_distribution(-0.00005f, 0.00005f);
 
-  auto evt1 =
-      oneapi::mkl::rng::generate(rng_distribution, engine, N, sig1);  // Noise
+  auto evt1 = oneapi::mkl::rng::generate(rng_distribution, engine, N, sig1);
   auto evt2 = oneapi::mkl::rng::generate(rng_distribution, engine, N, sig2);
-  evt1.wait();
-  evt2.wait();
 
-  Q.single_task<>([=]() {
-     sig1[N - N / 4 - 1] = 1.0;
-     sig1[N - N / 4] = 1.0;
-     sig1[N - N / 4 + 1] = 1.0;  // Signal
-     sig2[N / 4 - 1] = 1.0;
-     sig2[N / 4] = 1.0;
-     sig2[N / 4 + 1] = 1.0;
-   })
-      .wait();
-
-  // Initialize FFT descriptor
+  // Set the (relevant) signal data as shifted versions of one another
+  auto evt = Q.single_task<>({evt1, evt2}, [=]() {
+    sig1[N - N / 4 - 1] = 1.0f;
+    sig1[N - N / 4]     = 1.0f;
+    sig1[N - N / 4 + 1] = 1.0f;
+    sig2[N / 4 - 1]     = 1.0f;
+    sig2[N / 4]         = 1.0f;
+    sig2[N / 4 + 1]     = 1.0f;
+  });
+  // Calculate L2 norms of both input signals before proceeding (for
+  // normalization purposes and for the definition of error tolerance)
+  float *norm_sig1 = sycl::malloc_shared<float>(1, Q);
+  float *norm_sig2 = sycl::malloc_shared<float>(1, Q);
+  evt1 = oneapi::mkl::blas::nrm2(Q, N, sig1, 1, norm_sig1, {evt});
+  evt2 = oneapi::mkl::blas::nrm2(Q, N, sig2, 1, norm_sig2, {evt});
+  // 1) Calculate the cross-correlation naively (for verification purposes);
+  naive_cross_correlation(Q, N, sig1, sig2, naive_corr, {evt}).wait();
+  // 2) Calculate the cross-correlation via Discrete Fourier Transforms (DFTs):
+  //       corr = (1/N) * iDFT(DFT(sig1) * CONJ(DFT(sig2)))
+  // Initialize DFT descriptor
   oneapi::mkl::dft::descriptor<oneapi::mkl::dft::precision::SINGLE,
-                               oneapi::mkl::dft::domain::REAL>
-      transform_plan(N);
-  transform_plan.commit(Q);
+                               oneapi::mkl::dft::domain::REAL> desc(N);
+  desc.set_value(oneapi::mkl::dft::config_param::BACKWARD_SCALE, 1.0f / N);
+  desc.commit(Q);
+  // Compute in-place forward transforms of both signals:
+  // sig1 <- DFT(sig1)
+  evt1 = oneapi::mkl::dft::compute_forward(desc, sig1, {evt1});
+  // sig2 <- DFT(sig2)
+  evt2 = oneapi::mkl::dft::compute_forward(desc, sig2, {evt2});
+  // Compute the element-wise multipication of (complex) coefficients in
+  // backward domain:
+  // corr <- sig1 * CONJ(sig2) [component-wise]
+  evt = oneapi::mkl::vm::mulbyconj(
+          Q, N / 2 + 1,
+          reinterpret_cast<std::complex<float>*>(sig1),
+          reinterpret_cast<std::complex<float>*>(sig2),
+          reinterpret_cast<std::complex<float>*>(corr), {evt1, evt2});
+  // Compute in-place (scaled) backward transform:
+  // corr <- (1/N) * iDFT(corr)
+  oneapi::mkl::dft::compute_backward(desc, corr, {evt}).wait();
 
-  // Perform forward transforms on real arrays
-  evt1 = oneapi::mkl::dft::compute_forward(transform_plan, sig1);
-  evt2 = oneapi::mkl::dft::compute_forward(transform_plan, sig2);
-
-  // Compute: DFT(sig1) * CONJG(DFT(sig2))
-  oneapi::mkl::vm::mulbyconj(
-      Q, N / 2, reinterpret_cast<std::complex<float>*>(sig1),
-      reinterpret_cast<std::complex<float>*>(sig2),
-      reinterpret_cast<std::complex<float>*>(corr), {evt1, evt2})
-      .wait();
-
-  // Perform backward transform on complex correlation array
-  oneapi::mkl::dft::compute_backward(transform_plan, corr).wait();
-
-  // Find the shift that gives maximum correlation value using parallel maxloc
-  // reduction
-  std::pair<float, int>* max_res =
-       sycl::malloc_shared<std::pair<float, int>>(1, Q);
-  std::pair<float, int> max_identity = {std::numeric_limits<float>::min(),
-                                        std::numeric_limits<int>::min()};
-  *max_res = max_identity;
-  auto red_max = reduction(max_res, max_identity, maxloc<float, int>());
-
-  Q.parallel_for(sycl::nd_range<1>{N, L}, red_max,
-                 [=](sycl::nd_item<1> item, auto& max_res) {
-                    int i = item.get_global_id(0);
-		    std::pair<float, int> partial = {corr[i], i};
-                    max_res.combine(partial);
-   })
-      .wait();
-  float max_corr = max_res->first;
-  int shift = max_res->second;
-  shift =
-      (shift > N / 2) ? shift - N : shift;  // Treat the signals as circularly
-                                            // shifted versions of each other.
-  std::cout << "Shift the second signal " << shift
-            << " elements relative to the first signal to get a maximum, "
-               "normalized correlation score of "
-            << max_corr / N << ".\n";
+  // Error bound for naive calculations:
+  float max_err_threshold =
+    2.0f * std::numeric_limits<float>::epsilon() * norm_sig1[0] * norm_sig2[0];
+  // Adding an (empirical) error bound for the DFT-based calculation defined as
+  //           epsilon * O(log(N)) * scaling_factor * nrm2(input data),
+  // wherein (for the last DFT at play)
+  // - scaling_factor = 1.0 / N;
+  // - nrm2(input data) = norm_sig1[0] * norm_sig2[0] * N
+  // - O(log(N)) ~ 2 * log(N) [arbitrary choice; implementation-dependent behavior]
+  max_err_threshold +=
+    2.0f * logf(N) * std::numeric_limits<float>::epsilon()
+         * norm_sig1[0] * norm_sig2[0];
+  // Verify results by comparing DFT-based and naive calculations to each other,
+  // and fetch optimal shift maximizing correlation (DFT-based calculation).
+  float max_err = 0.0f;
+  float max_corr = corr[0];
+  int optimal_shift = 0;
+  for (size_t s = 0; s < N; s++) {
+    const float local_err = fabs(naive_corr[s] - corr[s]);
+    if (local_err > max_err)
+      max_err = local_err;
+    if (max_err > max_err_threshold) {
+      std::cerr << "An error was found when verifying the results." << std::endl;
+      std::cerr << "For shift value s = " << s << ":" << std::endl;
+      std::cerr << "\tNaive calculation results in " << naive_corr[s] << std::endl;
+      std::cerr << "\tFourier-based calculation results in " << corr[s] << std::endl;
+      std::cerr << "The error (" << max_err
+                << ") exceeds the threshold value of "
+                << max_err_threshold <<  std::endl;
+      return_code = 1;
+      break;
+    }
+    if (corr[s] > max_corr) {
+      max_corr = corr[s];
+      optimal_shift = s;
+    }
+  }
+  // Conclude:
+  if (return_code == 0) {
+    // Get average and standard deviation of either signal for normalizing the
+    // correlation "score"
+    const float avg_sig1 = sig1[0] / N;
+    const float avg_sig2 = sig2[0] / N;
+    const float std_dev_sig1 =
+          sqrt((norm_sig1[0] * norm_sig1[0] - N * avg_sig1 * avg_sig1) / N);
+    const float std_dev_sig2 =
+          sqrt((norm_sig2[0] * norm_sig2[0] - N * avg_sig2 * avg_sig2) / N);
+    const float normalized_corr =
+      (max_corr / N - avg_sig1 * avg_sig2) / (std_dev_sig1 * std_dev_sig2);
+    std::cout << "Right-shift the second signal " << optimal_shift
+              << " elements to get a maximum, normalized correlation score of "
+              << normalized_corr
+              << " (treating the signals as periodic)." << std::endl;
+    std::cout << "Max difference between naive and Fourier-based calculations : "
+              << max_err << " (verification threshold: " << max_err_threshold
+              << ")." << std::endl;
+  }
 
   // Cleanup
   sycl::free(sig1, Q);
   sycl::free(sig2, Q);
   sycl::free(corr, Q);
-  sycl::free(max_res, Q);
+  sycl::free(naive_corr, Q);
+  sycl::free(norm_sig1, Q);
+  sycl::free(norm_sig2, Q);
+  return return_code;
 }

--- a/Libraries/oneMKL/fourier_correlation/fcorr_1d_usm.cpp
+++ b/Libraries/oneMKL/fourier_correlation/fcorr_1d_usm.cpp
@@ -156,7 +156,7 @@ int main(int argc, char** argv) {
   float max_corr = corr[0];
   int optimal_shift = 0;
   for (size_t s = 0; s < N; s++) {
-    const float local_err = fabs(naive_corr[s] - corr[s]);
+    const float local_err = std::fabs(naive_corr[s] - corr[s]);
     if (local_err > max_err)
       max_err = local_err;
     if (max_err > max_err_threshold) {

--- a/Libraries/oneMKL/fourier_correlation/fcorr_2d_usm.cpp
+++ b/Libraries/oneMKL/fourier_correlation/fcorr_2d_usm.cpp
@@ -253,7 +253,7 @@ int main(int argc, char **argv) {
     for (size_t p = 0; p < n_cols && return_code == 0; p++) {
       const float naive_val = naive_corr[s * col_stride_fwd_domain + p];
       const float dft_val   = corr[s * col_stride_fwd_domain + p];
-      const float local_err = fabs(naive_val - dft_val);
+      const float local_err = std::fabs(naive_val - dft_val);
       if (local_err > max_err)
         max_err = local_err;
       if (max_err > max_err_threshold) {

--- a/Libraries/oneMKL/fourier_correlation/fcorr_2d_usm.cpp
+++ b/Libraries/oneMKL/fourier_correlation/fcorr_2d_usm.cpp
@@ -6,151 +6,291 @@
 //
 //  Content:
 //     This code implements the 2D Fourier correlation algorithm
-//     using SYCL, oneMKL, oneDPL, and unified shared memory
-//     (USM).
+//     using SYCL, oneMKL, and unified shared memory (USM).
 //
 // =============================================================
 
-#include <oneapi/dpl/algorithm>
-#include <oneapi/dpl/execution>
-#include <oneapi/dpl/iterator>
-
-#include <sycl/sycl.hpp>
-#include <oneapi/mkl/dfti.hpp>
-#include <oneapi/mkl/vm.hpp>
 #include <mkl.h>
-
+#include <sycl/sycl.hpp>
 #include <iostream>
+#include <oneapi/mkl/dft.hpp>
+#include <oneapi/mkl/vm.hpp>
 
-int main(int argc, char **argv)
-{
-    // Initialize SYCL queue
-    sycl::queue Q(sycl::default_selector_v);
-    std::cout << "Running on: "
-              << Q.get_device().get_info<sycl::info::device::name>()
+template <typename T>
+static bool is_device_accessible(const T* x, const sycl::queue& Q) {
+  sycl::usm::alloc alloc_type = sycl::get_pointer_type(x, Q.get_context());
+  return (alloc_type == sycl::usm::alloc::shared
+          || alloc_type == sycl::usm::alloc::device);
+}
+
+template <typename T>
+static bool is_host_accessible(const T* x, const sycl::queue& Q) {
+  sycl::usm::alloc alloc_type = sycl::get_pointer_type(x, Q.get_context());
+  return (alloc_type == sycl::usm::alloc::shared
+          || alloc_type == sycl::usm::alloc::host);
+}
+
+static void
+print_image(const float* img, const sycl::queue& Q,
+            const unsigned& n_rows, const unsigned& n_cols,
+            const unsigned& col_stride, const std::string& header) {
+  if (!is_host_accessible(img, Q)) {
+    throw std::invalid_argument("img must be host-accessible");
+  }
+  std::cout << header << std::endl;
+  // img must contain (at least)
+  // ((n_rows - 1) * col_stride + n_cols - 1) float values
+  for (auto row = 0; row < n_rows; row++) {
+    for (auto col = 0; col < n_cols; col++) {
+      std::cout << img[row * col_stride + col] << " ";
+    }
+    std::cout << std::endl;
+  }
+}
+
+static float
+calc_frobenius_norm(const float* img, sycl::queue& Q,
+                    const unsigned& n_rows, const unsigned& n_cols,
+                    const unsigned& col_stride) {
+  if (!is_device_accessible(img, Q)) {
+    throw std::invalid_argument("img must be device-accessible");
+  }
+  float* temp = sycl::malloc_shared<float>(1, Q);
+  temp[0] = 0.0f;
+  Q.submit([&](sycl::handler &cgh) {
+    auto sumReduction = sycl::reduction(temp, 0.0f, sycl::plus<float>());
+    cgh.parallel_for(sycl::range<2>{n_rows, n_cols},
+                     sumReduction,
+                     [=](sycl::id<2> idx, auto& sum) {
+      size_t row = idx[0];
+      size_t col = idx[1];
+      sum += img[row * col_stride + col] * img[row * col_stride + col];
+    });
+  }).wait();
+  const float frobenius_norm = sqrtf(temp[0]);
+  sycl::free(temp, Q);
+  return frobenius_norm;
+}
+
+static sycl::event
+naive_cross_correlation(sycl::queue& Q,
+                        const unsigned& n_rows,
+                        const unsigned& n_cols,
+                        const unsigned& col_stride,
+                        const float* u,
+                        const float* v,
+                        float* w,
+                        const std::vector<sycl::event> deps = {}) {
+  // u, v and w must be USM allocations of (at least)
+  // ((n_rows - 1) * col_stride + n_cols - 1) float values (w must be writable)
+  if (!is_device_accessible(u, Q) ||
+      !is_device_accessible(v, Q) ||
+      !is_device_accessible(w, Q)) {
+    throw std::invalid_argument("Image arrays must be device-accessible");
+  }
+  sycl::event ev = Q.parallel_for(sycl::range<2>{n_rows, n_cols},
+                                  [=](sycl::id<2> idx) {
+    const size_t s = idx[0];
+    const size_t p = idx[1];
+    const size_t w_idx = s * col_stride + p;
+    w[w_idx] = 0.0f;
+    for (size_t j = 0; j < n_rows; j++) {
+      for (size_t k = 0; k < n_cols; k++) {
+        w[w_idx] += u[j * col_stride + k] *
+                    v[((j - s + n_rows) % n_rows) * col_stride
+                        + ((k - p + n_cols) % n_cols)];
+      }
+    }
+  });
+  return ev;
+}
+
+int main(int argc, char **argv) {
+  int temp = (argc <= 1) ? 8 : std::stoi(argv[1]);
+  // n_rows >= 6 required for the arbitrary signals as defined herein
+  if (temp < 6)
+    throw std::invalid_argument("The first argument (n_rows) must be 6 or greater.");
+  const unsigned n_rows = temp;
+  temp = (argc <= 2) ? 8 : std::stoi(argv[2]);
+  // n_cols >= 7 required for the arbitrary signals as defined herein
+  if (temp < 7)
+    throw std::invalid_argument("The second argument (n_cols) must be 7 or greater.");
+  const unsigned n_cols = temp;
+  const unsigned num_elem = n_rows * n_cols;
+
+  // Let s and p be integer s.t. 0 <= s < n_rows, 0 <= p < n_cols, and let
+  // corr(s, p) =
+  //  \sum_{j = 0}^{n_rows - 1} \sum_{k = 0}^{n_cols - 1} \
+  //    img1(j, k) * img2((j - s + n_rows) mod n_rows, (k - p + n_cols) mod n_cols)
+  // be the cross-correlation between two real periodic signals img1 and img2
+  // of periods (n_rows, n_cols). This code shows how to calculate corr using
+  // Discrete Fourier Transforms (DFTs).
+  // Note: in the above, the notation "x(i, j)" represents the entry of
+  // multi-index (i, j) within a (real) data sequence "x". If the latter is
+  // stored in memory in an allocation "x_alloc" using a unit row stride and a
+  // column stride col_stride (col_stride >= n_cols), we have
+  //           x_alloc[i * col_stride + j] <- "x(i,j)"
+
+  // This program returns 0 (resp. 1) if naive and DFT-based calculations are
+  // (resp. are not) within error tolerance of one another.
+  int return_code = 0;
+  
+  // Initialize SYCL queue
+  sycl::queue Q(sycl::default_selector_v);
+  std::cout << "Running on: "
+            << Q.get_device().get_info<sycl::info::device::name>()
+            << std::endl;
+
+  // Initialize 2D image and correlation arrays. The arrays must be large enough
+  // to store the forward and backward domains' data, consisting of
+  // n_rows * n_cols real values and n_rows * (n_cols / 2 + 1) complex values,
+  // respectively (for the DFT-based calculations).
+  auto img1 = sycl::malloc_shared<float>(n_rows * (n_cols / 2 + 1) * 2, Q);
+  auto img2 = sycl::malloc_shared<float>(n_rows * (n_cols / 2 + 1) * 2, Q);
+  auto corr = sycl::malloc_shared<float>(n_rows * (n_cols / 2 + 1) * 2, Q);
+  // For in-place calculations, the address of the 0th element in every row must
+  // also be identical in forward and backward domains so we use
+  const unsigned col_stride_fwd_domain = 2 * (n_cols / 2 + 1);
+  // in forward (real) domain.
+  // Note: col_stride_fwd_domain / 2 is to be used in backward (complex)
+  // domain since complex values consist of 2 contiguous real values.
+
+  // Initialize array for calculating corr without Discrete Fourier Transforms
+  // (for comparison purposes). The same column stride as for DFT-based
+  // calculations is used to satisfy the requirements of naive_cross_correlation:
+  auto naive_corr = sycl::malloc_shared<float>(n_rows * (n_cols / 2 + 1) * 2, Q);
+
+  // Set the relevant image data as shifted versions of one another
+  auto evt = Q.parallel_for(sycl::range<2>{n_rows, n_cols},
+                           [=](sycl::id<2> idx) {
+    size_t row = idx[0];
+    size_t col = idx[1];
+    img1[row * col_stride_fwd_domain + col] = 0.0f;
+    img2[row * col_stride_fwd_domain + col] = 0.0f;
+  });
+  Q.single_task<>({evt}, [=]() {
+    // Set a box of unit elements in multi-indices (4-5, 5-6) for the first
+    // image
+    img1[4 * col_stride_fwd_domain + 5] = 1.0f;
+    img1[4 * col_stride_fwd_domain + 6] = 1.0f;
+    img1[5 * col_stride_fwd_domain + 5] = 1.0f;
+    img1[5 * col_stride_fwd_domain + 6] = 1.0f;
+    // Set a box of unit elements in multi-indices (1-2, 1-2) for the second
+    // image
+    img2[1 * col_stride_fwd_domain + 1] = 1.0f;
+    img2[1 * col_stride_fwd_domain + 2] = 1.0f;
+    img2[2 * col_stride_fwd_domain + 1] = 1.0f;
+    img2[2 * col_stride_fwd_domain + 2] = 1.0f;
+  }).wait();
+
+  print_image(img1, Q, n_rows, n_cols, col_stride_fwd_domain, "First image:");
+  print_image(img2, Q, n_rows, n_cols, col_stride_fwd_domain, "Second image:");
+  // Calculate Frobenius norms of both input images before proceeding (for
+  // normalization purposes and for the definition of error tolerance)
+  const float norm_img1 =
+          calc_frobenius_norm(img1, Q, n_rows, n_cols, col_stride_fwd_domain);
+  const float norm_img2 =
+          calc_frobenius_norm(img2, Q, n_rows, n_cols, col_stride_fwd_domain);
+  // 1) Calculate the cross-correlation naively (for verification purposes);
+  naive_cross_correlation(Q, n_rows, n_cols, col_stride_fwd_domain,
+                          img1, img2, naive_corr).wait();
+  // 2) Calculate the cross-correlation via Discrete Fourier Transforms (DFTs):
+  //         corr = (1/num_elem) * iDFT(DFT(sig1) * CONJ(DFT(sig2)))
+  // Initialize DFT descriptor
+  oneapi::mkl::dft::descriptor<oneapi::mkl::dft::precision::SINGLE,
+                               oneapi::mkl::dft::domain::REAL>
+    desc({n_rows, n_cols});
+  desc.set_value(oneapi::mkl::dft::config_param::BACKWARD_SCALE,
+                 1.0f / num_elem);
+  desc.commit(Q);
+  // --> desc operates in-place with the strides used herein by default.
+
+  // Compute in-place forward transforms of both signals:
+  // img1 <- DFT(img1)
+  auto evt1 = oneapi::mkl::dft::compute_forward(desc, img1);
+  // img2 <- DFT(img2)
+  auto evt2 = oneapi::mkl::dft::compute_forward(desc, img2);
+  // Compute the element-wise multipication of (complex) coefficients in
+  // backward domain:
+  // corr <- sig1 * CONJ(sig2) [component-wise]
+  evt = oneapi::mkl::vm::mulbyconj(
+          Q, n_rows * (n_cols / 2 + 1),
+          reinterpret_cast<std::complex<float>*>(img1),
+          reinterpret_cast<std::complex<float>*>(img2),
+          reinterpret_cast<std::complex<float>*>(corr),
+          {evt1, evt2});
+  // Compute in-place (scaled) backward transform:
+  // corr <- (1 / num_elem) * iDFT(corr)
+  oneapi::mkl::dft::compute_backward(desc, corr, {evt}).wait();
+
+  // Error bound for naive calculations:
+  float max_err_threshold =
+    2.0f * std::numeric_limits<float>::epsilon() * norm_img1 * norm_img2;
+  // Adding an (empirical) error bound for the DFT-based calculation defined as
+  //    epsilon * O(log(num_elem)) * scaling_factor * nrm2(input data),
+  // wherein (for the last DFT at play)
+  // - scaling_factor = 1.0 / num_elem;
+  // - nrm2(input data) = norm_sig1[0] * norm_sig2[0] * num_elem
+  // - O(log(num_elem)) ~ 2 * log(num_elem)
+  //   [arbitrary choice; implementation-dependent behavior]
+  max_err_threshold +=
+    2.0f * logf(num_elem) * std::numeric_limits<float>::epsilon()
+         * norm_img1 * norm_img2;
+  // Verify results by comparing DFT-based and naive calculations to each other,
+  // and fetch optimal shift maximizing correlation (DFT-based calculation).
+  float max_err = 0.0f;
+  float max_corr = corr[0];
+  std::pair<unsigned, unsigned> optimal_shift(0, 0);
+  for (size_t s = 0; s < n_rows && return_code == 0; s++) {
+    for (size_t p = 0; p < n_cols && return_code == 0; p++) {
+      const float naive_val = naive_corr[s * col_stride_fwd_domain + p];
+      const float dft_val   = corr[s * col_stride_fwd_domain + p];
+      const float local_err = fabs(naive_val - dft_val);
+      if (local_err > max_err)
+        max_err = local_err;
+      if (max_err > max_err_threshold) {
+        std::cerr << "An error was found when verifying the results." << std::endl;
+        std::cerr << "For shift value (s, p) = (" << s << ", " << p  << "):" << std::endl;
+        std::cerr << "\tNaive calculation results in " << naive_val << std::endl;
+        std::cerr << "\tFourier-based calculation results in " << dft_val << std::endl;
+        std::cerr << "The error (" << max_err
+                  << ") exceeds the threshold value of "
+                  << max_err_threshold <<  std::endl;
+        return_code = 1;
+      }
+      if (dft_val > max_corr) {
+        max_corr = dft_val;
+        optimal_shift.first   = s;
+        optimal_shift.second  = p;
+      }
+    }
+  }
+  // Conclude:
+  if (return_code == 0) {
+    // Get average and standard deviation of either signal for normalizing the
+    // correlation "score"
+    const float avg_sig1 = img1[0] / num_elem;
+    const float avg_sig2 = img2[0] / num_elem;
+    const float std_dev_sig1 =
+          sqrt((norm_img1 * norm_img1 - num_elem * avg_sig1 * avg_sig1) / num_elem);
+    const float std_dev_sig2 =
+          sqrt((norm_img2 * norm_img2 - num_elem * avg_sig2 * avg_sig2) / num_elem);
+    const float normalized_corr =
+      (max_corr / num_elem - avg_sig1 * avg_sig2) / (std_dev_sig1 * std_dev_sig2);
+    std::cout << "Shift the second signal by translation vector ("
+              << optimal_shift.first << ", " << optimal_shift.second
+              << ") to get a maximum, normalized correlation score of "
+              << normalized_corr
+              << " (treating the signals as periodic along both dimensions)."
               << std::endl;
-
-    // Allocate 2D image and correlation arrays
-    unsigned int n_rows = 8, n_cols = 8;
-    auto img1 = sycl::malloc_shared<float>(n_rows * n_cols * 2 + 2, Q);
-    auto img2 = sycl::malloc_shared<float>(n_rows * n_cols * 2 + 2, Q);
-    auto corr = sycl::malloc_shared<float>(n_rows * n_cols * 2 + 2, Q);
-
-    // Initialize input images with artificial data. Do initialization on the device.
-    // Generalized strides for row-major addressing
-    int r_stride = 1, c_stride = (n_cols / 2 + 1) * 2, c_stride_h = (n_cols / 2 + 1);
-    Q.parallel_for<>(sycl::range<2>{n_rows, n_cols}, [=](sycl::id<2> idx) {
-        unsigned int r = idx[0];
-        unsigned int c = idx[1];
-        img1[r * c_stride + c * r_stride] = 0.0;
-        img2[r * c_stride + c * r_stride] = 0.0;
-        corr[r * c_stride + c * r_stride] = 0.0;
-    }).wait();
-    Q.single_task<>([=]() {
-        // Set a box of elements in the lower right of the first image
-        img1[4 * c_stride + 5 * r_stride] = 1.0;
-        img1[4 * c_stride + 6 * r_stride] = 1.0;
-        img1[5 * c_stride + 5 * r_stride] = 1.0;
-        img1[5 * c_stride + 6 * r_stride] = 1.0;
-
-        // Set a box of elements in the upper left of the second image
-        img2[1 * c_stride + 1 * r_stride] = 1.0;
-        img2[1 * c_stride + 2 * r_stride] = 1.0;
-        img2[2 * c_stride + 1 * r_stride] = 1.0;
-        img2[2 * c_stride + 2 * r_stride] = 1.0;
-    }).wait();
-
-    std::cout << std::endl << "First image:" << std::endl;
-    for (unsigned int r = 0; r < n_rows; r++) {
-        for (unsigned int c = 0; c < n_cols; c++) {
-            std::cout << img1[r * c_stride + c * r_stride] << " ";
-        }
-        std::cout << std::endl;
-    }
-    std::cout << std::endl << "Second image:" << std::endl;
-    for (unsigned int r = 0; r < n_rows; r++) {
-        for (unsigned int c = 0; c < n_cols; c++) {
-            std::cout << img2[r * c_stride + c * r_stride] << " ";
-        }
-        std::cout << std::endl;
-    }
-
-    // Initialize FFT descriptor
-    oneapi::mkl::dft::descriptor<oneapi::mkl::dft::precision::SINGLE,
-                                 oneapi::mkl::dft::domain::REAL>
-        forward_plan({n_rows, n_cols});
-
-    // Data layout in real domain
-    std::int64_t real_layout[4] = {0, c_stride, 1};
-    forward_plan.set_value(oneapi::mkl::dft::config_param::INPUT_STRIDES,
-                           real_layout);
-
-    // Data layout in conjugate-even domain
-    std::int64_t complex_layout[4] = {0, c_stride_h, 1};
-    forward_plan.set_value(oneapi::mkl::dft::config_param::OUTPUT_STRIDES,
-                           complex_layout);
-
-    // Perform forward transforms on real arrays
-    forward_plan.commit(Q);
-    auto evt1 = oneapi::mkl::dft::compute_forward(forward_plan, img1);
-    auto evt2 = oneapi::mkl::dft::compute_forward(forward_plan, img2);
-
-    // Compute: DFT(img1) * CONJG(DFT(img2))
-    oneapi::mkl::vm::mulbyconj(Q, n_rows * c_stride_h,
-                               reinterpret_cast<std::complex<float>*>(img1),
-                               reinterpret_cast<std::complex<float>*>(img2),
-                               reinterpret_cast<std::complex<float>*>(corr),
-                               {evt1, evt2})
-                               .wait();
-
-    // Perform backward transform on complex correlation array
-    oneapi::mkl::dft::descriptor<oneapi::mkl::dft::precision::SINGLE,
-                                 oneapi::mkl::dft::domain::REAL>
-        backward_plan({n_rows, n_cols});
-
-    // Data layout in conjugate-even domain
-    backward_plan.set_value(oneapi::mkl::dft::config_param::INPUT_STRIDES,
-                            complex_layout);
-
-    // Data layout in real domain
-    backward_plan.set_value(oneapi::mkl::dft::config_param::OUTPUT_STRIDES,
-                            real_layout);
-
-    backward_plan.commit(Q);
-    auto bwd = oneapi::mkl::dft::compute_backward(backward_plan, corr);
-    bwd.wait();
-
-    std::cout << std::endl << "Normalized Fourier correlation result:"
-              << std::endl;
-    for (unsigned int r = 0; r < n_rows; r++) {
-        for (unsigned int c = 0; c < n_cols; c++) {
-            std::cout << corr[r * c_stride + c * r_stride] / (n_rows * n_cols)
-                      << " ";
-        }
-        std::cout << std::endl;
-    }
-
-    // Find the translation vector that gives maximum correlation value
-    auto policy = oneapi::dpl::execution::make_device_policy(Q);
-    auto maxloc = oneapi::dpl::max_element(policy,
-                                           corr,
-                                           corr + (n_rows * n_cols * 2 + 2));
-    policy.queue().wait();
-    auto s = oneapi::dpl::distance(corr, maxloc);
-    float max_corr = corr[s];
-    int x_shift = s % (n_cols + 2);
-    int y_shift = s / (n_rows + 2);
-
-    std::cout << std::endl << "Shift the second image (x, y) = (" << x_shift
-         << ", " << y_shift
-         << ") elements relative to the first image to get a maximum,"
-         << std::endl << "normalized correlation score of "
-         << max_corr / (n_rows * n_cols)
-         << ". Treat the images as circularly shifted versions of each other."
-         << std::endl;
-
-    // Cleanup
-    sycl::free(img1, Q);
-    sycl::free(img2, Q);
-    sycl::free(corr, Q);
+    std::cout << "Max difference between naive and Fourier-based calculations : "
+              << max_err << " (verification threshold: " << max_err_threshold
+              << ")." << std::endl;
+  }
+  // Cleanup
+  sycl::free(img1, Q);
+  sycl::free(img2, Q);
+  sycl::free(corr, Q);
+  sycl::free(naive_corr, Q);
+  return return_code;
 }

--- a/Libraries/oneMKL/fourier_correlation/fcorr_2d_usm.cpp
+++ b/Libraries/oneMKL/fourier_correlation/fcorr_2d_usm.cpp
@@ -148,7 +148,7 @@ int main(int argc, char **argv) {
   // n_rows * n_cols real values and n_rows * (n_cols / 2 + 1) complex values,
   // respectively (for the DFT-based calculations).
   // Note: 2 * (n_cols / 2 + 1) > n_cols for all n_cols > 0, so
-  //    max(n_rows * n_cols real,
+  //    max(n_rows * n_cols,
   //        n_rows * (n_cols / 2 + 1) * 2) == n_rows * (n_cols / 2 + 1) * 2
   // since n_rows > 0
   auto img1 = sycl::malloc_shared<float>(n_rows * (n_cols / 2 + 1) * 2, Q);

--- a/Libraries/oneMKL/fourier_correlation/fcorr_2d_usm.cpp
+++ b/Libraries/oneMKL/fourier_correlation/fcorr_2d_usm.cpp
@@ -67,7 +67,7 @@ calc_frobenius_norm(const float* img, sycl::queue& Q,
       sum += img[row * col_stride + col] * img[row * col_stride + col];
     });
   }).wait();
-  const float frobenius_norm = sqrtf(temp[0]);
+  const float frobenius_norm = std::sqrt(temp[0]);
   sycl::free(temp, Q);
   return frobenius_norm;
 }
@@ -234,8 +234,8 @@ int main(int argc, char **argv) {
   // - O(log(num_elem)) ~ 2 * log(num_elem)
   //   [arbitrary choice; implementation-dependent behavior]
   max_err_threshold +=
-    2.0f * logf(num_elem) * std::numeric_limits<float>::epsilon()
-         * norm_img1 * norm_img2;
+    2.0f * std::log(static_cast<float>(num_elem))
+         * std::numeric_limits<float>::epsilon() * norm_img1 * norm_img2;
   // Verify results by comparing DFT-based and naive calculations to each other,
   // and fetch optimal shift maximizing correlation (DFT-based calculation).
   float max_err = 0.0f;
@@ -272,9 +272,9 @@ int main(int argc, char **argv) {
     const float avg_sig1 = img1[0] / num_elem;
     const float avg_sig2 = img2[0] / num_elem;
     const float std_dev_sig1 =
-          sqrt((norm_img1 * norm_img1 - num_elem * avg_sig1 * avg_sig1) / num_elem);
+          std::sqrt((norm_img1 * norm_img1 - num_elem * avg_sig1 * avg_sig1) / num_elem);
     const float std_dev_sig2 =
-          sqrt((norm_img2 * norm_img2 - num_elem * avg_sig2 * avg_sig2) / num_elem);
+          std::sqrt((norm_img2 * norm_img2 - num_elem * avg_sig2 * avg_sig2) / num_elem);
     const float normalized_corr =
       (max_corr / num_elem - avg_sig1 * avg_sig2) / (std_dev_sig1 * std_dev_sig2);
     std::cout << "Shift the second signal by translation vector ("

--- a/Libraries/oneMKL/fourier_correlation/sample.json
+++ b/Libraries/oneMKL/fourier_correlation/sample.json
@@ -4,7 +4,7 @@
   "categories": ["Toolkit/oneAPI Libraries/oneMKL"],
   "description": "Compute Fourier correlation with oneAPI",
   "toolchain": [ "dpcpp" ],
-  "dependencies": [ "oneMKL", "oneDPL" ],
+  "dependencies": [ "oneMKL" ],
   "languages": [ { "cpp": { "properties": { "projectOptions": [ { "projectType": "makefile" } ] } } } ],
   "targetDevice": [ "CPU", "GPU" ],
   "os": [ "linux", "windows" ],


### PR DESCRIPTION
# Existing Sample Changes
## Description

This pull request
- updates `Libraries/oneMKL/computed_tomography/computed_tomography.cpp` according to the recommended usage for oneMKL DFT APIs, starting from oneMKL-2025.0;
- modifies the content of `Libraries/oneMKL/fourier_correlation`
    - updating it to the recommended usage for oneMKL DFT SYCL APIs, starting from oneMKL-2025.0;
    - revising, _correcting_ and generalizing the operations at play therein. The `README` file was updated accordingly and captures the essence of the changes suggested herein in more details.

No new dependency is introduced,

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

The samples were executed (as documented), on an Intel(R) Data Center GPU Max 1550 GPU machine. The typical output was updated in the `README` for the "Fourier correlation" samples.
