### PR TITLE
[ONSAM-2083]Fix for IndexError

### DIFF
--- a/AI-and-Analytics/Features-and-Functionality/IntelTensorFlow_Enabling_Auto_Mixed_Precision_for_TransferLearning/scripts/plot.py
+++ b/AI-and-Analytics/Features-and-Functionality/IntelTensorFlow_Enabling_Auto_Mixed_Precision_for_TransferLearning/scripts/plot.py
@@ -8,8 +8,10 @@ for line in lines:
         throughput = line.split(': ')[1]
         throughput_list.append(float(throughput))
 
-print("Throughput list: ", throughput_list)
-speedup = float(throughput_list[1])/float(throughput_list[0])
-print("Speedup : ", speedup)
-df = pd.DataFrame({'pretrained_model':['saved model', 'optimized model'], 'Speedup':[1, speedup]})
-ax = df.plot.bar( x='pretrained_model', y='Speedup', rot=0)
+if len(throughput_list) >= 2:
+    speedup = float(throughput_list[1])/float(throughput_list[0])
+    print("Speedup : ", speedup)
+    df = pd.DataFrame({'pretrained_model':['saved model', 'optimized model'], 'Speedup':[1, speedup]})
+    ax = df.plot.bar( x='pretrained_model', y='Speedup', rot=0)
+else:
+    print("Insufficient data to calculate speedup")


### PR DESCRIPTION
This fixes IndexError in IntelTensorFlow_Enabling_Auto_Mixed_Precision_for_TransferLearning

Before this fix, throughput_list could be less than 2 elements and causing IndexError. With the added check, speedup will only be calculated if there are at least two elements.

Fixes [ONSAM-2083]

Signed-off-by: Yeo, Ray <ray.yeo@intel.com>

# Existing Sample Changes
## Description

This fixes IndexError in IntelTensorFlow_Enabling_Auto_Mixed_Precision_for_TransferLearning
https://jira.devtools.intel.com/browse/ONSAM-2083

Fixes Issue# 2083

## External Dependencies

List any external dependencies created as a result of this change.

## Type of change

Please delete options that are not relevant. Add a 'X' to the one that is applicable. 

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Implement fixes for ONSAM Jiras

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Command Line
- [ ] oneapi-cli
- [ ] Visual Studio
- [ ] Eclipse IDE
- [X] VSCode
- [ ] When compiling the compliler flag "-Wall -Wformat-security -Werror=format-security" was used

