### PR TITLE
FPGA: Force II=1 in Cholesky inversion IP

### DIFF
--- a/DirectProgramming/C++SYCL_FPGA/include/streaming_cholesky_inversion.hpp
+++ b/DirectProgramming/C++SYCL_FPGA/include/streaming_cholesky_inversion.hpp
@@ -164,7 +164,9 @@ struct StreamingCholeskyInversion {
       int diagonal_size = (kColumns > raw_latency ? kColumns : raw_latency) - 1;
       int col = diagonal_number;
       int row = 0;
-
+ 
+ 
+      [[intel::initiation_interval(1)]]
       [[intel::ivdep(raw_latency)]]  // NO-FORMAT: Attribute
       for (int it = 0; it < kTotalIterations + kInitIterations; it++) {
         // Only perform work when in not dummy iterations

--- a/DirectProgramming/C++SYCL_FPGA/include/streaming_cholesky_inversion.hpp
+++ b/DirectProgramming/C++SYCL_FPGA/include/streaming_cholesky_inversion.hpp
@@ -166,7 +166,7 @@ struct StreamingCholeskyInversion {
       int row = 0;
  
  
-      [[intel::initiation_interval(1)]]
+      [[intel::initiation_interval(1)]] // NO-FORMAT: Attribute
       [[intel::ivdep(raw_latency)]]  // NO-FORMAT: Attribute
       for (int it = 0; it < kTotalIterations + kInitIterations; it++) {
         // Only perform work when in not dummy iterations


### PR DESCRIPTION
This change forces the main compute loop of the Cholesky matrix inversion IP to have an II of 1.