### PR TITLE
[ONSAM-2066] Update README with adding command to register Conda kernel with Jupyter kernel

### DIFF
--- a/AI-and-Analytics/Getting-Started-Samples/INC-Quantization-Sample-for-PyTorch/README.MD
+++ b/AI-and-Analytics/Getting-Started-Samples/INC-Quantization-Sample-for-PyTorch/README.MD
@@ -74,7 +74,7 @@ conda activate pytorch
 3. Clone the GitHub repository:
 ``` 
 git clone https://github.com/oneapi-src/oneAPI-samples.git
-cd oneAPI-samples/AI-and-Analytics/Getting-Started-Samples
+cd oneAPI-samples/AI-and-Analytics/Getting-Started-Samples/INC-Quantization-Sample-for-PyTorch
 ```
 4. Install dependencies:
 ```
@@ -85,6 +85,10 @@ pip install -r requirements.txt
 5. Register Conda kernel to Jupyter Notebook kernel:
 ```
 $HOME/intel/oneapi/intelpython/bin/python -m ipykernel install --user --name=base
+```
+If a non-default path is used:
+```
+<custom_path>/bin/python -m ipykernel install --user --name=base
 ```
 > **Note**: There is another way to regisyer Conda kernel to Jupyter Notebook kernel, feel free to check [the instruction](https://github.com/IntelAI/models/tree/master/docs/notebooks/perf_analysis#option-1-conda-environment-creation)
 6. Launch Jupyter Notebook: 
@@ -104,7 +108,7 @@ quantize_with_inc.ipynb
 1. Clone the GitHub repository:
 ``` 
 git clone https://github.com/oneapi-src/oneAPI-samples.git
-cd oneAPI-samples/AI-and-Analytics/Getting-Started-Samples
+cd oneAPI-samples/AI-and-Analytics/Getting-Started-Samples/INC-Quantization-Sample-for-PyTorch
 ```
 2. Install dependencies:
 ```

--- a/AI-and-Analytics/Getting-Started-Samples/INC-Quantization-Sample-for-PyTorch/README.MD
+++ b/AI-and-Analytics/Getting-Started-Samples/INC-Quantization-Sample-for-PyTorch/README.MD
@@ -111,12 +111,13 @@ cd oneAPI-samples/AI-and-Analytics/Getting-Started-Samples
 pip install -r requirements.txt
 ```
 **Install Jupyter Notebook** by running `pip install notebook`. Alternatively, see [Installing Jupyter](https://jupyter.org/install) for detailed installation instructions.
+
 3. Register Conda kernel to Jupyter Notebook kernel:
 ```
 <CONDA_PATH_TO_ENV>/bin/python -m ipykernel install --user --name=<your-env-name>
 ```
 **Run** `conda env list` to find your Conda environment path <CONDA_PATH_ENV>
-> **Note**: There is another way to regisyer Conda kernel to Jupyter Notebook kernel, feel free to check [the instruction](https://github.com/IntelAI/models/tree/master/docs/notebooks/perf_analysis#option-1-conda-environment-creation)
+> **Note**: There is another way to register Conda kernel to Jupyter Notebook kernel, feel free to check [the instruction](https://github.com/IntelAI/models/tree/master/docs/notebooks/perf_analysis#option-1-conda-environment-creation)
 4. Launch Jupyter Notebook: 
 ```
 jupyter notebook --ip=0.0.0.0

--- a/AI-and-Analytics/Getting-Started-Samples/INC-Quantization-Sample-for-PyTorch/README.MD
+++ b/AI-and-Analytics/Getting-Started-Samples/INC-Quantization-Sample-for-PyTorch/README.MD
@@ -81,19 +81,23 @@ cd oneAPI-samples/AI-and-Analytics/Getting-Started-Samples
 pip install -r requirements.txt
 ```
 **Install Jupyter Notebook** by running `pip install notebook`. Alternatively, see [Installing Jupyter](https://jupyter.org/install) for detailed installation instructions.
-5. Launch Jupyter Notebook: 
-> **Note**: You might need to register Conda kernel to Jupyter Notebook kernel, 
-feel free to check [the instruction](https://github.com/IntelAI/models/tree/master/docs/notebooks/perf_analysis#option-1-conda-environment-creation)
+
+5. Register Conda kernel to Jupyter Notebook kernel:
+```
+$HOME/intel/oneapi/intelpython/bin/python -m ipykernel install --user --name=base
+```
+> **Note**: There is another way to regisyer Conda kernel to Jupyter Notebook kernel, feel free to check [the instruction](https://github.com/IntelAI/models/tree/master/docs/notebooks/perf_analysis#option-1-conda-environment-creation)
+6. Launch Jupyter Notebook: 
 ```
 jupyter notebook --ip=0.0.0.0
 ```
-6. Follow the instructions to open the URL with the token in your browser.
-7. Select the Notebook:
+7. Follow the instructions to open the URL with the token in your browser.
+8. Select the Notebook:
 ```
 quantize_with_inc.ipynb
 ```
-8. Change the kernel to `pytorch`
-9. Run every cell in the Notebook in sequence.
+9. Change the kernel to `pytorch`
+10. Run every cell in the Notebook in sequence.
 
 ### Conda/PIP
 > **Note**: Make sure your Conda/Python environment with AI Tools installed is activated
@@ -107,19 +111,22 @@ cd oneAPI-samples/AI-and-Analytics/Getting-Started-Samples
 pip install -r requirements.txt
 ```
 **Install Jupyter Notebook** by running `pip install notebook`. Alternatively, see [Installing Jupyter](https://jupyter.org/install) for detailed installation instructions.
-
-3. Launch Jupyter Notebook: 
-> **Note**: You might need to register Conda kernel to Jupyter Notebook kernel, 
-feel free to check [the instruction](https://github.com/IntelAI/models/tree/master/docs/notebooks/perf_analysis#option-1-conda-environment-creation)
+3. Register Conda kernel to Jupyter Notebook kernel:
+```
+<CONDA_PATH_TO_ENV>/bin/python -m ipykernel install --user --name=<your-env-name>
+```
+**Run** `conda env list` to find your Conda environment path <CONDA_PATH_ENV>
+> **Note**: There is another way to regisyer Conda kernel to Jupyter Notebook kernel, feel free to check [the instruction](https://github.com/IntelAI/models/tree/master/docs/notebooks/perf_analysis#option-1-conda-environment-creation)
+4. Launch Jupyter Notebook: 
 ```
 jupyter notebook --ip=0.0.0.0
 ```
-4. Follow the instructions to open the URL with the token in your browser.
-5. Select the Notebook:
+5. Follow the instructions to open the URL with the token in your browser.
+6. Select the Notebook:
 ```
 quantize_with_inc.ipynb
 ```
-6. Run every cell in the Notebook in sequence.
+7. Run every cell in the Notebook in sequence.
 
 ### Docker
 AI Tools Docker images already have Get Started samples pre-installed. Refer to [Working with Preset Containers](https://github.com/intel/ai-containers/tree/main/preset) to learn how to run the docker and samples.


### PR DESCRIPTION
# Existing Sample Changes
## Description

In README, a step on registering Conda kernel with Jupyter kernel is missing for AI Tools Offline Installer (Validated) and Conda/PIP. This PR adds the step and the command with descriptions.

Fixes Issue# ONSAM-2066

Co-authored-by: Ooi Boon Sin <boon.sin.ooi@intel.com>
Signed-off-by: Frankie Wei Quan Ong <frankie.wei.quan.ong@intel.com>
Signed-off-by: Ooi Boon Sin <boon.sin.ooi@intel.com>

## External Dependencies

None

## Type of change

Please delete options that are not relevant. Add a 'X' to the one that is applicable. 

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Implement fixes for ONSAM Jiras

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Command Line
- [ ] oneapi-cli
- [ ] Visual Studio
- [ ] Eclipse IDE
- [x] VSCode
- [ ] When compiling the compliler flag "-Wall -Wformat-security -Werror=format-security" was used
