### PR TITLE
[oneMKL samples][computed tomography] Revisions, refactoring and addition of a functional verification

### DIFF
--- a/Libraries/oneMKL/computed_tomography/GNUmakefile
+++ b/Libraries/oneMKL/computed_tomography/GNUmakefile
@@ -7,7 +7,7 @@ all: run
 run: computed_tomography
 	./computed_tomography
 
-MKL_COPTS = -DMKL_ILP64  -qmkl -qmkl-sycl-impl=dft
+MKL_COPTS = -qmkl -qmkl-sycl-impl=dft
 
 DPCPP_OPTS = $(MKL_COPTS) -fsycl-device-code-split=per_kernel
 

--- a/Libraries/oneMKL/computed_tomography/GNUmakefile
+++ b/Libraries/oneMKL/computed_tomography/GNUmakefile
@@ -5,7 +5,7 @@ default: run
 all: run
 
 run: computed_tomography
-	./computed_tomography 400 400 input.bmp radon.bmp restored.bmp
+	./computed_tomography
 
 MKL_COPTS = -DMKL_ILP64  -qmkl -qmkl-sycl-impl=dft
 

--- a/Libraries/oneMKL/computed_tomography/GNUmakefile
+++ b/Libraries/oneMKL/computed_tomography/GNUmakefile
@@ -15,6 +15,6 @@ computed_tomography: computed_tomography.cpp
 	icpx $< -fsycl -o $@ $(DPCPP_OPTS)
 
 clean:
-	-rm -f computed_tomography radon.bmp restored.bmp
+	-rm -f computed_tomography radon.bmp restored.bmp errors.bmp
 
 .PHONY: clean run all

--- a/Libraries/oneMKL/computed_tomography/README.md
+++ b/Libraries/oneMKL/computed_tomography/README.md
@@ -16,15 +16,13 @@ For more information on oneMKL and complete documentation of all oneMKL routines
 
 Computed Tomography uses oneMKL discrete Fourier transform (DFT) routines to transform simulated raw CT data (as collected by a CT scanner) into a reconstructed image of the scanned object.
 
-In computed tomography, the raw imaging data is a set of line integrals over the actual object, also known as its _Radon transform_. From this data, the original image must be recovered by approximately inverting the Radon transform. This sample uses the filtered back projection method for inverting the Radon transform, which involves a 1D DFT, followed by filtering, then an inverse 2D DFT to perform the final reconstruction.
+In computed tomography, the raw imaging data is a set of line integrals over the actual object, also known as its _Radon transform_. From this data, the original image must be recovered by approximately inverting the Radon transform. This sample uses Fourier reconstruction for inverting the Radon transform of a user-provided input image: using batched 1D real DFT of Radon transform data points, samples of the input image's Fourier spectrum may be estimated on a polar grid; after interpolating the latter onto a Cartesian grid, an inverse 2D real DFT produces a fair reproduction of the original image.
 
-This sample performs its computations on the default SYCL* device. You can set the `SYCL_DEVICE_TYPE` environment variable to `cpu` or `gpu` to select the device to use.
-
-This article explains in detail how oneMKL fast Fourier transform (FFT) functions can be used to reconstruct the original image from the Computer Tomography (CT) data: https://www.intel.com/content/www/us/en/docs/onemkl/cookbook/current/ffts-for-computer-tomography-image-reconstruction.html.
+This sample performs its computations on the default SYCL device. You can set the `ONEAPI_DEVICE_SELECTOR` environment variable to `*:cpu` or `*:gpu` to select the device to use.
 
 ## Key Implementation Details
 
-To use oneMKL DFT routines, the sample creates a descriptor object for the given precision and domain (real-to-complex or complex-to-complex), calls the `commit` method, and provides a `sycl::queue` object to define the device and context. The `compute_*` routines are then called to perform the actual computation with the appropriate descriptor object and input/output buffers.
+To use oneMKL DFT routines, the sample creates double-precision real DFT descriptor objects, calls the `commit` member function with a `sycl::queue` object to define the device and context. The `compute_*` routines are then called to perform the actual computation with the appropriate descriptor object and input data.
 
 ## Using Visual Studio Code* (Optional)
 You can use Visual Studio Code (VS Code) extensions to set your environment, create launch configurations,
@@ -70,18 +68,18 @@ Run `nmake` to build and run the sample. `nmake clean` removes temporary files.
 ## Running the Computed Tomography Reconstruction Sample
 
 ### Example of Output
-If everything is working correctly, the example program will start with the 400x400 example image `input.bmp` then create simulated CT data from it (stored as `restored.bmp`). It will then reconstruct the original image in grayscale and store it as `restored.bmp`.
+If everything is working correctly, the example program will start with the 400x400 example image `input.bmp` then create simulated CT data from it (stored as `radon.bmp`). It will then reconstruct the original image in grayscale and store it as `restored.bmp`.
 
 ```
-./computed_tomography 400 400 input.bmp radon.bmp restored.bmp
+./computed_tomography
 Reading original image from input.bmp
-Allocating radonImage for backprojection
-Performing backprojection
-Restoring original: step1 - fft_1d in-place
-Allocating array for radial->cartesian interpolation
-Restoring original: step2 - interpolation
-Restoring original: step3 - ifft_2d in-place
-Saving restored image to restored.bmp
+Generating Radon transform data from input.bmp
+Saving Radon transform data in radon.bmp
+Reconstructing image from the Radon projection data
+        Step 1 - Batch of 400 real 1D in-place forward DFTs of length 400
+        Step 2 - Interpolating spectrum from polar to cartesian grid
+        Step 3 - In-place backward real 2D DFT of size 400x400
+Saving restored image in restored.bmp
 ```
 
 ### Troubleshooting

--- a/Libraries/oneMKL/computed_tomography/README.md
+++ b/Libraries/oneMKL/computed_tomography/README.md
@@ -16,13 +16,13 @@ For more information on oneMKL and complete documentation of all oneMKL routines
 
 Computed Tomography uses oneMKL discrete Fourier transform (DFT) routines to transform simulated raw CT data (as collected by a CT scanner) into a reconstructed image of the scanned object.
 
-In computed tomography, the raw imaging data is a set of line integrals over the actual object, also known as its _Radon transform_. From this data, the original image must be recovered by approximately inverting the Radon transform. This sample uses Fourier reconstruction for inverting the Radon transform of a user-provided input image: using batched 1D real DFT of Radon transform data points, samples of the input image's Fourier spectrum may be estimated on a polar grid; after interpolating the latter onto a Cartesian grid, an inverse 2D real DFT produces a fair reproduction of the original image.
+In computed tomography, the raw imaging data is a set of line integrals over the actual object, also known as its _Radon transform_. From this data, the original image must be recovered by approximately inverting the Radon transform. This sample uses Fourier reconstruction for inverting the Radon transform of a user-provided input image. Using batched 1D real DFT of Radon transform data points, samples of the input image's Fourier spectrum may be estimated on a polar grid. After interpolating the latter onto a Cartesian grid, an inverse 2D real DFT produces a fair reproduction of the original image.
 
 This sample performs its computations on the default SYCL device. You can set the `ONEAPI_DEVICE_SELECTOR` environment variable to `*:cpu` or `*:gpu` to select the device to use.
 
 ## Key Implementation Details
 
-To use oneMKL DFT routines, the sample creates double-precision real DFT descriptor objects, calls the `commit` member function with a `sycl::queue` object to define the device and context. The `compute_*` routines are then called to perform the actual computation with the appropriate descriptor object and input data.
+To use oneMKL DFT routines, the sample creates double-precision real DFT descriptor objects and calls the `commit` member function with a `sycl::queue` object to define the device and context. The `compute_*` routines are then called to perform the actual computation with the appropriate descriptor object and input data.
 
 ## Using Visual Studio Code* (Optional)
 You can use Visual Studio Code (VS Code) extensions to set your environment, create launch configurations,

--- a/Libraries/oneMKL/computed_tomography/computed_tomography.cpp
+++ b/Libraries/oneMKL/computed_tomography/computed_tomography.cpp
@@ -241,12 +241,14 @@ int main(int argc, char **argv) {
     // evaluate the mean error, pixel by pixel in the reconstructed image
     padded_matrix errors(main_queue);
     const double mean_error = compute_errors(errors, S, original, reconstruction);
-    std::cout << "The mean error in the reconstruction image is " << mean_error
+    std::cout << "The normalized mean difference between the reconstructed "
+              << "image and the original image is " << 100*mean_error << "%."
               << std::endl;
     if (mean_error / max_input_value > arbitrary_error_threshold) {
-        std::cerr << "The mean error exceeds the (arbitrarily-chosen) "
-                  << "threshold of " << 100.0*arbitrary_error_threshold
-                  << "% of the original image's maximum gray-scale value"
+        std::cerr << "The normalized mean difference exceeds the "
+                  << "(arbitrarily-chosen) threshold of "
+                  << 100.0*arbitrary_error_threshold
+                  << "% of the original image's maximum gray-scale value."
                   << std::endl;
         if (std::fabs(p * S_to_D - q) > 0.2*std::max(p*S_to_D, double(q))) {
             std::cerr << "It is recommended to use values of p and q such that "
@@ -263,7 +265,7 @@ int main(int argc, char **argv) {
                       << "one another to reduce interpolation errors."
                       << std::endl;
         }
-        std::cerr << "Saving local errors in " << errors_bmpname
+        std::cerr << "Saving local errors in " << errors_bmpname << "."
                   << std::endl;
         // same relevant pixel indices for errors as for reconstruction
         bmp_write(errors_bmpname, errors, i_range, j_range);

--- a/Libraries/oneMKL/computed_tomography/computed_tomography.cpp
+++ b/Libraries/oneMKL/computed_tomography/computed_tomography.cpp
@@ -172,8 +172,8 @@ void bmp_write(const std::string& fname, const padded_matrix &image,
     if (max_i <= min_i || max_j <= min_j)
         die("invalid range of pixel indices for bmp_write to export");
 
-    unsigned sizeof_line  = ((max_j - min_j) * 3 + 3) / 4 * 4;
-    unsigned sizeof_image = (max_i - min_i) * sizeof_line;
+    unsigned int sizeof_line  = ((max_j - min_j) * 3 + 3) / 4 * 4;
+    unsigned int sizeof_image = (max_i - min_i) * sizeof_line;
 
     bmp_header header = {{'B', 'M'},
                         unsigned(sizeof(header) + sizeof_image),

--- a/Libraries/oneMKL/computed_tomography/computed_tomography.cpp
+++ b/Libraries/oneMKL/computed_tomography/computed_tomography.cpp
@@ -154,8 +154,7 @@ struct pixel {
 };
 // Routine terminating the application and reporting ad-hoc information.
 void die(const std::string& err) {
-    std::cerr << "Fatal error: " << err << " " << std::endl
-              << std::flush;
+    std::cerr << "Fatal error: " << err << std::endl;
     std::exit(EXIT_FAILURE);
 }
 // Routine reading a 24-bit uncompressed bitmap image file and converting it to
@@ -823,6 +822,11 @@ double compute_errors(padded_matrix& errors,
 }
 
 int main(int argc, char **argv) {
+    if (argc > 1 &&
+        (std::strcmp(argv[1], "-h") == 0 || std::strcmp(argv[1], "-H") == 0)) {
+        std::cout << usage_info << std::endl;
+        return EXIT_SUCCESS;
+    }
     const int p                         = argc > 1 ? std::atoi(argv[1]) :
                                                      default_p;
     const int q                         = argc > 2 ? std::atoi(argv[2]) :
@@ -933,7 +937,7 @@ int main(int argc, char **argv) {
                       << std::endl;
         }
         std::cerr << "Saving local errors in " << errors_bmpname
-                  << std::endl << std::flush;
+                  << std::endl;
         // same relevant pixel indices for errors as for reconstruction
         bmp_write(errors_bmpname, errors, i_range, j_range);
         return EXIT_FAILURE;

--- a/Libraries/oneMKL/computed_tomography/makefile
+++ b/Libraries/oneMKL/computed_tomography/makefile
@@ -10,9 +10,9 @@ run: computed_tomography.exe
 DPCPP_OPTS=/I"$(MKLROOT)\include" /Qmkl /Qmkl-sycl-impl=dft /EHsc -fsycl-device-code-split=per_kernel OpenCL.lib
 
 computed_tomography.exe: computed_tomography.cpp
-	icx-cl -fsycl computed_tomography.cpp /Fecomputed_tomography.exe $(DPCPP_OPTS)
+	icx-cl -fsycl $< /Fe$@ $(DPCPP_OPTS)
 
 clean:
-	del /q computed_tomography.exe computed_tomography.exp computed_tomography.lib radon.bmp restored.bmp errors.bmp
+	del /q /f computed_tomography.exe computed_tomography.exp computed_tomography.lib radon.bmp restored.bmp errors.bmp
 
 pseudo: clean run all

--- a/Libraries/oneMKL/computed_tomography/makefile
+++ b/Libraries/oneMKL/computed_tomography/makefile
@@ -13,6 +13,6 @@ computed_tomography.exe: computed_tomography.cpp
 	icx-cl -fsycl computed_tomography.cpp /Fecomputed_tomography.exe $(DPCPP_OPTS)
 
 clean:
-	del /q computed_tomography.exe computed_tomography.exp computed_tomography.lib radon.bmp restored.bmp
+	del /q computed_tomography.exe computed_tomography.exp computed_tomography.lib radon.bmp restored.bmp errors.bmp
 
 pseudo: clean run all

--- a/Libraries/oneMKL/computed_tomography/makefile
+++ b/Libraries/oneMKL/computed_tomography/makefile
@@ -5,7 +5,7 @@ default: run
 all: run
 
 run: computed_tomography.exe
-	.\computed_tomography.exe 400 400 input.bmp radon.bmp restored.bmp
+	.\computed_tomography.exe
 
 DPCPP_OPTS=/I"$(MKLROOT)\include" /Qmkl /Qmkl-sycl-impl=dft /EHsc -fsycl-device-code-split=per_kernel OpenCL.lib
 
@@ -13,6 +13,6 @@ computed_tomography.exe: computed_tomography.cpp
 	icx-cl -fsycl computed_tomography.cpp /Fecomputed_tomography.exe $(DPCPP_OPTS)
 
 clean:
-	del /q computed_tomography.exe computed_tomography.exp computed_tomography.lib
+	del /q computed_tomography.exe computed_tomography.exp computed_tomography.lib radon.bmp restored.bmp
 
 pseudo: clean run all

--- a/Libraries/oneMKL/computed_tomography/makefile
+++ b/Libraries/oneMKL/computed_tomography/makefile
@@ -10,7 +10,7 @@ run: computed_tomography.exe
 DPCPP_OPTS=/I"$(MKLROOT)\include" /Qmkl /Qmkl-sycl-impl=dft /EHsc -fsycl-device-code-split=per_kernel OpenCL.lib
 
 computed_tomography.exe: computed_tomography.cpp
-	icx-cl -fsycl $< /Fe$@ $(DPCPP_OPTS)
+	icx-cl -fsycl $? /Fe$@ $(DPCPP_OPTS)
 
 clean:
 	del /q /f computed_tomography.exe computed_tomography.exp computed_tomography.lib radon.bmp restored.bmp errors.bmp


### PR DESCRIPTION
## Description

This PR revises the "computed tomography" oneAPI sample.

The sample itself was revised so that the application creates reconstructed signal/image samples that are real (no longer complex) and so that those generated real values are directly comparable to the input image's (gray-scale-converted) values themselves. These changes are motivated by the desire to introduce a legitimate functional validation step (introduced herein as well), but that need triggered more thorough revision(s) of the sample's source code.

Extensive explanatory comments were added to the source code, explaining the mathematical nature of the operations at play and/or the technical details related to the suggested implementation.

## Type of change

- [X] Implement fixes for ONSAM Jiras

## How Has This Been Tested?

This was extensively tested on a PVC GPU (512 EUs) and a SPR CPU using a machine operating Ubuntu 22.04. The default input file as well as others (not added to this PR) were considered along with an extensive range of input parameters. Due to the nature of the operations at play, one simply cannot guarantee that the mean global error will be below the arbitrarily-chosen threshold for _any_ input file and any choice of (supported) input parameters. However,
- the default operations were verified to pass the added tests by a large margin;
- the application was augmented with explanatory messages advising how to tweak input parameter(s) to improve accuracy of the results, if found inaccurate for other input file and/or input parameters.

The updated sample's default behavior was also successfully tested on a BMG GPU machine operating Windows 11.

Regarding instructions to test or to run the sample with different inputs, please refer to the application's "Usage" information (printed in case of invalid usage).