### PR TITLE
[oneMKL] Changes for README files regarding SYCL device setting

### DIFF
--- a/Libraries/oneMKL/binomial/README.md
+++ b/Libraries/oneMKL/binomial/README.md
@@ -25,7 +25,8 @@ The sample first generates a portfolio within given constraints using a uniform
 distribution and a Philox-type generator provided by the oneMKL RNG API.
 
 This sample performs its computations on the default SYCL* device. You can set
-the `SYCL_DEVICE_FILTER` environment variable to `cpu` or `gpu` to select the device to use.
+the `ONEAPI_DEVICE_SELECTOR` environment variable to `"*:cpu"` or `"*:gpu"`
+to select the device to use.
 
 ## Key Implementation Details
 

--- a/Libraries/oneMKL/black_scholes/README.md
+++ b/Libraries/oneMKL/black_scholes/README.md
@@ -26,7 +26,8 @@ The sample first generates a portfolio within given constraints using a uniform
 distribution and a Philox-type generator provided by the oneMKL RNG API.
 
 This sample performs its computations on the default SYCL* device. You can set
-the `SYCL_DEVICE_FILTER` environment variable to `cpu` or `gpu` to select the device to use.
+the `ONEAPI_DEVICE_SELECTOR` environment variable to `"*:cpu"` or `"*:gpu"`
+to select the device to use.
 
 This article explains in detail how oneMKL functions speed up Black-Scholes
 computation of European options pricing:

--- a/Libraries/oneMKL/matrix_mul_mkl/README.md
+++ b/Libraries/oneMKL/matrix_mul_mkl/README.md
@@ -16,7 +16,9 @@ For more information on oneMKL and complete documentation of all oneMKL routines
 
 Matrix Multiplication uses oneMKL to multiply two large matrices and measure device performance.
 
-This sample performs its computations on the default SYCL* device. You can set the `SYCL_DEVICE_FILTER` environment variable to `cpu` or `gpu` to select the device to use.
+This sample performs its computations on the default SYCL* device. You can set
+the `ONEAPI_DEVICE_SELECTOR` environment variable to `"*:cpu"` or `"*:gpu"`
+to select the device to use.
 
 ## Key Implementation Details
 


### PR DESCRIPTION
# Existing Sample Changes

`SYCL_DEVICE_FILTER` has been changed to `ONEAPI_DEVICE_SELECTOR`. Let's make changes for readme files to let users know about changes in environmental variables.