### PR TITLE
use uv tool for isolate cicd env, samples include

### DIFF
--- a/AI-and-Analytics/Features-and-Functionality/IntelPython_GPU_dpnp_Genetic_Algorithm/sample.json
+++ b/AI-and-Analytics/Features-and-Functionality/IntelPython_GPU_dpnp_Genetic_Algorithm/sample.json
@@ -9,18 +9,22 @@
   "os":["linux"],
   "targetDevice": ["GPU"],
   "ciTests": {
-  	"linux": [
+    "linux": [
     {
-  		"env": [
+      "env": [
         "source /intel/oneapi/intelpython/bin/activate",
         "conda activate base",
-        "pip install -r requirements.txt"
+        "pip install uv",
+        "uv init",
+        "uv python pin $(which python)",
+        "uv venv --system-site-packages",
+        "uv add -r requirements.txt"
       ],
-  		"id": "idp_ga_dpnp_py",
-  		"steps": [
-         "python IntelPython_GPU_dpnp_Genetic_Algorithm.py" 
-  		 ]
-  	}
+      "id": "idp_ga_dpnp_py",
+      "steps": [
+         "uv run python IntelPython_GPU_dpnp_Genetic_Algorithm.py"
+      ]
+    }
     ]
 },
 "expertise": "Code Optimization"

--- a/AI-and-Analytics/Features-and-Functionality/IntelPython_XGBoost_Performance/requirements.txt
+++ b/AI-and-Analytics/Features-and-Functionality/IntelPython_XGBoost_Performance/requirements.txt
@@ -1,6 +1,6 @@
 ###### Requirements ######
 notebook
 matplot
-xgboost==0.81
+xgboost==0.82
 scikit-learn
 pandas

--- a/AI-and-Analytics/Features-and-Functionality/IntelPython_XGBoost_Performance/sample.json
+++ b/AI-and-Analytics/Features-and-Functionality/IntelPython_XGBoost_Performance/sample.json
@@ -9,17 +9,24 @@
   "os":["linux"],
   "targetDevice": ["CPU"],
   "ciTests": {
-  	"linux": [
+    "linux": [
     {
-  		"id": "idp_xgb_performance",
-  		"steps": [
-         	"source /intel/oneapi/intelpython/bin/activate",
-          "python IntelPython_XGBoost_Performance.py",
-          "conda remove xgboost --y",
-          "pip install -r requirements.txt",
-          "python IntelPython_XGBoost_Performance.py"		 
-  		 ]
-  	}
+      "env": [
+        "source /intel/oneapi/intelpython/bin/activate",
+        "conda activate base"
+      ],
+      "id": "idp_xgb_performance",
+      "steps": [
+        "python IntelPython_XGBoost_Performance.py",
+        "pip install uv",
+        "uv init",
+        "uv python pin $(which python)",
+        "uv venv --system-site-packages",
+        "uv add -r requirements.txt",
+        "uv add numpy==1.26.4",
+        "uv run python IntelPython_XGBoost_Performance.py"
+      ]
+    }
     ]
 },
 "expertise": "Code Optimization"

--- a/AI-and-Analytics/Features-and-Functionality/IntelPython_daal4py_DistributedKMeans/sample.json
+++ b/AI-and-Analytics/Features-and-Functionality/IntelPython_daal4py_DistributedKMeans/sample.json
@@ -15,11 +15,16 @@
 			"env": [
 				"source /intel/oneapi/intelpython/bin/activate",
 				"conda activate base",
-				"pip install -r requirements.txt"
+				"pip install uv",
+				"uv init",
+				"uv python pin $(which python)",
+				"uv venv --system-site-packages",
+				"uv add -r requirements.txt",
+				"uv add numpy==1.26.4"
 			],
 			"id": "idp_d4p_KM_Dist",
 			"steps": [
-				"mpirun -n 4 python ./IntelPython_daal4py_Distributed_Kmeans.py"
+				"uv run mpirun -n 4 python ./IntelPython_daal4py_Distributed_Kmeans.py"
 			]
 		}]
 	},

--- a/AI-and-Analytics/Features-and-Functionality/IntelTensorFlow_Enabling_Auto_Mixed_Precision_for_TransferLearning/sample.json
+++ b/AI-and-Analytics/Features-and-Functionality/IntelTensorFlow_Enabling_Auto_Mixed_Precision_for_TransferLearning/sample.json
@@ -17,10 +17,15 @@
 				"apt-get update && apt-get install tensorflow-model-server",
 				"source /intel/oneapi/intelpython/bin/activate",
 				"conda activate tensorflow",
-				"pip install -r requirements.txt --no-deps",
-				"pip install tensorflow==2.15.0.post1",
-				"pip install jupyter ipykernel",
-				"python -m ipykernel install --user --name=tensorflow"
+				"pip install uv",
+				"uv init",
+				"uv python pin $(which python)",
+				"uv venv --system-site-packages",
+				"uv add -r requirements.txt",
+				"uv add numpy==1.26.4",
+				"uv add --dev ipykernel",
+				"uv run ipython kernel install --user --name tensorflow",
+				"pip install notebook"
 			],
 			"id": "tensorflow_AMP_transfer_learning",
 			"steps": [

--- a/AI-and-Analytics/Features-and-Functionality/IntelTensorFlow_for_LLMs/sample.json
+++ b/AI-and-Analytics/Features-and-Functionality/IntelTensorFlow_for_LLMs/sample.json
@@ -10,14 +10,23 @@
   "cpuInstructionSets": ["AVX512", "AMX"],
   "ciTests": {
     "linux": [{
+      "env": [
+        "source /intel/oneapi/intelpython/bin/activate",
+        "conda activate tensorflow",
+        "pip install uv",
+        "uv init",
+        "uv python pin $(which python)",
+        "uv venv --system-site-packages",
+        "uv add -r requirements.txt",
+        "uv add py-cpuinfo nbformat nbconvert",
+        "uv add --dev ipykernel",
+        "uv run ipython kernel install --user --name tensorflow",
+        "uv add notebook nbconvert"
+      ],
       "id": "intel llm bf16 infrence and fine-tuning",
       "steps": [
-        "source activate tensorflow",
-        "pip install -r requirements.txt",
-        "python -m pip install py-cpuinfo",
-        "python GPTJ_finetuning.py",
-        "/opt/intel/oneapi/intelpython/latest/envs/tensorflow/bin/python -m ipykernel install --user --name=tensorflow",
-        "python ci_test.py"
+        "uv run python GPTJ_finetuning.py",
+        "uv run python ci_test.py"
       ]
     }]
   },

--- a/AI-and-Analytics/Features-and-Functionality/Intel_Extension_For_SKLearn_Performance_SVC_Adult/sample.json
+++ b/AI-and-Analytics/Features-and-Functionality/Intel_Extension_For_SKLearn_Performance_SVC_Adult/sample.json
@@ -13,11 +13,16 @@
         "env": [
           "source /intel/oneapi/intelpython/bin/activate",
           "conda activate base",
-          "pip install -r requirements.txt"
+          "pip install uv",
+          "uv init",
+          "uv python pin $(which python)",
+          "uv venv --system-site-packages",
+          "uv add -r requirements.txt",
+          "uv add numpy==1.26.4"
         ],
         "id": "skelarnex_svc",
         "steps": [
-          "python Intel_Extension_for_SKLearn_Performance_SVC_Adult.py"
+          "uv run python Intel_Extension_for_SKLearn_Performance_SVC_Adult.py"
         ]
       }
     ]


### PR DESCRIPTION
# Existing Sample Changes
## Description

The [UV tool](https://github.com/astral-sh/uv) is designed to streamline the management of Python environments for multiple test cases. One of its standout features is its ability to operate without altering the existing Python environment, ensuring that the **each unit test sample (sample.json)** won't affect **primary setup (AI Tool did with conda environment)**. This makes it an ideal solution without the hassle of environment conflicts or dependencies issues, and makes each sample isolation.

add uv tool management for samples:

    1.AI-and-Analytics/Features-and-Functionality/IntelPython_GPU_dpnp_Genetic_Algorithm
    2.AI-and-Analytics/Features-and-Functionality/IntelPython_XGBoost_Performance
    3.AI-and-Analytics/Features-and-Functionality/IntelPython_daal4py_DistributedKMeans
    4.AI-and-Analytics/Features-and-Functionality/IntelTensorFlow_Enabling_Auto_Mixed_Precision_for_TransferLearning
    5.AI-and-Analytics/Features-and-Functionality/IntelTensorFlow_for_LLMs
    6.AI-and-Analytics/Features-and-Functionality/Intel_Extension_For_SKLearn_Performance_SVC_Adult


## Type of change

Please delete options that are not relevant. Add a 'X' to the one that is applicable. 

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Implement fixes for ONSAM Jiras

ONSAM 1917