### PR TITLE
Update oneCCL Getting Started Jupyter Notebook

### DIFF
--- a/Libraries/oneCCL/tutorials/oneCCL_Getting_Started.ipynb
+++ b/Libraries/oneCCL/tutorials/oneCCL_Getting_Started.ipynb
@@ -78,7 +78,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!rm -rf lab;mkdir -p lab"
+    "!rm -rf lab; mkdir -p lab"
    ]
   },
   {
@@ -100,7 +100,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!cp $ONEAPI_INSTALL/ccl/latest/examples/cpu/cpu_allreduce_test.cpp lab/"
+    "!cp $ONEAPI_INSTALL/ccl/latest/share/doc/ccl/examples/cpu/cpu_allreduce_test.cpp lab/"
    ]
   },
   {
@@ -116,8 +116,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!cp $ONEAPI_INSTALL/ccl/latest/examples/cpu/CMakeLists.txt  lab/\n",
-    "!cp $ONEAPI_INSTALL/ccl/latest/examples/include/base.hpp lab/"
+    "!cp $ONEAPI_INSTALL/ccl/latest/share/doc/ccl/examples/cpu/CMakeLists.txt  lab/\n",
+    "!cp $ONEAPI_INSTALL/ccl/latest/share/doc/ccl/examples/include/base.hpp lab/"
    ]
   },
   {
@@ -204,7 +204,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!rm -rf cpu_gomp; chmod 755 q; chmod 755 build.sh; chmod 755 run.sh;if [ -x \"$(command -v qsub)\" ]; then ./q build.sh; ./q run.sh; else ./build.sh; ./run.sh; fi"
+    "!rm -rf cpu_gomp; chmod 755 build.sh; chmod 755 run.sh; ./build.sh; ./run.sh;"
    ]
   },
   {
@@ -258,7 +258,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "! chmod 755 vtune_collect.sh; if [ -x \"$(command -v qsub)\" ]; then ./q vtune_collect.sh; else ./vtune_collect.sh; fi"
+    "! chmod 755 vtune_collect.sh; ./vtune_collect.sh;"
    ]
   },
   {
@@ -329,7 +329,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "! chmod 755 vtune_collect.sh; if [ -x \"$(command -v qsub)\" ]; then ./q vtune_collect.sh; else ./vtune_collect.sh; fi"
+    "! chmod 755 vtune_collect.sh; ./vtune_collect.sh;"
    ]
   },
   {
@@ -408,9 +408,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!cp $ONEAPI_INSTALL/ccl/latest/examples/sycl/CMakeLists.txt  lab/\n",
-    "!cp $ONEAPI_INSTALL/ccl/latest/examples/include/sycl_base.hpp lab/\n",
-    "!cp $ONEAPI_INSTALL/ccl/latest/examples/include/base_utils.hpp lab/"
+    "!cp $ONEAPI_INSTALL/ccl/latest/share/doc/ccl/examples/sycl/CMakeLists.txt  lab/\n",
+    "!cp $ONEAPI_INSTALL/ccl/latest/share/doc/ccl/examples/include/sycl_base.hpp lab/\n",
+    "!cp $ONEAPI_INSTALL/ccl/latest/share/doc/ccl/examples/include/base_utils.hpp lab/"
    ]
   },
   {
@@ -426,7 +426,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!cp $ONEAPI_INSTALL/ccl/latest/examples/sycl/sycl_allreduce_test.cpp lab/"
+    "!cp $ONEAPI_INSTALL/ccl/latest/share/doc/ccl/examples/sycl/sycl_allreduce_test.cpp lab/"
    ]
   },
   {
@@ -627,7 +627,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!rm -rf dpcpp; chmod 755 q; chmod 755 build.sh; chmod 755 run.sh;if [ -x \"$(command -v qsub)\" ]; then ./q build.sh; ./q run.sh; else ./build.sh; ./run.sh; fi"
+    "!rm -rf dpcpp; chmod 755 build.sh; chmod 755 run.sh; ./build.sh; ./run.sh;"
    ]
   },
   {
@@ -681,7 +681,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "! chmod 755 vtune_collect.sh; if [ -x \"$(command -v qsub)\" ]; then ./q vtune_collect.sh; else ./vtune_collect.sh; fi"
+    "! chmod 755 vtune_collect.sh; ./vtune_collect.sh;"
    ]
   },
   {
@@ -746,7 +746,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "! chmod 755 vtune_collect.sh; if [ -x \"$(command -v qsub)\" ]; then ./q vtune_collect.sh; else ./vtune_collect.sh; fi"
+    "! chmod 755 vtune_collect.sh; ./vtune_collect.sh;"
    ]
   },
   {

--- a/Libraries/oneCCL/tutorials/oneCCL_Getting_Started.ipynb
+++ b/Libraries/oneCCL/tutorials/oneCCL_Getting_Started.ipynb
@@ -9,7 +9,7 @@
     "## Learning Objectives\n",
     "In this module, the developer will:\n",
     "* Learn different oneCCL configurations inside the Intel® oneAPI toolkit\n",
-    "* Learn how to compile a oneCCL sample with different configurations via batch jobs on the Intel® DevCloud for oneAPI or in local environments\n",
+    "* Learn how to compile a oneCCL sample with different configurations in local environment\n",
     "* Learn how to program oneCCL with a simple sample\n",
     "* Learn how to port a oneCCL sample from CPU-only version to CPU&GPU version by using DPC++\n",
     "* Learn how to collect VTune™ Amplifier data for CPU and GPU runs\n",
@@ -164,10 +164,10 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Once you achieve an all-clear from your compilation, you execute your program on the Intel DevCloud or in local environments.\n",
+    "Once you achieve an all-clear from your compilation, you execute your program in your local environment.\n",
     "\n",
     "#### Script - run.sh\n",
-    "the script **run.sh** encapsulates the program for submission to the job queue for execution.\n",
+    "The script **run.sh** encapsulates the program for execution.\n",
     "The user must switch to the g++ oneCCL configuration by inputting a custom configuration \"--ccl-configuration=cpu\" when running \"source setvars.sh\".\n"
    ]
   },
@@ -190,12 +190,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "\n",
-    "#### Submitting **build.sh** and **run.sh** to the job queue\n",
-    "Now we can submit the **build.sh** and **run.sh** to the job queue.\n",
-    "\n",
-    "##### NOTE - it is possible to execute any of the build and run commands in local environments.\n",
-    "To enable users to run their scripts both on the DevCloud or in local environments, this and subsequent training checks for the existence of the job submission command **qsub**.  If the check fails, it is assumed that build/run will be local."
+    "#### Run build.sh and run.sh"
    ]
   },
   {
@@ -589,10 +584,10 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Once you achieve an all-clear from your compilation, execute your program on the DevCloud or in local environments.\n",
+    "Once you achieve an all-clear from your compilation, execute your program in your local environment.\n",
     "\n",
     "#### Script - run.sh\n",
-    "The script **run.sh** encapsulates the program for submission to the job queue for execution.\n"
+    "The script **run.sh** encapsulates the program for execution.\n"
    ]
   },
   {
@@ -614,11 +609,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "#### Submitting **build.sh** and **run.sh** to the job queue\n",
-    "Now we can submit the **build.sh** and **run.sh** to the job queue.\n",
-    "\n",
-    "##### NOTE - it is possible to execute any of the build and run commands in local environments.\n",
-    "To enable users to run their scripts both on the Intel DevCloud or in local environments, this and subsequent training checks for the existence of the job submission command **qsub**.  If the check fails it is assumed that build/run will be local."
+    "#### Run build.sh and run.sh"
    ]
   },
   {
@@ -803,7 +794,7 @@
     "# Summary\n",
     "In this lab the developer will have learned the following:\n",
     "* Know different oneCCL configurations inside oneAPI toolkit\n",
-    "* Know how to compile a oneCCL sample with different configurations via batch jobs on the Intel oneAPI DevCloud or in local environments\n",
+    "* Know how to compile a oneCCL sample with different configurations in local environment\n",
     "* Know how to program oneCCL with a simple sample\n",
     "* Know how to port a oneCCL sample from CPU-only version to CPU&GPU version by using DPC++\n",
     "* Know how to collect VTune Amplifier data for CPU and GPU runs"


### PR DESCRIPTION
# Existing Sample Changes
## Description

This change updates the path to copy oneCCL source code and removes mention of DevCloud and qsub.

Fixes Issue# ONSAM-1998 and ONSAM-2044

## External Dependencies

None.

## Type of change

Please delete options that are not relevant. Add a 'X' to the one that is applicable. 

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] Implement fixes for ONSAM Jiras

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [X] Command Line
- [ ] oneapi-cli
- [ ] Visual Studio
- [ ] Eclipse IDE
- [ ] VSCode
- [ ] When compiling the compliler flag "-Wall -Wformat-security -Werror=format-security" was used