### PR TITLE
slightly upgraded sample based on user experience

### DIFF
--- a/Libraries/oneMKL/matrix_mul_mkl/matrix_mul_mkl.cpp
+++ b/Libraries/oneMKL/matrix_mul_mkl/matrix_mul_mkl.cpp
@@ -22,9 +22,10 @@
 using namespace sycl;
 
 template <typename T>
-void test(queue &Q, int M, int N, int K)
+static
+bool test(queue &Q, int M, int N, int K)
 {
-    std::cout << "\nBenchmarking (" << M << " x " << K << ") x (" << K << " x " << N << ") matrix multiplication, " << type_string<T>() << std::endl;;
+    std::cout << "\nBenchmarking (" << M << " x " << K << ") x (" << K << " x " << N << ") matrix multiplication, " << type_string<T>() << "\n";;
 
     std::cout << " -> Initializing data...\n";
 
@@ -38,7 +39,8 @@ void test(queue &Q, int M, int N, int K)
     auto C = malloc_device<T>(ldc * N, Q);
 
     constexpr int rd_size = 1048576;
-    auto host_data = malloc_host<T>(rd_size, Q);
+    std::vector<T> host_vector(rd_size);
+    auto host_data = host_vector.data();
 
     /* Measure time for a given number of GEMM calls */
     auto time_gemms = [=, &Q](int runs) -> double {
@@ -74,10 +76,9 @@ void test(queue &Q, int M, int N, int K)
         }
         if (linear_id >= elems) break;
     }
-    std::cout << (ok ? " passes." : " FAILS!") << std::endl;
-    if (!ok) {
-        exit(1);
-    }
+
+    std::cout << "gemm " << (ok ? " passes." : " FAILS!") << " for type: " << type_string<T>() << "\n";
+    if (!ok) { return false; }
 
     /* Fill A/B with random data */
     generate_random_data(rd_size, host_data);
@@ -114,15 +115,17 @@ void test(queue &Q, int M, int N, int K)
         unit = 'P';
     }
 
-    std::cout << "\nAverage performance: " << flops << unit << 'F' << std::endl;
+    std::cout << "\nAverage performance: " << flops << unit << 'F' << "\n";
 
     /* Free data */
-    free(A, Q);
-    free(B, Q);
     free(C, Q);
-    free(host_data, Q);
+    free(B, Q);
+    free(A, Q);
+
+    return true;
 }
 
+static
 void usage(const char *pname)
 {
     std::cerr << "Usage:\n"
@@ -133,17 +136,37 @@ void usage(const char *pname)
               << "   double    [default]\n"
               << "   single\n"
               << "   half\n"
+              << "   all(runs all above)\n"
               << "\n"
               << "This benchmark uses the default DPC++ device, which can be controlled using\n"
               << "  the ONEAPI_DEVICE_SELECTOR environment variable\n";
     std::exit(1);
 }
 
+static
+bool device_has_fp64(sycl::device const& D) {
+    return (D.get_info<sycl::info::device::double_fp_config>().size() != 0);
+}
+
+static
+void device_info(sycl::device const& D) {
+    std::cout << "oneMKL DPC++ GEMM benchmark\n"
+              << "---------------------------\n"
+              << "Platform:                " << D.get_platform().get_info<info::platform::name>()         << "\n"
+              << "Device:                  " << D.get_info<info::device::name>()                          << "\n"
+              << "Driver_version:          " << D.get_info<info::device::driver_version>()                << "\n"
+              << "Core/EU count:           " << D.get_info<info::device::max_compute_units>()             << "\n"
+              << "Maximum clock frequency: " << D.get_info<info::device::max_clock_frequency>() << " MHz" << "\n"
+              << "FP64 capability:         " << (device_has_fp64(D) ? "yes" : "no") << "\n"
+              << "\n"
+              ;
+}
+
 int main(int argc, char **argv)
 {
     auto pname = argv[0];
     int M = 4096, N = 4096, K = 4096;
-    std::string type = "double";
+    std::string type = "none";
 
     if (argc <= 1)
         usage(pname);
@@ -163,20 +186,55 @@ int main(int argc, char **argv)
     if (M <= 0 || N <= 0 || K <= 0)
         usage(pname);
 
-    queue Q;
+    bool g_success = true;
+    try { 
+        device D(default_selector_v);
+        device_info(D);
 
-    std::cout << "oneMKL DPC++ GEMM benchmark\n"
-              << "---------------------------\n"
-              << "Device:                  " << Q.get_device().get_info<info::device::name>()                          << std::endl
-              << "Core/EU count:           " << Q.get_device().get_info<info::device::max_compute_units>()             << std::endl
-              << "Maximum clock frequency: " << Q.get_device().get_info<info::device::max_clock_frequency>() << " MHz" << std::endl;
+        context C(D);
+        queue Q(C, D);
 
-    if (type == "double")
-        test<double>(Q, M, N, K);
-    else if (type == "single" || type == "float")
-        test<float>(Q, M, N, K);
-    else if (type == "half")
-        test<half>(Q, M, N, K);
-    else
-        usage(pname);
+        if ("none" == type)
+            std::string type = device_has_fp64(D) ? "double" : "float";
+
+        if (type == "double") {
+            if (device_has_fp64(D))
+                test<double>(Q, M, N, K);
+            else {
+                std::cout << "no FP64 capability on given SYCL device and type == \"double\"";
+                return 1;
+            }
+        }
+        else if (type == "single" || type == "float")
+            g_success = g_success && test<float>(Q, M, N, K);
+        else if (type == "half")
+            g_success = g_success && test<half>(Q, M, N, K);
+        else if (type == "all") {
+            type = "half";
+            g_success = g_success && test<half>(Q, M, N, K);
+
+            type = "float";
+            g_success = g_success && test<float>(Q, M, N, K);
+
+            if (device_has_fp64(D)) {
+                type = "double";
+                g_success = g_success && test<double>(Q, M, N, K);
+            }
+        } else {
+            type = "none";
+            usage(pname);
+        }
+    } catch (sycl::exception const& e) {
+        std::cerr << "SYCL exception: " << e.what() << "\n";
+        std::cerr << " while performing GEMM for" 
+            << " M=" << M 
+            << ", N=" << N
+            << ", K=" << K
+            << ", type `" << type << "`"
+            << "\n";
+        return 139;
+    }
+
+    return g_success ? 0 : 1;
 }
+

--- a/Libraries/oneMKL/matrix_mul_mkl/matrix_mul_mkl.cpp
+++ b/Libraries/oneMKL/matrix_mul_mkl/matrix_mul_mkl.cpp
@@ -136,7 +136,7 @@ void usage(const char *pname)
               << "   double    [default]\n"
               << "   single\n"
               << "   half\n"
-              << "   all(runs all above)\n"
+              << "   all (runs all above)\n"
               << "\n"
               << "This benchmark uses the default DPC++ device, which can be controlled using\n"
               << "  the ONEAPI_DEVICE_SELECTOR environment variable\n";


### PR DESCRIPTION
# Existing Sample Changes
## Description

1. Added try/catch block to report any spurious exceptions
2. Added "all" mode to run all supported precisions
3. Added FP64 capability detection demonstration
4. Added more output into device information


## External Dependencies

None 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Implement fixes for ONSAM Jiras

## How Has This Been Tested?

- [X] Command Line
- [X] When compiling the compliler flag "-Wall -Wformat-security -Werror=format-security" was used


typical output illustrating all new features.
```
$ ./a.out all
oneMKL DPC++ GEMM benchmark
---------------------------
Platform:                Intel(R) oneAPI Unified Runtime over Level-Zero
Device:                  Intel(R) Data Center GPU Max 1100
Driver_version:          1.6.32224+6
Core/EU count:           448
Maximum clock frequency: 1550 MHz
FP64 capability:         yes


Benchmarking (4096 x 4096) x (4096 x 4096) matrix multiplication, half precision
 -> Initializing data...
 -> Verification...gemm  passes. for type: half precision
 -> Warmup...
 -> Timing...

Average performance: 225.868TF

Benchmarking (4096 x 4096) x (4096 x 4096) matrix multiplication, single precision
 -> Initializing data...
 -> Verification...gemm  passes. for type: single precision
 -> Warmup...
 -> Timing...

Average performance: 21.3028TF

Benchmarking (4096 x 4096) x (4096 x 4096) matrix multiplication, double precision
 -> Initializing data...
 -> Verification...gemm  passes. for type: double precision
 -> Warmup...
 -> Timing...

Average performance: 13.0985TF
```