### PR TITLE
Standardize module naming in requirements.txt files

### DIFF
--- a/AI-and-Analytics/End-to-end-Workloads/JobRecommendationSystem/requirements.txt
+++ b/AI-and-Analytics/End-to-end-Workloads/JobRecommendationSystem/requirements.txt
@@ -1,10 +1,10 @@
 ipykernel
 matplotlib
-sentence_transformers
-transformers 
-datasets 
-accelerate 
-wordcloud  
-spacy 
+sentence-transformers
+transformers
+datasets
+accelerate
+wordcloud
+spacy
 jinja2
 nltk

--- a/AI-and-Analytics/Features-and-Functionality/IntelTensorFlow_AMX_BF16_Inference/requirements.txt
+++ b/AI-and-Analytics/Features-and-Functionality/IntelTensorFlow_AMX_BF16_Inference/requirements.txt
@@ -1,6 +1,6 @@
 notebook
 Pillow
-tensorflow_hub==0.16
+tensorflow-hub==0.16
 requests
 py-cpuinfo
 

--- a/AI-and-Analytics/Features-and-Functionality/IntelTensorFlow_Enabling_Auto_Mixed_Precision_for_TransferLearning/requirements.txt
+++ b/AI-and-Analytics/Features-and-Functionality/IntelTensorFlow_Enabling_Auto_Mixed_Precision_for_TransferLearning/requirements.txt
@@ -1,5 +1,5 @@
-neural_compressor==2.4.1
+neural-compressor==2.4.1
 Pillow
 py-cpuinfo
 requests
-tensorflow_hub==0.16.0
+tensorflow-hub==0.16.0

--- a/AI-and-Analytics/Features-and-Functionality/IntelTransformers_Quantization/requirements.txt
+++ b/AI-and-Analytics/Features-and-Functionality/IntelTransformers_Quantization/requirements.txt
@@ -1,7 +1,7 @@
 accelerate==0.29.3
 datasets==2.09.0
 intel-extension-for-transformers==1.4.1
-neural_speed==1.0
+neural-speed==1.0
 peft==0.10.0
 sentencepiece
 transformers==4.38.0

--- a/AI-and-Analytics/Getting-Started-Samples/INC-Quantization-Sample-for-PyTorch/requirements.txt
+++ b/AI-and-Analytics/Getting-Started-Samples/INC-Quantization-Sample-for-PyTorch/requirements.txt
@@ -1,3 +1,3 @@
-neural_compressor==2.1
+neural-compressor==2.1
 transformers>=4.27.4
 datasets>=2.4.0

--- a/AI-and-Analytics/Getting-Started-Samples/Intel_Extension_For_TensorFlow_GettingStarted/requirements.txt
+++ b/AI-and-Analytics/Getting-Started-Samples/Intel_Extension_For_TensorFlow_GettingStarted/requirements.txt
@@ -1,3 +1,3 @@
-tensorflow_hub
+tensorflow-hub
 ipykernel
 matplotlib


### PR DESCRIPTION
# Existing Sample Changes
## Description

Pip normalizes all package names which shouldn't have any errors when installing packages e.g., tensorflow_hub and tensorflow-hub is treated as the same and will install tensorflow-hub, however if users install using 'conda install' it will encounter module not found errors as conda does not normalize module package names. This change is also to standardize those module names to be the same as the names in package repositories.

Not related to any issue tickets.

## External Dependencies

No additional external dependencies.

## Type of change

Please delete options that are not relevant. Add a 'X' to the one that is applicable. 

- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [X] Command Line
- [ ] oneapi-cli
- [ ] Visual Studio
- [ ] Eclipse IDE
- [ ] VSCode
- [ ] When compiling the compliler flag "-Wall -Wformat-security -Werror=format-security" was used