### PR TITLE
[ONSAM-2083]Fix for IndexError

### DIFF
--- a/AI-and-Analytics/End-to-end-Workloads/JobRecommendationSystem/requirements.txt
+++ b/AI-and-Analytics/End-to-end-Workloads/JobRecommendationSystem/requirements.txt
@@ -1,6 +1,6 @@
 ipykernel
 matplotlib
-sentence_transformers
+sentence-transformers
 transformers 
 datasets 
 accelerate 

--- a/AI-and-Analytics/Features-and-Functionality/IntelTensorFlow_AMX_BF16_Inference/requirements.txt
+++ b/AI-and-Analytics/Features-and-Functionality/IntelTensorFlow_AMX_BF16_Inference/requirements.txt
@@ -1,6 +1,6 @@
 notebook
 Pillow
-tensorflow_hub==0.16
+tensorflow-hub==0.16
 requests
 py-cpuinfo
 

--- a/AI-and-Analytics/Features-and-Functionality/IntelTensorFlow_Enabling_Auto_Mixed_Precision_for_TransferLearning/requirements.txt
+++ b/AI-and-Analytics/Features-and-Functionality/IntelTensorFlow_Enabling_Auto_Mixed_Precision_for_TransferLearning/requirements.txt
@@ -1,5 +1,5 @@
-neural_compressor==2.4.1
+neural-compressor==2.4.1
 Pillow
 py-cpuinfo
 requests
-tensorflow_hub==0.16.0
+tensorflow-hub==0.16.0

--- a/AI-and-Analytics/Features-and-Functionality/IntelTensorFlow_Enabling_Auto_Mixed_Precision_for_TransferLearning/scripts/plot.py
+++ b/AI-and-Analytics/Features-and-Functionality/IntelTensorFlow_Enabling_Auto_Mixed_Precision_for_TransferLearning/scripts/plot.py
@@ -8,8 +8,10 @@ for line in lines:
         throughput = line.split(': ')[1]
         throughput_list.append(float(throughput))
 
-print("Throughput list: ", throughput_list)
-speedup = float(throughput_list[1])/float(throughput_list[0])
-print("Speedup : ", speedup)
-df = pd.DataFrame({'pretrained_model':['saved model', 'optimized model'], 'Speedup':[1, speedup]})
-ax = df.plot.bar( x='pretrained_model', y='Speedup', rot=0)
+if len(throughput_list) >= 2:
+    speedup = float(throughput_list[1])/float(throughput_list[0])
+    print("Speedup : ", speedup)
+    df = pd.DataFrame({'pretrained_model':['saved model', 'optimized model'], 'Speedup':[1, speedup]})
+    ax = df.plot.bar( x='pretrained_model', y='Speedup', rot=0)
+else:
+    print("Insufficient data to calculate speedup")

--- a/AI-and-Analytics/Features-and-Functionality/IntelTransformers_Quantization/requirements.txt
+++ b/AI-and-Analytics/Features-and-Functionality/IntelTransformers_Quantization/requirements.txt
@@ -1,7 +1,7 @@
 accelerate==0.29.3
 datasets==2.09.0
 intel-extension-for-transformers==1.4.1
-neural_speed==1.0
+neural-speed==1.0
 peft==0.10.0
 sentencepiece
 transformers==4.38.0

--- a/AI-and-Analytics/Getting-Started-Samples/INC-Quantization-Sample-for-PyTorch/requirements.txt
+++ b/AI-and-Analytics/Getting-Started-Samples/INC-Quantization-Sample-for-PyTorch/requirements.txt
@@ -1,3 +1,3 @@
-neural_compressor==2.1
+neural-compressor==2.1
 transformers>=4.27.4
 datasets>=2.4.0

--- a/AI-and-Analytics/Getting-Started-Samples/Intel_Extension_For_TensorFlow_GettingStarted/requirements.txt
+++ b/AI-and-Analytics/Getting-Started-Samples/Intel_Extension_For_TensorFlow_GettingStarted/requirements.txt
@@ -1,3 +1,3 @@
-tensorflow_hub
+tensorflow-hub
 ipykernel
 matplotlib


### PR DESCRIPTION
This fixes IndexError in ONSAM-2083

Before this fix, throughput_list could be less than 2 elements and causing IndexError. With the added check, speedup will only be calculated if there are at least two elements.

Fixes [ONSAM-2083]

Signed-off-by: Yeo, Ray <ray.yeo@intel.com>
Signed-off-by: Tan, Fong Jian <fong.jian.tan@intel.com>
Signed-off-by: Lim, Lukaz Wei Hwang <lukaz.wei.hwang.lim@intel.com>
Signed-off-by: Ong, Frankie Wei Quan <frankie.wei.quan.ong@intel.com>
Signed-off-by: Ooi, Boon Sin <boon.sin.ooi@intel.com>

# Existing Sample Changes
## Description

Before this fix, throughput_list could be less than 2 elements and causing IndexError. With the added check, speedup will only be calculated if there are at least two elements.

Fixes Issue# 2083

## External Dependencies

List any external dependencies created as a result of this change.

## Type of change

Please delete options that are not relevant. Add a 'X' to the one that is applicable. 

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Implement fixes for ONSAM Jiras

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Command Line
- [ ] oneapi-cli
- [ ] Visual Studio
- [ ] Eclipse IDE
- [X] VSCode
- [ ] When compiling the compliler flag "-Wall -Wformat-security -Werror=format-security" was used

