### PR TITLE
FPGA: Update the `gzip` code sample to use LSU builtins

### DIFF
--- a/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/gzip/CMakeLists.txt
+++ b/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/gzip/CMakeLists.txt
@@ -135,7 +135,7 @@ message(STATUS "NUM_REORDER=${NUM_REORDER}")
 
 # Use cmake -DUSER_FPGA_FLAGS=<flags> to set extra flags for FPGA backend
 # compilation. 
-set(USER_FPGA_FLAGS ${USER_FPGA_FLAGS};${SEED};-Xsopt-arg=\"-nocaching\";${NUM_REORDER})
+set(USER_FPGA_FLAGS ${USER_FPGA_FLAGS};${SEED};${NUM_REORDER})
 
 # Use cmake -DUSER_FLAGS=<flags> to set extra flags for general compilation.
 set(USER_FLAGS ${USER_FLAGS};-DNUM_ENGINES=${NUM_ENGINES})


### PR DESCRIPTION
The sample was relying on undocumented compiler flags.
This change updated the sample to instead use the documented LSU builtins to achieve the same goal.