### PR TITLE
FPGA: Fix II error and update namespace for device_ptr

### DIFF
--- a/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/svd/src/svd.hpp
+++ b/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/svd/src/svd.hpp
@@ -129,7 +129,6 @@ double SingularValueDecomposition(
   PtrAnn v_matrix_device_ptr(v_matrix_device);
 #endif
 
-
   // Check that the malloc succeeded.
   if (nullptr == input_matrix_device) {
     std::cerr << "Error when allocating the input matrix." << std::endl;
@@ -163,8 +162,7 @@ double SingularValueDecomposition(
         [=]() [[intel::kernel_args_restrict]] {
           MatrixReadFromDDRTo2PipesByBlocks<
               T, cols, rows, kNumElementsPerDDRBurst, InputMatrixPipe, InputMatrixPipe2>(
-	      input_matrix_device,
-	      matrix_count, repetitions);
+	      input_matrix_device, matrix_count, repetitions);
         });
   });
 

--- a/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/svd/src/svd.hpp
+++ b/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/svd/src/svd.hpp
@@ -126,8 +126,9 @@ double SingularValueDecomposition(
 		  				      dwidth<512>})>;
   PtrAnn u_matrix_device_ptr(u_matrix_device);
   PtrAnn s_matrix_device_ptr(s_matrix_device);
-  PtrAnn v_matrix_device_ptr(s_matrix_device);
+  PtrAnn v_matrix_device_ptr(v_matrix_device);
 #endif
+
 
   // Check that the malloc succeeded.
   if (nullptr == input_matrix_device) {
@@ -162,7 +163,8 @@ double SingularValueDecomposition(
         [=]() [[intel::kernel_args_restrict]] {
           MatrixReadFromDDRTo2PipesByBlocks<
               T, cols, rows, kNumElementsPerDDRBurst, InputMatrixPipe, InputMatrixPipe2>(
-              input_matrix_device, matrix_count, repetitions);
+	      input_matrix_device,
+	      matrix_count, repetitions);
         });
   });
 


### PR DESCRIPTION
## Description

There was a functional change that went into the compiler recently that means it will now correctly identify memory dependences. One of the results of this is that this design will now emit a message that it is unable to achieve a user specified II. 

To regain this performance we can use annotated_ptr's in the SYCL HLS flow to specify a larger interface width which will allow for the compiler to coalesce stores to memory, thus resulting in being able to achieve the user specified II again.

This change also corrects the address space of a call to `device_ptr`

## External Dependencies

* N/A

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

* Manually ran the full-system and IPA flows through simulation.
