### PR TITLE
[oneMKL] Replaced namespace for reqd_sub_group_size

### DIFF
--- a/Libraries/oneMKL/binomial/src/binomial_sycl.cpp
+++ b/Libraries/oneMKL/binomial/src/binomial_sycl.cpp
@@ -78,7 +78,7 @@ void Binomial<DATA_TYPE>::body() {
         sycl::nd_range(sycl::range<1>(opt_n * wg_size),
                        sycl::range<1>(wg_size)),
         [=](sycl::nd_item<1> item)
-            [[intel::kernel_args_restrict]] [[intel::reqd_sub_group_size(
+            [[intel::kernel_args_restrict]] [[sycl::reqd_sub_group_size(
                 sg_size)]] {
               const size_t opt = item.get_global_id(0) / wg_size;
               const DATA_TYPE sx = h_stock_price_local[opt];

--- a/Libraries/oneMKL/black_scholes/src/black_scholes_sycl.cpp
+++ b/Libraries/oneMKL/black_scholes/src/black_scholes_sycl.cpp
@@ -72,7 +72,7 @@ void BlackScholes<DATA_TYPE>::body() {
     DATA_TYPE* h_put_result_local = this->h_put_result;
 
     black_scholes_queue->parallel_for<k_BlackScholes<DATA_TYPE, block_size>>(sycl::nd_range(sycl::range<1>(opt_n / block_size), sycl::range<1>(wg_size)),
-                [=](sycl::nd_item<1> item) [[intel::kernel_args_restrict]] [[intel::reqd_sub_group_size(sg_size)]] {
+                [=](sycl::nd_item<1> item) [[intel::kernel_args_restrict]] [[sycl::reqd_sub_group_size(sg_size)]] {
                         auto local_id = item.get_local_linear_id();
                         auto group_id = item.get_group_linear_id();
 #pragma unroll


### PR DESCRIPTION
## Description

namespace for `reqd_sub_group_size` has been changed from `intel::` to `sycl::`

## Type of change

Please delete options that are not relevant. Add a 'X' to the one that is applicable. 

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Implement fixes for ONSAM Jiras

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [X] Command Line
- [ ] oneapi-cli
- [ ] Visual Studio
- [ ] Eclipse IDE
- [ ] VSCode
- [ ] When compiling the compliler flag "-Wall -Wformat-security -Werror=format-security" was used
