### PR TITLE
Fix 2025.0 build errors and warnings

### DIFF
--- a/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/svd/src/svd.hpp
+++ b/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/svd/src/svd.hpp
@@ -17,6 +17,8 @@
 #include "memory_transfers.hpp"
 #include "usv_from_eigens.hpp"
 
+using namespace sycl::ext::intel::experimental;
+using namespace sycl::ext::oneapi::experimental;
 
 // Forward declare the kernel and pipe names
 // (This prevents unwanted name mangling in the optimization report.)
@@ -118,6 +120,15 @@ double SingularValueDecomposition(
     std::terminate();
   }
 
+#if not defined (IS_BSP)
+  constexpr int BL0 = 0;
+  using PtrAnn = annotated_ptr<T, decltype(properties{buffer_location<BL0>,
+		  				      dwidth<512>})>;
+  PtrAnn u_matrix_device_ptr(u_matrix_device);
+  PtrAnn s_matrix_device_ptr(s_matrix_device);
+  PtrAnn v_matrix_device_ptr(v_matrix_device);
+#endif
+
   // Check that the malloc succeeded.
   if (nullptr == input_matrix_device) {
     std::cerr << "Error when allocating the input matrix." << std::endl;
@@ -151,7 +162,7 @@ double SingularValueDecomposition(
         [=]() [[intel::kernel_args_restrict]] {
           MatrixReadFromDDRTo2PipesByBlocks<
               T, cols, rows, kNumElementsPerDDRBurst, InputMatrixPipe, InputMatrixPipe2>(
-              input_matrix_device, matrix_count, repetitions);
+	      input_matrix_device, matrix_count, repetitions);
         });
   });
 
@@ -207,21 +218,39 @@ double SingularValueDecomposition(
   sycl::event u_matrix_event = q.single_task<IDUMatrixFromLocalMemToDDR>(
       [=]() [[intel::kernel_args_restrict]] {
         MatrixReadPipeToDDR<T, rows, rows, kNumElementsPerDDRBurst,
-                            UMatrixPipe>(u_matrix_device, matrix_count, repetitions);
+                            UMatrixPipe>(
+#if defined (IS_BSP)
+		u_matrix_device,
+#else
+		u_matrix_device_ptr,
+#endif	
+		matrix_count, repetitions);
       });
 
   // collecting s matrix from pipe into DDR
   sycl::event s_matrix_event = q.single_task<IDSMatrixFromLocalMemToDDR>(
       [=]() [[intel::kernel_args_restrict]] {
         MatrixReadPipeToDDR<T, rows, cols, kNumElementsPerDDRBurst,
-                            SMatrixPipe>(s_matrix_device, matrix_count, repetitions);
+                            SMatrixPipe>(
+#if defined (IS_BSP)
+		s_matrix_device,
+#else
+		s_matrix_device_ptr,
+#endif
+	       	matrix_count, repetitions);
       });
 
   // collecting V matrix from pipe into DDR
   sycl::event v_matrix_event = q.single_task<IDVMatrixFromLocalMemToDDR>(
       [=]() [[intel::kernel_args_restrict]] {
         MatrixReadPipeToDDR<T, cols, cols, kNumElementsPerDDRBurst,
-                            VMatrixPipe>(v_matrix_device, matrix_count, repetitions);
+                            VMatrixPipe>(
+#if defined (IS_BSP)
+		v_matrix_device,
+#else
+		v_matrix_device_ptr,
+#endif
+	       	matrix_count, repetitions);
       });
 
   // Wait for output memory access kernels to finish

--- a/Publications/GPU-Opt-Guide/OpenMP/22_mkl_dispatch/CMakeLists.txt
+++ b/Publications/GPU-Opt-Guide/OpenMP/22_mkl_dispatch/CMakeLists.txt
@@ -1,6 +1,5 @@
 include_directories(common)
 
-add_example_with_mkl(dgemm_target_variant_dispatch_c)
 add_example_with_mkl(dgemm_dispatch_c)
 add_example_with_mkl(dgemm_example_01)
 add_example_with_mkl(dgemm_example_02)

--- a/Publications/GPU-Opt-Guide/sub-group/sg-max-size.cpp
+++ b/Publications/GPU-Opt-Guide/sub-group/sg-max-size.cpp
@@ -10,7 +10,7 @@
 #include <random>
 #include <vector>
 
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 
 constexpr int N = 7;
 

--- a/Publications/GPU-Opt-Guide/sub-group/sub-group-0.cpp
+++ b/Publications/GPU-Opt-Guide/sub-group/sub-group-0.cpp
@@ -3,8 +3,8 @@
 //
 // SPDX-License-Identifier: MIT
 // =============================================================
-#include <CL/sycl.hpp>
 #include <iostream>
+#include <sycl/sycl.hpp>
 
 int main() {
   sycl::queue q{sycl::gpu_selector_v};

--- a/Publications/GPU-Opt-Guide/sub-group/sub-group-1.cpp
+++ b/Publications/GPU-Opt-Guide/sub-group/sub-group-1.cpp
@@ -3,8 +3,8 @@
 //
 // SPDX-License-Identifier: MIT
 // =============================================================
-#include <CL/sycl.hpp>
 #include <iostream>
+#include <sycl/sycl.hpp>
 
 int main() {
   sycl::queue q{sycl::gpu_selector_v};

--- a/Publications/GPU-Opt-Guide/sub-group/sub-group-2.cpp
+++ b/Publications/GPU-Opt-Guide/sub-group/sub-group-2.cpp
@@ -3,8 +3,8 @@
 //
 // SPDX-License-Identifier: MIT
 // =============================================================
-#include <CL/sycl.hpp>
 #include <iostream>
+#include <sycl/sycl.hpp>
 
 int main() {
   sycl::queue q{sycl::gpu_selector_v,

--- a/Publications/GPU-Opt-Guide/sub-group/sub-group-3.cpp
+++ b/Publications/GPU-Opt-Guide/sub-group/sub-group-3.cpp
@@ -3,8 +3,8 @@
 //
 // SPDX-License-Identifier: MIT
 // =============================================================
-#include <CL/sycl.hpp>
 #include <iostream>
+#include <sycl/sycl.hpp>
 
 int main() {
   sycl::queue q{sycl::gpu_selector_v,

--- a/Publications/GPU-Opt-Guide/sub-group/sub-group-4.cpp
+++ b/Publications/GPU-Opt-Guide/sub-group/sub-group-4.cpp
@@ -3,8 +3,8 @@
 //
 // SPDX-License-Identifier: MIT
 // =============================================================
-#include <CL/sycl.hpp>
 #include <iostream>
+#include <sycl/sycl.hpp>
 
 int main() {
   sycl::queue q{sycl::gpu_selector_v,

--- a/Publications/GPU-Opt-Guide/sub-group/sub-group-5.cpp
+++ b/Publications/GPU-Opt-Guide/sub-group/sub-group-5.cpp
@@ -3,8 +3,8 @@
 //
 // SPDX-License-Identifier: MIT
 // =============================================================
-#include <CL/sycl.hpp>
 #include <iostream>
+#include <sycl/sycl.hpp>
 
 int main() {
   sycl::queue q{sycl::gpu_selector_v,

--- a/Publications/GPU-Opt-Guide/sub-group/sub-group-6.cpp
+++ b/Publications/GPU-Opt-Guide/sub-group/sub-group-6.cpp
@@ -3,19 +3,16 @@
 //
 // SPDX-License-Identifier: MIT
 // =============================================================
-#include <CL/sycl.hpp>
 #include <iostream>
+#include <sycl/sycl.hpp>
 
-template <typename T>
-auto get_multi_ptr(T *raw_ptr) {
+template <typename T> auto get_multi_ptr(T *raw_ptr) {
   auto multi_ptr =
-    sycl::address_space_cast<
-      sycl::access::address_space::global_space,
-      sycl::access::decorated::yes>(raw_ptr);
+      sycl::address_space_cast<sycl::access::address_space::global_space,
+                               sycl::access::decorated::yes>(raw_ptr);
 
   return multi_ptr;
 }
-
 
 int main() {
   sycl::queue q{sycl::gpu_selector_v,
@@ -30,21 +27,21 @@ int main() {
   memset(data2, 0xFF, sizeof(int) * N);
 
   auto e = q.submit([&](auto &h) {
-    h.parallel_for(
-        sycl::nd_range(sycl::range{N / 16}, sycl::range{32}),
-        [=](sycl::nd_item<1> it) [[intel::reqd_sub_group_size(16)]] {
-          auto sg = it.get_sub_group();
-          sycl::vec<int, 8> x;
+    h.parallel_for(sycl::nd_range(sycl::range{N / 16}, sycl::range{32}),
+                   [=](sycl::nd_item<1> it) [[intel::reqd_sub_group_size(16)]] {
+                     auto sg = it.get_sub_group();
+                     sycl::vec<int, 8> x;
 
-          int base = (it.get_group(0) * 32 +
-                      sg.get_group_id()[0] * sg.get_local_range()[0]) *
-                     16;
+                     int base =
+                         (it.get_group(0) * 32 +
+                          sg.get_group_id()[0] * sg.get_local_range()[0]) *
+                         16;
 
-          x = sg.load<8>(get_multi_ptr(&(data2[base + 0])));
-          sg.store<8>(get_multi_ptr(&(data[base + 0])), x);
-          x = sg.load<8>(get_multi_ptr(&(data2[base + 128])));
-          sg.store<8>(get_multi_ptr(&(data[base + 128])), x);
-        });
+                     x = sg.load<8>(get_multi_ptr(&(data2[base + 0])));
+                     sg.store<8>(get_multi_ptr(&(data[base + 0])), x);
+                     x = sg.load<8>(get_multi_ptr(&(data2[base + 128])));
+                     sg.store<8>(get_multi_ptr(&(data[base + 128])), x);
+                   });
   });
   // Snippet end
   q.wait();

--- a/Publications/GPU-Opt-Guide/sub-group/sub-group-7.cpp
+++ b/Publications/GPU-Opt-Guide/sub-group/sub-group-7.cpp
@@ -3,15 +3,13 @@
 //
 // SPDX-License-Identifier: MIT
 // =============================================================
-#include <CL/sycl.hpp>
 #include <iostream>
+#include <sycl/sycl.hpp>
 
-template <typename T>
-auto get_multi_ptr(T *raw_ptr) {
+template <typename T> auto get_multi_ptr(T *raw_ptr) {
   auto multi_ptr =
-    sycl::address_space_cast<
-      sycl::access::address_space::global_space,
-      sycl::access::decorated::yes>(raw_ptr);
+      sycl::address_space_cast<sycl::access::address_space::global_space,
+                               sycl::access::decorated::yes>(raw_ptr);
   return multi_ptr;
 }
 
@@ -28,41 +26,40 @@ int main() {
   memset(data2, 0, sizeof(int) * N);
 
   auto e = q.submit([&](auto &h) {
-    h.parallel_for(
-        sycl::nd_range(sycl::range{N / 16}, sycl::range{32}),
-        [=](sycl::nd_item<1> it) [[intel::reqd_sub_group_size(16)]] {
-          auto sg = it.get_sub_group();
-          sycl::vec<int, 4> x;
+    h.parallel_for(sycl::nd_range(sycl::range{N / 16}, sycl::range{32}),
+                   [=](sycl::nd_item<1> it) [[intel::reqd_sub_group_size(16)]] {
+                     auto sg = it.get_sub_group();
+                     sycl::vec<int, 4> x;
 
-          int base = (it.get_group(0) * 32 +
-                      sg.get_group_id()[0] * sg.get_local_range()[0]) *
-                     16;
+                     int base =
+                         (it.get_group(0) * 32 +
+                          sg.get_group_id()[0] * sg.get_local_range()[0]) *
+                         16;
 
-	  auto load_ptr0 = get_multi_ptr(&(data2[base + 0*64]));
-          x = sg.load<4>(load_ptr0);
+                     auto load_ptr0 = get_multi_ptr(&(data2[base + 0 * 64]));
+                     x = sg.load<4>(load_ptr0);
 
-	  auto store_ptr0 = get_multi_ptr(&(data[base + 0*64]));
-          sg.store<4>(store_ptr0, x);
+                     auto store_ptr0 = get_multi_ptr(&(data[base + 0 * 64]));
+                     sg.store<4>(store_ptr0, x);
 
-	  auto load_ptr1 = get_multi_ptr(&(data2[base + 1*64]));
-          x = sg.load<4>(load_ptr1);
+                     auto load_ptr1 = get_multi_ptr(&(data2[base + 1 * 64]));
+                     x = sg.load<4>(load_ptr1);
 
-	  auto store_ptr1 = get_multi_ptr(&(data[base + 1*64]));
-          sg.store<4>(store_ptr1, x);
+                     auto store_ptr1 = get_multi_ptr(&(data[base + 1 * 64]));
+                     sg.store<4>(store_ptr1, x);
 
-	  auto load_ptr2 = get_multi_ptr(&(data2[base + 2*64]));
-          x = sg.load<4>(load_ptr2);
+                     auto load_ptr2 = get_multi_ptr(&(data2[base + 2 * 64]));
+                     x = sg.load<4>(load_ptr2);
 
-	  auto store_ptr2 = get_multi_ptr(&(data[base + 2*64]));
-          sg.store<4>(store_ptr2, x);
+                     auto store_ptr2 = get_multi_ptr(&(data[base + 2 * 64]));
+                     sg.store<4>(store_ptr2, x);
 
-	  auto load_ptr3 = get_multi_ptr(&(data2[base + 3*64]));
-          x = sg.load<4>(load_ptr3);
+                     auto load_ptr3 = get_multi_ptr(&(data2[base + 3 * 64]));
+                     x = sg.load<4>(load_ptr3);
 
-	  auto store_ptr3 = get_multi_ptr(&(data[base + 3*64]));
-          sg.store<4>(store_ptr3, x);
-
-        });
+                     auto store_ptr3 = get_multi_ptr(&(data[base + 3 * 64]));
+                     sg.store<4>(store_ptr3, x);
+                   });
   });
   // Snippet end
   q.wait();

--- a/Publications/GPU-Opt-Guide/sub-group/sub-group-8.cpp
+++ b/Publications/GPU-Opt-Guide/sub-group/sub-group-8.cpp
@@ -3,8 +3,8 @@
 //
 // SPDX-License-Identifier: MIT
 // =============================================================
-#include <CL/sycl.hpp>
 #include <iostream>
+#include <sycl/sycl.hpp>
 
 int main() {
   sycl::queue q{sycl::gpu_selector_v,

--- a/Publications/GPU-Opt-Guide/sub-group/sub-group-sizes.cpp
+++ b/Publications/GPU-Opt-Guide/sub-group/sub-group-sizes.cpp
@@ -3,8 +3,8 @@
 //
 // SPDX-License-Identifier: MIT
 // =============================================================
-#include <CL/sycl.hpp>
 #include <iostream>
+#include <sycl/sycl.hpp>
 
 int main(void) {
   sycl::queue q{sycl::gpu_selector_v};

--- a/Publications/GPU-Opt-Guide/sub-group/transpose.cpp
+++ b/Publications/GPU-Opt-Guide/sub-group/transpose.cpp
@@ -7,7 +7,7 @@
 #include <iostream>
 #include <vector>
 
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 
 constexpr size_t N = 16;
 typedef unsigned int uint;
@@ -59,7 +59,7 @@ int main() {
             int aj = BLOCK_SIZE * gj;
 
             for (uint k = 0; k < BLOCK_SIZE; k++) {
-              bcol[k] = sg.load(marr.template get_multi_ptr<sycl::access::decorated::yes>() + (ai + k) * N + aj);
+              bcol[k] = sg.load(marr.get_pointer() + (ai + k) * N + aj);
             }
 
             uint tcol[BLOCK_SIZE];
@@ -72,7 +72,7 @@ int main() {
             }
 
             for (uint k = 0; k < BLOCK_SIZE; k++) {
-              sg.store(marr.template get_multi_ptr<sycl::access::decorated::yes>() + (ai + k) * N + aj, tcol[k]);
+              sg.store(marr.get_pointer() + (ai + k) * N + aj, tcol[k]);
             }
           });
     });

--- a/Publications/GPU-Opt-Guide/usm/usm-buffer.cpp
+++ b/Publications/GPU-Opt-Guide/usm/usm-buffer.cpp
@@ -5,7 +5,7 @@
 // =============================================================
 #include <iomanip>
 
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 
 #include "utils.hpp"
 

--- a/Publications/GPU-Opt-Guide/work-group-size/reduction-wg-size.cpp
+++ b/Publications/GPU-Opt-Guide/work-group-size/reduction-wg-size.cpp
@@ -3,10 +3,10 @@
 //
 // SPDX-License-Identifier: MIT
 // =============================================================
-#include <CL/sycl.hpp>
 #include <chrono>
 #include <iostream>
 #include <string>
+#include <sycl/sycl.hpp>
 #include <unistd.h>
 #include <vector>
 

--- a/Publications/GPU-Opt-Guide/work-group-size/vec-copy.cpp
+++ b/Publications/GPU-Opt-Guide/work-group-size/vec-copy.cpp
@@ -3,10 +3,10 @@
 //
 // SPDX-License-Identifier: MIT
 // =============================================================
-#include <CL/sycl.hpp>
 #include <chrono>
 #include <iostream>
 #include <string>
+#include <sycl/sycl.hpp>
 #include <unistd.h>
 #include <vector>
 

--- a/README.md
+++ b/README.md
@@ -82,24 +82,21 @@ The oneAPI-sample repository is organized by high-level categories.
 
 ## Platform Validation
 
-Samples in this release are validated on the following platforms.
-
 ### Ubuntu 22.04
-12th Gen Intel(R) Core(TM) i9-12900 \
-Intel(R) UHD Graphics 770 3.0 ; (gen12, AlderLake-S GT1 [8086:4680]) \
-Opencl driver: Intel(R) FPGA Emulation Platform for OpenCL(TM), Intel(R) FPGA Emulation Device OpenCL 1.2 [2024.17.3.0.08_160000] \
-Level Zero driver: Intel(R) Level-Zero, Intel(R) UHD Graphics 770 1.3 [1.3.28202] \
+Intel(R) Xeon(R) Platinum 8468V \
+Intel(R) Data Center GPU Max 1100 \
+OpenCL Driver: Intel(R) OpenCL, Intel(R) Xeon(R) Platinum 8468V OpenCL 3.0 (Build 0) [2024.18.7.0.11_160000] \
+Level Zero Driver: Intel(R) Level-Zero, Intel(R) Data Center GPU Max 1100 1.3 [1.3.28202] \
 oneAPI package version: \
-&dash; Intel oneAPI Base Toolkit Build Version: 2024.2.0.634 \
-&dash; Intel oneAPI HPC Toolkit Build Version: 2024.2.0.635 \
+&dash; Intel oneAPI HPC Toolkit Build Version: 2025.0.0.825 \
 
 ### Windows 11
-12th Gen Intel(R) Core(TM) i9-12900 Intel(R) UHD Graphics 770 3.0 ; (gen12, AlderLake-S GT1 [8086:4680]) \
-Opencl driver: Intel(R) FPGA Emulation Platform for OpenCL(TM), Intel(R) FPGA Emulation Device OpenCL 1.2 [2024.17.3.0.08_160000] \
-Level Zero driver: Intel(R) Level-Zero, Intel(R) UHD Graphics 770 1.3 [1.3.28597] \
+11th Gen Intel(R) Core(TM) i7-1185G7 @ 3.00GHz \
+Intel(R) Iris(R) Xe Graphics OpenCL 3.0 NEO \
+OpenCL Driver: Intel(R) OpenCL, 11th Gen Intel(R) Core(TM) i7-1185G7 @ 3.00GHz OpenCL 3.0 (Build 0) [2024.18.9.0.28_160000] \
+Level Zero Driver: Intel(R) oneAPI Unified Runtime over Level-Zero, Intel(R) Iris(R) Xe Graphics 12.0.0 [1.3.27193] \
 oneAPI package version: \
-&dash; Intel oneAPI Base Toolkit Build Version: 2024.2.0.635 \
-&dash; Intel oneAPI HPC Toolkit Build Version: 2024.2.0.633 \
+&dash; Intel oneAPI HPC Toolkit Build Version: 2025.0.0.822 \
 
 ## Known Issues and Limitations
 

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ Intel(R) Data Center GPU Max 1100 \
 OpenCL Driver: Intel(R) OpenCL, Intel(R) Xeon(R) Platinum 8468V OpenCL 3.0 (Build 0) [2024.18.7.0.11_160000] \
 Level Zero Driver: Intel(R) Level-Zero, Intel(R) Data Center GPU Max 1100 1.3 [1.3.28202] \
 oneAPI package version: \
-&dash; Intel oneAPI HPC Toolkit Build Version: 2025.0.0.825 \
+&dash; Intel oneAPI HPC Toolkit Build Version: 2025.0.0.825
 
 ### Windows 11
 11th Gen Intel(R) Core(TM) i7-1185G7 @ 3.00GHz \
@@ -96,7 +96,7 @@ Intel(R) Iris(R) Xe Graphics OpenCL 3.0 NEO \
 OpenCL Driver: Intel(R) OpenCL, 11th Gen Intel(R) Core(TM) i7-1185G7 @ 3.00GHz OpenCL 3.0 (Build 0) [2024.18.9.0.28_160000] \
 Level Zero Driver: Intel(R) oneAPI Unified Runtime over Level-Zero, Intel(R) Iris(R) Xe Graphics 12.0.0 [1.3.27193] \
 oneAPI package version: \
-&dash; Intel oneAPI HPC Toolkit Build Version: 2025.0.0.822 \
+&dash; Intel oneAPI HPC Toolkit Build Version: 2025.0.0.822
 
 ## Known Issues and Limitations
 


### PR DESCRIPTION
# Existing Sample Changes
## Description

Some features are deprecated in 2025.0 release and the deprecation causes build errors and warning in the GoG samples.

Fixes Issue# 

GoG samples build errors and warnings

## External Dependencies

None

## Type of change

Please delete options that are not relevant. Add a 'X' to the one that is applicable. 

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Implement fixes for ONSAM Jiras

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Command Line
- [ ] oneapi-cli
- [ ] Visual Studio
- [ ] Eclipse IDE
- [ ] VSCode
- [ ] When compiling the compliler flag "-Wall -Wformat-security -Werror=format-security" was used
