### PR TITLE
[FPGA] Add default fmax and high fmax for Agilex5

### DIFF
--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/scheduler_target_fmax/src/scheduler_target_fmax.cpp
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/scheduler_target_fmax/src/scheduler_target_fmax.cpp
@@ -28,11 +28,14 @@ constexpr int kDefaultFmax = 200;
 #elif defined(S10)
 constexpr int kHighFmax = 540;
 constexpr int kDefaultFmax = 480;
+#elif defined(Agilex5)
+constexpr int kHighFmax = 540;
+constexpr int kDefaultFmax = 480;
 #elif defined(Agilex7)
 constexpr int kHighFmax = 540;
 constexpr int kDefaultFmax = 480;
 #else
-  std::static_assert(false, "Invalid FPGA board macro");
+  static_assert(false, "Invalid FPGA board macro");
 #endif
 
 


### PR DESCRIPTION
# Existing Sample Changes
## Description

Add default fmax and high fmax for Agilex5 as a target. 

Fixes Issue# 

## Type of change

Please delete options that are not relevant. Add a 'X' to the one that is applicable. 

- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [X] Command Line