### PR TITLE
[oneMKL] Corrected the flag for the OpenCL library on Windows

### DIFF
--- a/Libraries/oneMKL/monte_carlo_european_opt/makefile
+++ b/Libraries/oneMKL/monte_carlo_european_opt/makefile
@@ -12,7 +12,7 @@ all: montecarlo
         INIT_ON_HOST=/DINIT_ON_HOST=1
 !endif
 
-DPCPP_OPTS=/I"$(MKLROOT)\include" /DMKL_ILP64 $(GENERATOR) /EHsc -fsycl $(INIT_ON_HOST) /Qmkl /Qmkl-sycl-impl=rng -lOpenCL
+DPCPP_OPTS=/I"$(MKLROOT)\include" /DMKL_ILP64 $(GENERATOR) /EHsc -fsycl $(INIT_ON_HOST) /Qmkl /Qmkl-sycl-impl=rng OpenCL.lib
 
 montecarlo: src/montecarlo_main.cpp
 	icx src/montecarlo_main.cpp /omontecarlo.exe $(DPCPP_OPTS)


### PR DESCRIPTION
# Existing Sample Changes

Corrected the flag for the OpenCL library on Windows since it leads to the warning: `unknown argument ignored in clang-cl: -lOpenCL [-Wunknown-argument]`.

## Type of change

Please delete options that are not relevant. Add a 'X' to the one that is applicable. 

- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [X] Command Line
- [ ] oneapi-cli
- [ ] Visual Studio
- [ ] Eclipse IDE
- [ ] VSCode
- [ ] When compiling the compliler flag "-Wall -Wformat-security -Werror=format-security" was used
