### PR TITLE
FPGA: Fix typo in SVD code sample

### DIFF
--- a/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/svd/src/svd.hpp
+++ b/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/svd/src/svd.hpp
@@ -126,7 +126,7 @@ double SingularValueDecomposition(
 		  				      dwidth<512>})>;
   PtrAnn u_matrix_device_ptr(u_matrix_device);
   PtrAnn s_matrix_device_ptr(s_matrix_device);
-  PtrAnn v_matrix_device_ptr(s_matrix_device);
+  PtrAnn v_matrix_device_ptr(v_matrix_device);
 #endif
 
   // Check that the malloc succeeded.


### PR DESCRIPTION
## Description

This PR fixes a typo that was introduced in a previous PR that was to address some compilation crashes. This typo was leading to functional incorrectness (i.e., failures).

## External Dependencies

* N/A

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [X] Command Line

* Manually ran this through full-system and SYCL-HLS flows in Emulation and in Simulation.

