### PR TITLE
FPGA: Fix broken URLs

### DIFF
--- a/DirectProgramming/C++SYCL_FPGA/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/README.md
@@ -2,6 +2,6 @@
 
 Deprecation Notice: The Intel® oneAPI DPC++/C++ Compiler integrated support for Altera FPGA is now deprecated and will be removed with the compiler's release in the first quarter of 2025. Altera* will continue to provide FPGA support through their dedicated FPGA software development tools. Existing customers can continue to use the Intel® oneAPI DPC++/C++ Compiler 2025.0 release which supports FPGA development and is available through Linux* package managers such as APT, YUM/DNF, or Zypper. Additionally, customers with an active support license can access the Intel® oneAPI DPC++/C++ Compiler 2025.0 via their customer support account. 
 
-Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the approriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
+Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the appropriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
 Find FPGA samples for 2025.0 and subsequent patches in the new Altera [hls-samples](https://github.com/altera-fpga/hls-samples) git repository.
 

--- a/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/anr/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/anr/README.md
@@ -5,4 +5,4 @@ Deprecation Notice: The Intel® oneAPI DPC++/C++ Compiler integrated support for
 Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the appropriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
 Find FPGA samples for 2025.0 and subsequent patches in the new Altera [hls-samples](https://github.com/altera-fpga/hls-samples) git repository.
 
-This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/ReferenceDesigns/anr/README.md).
+This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/tree/main/ReferenceDesigns/anr/README.md).

--- a/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/anr/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/anr/README.md
@@ -2,7 +2,7 @@
 
 Deprecation Notice: The Intel® oneAPI DPC++/C++ Compiler integrated support for Altera FPGA is now deprecated and will be removed with the compiler's release in the first quarter of 2025. Altera* will continue to provide FPGA support through their dedicated FPGA software development tools. Existing customers can continue to use the Intel® oneAPI DPC++/C++ Compiler 2025.0 release which supports FPGA development and is available through Linux* package managers such as APT, YUM/DNF, or Zypper. Additionally, customers with an active support license can access the Intel® oneAPI DPC++/C++ Compiler 2025.0 via their customer support account. 
 
-Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the approriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
+Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the appropriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
 Find FPGA samples for 2025.0 and subsequent patches in the new Altera [hls-samples](https://github.com/altera-fpga/hls-samples) git repository.
 
 This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/ReferenceDesigns/anr/README.md).

--- a/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/board_test/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/board_test/README.md
@@ -2,7 +2,7 @@
 
 Deprecation Notice: The Intel® oneAPI DPC++/C++ Compiler integrated support for Altera FPGA is now deprecated and will be removed with the compiler's release in the first quarter of 2025. Altera* will continue to provide FPGA support through their dedicated FPGA software development tools. Existing customers can continue to use the Intel® oneAPI DPC++/C++ Compiler 2025.0 release which supports FPGA development and is available through Linux* package managers such as APT, YUM/DNF, or Zypper. Additionally, customers with an active support license can access the Intel® oneAPI DPC++/C++ Compiler 2025.0 via their customer support account. 
 
-Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the approriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
+Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the appropriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
 Find FPGA samples for 2025.0 and subsequent patches in the new Altera [hls-samples](https://github.com/altera-fpga/hls-samples) git repository.
 
 This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/ReferenceDesigns/board_test/README.md).

--- a/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/board_test/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/board_test/README.md
@@ -5,4 +5,4 @@ Deprecation Notice: The Intel® oneAPI DPC++/C++ Compiler integrated support for
 Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the appropriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
 Find FPGA samples for 2025.0 and subsequent patches in the new Altera [hls-samples](https://github.com/altera-fpga/hls-samples) git repository.
 
-This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/ReferenceDesigns/board_test/README.md).
+This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/tree/main/ReferenceDesigns/board_test/README.md).

--- a/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/cholesky/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/cholesky/README.md
@@ -5,4 +5,4 @@ Deprecation Notice: The Intel® oneAPI DPC++/C++ Compiler integrated support for
 Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the appropriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
 Find FPGA samples for 2025.0 and subsequent patches in the new Altera [hls-samples](https://github.com/altera-fpga/hls-samples) git repository.
 
-This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/ReferenceDesigns/cholesky/README.md).
+This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/tree/main/ReferenceDesigns/cholesky/README.md).

--- a/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/cholesky/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/cholesky/README.md
@@ -2,7 +2,7 @@
 
 Deprecation Notice: The Intel® oneAPI DPC++/C++ Compiler integrated support for Altera FPGA is now deprecated and will be removed with the compiler's release in the first quarter of 2025. Altera* will continue to provide FPGA support through their dedicated FPGA software development tools. Existing customers can continue to use the Intel® oneAPI DPC++/C++ Compiler 2025.0 release which supports FPGA development and is available through Linux* package managers such as APT, YUM/DNF, or Zypper. Additionally, customers with an active support license can access the Intel® oneAPI DPC++/C++ Compiler 2025.0 via their customer support account. 
 
-Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the approriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
+Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the appropriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
 Find FPGA samples for 2025.0 and subsequent patches in the new Altera [hls-samples](https://github.com/altera-fpga/hls-samples) git repository.
 
 This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/ReferenceDesigns/cholesky/README.md).

--- a/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/cholesky_inversion/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/cholesky_inversion/README.md
@@ -2,7 +2,7 @@
 
 Deprecation Notice: The Intel® oneAPI DPC++/C++ Compiler integrated support for Altera FPGA is now deprecated and will be removed with the compiler's release in the first quarter of 2025. Altera* will continue to provide FPGA support through their dedicated FPGA software development tools. Existing customers can continue to use the Intel® oneAPI DPC++/C++ Compiler 2025.0 release which supports FPGA development and is available through Linux* package managers such as APT, YUM/DNF, or Zypper. Additionally, customers with an active support license can access the Intel® oneAPI DPC++/C++ Compiler 2025.0 via their customer support account. 
 
-Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the approriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
+Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the appropriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
 Find FPGA samples for 2025.0 and subsequent patches in the new Altera [hls-samples](https://github.com/altera-fpga/hls-samples) git repository.
 
 This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/ReferenceDesigns/cholesky_inversion/README.md).

--- a/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/cholesky_inversion/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/cholesky_inversion/README.md
@@ -5,4 +5,4 @@ Deprecation Notice: The Intel® oneAPI DPC++/C++ Compiler integrated support for
 Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the appropriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
 Find FPGA samples for 2025.0 and subsequent patches in the new Altera [hls-samples](https://github.com/altera-fpga/hls-samples) git repository.
 
-This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/ReferenceDesigns/cholesky_inversion/README.md).
+This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/tree/main/ReferenceDesigns/cholesky_inversion/README.md).

--- a/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/convolution2d/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/convolution2d/README.md
@@ -2,7 +2,7 @@
 
 Deprecation Notice: The Intel® oneAPI DPC++/C++ Compiler integrated support for Altera FPGA is now deprecated and will be removed with the compiler's release in the first quarter of 2025. Altera* will continue to provide FPGA support through their dedicated FPGA software development tools. Existing customers can continue to use the Intel® oneAPI DPC++/C++ Compiler 2025.0 release which supports FPGA development and is available through Linux* package managers such as APT, YUM/DNF, or Zypper. Additionally, customers with an active support license can access the Intel® oneAPI DPC++/C++ Compiler 2025.0 via their customer support account. 
 
-Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the approriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
+Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the appropriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
 Find FPGA samples for 2025.0 and subsequent patches in the new Altera [hls-samples](https://github.com/altera-fpga/hls-samples) git repository.
 
 This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/ReferenceDesigns/convolution2d/README.md).

--- a/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/convolution2d/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/convolution2d/README.md
@@ -5,4 +5,4 @@ Deprecation Notice: The Intel® oneAPI DPC++/C++ Compiler integrated support for
 Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the appropriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
 Find FPGA samples for 2025.0 and subsequent patches in the new Altera [hls-samples](https://github.com/altera-fpga/hls-samples) git repository.
 
-This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/ReferenceDesigns/convolution2d/README.md).
+This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/tree/main/ReferenceDesigns/convolution2d/README.md).

--- a/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/crr/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/crr/README.md
@@ -5,4 +5,4 @@ Deprecation Notice: The Intel® oneAPI DPC++/C++ Compiler integrated support for
 Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the appropriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
 Find FPGA samples for 2025.0 and subsequent patches in the new Altera [hls-samples](https://github.com/altera-fpga/hls-samples) git repository.
 
-This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/ReferenceDesigns/crr/README.md).
+This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/tree/main/ReferenceDesigns/crr/README.md).

--- a/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/crr/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/crr/README.md
@@ -2,7 +2,7 @@
 
 Deprecation Notice: The Intel® oneAPI DPC++/C++ Compiler integrated support for Altera FPGA is now deprecated and will be removed with the compiler's release in the first quarter of 2025. Altera* will continue to provide FPGA support through their dedicated FPGA software development tools. Existing customers can continue to use the Intel® oneAPI DPC++/C++ Compiler 2025.0 release which supports FPGA development and is available through Linux* package managers such as APT, YUM/DNF, or Zypper. Additionally, customers with an active support license can access the Intel® oneAPI DPC++/C++ Compiler 2025.0 via their customer support account. 
 
-Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the approriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
+Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the appropriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
 Find FPGA samples for 2025.0 and subsequent patches in the new Altera [hls-samples](https://github.com/altera-fpga/hls-samples) git repository.
 
 This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/ReferenceDesigns/crr/README.md).

--- a/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/db/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/db/README.md
@@ -2,7 +2,7 @@
 
 Deprecation Notice: The Intel® oneAPI DPC++/C++ Compiler integrated support for Altera FPGA is now deprecated and will be removed with the compiler's release in the first quarter of 2025. Altera* will continue to provide FPGA support through their dedicated FPGA software development tools. Existing customers can continue to use the Intel® oneAPI DPC++/C++ Compiler 2025.0 release which supports FPGA development and is available through Linux* package managers such as APT, YUM/DNF, or Zypper. Additionally, customers with an active support license can access the Intel® oneAPI DPC++/C++ Compiler 2025.0 via their customer support account. 
 
-Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the approriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
+Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the appropriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
 Find FPGA samples for 2025.0 and subsequent patches in the new Altera [hls-samples](https://github.com/altera-fpga/hls-samples) git repository.
 
 This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/ReferenceDesigns/db/README.md).

--- a/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/db/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/db/README.md
@@ -5,4 +5,4 @@ Deprecation Notice: The Intel® oneAPI DPC++/C++ Compiler integrated support for
 Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the appropriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
 Find FPGA samples for 2025.0 and subsequent patches in the new Altera [hls-samples](https://github.com/altera-fpga/hls-samples) git repository.
 
-This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/ReferenceDesigns/db/README.md).
+This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/tree/main/ReferenceDesigns/db/README.md).

--- a/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/decompress/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/decompress/README.md
@@ -2,7 +2,7 @@
 
 Deprecation Notice: The Intel® oneAPI DPC++/C++ Compiler integrated support for Altera FPGA is now deprecated and will be removed with the compiler's release in the first quarter of 2025. Altera* will continue to provide FPGA support through their dedicated FPGA software development tools. Existing customers can continue to use the Intel® oneAPI DPC++/C++ Compiler 2025.0 release which supports FPGA development and is available through Linux* package managers such as APT, YUM/DNF, or Zypper. Additionally, customers with an active support license can access the Intel® oneAPI DPC++/C++ Compiler 2025.0 via their customer support account. 
 
-Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the approriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
+Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the appropriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
 Find FPGA samples for 2025.0 and subsequent patches in the new Altera [hls-samples](https://github.com/altera-fpga/hls-samples) git repository.
 
 This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/ReferenceDesigns/decompress/README.md).

--- a/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/decompress/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/decompress/README.md
@@ -5,4 +5,4 @@ Deprecation Notice: The Intel® oneAPI DPC++/C++ Compiler integrated support for
 Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the appropriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
 Find FPGA samples for 2025.0 and subsequent patches in the new Altera [hls-samples](https://github.com/altera-fpga/hls-samples) git repository.
 
-This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/ReferenceDesigns/decompress/README.md).
+This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/tree/main/ReferenceDesigns/decompress/README.md).

--- a/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/fft2d/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/fft2d/README.md
@@ -5,4 +5,4 @@ Deprecation Notice: The Intel® oneAPI DPC++/C++ Compiler integrated support for
 Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the appropriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
 Find FPGA samples for 2025.0 and subsequent patches in the new Altera [hls-samples](https://github.com/altera-fpga/hls-samples) git repository.
 
-This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/ReferenceDesigns/fft2d/README.md).
+This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/tree/main/ReferenceDesigns/fft2d/README.md).

--- a/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/fft2d/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/fft2d/README.md
@@ -2,7 +2,7 @@
 
 Deprecation Notice: The Intel® oneAPI DPC++/C++ Compiler integrated support for Altera FPGA is now deprecated and will be removed with the compiler's release in the first quarter of 2025. Altera* will continue to provide FPGA support through their dedicated FPGA software development tools. Existing customers can continue to use the Intel® oneAPI DPC++/C++ Compiler 2025.0 release which supports FPGA development and is available through Linux* package managers such as APT, YUM/DNF, or Zypper. Additionally, customers with an active support license can access the Intel® oneAPI DPC++/C++ Compiler 2025.0 via their customer support account. 
 
-Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the approriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
+Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the appropriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
 Find FPGA samples for 2025.0 and subsequent patches in the new Altera [hls-samples](https://github.com/altera-fpga/hls-samples) git repository.
 
 This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/ReferenceDesigns/fft2d/README.md).

--- a/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/gzip/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/gzip/README.md
@@ -2,7 +2,7 @@
 
 Deprecation Notice: The Intel® oneAPI DPC++/C++ Compiler integrated support for Altera FPGA is now deprecated and will be removed with the compiler's release in the first quarter of 2025. Altera* will continue to provide FPGA support through their dedicated FPGA software development tools. Existing customers can continue to use the Intel® oneAPI DPC++/C++ Compiler 2025.0 release which supports FPGA development and is available through Linux* package managers such as APT, YUM/DNF, or Zypper. Additionally, customers with an active support license can access the Intel® oneAPI DPC++/C++ Compiler 2025.0 via their customer support account. 
 
-Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the approriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
+Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the appropriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
 Find FPGA samples for 2025.0 and subsequent patches in the new Altera [hls-samples](https://github.com/altera-fpga/hls-samples) git repository.
 
 This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/ReferenceDesigns/gzip/README.md).

--- a/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/gzip/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/gzip/README.md
@@ -5,4 +5,4 @@ Deprecation Notice: The Intel® oneAPI DPC++/C++ Compiler integrated support for
 Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the appropriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
 Find FPGA samples for 2025.0 and subsequent patches in the new Altera [hls-samples](https://github.com/altera-fpga/hls-samples) git repository.
 
-This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/ReferenceDesigns/gzip/README.md).
+This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/tree/main/ReferenceDesigns/gzip/README.md).

--- a/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/matmul/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/matmul/README.md
@@ -5,4 +5,4 @@ Deprecation Notice: The Intel® oneAPI DPC++/C++ Compiler integrated support for
 Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the appropriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
 Find FPGA samples for 2025.0 and subsequent patches in the new Altera [hls-samples](https://github.com/altera-fpga/hls-samples) git repository.
 
-This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/ReferenceDesigns/matmul/README.md).
+This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/tree/main/ReferenceDesigns/matmul/README.md).

--- a/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/matmul/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/matmul/README.md
@@ -2,7 +2,7 @@
 
 Deprecation Notice: The Intel® oneAPI DPC++/C++ Compiler integrated support for Altera FPGA is now deprecated and will be removed with the compiler's release in the first quarter of 2025. Altera* will continue to provide FPGA support through their dedicated FPGA software development tools. Existing customers can continue to use the Intel® oneAPI DPC++/C++ Compiler 2025.0 release which supports FPGA development and is available through Linux* package managers such as APT, YUM/DNF, or Zypper. Additionally, customers with an active support license can access the Intel® oneAPI DPC++/C++ Compiler 2025.0 via their customer support account. 
 
-Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the approriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
+Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the appropriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
 Find FPGA samples for 2025.0 and subsequent patches in the new Altera [hls-samples](https://github.com/altera-fpga/hls-samples) git repository.
 
 This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/ReferenceDesigns/matmul/README.md).

--- a/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/merge_sort/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/merge_sort/README.md
@@ -2,7 +2,7 @@
 
 Deprecation Notice: The Intel® oneAPI DPC++/C++ Compiler integrated support for Altera FPGA is now deprecated and will be removed with the compiler's release in the first quarter of 2025. Altera* will continue to provide FPGA support through their dedicated FPGA software development tools. Existing customers can continue to use the Intel® oneAPI DPC++/C++ Compiler 2025.0 release which supports FPGA development and is available through Linux* package managers such as APT, YUM/DNF, or Zypper. Additionally, customers with an active support license can access the Intel® oneAPI DPC++/C++ Compiler 2025.0 via their customer support account. 
 
-Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the approriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
+Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the appropriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
 Find FPGA samples for 2025.0 and subsequent patches in the new Altera [hls-samples](https://github.com/altera-fpga/hls-samples) git repository.
 
 This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/ReferenceDesigns/merge_sort/README.md).

--- a/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/merge_sort/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/merge_sort/README.md
@@ -5,4 +5,4 @@ Deprecation Notice: The Intel® oneAPI DPC++/C++ Compiler integrated support for
 Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the appropriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
 Find FPGA samples for 2025.0 and subsequent patches in the new Altera [hls-samples](https://github.com/altera-fpga/hls-samples) git repository.
 
-This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/ReferenceDesigns/merge_sort/README.md).
+This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/tree/main/ReferenceDesigns/merge_sort/README.md).

--- a/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/mvdr_beamforming/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/mvdr_beamforming/README.md
@@ -2,7 +2,7 @@
 
 Deprecation Notice: The Intel® oneAPI DPC++/C++ Compiler integrated support for Altera FPGA is now deprecated and will be removed with the compiler's release in the first quarter of 2025. Altera* will continue to provide FPGA support through their dedicated FPGA software development tools. Existing customers can continue to use the Intel® oneAPI DPC++/C++ Compiler 2025.0 release which supports FPGA development and is available through Linux* package managers such as APT, YUM/DNF, or Zypper. Additionally, customers with an active support license can access the Intel® oneAPI DPC++/C++ Compiler 2025.0 via their customer support account. 
 
-Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the approriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
+Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the appropriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
 Find FPGA samples for 2025.0 and subsequent patches in the new Altera [hls-samples](https://github.com/altera-fpga/hls-samples) git repository.
 
 This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/ReferenceDesigns/mvdr_beamforming/README.md).

--- a/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/mvdr_beamforming/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/mvdr_beamforming/README.md
@@ -5,4 +5,4 @@ Deprecation Notice: The Intel® oneAPI DPC++/C++ Compiler integrated support for
 Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the appropriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
 Find FPGA samples for 2025.0 and subsequent patches in the new Altera [hls-samples](https://github.com/altera-fpga/hls-samples) git repository.
 
-This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/ReferenceDesigns/mvdr_beamforming/README.md).
+This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/tree/main/ReferenceDesigns/mvdr_beamforming/README.md).

--- a/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/niosv/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/niosv/README.md
@@ -2,7 +2,7 @@
 
 Deprecation Notice: The Intel® oneAPI DPC++/C++ Compiler integrated support for Altera FPGA is now deprecated and will be removed with the compiler's release in the first quarter of 2025. Altera* will continue to provide FPGA support through their dedicated FPGA software development tools. Existing customers can continue to use the Intel® oneAPI DPC++/C++ Compiler 2025.0 release which supports FPGA development and is available through Linux* package managers such as APT, YUM/DNF, or Zypper. Additionally, customers with an active support license can access the Intel® oneAPI DPC++/C++ Compiler 2025.0 via their customer support account. 
 
-Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the approriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
+Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the appropriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
 Find FPGA samples for 2025.0 and subsequent patches in the new Altera [hls-samples](https://github.com/altera-fpga/hls-samples) git repository.
 
 This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/ReferenceDesigns/niosv/README.md).

--- a/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/niosv/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/niosv/README.md
@@ -5,4 +5,4 @@ Deprecation Notice: The Intel® oneAPI DPC++/C++ Compiler integrated support for
 Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the appropriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
 Find FPGA samples for 2025.0 and subsequent patches in the new Altera [hls-samples](https://github.com/altera-fpga/hls-samples) git repository.
 
-This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/ReferenceDesigns/niosv/README.md).
+This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/tree/main/ReferenceDesigns/niosv/README.md).

--- a/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/pca/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/pca/README.md
@@ -2,7 +2,7 @@
 
 Deprecation Notice: The Intel® oneAPI DPC++/C++ Compiler integrated support for Altera FPGA is now deprecated and will be removed with the compiler's release in the first quarter of 2025. Altera* will continue to provide FPGA support through their dedicated FPGA software development tools. Existing customers can continue to use the Intel® oneAPI DPC++/C++ Compiler 2025.0 release which supports FPGA development and is available through Linux* package managers such as APT, YUM/DNF, or Zypper. Additionally, customers with an active support license can access the Intel® oneAPI DPC++/C++ Compiler 2025.0 via their customer support account. 
 
-Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the approriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
+Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the appropriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
 Find FPGA samples for 2025.0 and subsequent patches in the new Altera [hls-samples](https://github.com/altera-fpga/hls-samples) git repository.
 
 This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/ReferenceDesigns/pca/README.md).

--- a/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/pca/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/pca/README.md
@@ -5,4 +5,4 @@ Deprecation Notice: The Intel® oneAPI DPC++/C++ Compiler integrated support for
 Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the appropriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
 Find FPGA samples for 2025.0 and subsequent patches in the new Altera [hls-samples](https://github.com/altera-fpga/hls-samples) git repository.
 
-This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/ReferenceDesigns/pca/README.md).
+This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/tree/main/ReferenceDesigns/pca/README.md).

--- a/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/qrd/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/qrd/README.md
@@ -5,4 +5,4 @@ Deprecation Notice: The Intel® oneAPI DPC++/C++ Compiler integrated support for
 Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the appropriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
 Find FPGA samples for 2025.0 and subsequent patches in the new Altera [hls-samples](https://github.com/altera-fpga/hls-samples) git repository.
 
-This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/ReferenceDesigns/qrd/README.md).
+This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/tree/main/ReferenceDesigns/qrd/README.md).

--- a/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/qrd/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/qrd/README.md
@@ -2,7 +2,7 @@
 
 Deprecation Notice: The Intel® oneAPI DPC++/C++ Compiler integrated support for Altera FPGA is now deprecated and will be removed with the compiler's release in the first quarter of 2025. Altera* will continue to provide FPGA support through their dedicated FPGA software development tools. Existing customers can continue to use the Intel® oneAPI DPC++/C++ Compiler 2025.0 release which supports FPGA development and is available through Linux* package managers such as APT, YUM/DNF, or Zypper. Additionally, customers with an active support license can access the Intel® oneAPI DPC++/C++ Compiler 2025.0 via their customer support account. 
 
-Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the approriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
+Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the appropriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
 Find FPGA samples for 2025.0 and subsequent patches in the new Altera [hls-samples](https://github.com/altera-fpga/hls-samples) git repository.
 
 This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/ReferenceDesigns/qrd/README.md).

--- a/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/qri/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/qri/README.md
@@ -2,7 +2,7 @@
 
 Deprecation Notice: The Intel® oneAPI DPC++/C++ Compiler integrated support for Altera FPGA is now deprecated and will be removed with the compiler's release in the first quarter of 2025. Altera* will continue to provide FPGA support through their dedicated FPGA software development tools. Existing customers can continue to use the Intel® oneAPI DPC++/C++ Compiler 2025.0 release which supports FPGA development and is available through Linux* package managers such as APT, YUM/DNF, or Zypper. Additionally, customers with an active support license can access the Intel® oneAPI DPC++/C++ Compiler 2025.0 via their customer support account. 
 
-Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the approriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
+Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the appropriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
 Find FPGA samples for 2025.0 and subsequent patches in the new Altera [hls-samples](https://github.com/altera-fpga/hls-samples) git repository.
 
 This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/ReferenceDesigns/qri/README.md).

--- a/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/qri/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/qri/README.md
@@ -5,4 +5,4 @@ Deprecation Notice: The Intel® oneAPI DPC++/C++ Compiler integrated support for
 Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the appropriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
 Find FPGA samples for 2025.0 and subsequent patches in the new Altera [hls-samples](https://github.com/altera-fpga/hls-samples) git repository.
 
-This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/ReferenceDesigns/qri/README.md).
+This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/tree/main/ReferenceDesigns/qri/README.md).

--- a/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/svd/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/svd/README.md
@@ -5,4 +5,4 @@ Deprecation Notice: The Intel® oneAPI DPC++/C++ Compiler integrated support for
 Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the appropriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
 Find FPGA samples for 2025.0 and subsequent patches in the new Altera [hls-samples](https://github.com/altera-fpga/hls-samples) git repository.
 
-This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/ReferenceDesigns/svd/README.md).
+This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/tree/main/ReferenceDesigns/svd/README.md).

--- a/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/svd/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/svd/README.md
@@ -2,7 +2,7 @@
 
 Deprecation Notice: The Intel® oneAPI DPC++/C++ Compiler integrated support for Altera FPGA is now deprecated and will be removed with the compiler's release in the first quarter of 2025. Altera* will continue to provide FPGA support through their dedicated FPGA software development tools. Existing customers can continue to use the Intel® oneAPI DPC++/C++ Compiler 2025.0 release which supports FPGA development and is available through Linux* package managers such as APT, YUM/DNF, or Zypper. Additionally, customers with an active support license can access the Intel® oneAPI DPC++/C++ Compiler 2025.0 via their customer support account. 
 
-Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the approriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
+Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the appropriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
 Find FPGA samples for 2025.0 and subsequent patches in the new Altera [hls-samples](https://github.com/altera-fpga/hls-samples) git repository.
 
 This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/ReferenceDesigns/svd/README.md).

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/autorun/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/autorun/README.md
@@ -2,7 +2,7 @@
 
 Deprecation Notice: The Intel® oneAPI DPC++/C++ Compiler integrated support for Altera FPGA is now deprecated and will be removed with the compiler's release in the first quarter of 2025. Altera* will continue to provide FPGA support through their dedicated FPGA software development tools. Existing customers can continue to use the Intel® oneAPI DPC++/C++ Compiler 2025.0 release which supports FPGA development and is available through Linux* package managers such as APT, YUM/DNF, or Zypper. Additionally, customers with an active support license can access the Intel® oneAPI DPC++/C++ Compiler 2025.0 via their customer support account. 
 
-Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the approriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
+Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the appropriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
 Find FPGA samples for 2025.0 and subsequent patches in the new Altera [hls-samples](https://github.com/altera-fpga/hls-samples) git repository.
 
 This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/Tutorials/DesignPatterns/autorun/README.md).

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/autorun/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/autorun/README.md
@@ -5,4 +5,4 @@ Deprecation Notice: The Intel® oneAPI DPC++/C++ Compiler integrated support for
 Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the appropriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
 Find FPGA samples for 2025.0 and subsequent patches in the new Altera [hls-samples](https://github.com/altera-fpga/hls-samples) git repository.
 
-This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/Tutorials/DesignPatterns/autorun/README.md).
+This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/tree/main/Tutorials/DesignPatterns/autorun/README.md).

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/banked_memory_system/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/banked_memory_system/README.md
@@ -2,7 +2,7 @@
 
 Deprecation Notice: The Intel® oneAPI DPC++/C++ Compiler integrated support for Altera FPGA is now deprecated and will be removed with the compiler's release in the first quarter of 2025. Altera* will continue to provide FPGA support through their dedicated FPGA software development tools. Existing customers can continue to use the Intel® oneAPI DPC++/C++ Compiler 2025.0 release which supports FPGA development and is available through Linux* package managers such as APT, YUM/DNF, or Zypper. Additionally, customers with an active support license can access the Intel® oneAPI DPC++/C++ Compiler 2025.0 via their customer support account. 
 
-Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the approriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
+Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the appropriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
 Find FPGA samples for 2025.0 and subsequent patches in the new Altera [hls-samples](https://github.com/altera-fpga/hls-samples) git repository.
 
 This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/Tutorials/DesignPatterns/banked_memory_system/README.md).

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/banked_memory_system/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/banked_memory_system/README.md
@@ -5,4 +5,4 @@ Deprecation Notice: The Intel® oneAPI DPC++/C++ Compiler integrated support for
 Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the appropriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
 Find FPGA samples for 2025.0 and subsequent patches in the new Altera [hls-samples](https://github.com/altera-fpga/hls-samples) git repository.
 
-This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/Tutorials/DesignPatterns/banked_memory_system/README.md).
+This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/tree/main/Tutorials/DesignPatterns/banked_memory_system/README.md).

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/buffered_host_streaming/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/buffered_host_streaming/README.md
@@ -2,7 +2,7 @@
 
 Deprecation Notice: The Intel® oneAPI DPC++/C++ Compiler integrated support for Altera FPGA is now deprecated and will be removed with the compiler's release in the first quarter of 2025. Altera* will continue to provide FPGA support through their dedicated FPGA software development tools. Existing customers can continue to use the Intel® oneAPI DPC++/C++ Compiler 2025.0 release which supports FPGA development and is available through Linux* package managers such as APT, YUM/DNF, or Zypper. Additionally, customers with an active support license can access the Intel® oneAPI DPC++/C++ Compiler 2025.0 via their customer support account. 
 
-Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the approriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
+Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the appropriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
 Find FPGA samples for 2025.0 and subsequent patches in the new Altera [hls-samples](https://github.com/altera-fpga/hls-samples) git repository.
 
 This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/Tutorials/DesignPatterns/buffered_host_streaming/README.md).

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/buffered_host_streaming/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/buffered_host_streaming/README.md
@@ -5,4 +5,4 @@ Deprecation Notice: The Intel® oneAPI DPC++/C++ Compiler integrated support for
 Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the appropriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
 Find FPGA samples for 2025.0 and subsequent patches in the new Altera [hls-samples](https://github.com/altera-fpga/hls-samples) git repository.
 
-This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/Tutorials/DesignPatterns/buffered_host_streaming/README.md).
+This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/tree/main/Tutorials/DesignPatterns/buffered_host_streaming/README.md).

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/compute_units/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/compute_units/README.md
@@ -5,4 +5,4 @@ Deprecation Notice: The Intel® oneAPI DPC++/C++ Compiler integrated support for
 Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the appropriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
 Find FPGA samples for 2025.0 and subsequent patches in the new Altera [hls-samples](https://github.com/altera-fpga/hls-samples) git repository.
 
-This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/Tutorials/DesignPatterns/compute_units/README.md).
+This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/tree/main/Tutorials/DesignPatterns/compute_units/README.md).

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/compute_units/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/compute_units/README.md
@@ -2,7 +2,7 @@
 
 Deprecation Notice: The Intel® oneAPI DPC++/C++ Compiler integrated support for Altera FPGA is now deprecated and will be removed with the compiler's release in the first quarter of 2025. Altera* will continue to provide FPGA support through their dedicated FPGA software development tools. Existing customers can continue to use the Intel® oneAPI DPC++/C++ Compiler 2025.0 release which supports FPGA development and is available through Linux* package managers such as APT, YUM/DNF, or Zypper. Additionally, customers with an active support license can access the Intel® oneAPI DPC++/C++ Compiler 2025.0 via their customer support account. 
 
-Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the approriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
+Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the appropriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
 Find FPGA samples for 2025.0 and subsequent patches in the new Altera [hls-samples](https://github.com/altera-fpga/hls-samples) git repository.
 
 This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/Tutorials/DesignPatterns/compute_units/README.md).

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/double_buffering/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/double_buffering/README.md
@@ -2,7 +2,7 @@
 
 Deprecation Notice: The Intel® oneAPI DPC++/C++ Compiler integrated support for Altera FPGA is now deprecated and will be removed with the compiler's release in the first quarter of 2025. Altera* will continue to provide FPGA support through their dedicated FPGA software development tools. Existing customers can continue to use the Intel® oneAPI DPC++/C++ Compiler 2025.0 release which supports FPGA development and is available through Linux* package managers such as APT, YUM/DNF, or Zypper. Additionally, customers with an active support license can access the Intel® oneAPI DPC++/C++ Compiler 2025.0 via their customer support account. 
 
-Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the approriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
+Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the appropriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
 Find FPGA samples for 2025.0 and subsequent patches in the new Altera [hls-samples](https://github.com/altera-fpga/hls-samples) git repository.
 
 This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/Tutorials/DesignPatterns/double_buffering/README.md).

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/double_buffering/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/double_buffering/README.md
@@ -5,4 +5,4 @@ Deprecation Notice: The Intel® oneAPI DPC++/C++ Compiler integrated support for
 Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the appropriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
 Find FPGA samples for 2025.0 and subsequent patches in the new Altera [hls-samples](https://github.com/altera-fpga/hls-samples) git repository.
 
-This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/Tutorials/DesignPatterns/double_buffering/README.md).
+This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/tree/main/Tutorials/DesignPatterns/double_buffering/README.md).

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/explicit_data_movement/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/explicit_data_movement/README.md
@@ -5,4 +5,4 @@ Deprecation Notice: The Intel® oneAPI DPC++/C++ Compiler integrated support for
 Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the appropriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
 Find FPGA samples for 2025.0 and subsequent patches in the new Altera [hls-samples](https://github.com/altera-fpga/hls-samples) git repository.
 
-This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/Tutorials/DesignPatterns/explicit_data_movement/README.md).
+This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/tree/main/Tutorials/DesignPatterns/explicit_data_movement/README.md).

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/explicit_data_movement/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/explicit_data_movement/README.md
@@ -2,7 +2,7 @@
 
 Deprecation Notice: The Intel® oneAPI DPC++/C++ Compiler integrated support for Altera FPGA is now deprecated and will be removed with the compiler's release in the first quarter of 2025. Altera* will continue to provide FPGA support through their dedicated FPGA software development tools. Existing customers can continue to use the Intel® oneAPI DPC++/C++ Compiler 2025.0 release which supports FPGA development and is available through Linux* package managers such as APT, YUM/DNF, or Zypper. Additionally, customers with an active support license can access the Intel® oneAPI DPC++/C++ Compiler 2025.0 via their customer support account. 
 
-Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the approriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
+Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the appropriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
 Find FPGA samples for 2025.0 and subsequent patches in the new Altera [hls-samples](https://github.com/altera-fpga/hls-samples) git repository.
 
 This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/Tutorials/DesignPatterns/explicit_data_movement/README.md).

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/io_streaming/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/io_streaming/README.md
@@ -5,4 +5,4 @@ Deprecation Notice: The Intel® oneAPI DPC++/C++ Compiler integrated support for
 Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the appropriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
 Find FPGA samples for 2025.0 and subsequent patches in the new Altera [hls-samples](https://github.com/altera-fpga/hls-samples) git repository.
 
-This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/Tutorials/DesignPatterns/io_streaming/README.md).
+This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/tree/main/Tutorials/DesignPatterns/io_streaming/README.md).

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/io_streaming/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/io_streaming/README.md
@@ -2,7 +2,7 @@
 
 Deprecation Notice: The Intel® oneAPI DPC++/C++ Compiler integrated support for Altera FPGA is now deprecated and will be removed with the compiler's release in the first quarter of 2025. Altera* will continue to provide FPGA support through their dedicated FPGA software development tools. Existing customers can continue to use the Intel® oneAPI DPC++/C++ Compiler 2025.0 release which supports FPGA development and is available through Linux* package managers such as APT, YUM/DNF, or Zypper. Additionally, customers with an active support license can access the Intel® oneAPI DPC++/C++ Compiler 2025.0 via their customer support account. 
 
-Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the approriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
+Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the appropriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
 Find FPGA samples for 2025.0 and subsequent patches in the new Altera [hls-samples](https://github.com/altera-fpga/hls-samples) git repository.
 
 This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/Tutorials/DesignPatterns/io_streaming/README.md).

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/loop_carried_dependency/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/loop_carried_dependency/README.md
@@ -2,7 +2,7 @@
 
 Deprecation Notice: The Intel® oneAPI DPC++/C++ Compiler integrated support for Altera FPGA is now deprecated and will be removed with the compiler's release in the first quarter of 2025. Altera* will continue to provide FPGA support through their dedicated FPGA software development tools. Existing customers can continue to use the Intel® oneAPI DPC++/C++ Compiler 2025.0 release which supports FPGA development and is available through Linux* package managers such as APT, YUM/DNF, or Zypper. Additionally, customers with an active support license can access the Intel® oneAPI DPC++/C++ Compiler 2025.0 via their customer support account. 
 
-Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the approriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
+Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the appropriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
 Find FPGA samples for 2025.0 and subsequent patches in the new Altera [hls-samples](https://github.com/altera-fpga/hls-samples) git repository.
 
 This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/Tutorials/DesignPatterns/loop_carried_dependency/README.md).

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/loop_carried_dependency/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/loop_carried_dependency/README.md
@@ -5,4 +5,4 @@ Deprecation Notice: The Intel® oneAPI DPC++/C++ Compiler integrated support for
 Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the appropriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
 Find FPGA samples for 2025.0 and subsequent patches in the new Altera [hls-samples](https://github.com/altera-fpga/hls-samples) git repository.
 
-This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/Tutorials/DesignPatterns/loop_carried_dependency/README.md).
+This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/tree/main/Tutorials/DesignPatterns/loop_carried_dependency/README.md).

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/n_way_buffering/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/n_way_buffering/README.md
@@ -5,4 +5,4 @@ Deprecation Notice: The Intel® oneAPI DPC++/C++ Compiler integrated support for
 Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the appropriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
 Find FPGA samples for 2025.0 and subsequent patches in the new Altera [hls-samples](https://github.com/altera-fpga/hls-samples) git repository.
 
-This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/Tutorials/DesignPatterns/n_way_buffering/README.md).
+This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/tree/main/Tutorials/DesignPatterns/n_way_buffering/README.md).

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/n_way_buffering/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/n_way_buffering/README.md
@@ -2,7 +2,7 @@
 
 Deprecation Notice: The Intel® oneAPI DPC++/C++ Compiler integrated support for Altera FPGA is now deprecated and will be removed with the compiler's release in the first quarter of 2025. Altera* will continue to provide FPGA support through their dedicated FPGA software development tools. Existing customers can continue to use the Intel® oneAPI DPC++/C++ Compiler 2025.0 release which supports FPGA development and is available through Linux* package managers such as APT, YUM/DNF, or Zypper. Additionally, customers with an active support license can access the Intel® oneAPI DPC++/C++ Compiler 2025.0 via their customer support account. 
 
-Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the approriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
+Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the appropriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
 Find FPGA samples for 2025.0 and subsequent patches in the new Altera [hls-samples](https://github.com/altera-fpga/hls-samples) git repository.
 
 This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/Tutorials/DesignPatterns/n_way_buffering/README.md).

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/onchip_memory_cache/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/onchip_memory_cache/README.md
@@ -2,7 +2,7 @@
 
 Deprecation Notice: The Intel® oneAPI DPC++/C++ Compiler integrated support for Altera FPGA is now deprecated and will be removed with the compiler's release in the first quarter of 2025. Altera* will continue to provide FPGA support through their dedicated FPGA software development tools. Existing customers can continue to use the Intel® oneAPI DPC++/C++ Compiler 2025.0 release which supports FPGA development and is available through Linux* package managers such as APT, YUM/DNF, or Zypper. Additionally, customers with an active support license can access the Intel® oneAPI DPC++/C++ Compiler 2025.0 via their customer support account. 
 
-Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the approriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
+Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the appropriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
 Find FPGA samples for 2025.0 and subsequent patches in the new Altera [hls-samples](https://github.com/altera-fpga/hls-samples) git repository.
 
 This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/Tutorials/DesignPatterns/onchip_memory_cache/README.md).

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/onchip_memory_cache/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/onchip_memory_cache/README.md
@@ -5,4 +5,4 @@ Deprecation Notice: The Intel® oneAPI DPC++/C++ Compiler integrated support for
 Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the appropriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
 Find FPGA samples for 2025.0 and subsequent patches in the new Altera [hls-samples](https://github.com/altera-fpga/hls-samples) git repository.
 
-This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/Tutorials/DesignPatterns/onchip_memory_cache/README.md).
+This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/tree/main/Tutorials/DesignPatterns/onchip_memory_cache/README.md).

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/optimize_inner_loop/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/optimize_inner_loop/README.md
@@ -5,4 +5,4 @@ Deprecation Notice: The Intel® oneAPI DPC++/C++ Compiler integrated support for
 Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the appropriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
 Find FPGA samples for 2025.0 and subsequent patches in the new Altera [hls-samples](https://github.com/altera-fpga/hls-samples) git repository.
 
-This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/Tutorials/DesignPatterns/optimize_inner_loop/README.md).
+This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/tree/main/Tutorials/DesignPatterns/optimize_inner_loop/README.md).

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/optimize_inner_loop/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/optimize_inner_loop/README.md
@@ -2,7 +2,7 @@
 
 Deprecation Notice: The Intel® oneAPI DPC++/C++ Compiler integrated support for Altera FPGA is now deprecated and will be removed with the compiler's release in the first quarter of 2025. Altera* will continue to provide FPGA support through their dedicated FPGA software development tools. Existing customers can continue to use the Intel® oneAPI DPC++/C++ Compiler 2025.0 release which supports FPGA development and is available through Linux* package managers such as APT, YUM/DNF, or Zypper. Additionally, customers with an active support license can access the Intel® oneAPI DPC++/C++ Compiler 2025.0 via their customer support account. 
 
-Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the approriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
+Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the appropriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
 Find FPGA samples for 2025.0 and subsequent patches in the new Altera [hls-samples](https://github.com/altera-fpga/hls-samples) git repository.
 
 This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/Tutorials/DesignPatterns/optimize_inner_loop/README.md).

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/pipe_array/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/pipe_array/README.md
@@ -2,7 +2,7 @@
 
 Deprecation Notice: The Intel® oneAPI DPC++/C++ Compiler integrated support for Altera FPGA is now deprecated and will be removed with the compiler's release in the first quarter of 2025. Altera* will continue to provide FPGA support through their dedicated FPGA software development tools. Existing customers can continue to use the Intel® oneAPI DPC++/C++ Compiler 2025.0 release which supports FPGA development and is available through Linux* package managers such as APT, YUM/DNF, or Zypper. Additionally, customers with an active support license can access the Intel® oneAPI DPC++/C++ Compiler 2025.0 via their customer support account. 
 
-Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the approriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
+Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the appropriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
 Find FPGA samples for 2025.0 and subsequent patches in the new Altera [hls-samples](https://github.com/altera-fpga/hls-samples) git repository.
 
 This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/Tutorials/DesignPatterns/pipe_array/README.md).

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/pipe_array/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/pipe_array/README.md
@@ -5,4 +5,4 @@ Deprecation Notice: The Intel® oneAPI DPC++/C++ Compiler integrated support for
 Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the appropriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
 Find FPGA samples for 2025.0 and subsequent patches in the new Altera [hls-samples](https://github.com/altera-fpga/hls-samples) git repository.
 
-This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/Tutorials/DesignPatterns/pipe_array/README.md).
+This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/tree/main/Tutorials/DesignPatterns/pipe_array/README.md).

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/restartable_streaming_kernel/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/restartable_streaming_kernel/README.md
@@ -2,7 +2,7 @@
 
 Deprecation Notice: The Intel® oneAPI DPC++/C++ Compiler integrated support for Altera FPGA is now deprecated and will be removed with the compiler's release in the first quarter of 2025. Altera* will continue to provide FPGA support through their dedicated FPGA software development tools. Existing customers can continue to use the Intel® oneAPI DPC++/C++ Compiler 2025.0 release which supports FPGA development and is available through Linux* package managers such as APT, YUM/DNF, or Zypper. Additionally, customers with an active support license can access the Intel® oneAPI DPC++/C++ Compiler 2025.0 via their customer support account. 
 
-Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the approriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
+Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the appropriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
 Find FPGA samples for 2025.0 and subsequent patches in the new Altera [hls-samples](https://github.com/altera-fpga/hls-samples) git repository.
 
 This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/Tutorials/DesignPatterns/restartable_streaming_kernel/README.md).

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/restartable_streaming_kernel/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/restartable_streaming_kernel/README.md
@@ -5,4 +5,4 @@ Deprecation Notice: The Intel® oneAPI DPC++/C++ Compiler integrated support for
 Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the appropriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
 Find FPGA samples for 2025.0 and subsequent patches in the new Altera [hls-samples](https://github.com/altera-fpga/hls-samples) git repository.
 
-This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/Tutorials/DesignPatterns/restartable_streaming_kernel/README.md).
+This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/tree/main/Tutorials/DesignPatterns/restartable_streaming_kernel/README.md).

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/shannonization/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/shannonization/README.md
@@ -2,7 +2,7 @@
 
 Deprecation Notice: The Intel® oneAPI DPC++/C++ Compiler integrated support for Altera FPGA is now deprecated and will be removed with the compiler's release in the first quarter of 2025. Altera* will continue to provide FPGA support through their dedicated FPGA software development tools. Existing customers can continue to use the Intel® oneAPI DPC++/C++ Compiler 2025.0 release which supports FPGA development and is available through Linux* package managers such as APT, YUM/DNF, or Zypper. Additionally, customers with an active support license can access the Intel® oneAPI DPC++/C++ Compiler 2025.0 via their customer support account. 
 
-Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the approriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
+Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the appropriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
 Find FPGA samples for 2025.0 and subsequent patches in the new Altera [hls-samples](https://github.com/altera-fpga/hls-samples) git repository.
 
 This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/Tutorials/DesignPatterns/shannonization/README.md).

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/shannonization/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/shannonization/README.md
@@ -5,4 +5,4 @@ Deprecation Notice: The Intel® oneAPI DPC++/C++ Compiler integrated support for
 Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the appropriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
 Find FPGA samples for 2025.0 and subsequent patches in the new Altera [hls-samples](https://github.com/altera-fpga/hls-samples) git repository.
 
-This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/Tutorials/DesignPatterns/shannonization/README.md).
+This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/tree/main/Tutorials/DesignPatterns/shannonization/README.md).

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/simple_host_streaming/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/simple_host_streaming/README.md
@@ -5,4 +5,4 @@ Deprecation Notice: The Intel® oneAPI DPC++/C++ Compiler integrated support for
 Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the appropriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
 Find FPGA samples for 2025.0 and subsequent patches in the new Altera [hls-samples](https://github.com/altera-fpga/hls-samples) git repository.
 
-This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/Tutorials/DesignPatterns/simple_host_streaming/README.md).
+This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/tree/main/Tutorials/DesignPatterns/simple_host_streaming/README.md).

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/simple_host_streaming/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/simple_host_streaming/README.md
@@ -2,7 +2,7 @@
 
 Deprecation Notice: The Intel® oneAPI DPC++/C++ Compiler integrated support for Altera FPGA is now deprecated and will be removed with the compiler's release in the first quarter of 2025. Altera* will continue to provide FPGA support through their dedicated FPGA software development tools. Existing customers can continue to use the Intel® oneAPI DPC++/C++ Compiler 2025.0 release which supports FPGA development and is available through Linux* package managers such as APT, YUM/DNF, or Zypper. Additionally, customers with an active support license can access the Intel® oneAPI DPC++/C++ Compiler 2025.0 via their customer support account. 
 
-Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the approriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
+Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the appropriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
 Find FPGA samples for 2025.0 and subsequent patches in the new Altera [hls-samples](https://github.com/altera-fpga/hls-samples) git repository.
 
 This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/Tutorials/DesignPatterns/simple_host_streaming/README.md).

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/triangular_loop/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/triangular_loop/README.md
@@ -5,4 +5,4 @@ Deprecation Notice: The Intel® oneAPI DPC++/C++ Compiler integrated support for
 Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the appropriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
 Find FPGA samples for 2025.0 and subsequent patches in the new Altera [hls-samples](https://github.com/altera-fpga/hls-samples) git repository.
 
-This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/Tutorials/DesignPatterns/triangular_loop/README.md).
+This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/tree/main/Tutorials/DesignPatterns/triangular_loop/README.md).

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/triangular_loop/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/triangular_loop/README.md
@@ -2,7 +2,7 @@
 
 Deprecation Notice: The Intel® oneAPI DPC++/C++ Compiler integrated support for Altera FPGA is now deprecated and will be removed with the compiler's release in the first quarter of 2025. Altera* will continue to provide FPGA support through their dedicated FPGA software development tools. Existing customers can continue to use the Intel® oneAPI DPC++/C++ Compiler 2025.0 release which supports FPGA development and is available through Linux* package managers such as APT, YUM/DNF, or Zypper. Additionally, customers with an active support license can access the Intel® oneAPI DPC++/C++ Compiler 2025.0 via their customer support account. 
 
-Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the approriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
+Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the appropriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
 Find FPGA samples for 2025.0 and subsequent patches in the new Altera [hls-samples](https://github.com/altera-fpga/hls-samples) git repository.
 
 This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/Tutorials/DesignPatterns/triangular_loop/README.md).

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/zero_copy_data_transfer/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/zero_copy_data_transfer/README.md
@@ -2,7 +2,7 @@
 
 Deprecation Notice: The Intel® oneAPI DPC++/C++ Compiler integrated support for Altera FPGA is now deprecated and will be removed with the compiler's release in the first quarter of 2025. Altera* will continue to provide FPGA support through their dedicated FPGA software development tools. Existing customers can continue to use the Intel® oneAPI DPC++/C++ Compiler 2025.0 release which supports FPGA development and is available through Linux* package managers such as APT, YUM/DNF, or Zypper. Additionally, customers with an active support license can access the Intel® oneAPI DPC++/C++ Compiler 2025.0 via their customer support account. 
 
-Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the approriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
+Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the appropriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
 Find FPGA samples for 2025.0 and subsequent patches in the new Altera [hls-samples](https://github.com/altera-fpga/hls-samples) git repository.
 
 This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/Tutorials/DesignPatterns/zero_copy_data_transfer/README.md).

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/zero_copy_data_transfer/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/zero_copy_data_transfer/README.md
@@ -5,4 +5,4 @@ Deprecation Notice: The Intel® oneAPI DPC++/C++ Compiler integrated support for
 Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the appropriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
 Find FPGA samples for 2025.0 and subsequent patches in the new Altera [hls-samples](https://github.com/altera-fpga/hls-samples) git repository.
 
-This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/Tutorials/DesignPatterns/zero_copy_data_transfer/README.md).
+This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/tree/main/Tutorials/DesignPatterns/zero_copy_data_transfer/README.md).

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/ac_fixed/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/ac_fixed/README.md
@@ -2,7 +2,7 @@
 
 Deprecation Notice: The Intel® oneAPI DPC++/C++ Compiler integrated support for Altera FPGA is now deprecated and will be removed with the compiler's release in the first quarter of 2025. Altera* will continue to provide FPGA support through their dedicated FPGA software development tools. Existing customers can continue to use the Intel® oneAPI DPC++/C++ Compiler 2025.0 release which supports FPGA development and is available through Linux* package managers such as APT, YUM/DNF, or Zypper. Additionally, customers with an active support license can access the Intel® oneAPI DPC++/C++ Compiler 2025.0 via their customer support account. 
 
-Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the approriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
+Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the appropriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
 Find FPGA samples for 2025.0 and subsequent patches in the new Altera [hls-samples](https://github.com/altera-fpga/hls-samples) git repository.
 
 This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/Tutorials/Features/ac_fixed/README.md).

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/ac_fixed/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/ac_fixed/README.md
@@ -5,4 +5,4 @@ Deprecation Notice: The Intel® oneAPI DPC++/C++ Compiler integrated support for
 Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the appropriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
 Find FPGA samples for 2025.0 and subsequent patches in the new Altera [hls-samples](https://github.com/altera-fpga/hls-samples) git repository.
 
-This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/Tutorials/Features/ac_fixed/README.md).
+This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/tree/main/Tutorials/Features/ac_fixed/README.md).

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/ac_int/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/ac_int/README.md
@@ -2,7 +2,7 @@
 
 Deprecation Notice: The Intel® oneAPI DPC++/C++ Compiler integrated support for Altera FPGA is now deprecated and will be removed with the compiler's release in the first quarter of 2025. Altera* will continue to provide FPGA support through their dedicated FPGA software development tools. Existing customers can continue to use the Intel® oneAPI DPC++/C++ Compiler 2025.0 release which supports FPGA development and is available through Linux* package managers such as APT, YUM/DNF, or Zypper. Additionally, customers with an active support license can access the Intel® oneAPI DPC++/C++ Compiler 2025.0 via their customer support account. 
 
-Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the approriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
+Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the appropriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
 Find FPGA samples for 2025.0 and subsequent patches in the new Altera [hls-samples](https://github.com/altera-fpga/hls-samples) git repository.
 
 This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/Tutorials/Features/ac_int/README.md).

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/ac_int/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/ac_int/README.md
@@ -5,4 +5,4 @@ Deprecation Notice: The Intel® oneAPI DPC++/C++ Compiler integrated support for
 Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the appropriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
 Find FPGA samples for 2025.0 and subsequent patches in the new Altera [hls-samples](https://github.com/altera-fpga/hls-samples) git repository.
 
-This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/Tutorials/Features/ac_int/README.md).
+This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/tree/main/Tutorials/Features/ac_int/README.md).

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/dsp_control/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/dsp_control/README.md
@@ -5,4 +5,4 @@ Deprecation Notice: The Intel® oneAPI DPC++/C++ Compiler integrated support for
 Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the appropriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
 Find FPGA samples for 2025.0 and subsequent patches in the new Altera [hls-samples](https://github.com/altera-fpga/hls-samples) git repository.
 
-This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/Tutorials/Features/dsp_control/README.md).
+This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/tree/main/Tutorials/Features/dsp_control/README.md).

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/dsp_control/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/dsp_control/README.md
@@ -2,7 +2,7 @@
 
 Deprecation Notice: The Intel® oneAPI DPC++/C++ Compiler integrated support for Altera FPGA is now deprecated and will be removed with the compiler's release in the first quarter of 2025. Altera* will continue to provide FPGA support through their dedicated FPGA software development tools. Existing customers can continue to use the Intel® oneAPI DPC++/C++ Compiler 2025.0 release which supports FPGA development and is available through Linux* package managers such as APT, YUM/DNF, or Zypper. Additionally, customers with an active support license can access the Intel® oneAPI DPC++/C++ Compiler 2025.0 via their customer support account. 
 
-Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the approriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
+Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the appropriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
 Find FPGA samples for 2025.0 and subsequent patches in the new Altera [hls-samples](https://github.com/altera-fpga/hls-samples) git repository.
 
 This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/Tutorials/Features/dsp_control/README.md).

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/experimental/annotated_class_clean_coding/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/experimental/annotated_class_clean_coding/README.md
@@ -5,4 +5,4 @@ Deprecation Notice: The Intel® oneAPI DPC++/C++ Compiler integrated support for
 Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the appropriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
 Find FPGA samples for 2025.0 and subsequent patches in the new Altera [hls-samples](https://github.com/altera-fpga/hls-samples) git repository.
 
-This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/Tutorials/Features/experimental/annotated_class_clean_coding/README.md).
+This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/tree/main/Tutorials/Features/experimental/annotated_class_clean_coding/README.md).

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/experimental/annotated_class_clean_coding/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/experimental/annotated_class_clean_coding/README.md
@@ -2,7 +2,7 @@
 
 Deprecation Notice: The Intel® oneAPI DPC++/C++ Compiler integrated support for Altera FPGA is now deprecated and will be removed with the compiler's release in the first quarter of 2025. Altera* will continue to provide FPGA support through their dedicated FPGA software development tools. Existing customers can continue to use the Intel® oneAPI DPC++/C++ Compiler 2025.0 release which supports FPGA development and is available through Linux* package managers such as APT, YUM/DNF, or Zypper. Additionally, customers with an active support license can access the Intel® oneAPI DPC++/C++ Compiler 2025.0 via their customer support account. 
 
-Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the approriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
+Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the appropriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
 Find FPGA samples for 2025.0 and subsequent patches in the new Altera [hls-samples](https://github.com/altera-fpga/hls-samples) git repository.
 
 This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/Tutorials/Features/experimental/annotated_class_clean_coding/README.md).

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/experimental/annotated_ptr/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/experimental/annotated_ptr/README.md
@@ -2,7 +2,7 @@
 
 Deprecation Notice: The Intel® oneAPI DPC++/C++ Compiler integrated support for Altera FPGA is now deprecated and will be removed with the compiler's release in the first quarter of 2025. Altera* will continue to provide FPGA support through their dedicated FPGA software development tools. Existing customers can continue to use the Intel® oneAPI DPC++/C++ Compiler 2025.0 release which supports FPGA development and is available through Linux* package managers such as APT, YUM/DNF, or Zypper. Additionally, customers with an active support license can access the Intel® oneAPI DPC++/C++ Compiler 2025.0 via their customer support account. 
 
-Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the approriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
+Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the appropriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
 Find FPGA samples for 2025.0 and subsequent patches in the new Altera [hls-samples](https://github.com/altera-fpga/hls-samples) git repository.
 
 This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/Tutorials/Features/experimental/annotated_ptr/README.md).

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/experimental/annotated_ptr/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/experimental/annotated_ptr/README.md
@@ -5,4 +5,4 @@ Deprecation Notice: The Intel® oneAPI DPC++/C++ Compiler integrated support for
 Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the appropriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
 Find FPGA samples for 2025.0 and subsequent patches in the new Altera [hls-samples](https://github.com/altera-fpga/hls-samples) git repository.
 
-This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/Tutorials/Features/experimental/annotated_ptr/README.md).
+This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/tree/main/Tutorials/Features/experimental/annotated_ptr/README.md).

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/experimental/device_global/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/experimental/device_global/README.md
@@ -5,4 +5,4 @@ Deprecation Notice: The Intel® oneAPI DPC++/C++ Compiler integrated support for
 Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the appropriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
 Find FPGA samples for 2025.0 and subsequent patches in the new Altera [hls-samples](https://github.com/altera-fpga/hls-samples) git repository.
 
-This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/Tutorials/Features/experimental/device_global/README.md).
+This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/tree/main/Tutorials/Features/experimental/device_global/README.md).

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/experimental/device_global/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/experimental/device_global/README.md
@@ -2,7 +2,7 @@
 
 Deprecation Notice: The Intel® oneAPI DPC++/C++ Compiler integrated support for Altera FPGA is now deprecated and will be removed with the compiler's release in the first quarter of 2025. Altera* will continue to provide FPGA support through their dedicated FPGA software development tools. Existing customers can continue to use the Intel® oneAPI DPC++/C++ Compiler 2025.0 release which supports FPGA development and is available through Linux* package managers such as APT, YUM/DNF, or Zypper. Additionally, customers with an active support license can access the Intel® oneAPI DPC++/C++ Compiler 2025.0 via their customer support account. 
 
-Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the approriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
+Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the appropriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
 Find FPGA samples for 2025.0 and subsequent patches in the new Altera [hls-samples](https://github.com/altera-fpga/hls-samples) git repository.
 
 This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/Tutorials/Features/experimental/device_global/README.md).

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/experimental/hostpipes/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/experimental/hostpipes/README.md
@@ -2,7 +2,7 @@
 
 Deprecation Notice: The Intel® oneAPI DPC++/C++ Compiler integrated support for Altera FPGA is now deprecated and will be removed with the compiler's release in the first quarter of 2025. Altera* will continue to provide FPGA support through their dedicated FPGA software development tools. Existing customers can continue to use the Intel® oneAPI DPC++/C++ Compiler 2025.0 release which supports FPGA development and is available through Linux* package managers such as APT, YUM/DNF, or Zypper. Additionally, customers with an active support license can access the Intel® oneAPI DPC++/C++ Compiler 2025.0 via their customer support account. 
 
-Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the approriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
+Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the appropriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
 Find FPGA samples for 2025.0 and subsequent patches in the new Altera [hls-samples](https://github.com/altera-fpga/hls-samples) git repository.
 
 This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/Tutorials/Features/experimental/hostpipes/README.md).

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/experimental/hostpipes/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/experimental/hostpipes/README.md
@@ -5,4 +5,4 @@ Deprecation Notice: The Intel® oneAPI DPC++/C++ Compiler integrated support for
 Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the appropriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
 Find FPGA samples for 2025.0 and subsequent patches in the new Altera [hls-samples](https://github.com/altera-fpga/hls-samples) git repository.
 
-This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/Tutorials/Features/experimental/hostpipes/README.md).
+This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/tree/main/Tutorials/Features/experimental/hostpipes/README.md).

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/experimental/latency_control/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/experimental/latency_control/README.md
@@ -5,4 +5,4 @@ Deprecation Notice: The Intel® oneAPI DPC++/C++ Compiler integrated support for
 Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the appropriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
 Find FPGA samples for 2025.0 and subsequent patches in the new Altera [hls-samples](https://github.com/altera-fpga/hls-samples) git repository.
 
-This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/Tutorials/Features/experimental/latency_control/README.md).
+This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/tree/main/Tutorials/Features/experimental/latency_control/README.md).

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/experimental/latency_control/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/experimental/latency_control/README.md
@@ -2,7 +2,7 @@
 
 Deprecation Notice: The Intel® oneAPI DPC++/C++ Compiler integrated support for Altera FPGA is now deprecated and will be removed with the compiler's release in the first quarter of 2025. Altera* will continue to provide FPGA support through their dedicated FPGA software development tools. Existing customers can continue to use the Intel® oneAPI DPC++/C++ Compiler 2025.0 release which supports FPGA development and is available through Linux* package managers such as APT, YUM/DNF, or Zypper. Additionally, customers with an active support license can access the Intel® oneAPI DPC++/C++ Compiler 2025.0 via their customer support account. 
 
-Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the approriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
+Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the appropriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
 Find FPGA samples for 2025.0 and subsequent patches in the new Altera [hls-samples](https://github.com/altera-fpga/hls-samples) git repository.
 
 This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/Tutorials/Features/experimental/latency_control/README.md).

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/fpga_reg/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/fpga_reg/README.md
@@ -5,4 +5,4 @@ Deprecation Notice: The Intel® oneAPI DPC++/C++ Compiler integrated support for
 Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the appropriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
 Find FPGA samples for 2025.0 and subsequent patches in the new Altera [hls-samples](https://github.com/altera-fpga/hls-samples) git repository.
 
-This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/Tutorials/Features/fpga_reg/README.md).
+This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/tree/main/Tutorials/Features/fpga_reg/README.md).

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/fpga_reg/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/fpga_reg/README.md
@@ -2,7 +2,7 @@
 
 Deprecation Notice: The Intel® oneAPI DPC++/C++ Compiler integrated support for Altera FPGA is now deprecated and will be removed with the compiler's release in the first quarter of 2025. Altera* will continue to provide FPGA support through their dedicated FPGA software development tools. Existing customers can continue to use the Intel® oneAPI DPC++/C++ Compiler 2025.0 release which supports FPGA development and is available through Linux* package managers such as APT, YUM/DNF, or Zypper. Additionally, customers with an active support license can access the Intel® oneAPI DPC++/C++ Compiler 2025.0 via their customer support account. 
 
-Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the approriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
+Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the appropriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
 Find FPGA samples for 2025.0 and subsequent patches in the new Altera [hls-samples](https://github.com/altera-fpga/hls-samples) git repository.
 
 This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/Tutorials/Features/fpga_reg/README.md).

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/hls_flow_interfaces/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/hls_flow_interfaces/README.md
@@ -2,7 +2,7 @@
 
 Deprecation Notice: The Intel® oneAPI DPC++/C++ Compiler integrated support for Altera FPGA is now deprecated and will be removed with the compiler's release in the first quarter of 2025. Altera* will continue to provide FPGA support through their dedicated FPGA software development tools. Existing customers can continue to use the Intel® oneAPI DPC++/C++ Compiler 2025.0 release which supports FPGA development and is available through Linux* package managers such as APT, YUM/DNF, or Zypper. Additionally, customers with an active support license can access the Intel® oneAPI DPC++/C++ Compiler 2025.0 via their customer support account. 
 
-Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the approriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
+Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the appropriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
 Find FPGA samples for 2025.0 and subsequent patches in the new Altera [hls-samples](https://github.com/altera-fpga/hls-samples) git repository.
 
 This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/Tutorials/Features/hls_flow_interfaces/README.md).

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/hls_flow_interfaces/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/hls_flow_interfaces/README.md
@@ -5,4 +5,4 @@ Deprecation Notice: The Intel® oneAPI DPC++/C++ Compiler integrated support for
 Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the appropriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
 Find FPGA samples for 2025.0 and subsequent patches in the new Altera [hls-samples](https://github.com/altera-fpga/hls-samples) git repository.
 
-This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/Tutorials/Features/hls_flow_interfaces/README.md).
+This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/tree/main/Tutorials/Features/hls_flow_interfaces/README.md).

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/hls_flow_interfaces/component_interfaces_comparison/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/hls_flow_interfaces/component_interfaces_comparison/README.md
@@ -5,4 +5,4 @@ Deprecation Notice: The Intel® oneAPI DPC++/C++ Compiler integrated support for
 Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the appropriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
 Find FPGA samples for 2025.0 and subsequent patches in the new Altera [hls-samples](https://github.com/altera-fpga/hls-samples) git repository.
 
-This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/Tutorials/Features/hls_flow_interfaces/component_interfaces_comparison/README.md).
+This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/tree/main/Tutorials/Features/hls_flow_interfaces/component_interfaces_comparison/README.md).

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/hls_flow_interfaces/component_interfaces_comparison/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/hls_flow_interfaces/component_interfaces_comparison/README.md
@@ -2,7 +2,7 @@
 
 Deprecation Notice: The Intel® oneAPI DPC++/C++ Compiler integrated support for Altera FPGA is now deprecated and will be removed with the compiler's release in the first quarter of 2025. Altera* will continue to provide FPGA support through their dedicated FPGA software development tools. Existing customers can continue to use the Intel® oneAPI DPC++/C++ Compiler 2025.0 release which supports FPGA development and is available through Linux* package managers such as APT, YUM/DNF, or Zypper. Additionally, customers with an active support license can access the Intel® oneAPI DPC++/C++ Compiler 2025.0 via their customer support account. 
 
-Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the approriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
+Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the appropriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
 Find FPGA samples for 2025.0 and subsequent patches in the new Altera [hls-samples](https://github.com/altera-fpga/hls-samples) git repository.
 
 This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/Tutorials/Features/hls_flow_interfaces/component_interfaces_comparison/README.md).

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/hls_flow_interfaces/component_interfaces_comparison/csr-pipes/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/hls_flow_interfaces/component_interfaces_comparison/csr-pipes/README.md
@@ -2,7 +2,7 @@
 
 Deprecation Notice: The Intel® oneAPI DPC++/C++ Compiler integrated support for Altera FPGA is now deprecated and will be removed with the compiler's release in the first quarter of 2025. Altera* will continue to provide FPGA support through their dedicated FPGA software development tools. Existing customers can continue to use the Intel® oneAPI DPC++/C++ Compiler 2025.0 release which supports FPGA development and is available through Linux* package managers such as APT, YUM/DNF, or Zypper. Additionally, customers with an active support license can access the Intel® oneAPI DPC++/C++ Compiler 2025.0 via their customer support account. 
 
-Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the approriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
+Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the appropriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
 Find FPGA samples for 2025.0 and subsequent patches in the new Altera [hls-samples](https://github.com/altera-fpga/hls-samples) git repository.
 
 This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/Tutorials/Features/hls_flow_interfaces/component_interfaces_comparison/csr-pipes/README.md).

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/hls_flow_interfaces/component_interfaces_comparison/csr-pipes/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/hls_flow_interfaces/component_interfaces_comparison/csr-pipes/README.md
@@ -5,4 +5,4 @@ Deprecation Notice: The Intel® oneAPI DPC++/C++ Compiler integrated support for
 Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the appropriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
 Find FPGA samples for 2025.0 and subsequent patches in the new Altera [hls-samples](https://github.com/altera-fpga/hls-samples) git repository.
 
-This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/Tutorials/Features/hls_flow_interfaces/component_interfaces_comparison/csr-pipes/README.md).
+This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/tree/main/Tutorials/Features/hls_flow_interfaces/component_interfaces_comparison/csr-pipes/README.md).

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/hls_flow_interfaces/component_interfaces_comparison/mm-host/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/hls_flow_interfaces/component_interfaces_comparison/mm-host/README.md
@@ -5,4 +5,4 @@ Deprecation Notice: The Intel® oneAPI DPC++/C++ Compiler integrated support for
 Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the appropriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
 Find FPGA samples for 2025.0 and subsequent patches in the new Altera [hls-samples](https://github.com/altera-fpga/hls-samples) git repository.
 
-This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/Tutorials/Features/hls_flow_interfaces/component_interfaces_comparison/mm-host/README.md).
+This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/tree/main/Tutorials/Features/hls_flow_interfaces/component_interfaces_comparison/mm-host/README.md).

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/hls_flow_interfaces/component_interfaces_comparison/mm-host/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/hls_flow_interfaces/component_interfaces_comparison/mm-host/README.md
@@ -2,7 +2,7 @@
 
 Deprecation Notice: The Intel® oneAPI DPC++/C++ Compiler integrated support for Altera FPGA is now deprecated and will be removed with the compiler's release in the first quarter of 2025. Altera* will continue to provide FPGA support through their dedicated FPGA software development tools. Existing customers can continue to use the Intel® oneAPI DPC++/C++ Compiler 2025.0 release which supports FPGA development and is available through Linux* package managers such as APT, YUM/DNF, or Zypper. Additionally, customers with an active support license can access the Intel® oneAPI DPC++/C++ Compiler 2025.0 via their customer support account. 
 
-Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the approriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
+Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the appropriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
 Find FPGA samples for 2025.0 and subsequent patches in the new Altera [hls-samples](https://github.com/altera-fpga/hls-samples) git repository.
 
 This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/Tutorials/Features/hls_flow_interfaces/component_interfaces_comparison/mm-host/README.md).

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/hls_flow_interfaces/component_interfaces_comparison/naive/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/hls_flow_interfaces/component_interfaces_comparison/naive/README.md
@@ -2,7 +2,7 @@
 
 Deprecation Notice: The Intel® oneAPI DPC++/C++ Compiler integrated support for Altera FPGA is now deprecated and will be removed with the compiler's release in the first quarter of 2025. Altera* will continue to provide FPGA support through their dedicated FPGA software development tools. Existing customers can continue to use the Intel® oneAPI DPC++/C++ Compiler 2025.0 release which supports FPGA development and is available through Linux* package managers such as APT, YUM/DNF, or Zypper. Additionally, customers with an active support license can access the Intel® oneAPI DPC++/C++ Compiler 2025.0 via their customer support account. 
 
-Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the approriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
+Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the appropriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
 Find FPGA samples for 2025.0 and subsequent patches in the new Altera [hls-samples](https://github.com/altera-fpga/hls-samples) git repository.
 
 This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/Tutorials/Features/hls_flow_interfaces/component_interfaces_comparison/naive/README.md).

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/hls_flow_interfaces/component_interfaces_comparison/naive/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/hls_flow_interfaces/component_interfaces_comparison/naive/README.md
@@ -5,4 +5,4 @@ Deprecation Notice: The Intel® oneAPI DPC++/C++ Compiler integrated support for
 Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the appropriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
 Find FPGA samples for 2025.0 and subsequent patches in the new Altera [hls-samples](https://github.com/altera-fpga/hls-samples) git repository.
 
-This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/Tutorials/Features/hls_flow_interfaces/component_interfaces_comparison/naive/README.md).
+This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/tree/main/Tutorials/Features/hls_flow_interfaces/component_interfaces_comparison/naive/README.md).

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/hls_flow_interfaces/component_interfaces_comparison/pipes/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/hls_flow_interfaces/component_interfaces_comparison/pipes/README.md
@@ -5,4 +5,4 @@ Deprecation Notice: The Intel® oneAPI DPC++/C++ Compiler integrated support for
 Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the appropriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
 Find FPGA samples for 2025.0 and subsequent patches in the new Altera [hls-samples](https://github.com/altera-fpga/hls-samples) git repository.
 
-This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/Tutorials/Features/hls_flow_interfaces/component_interfaces_comparison/pipes/README.md).
+This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/tree/main/Tutorials/Features/hls_flow_interfaces/component_interfaces_comparison/pipes/README.md).

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/hls_flow_interfaces/component_interfaces_comparison/pipes/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/hls_flow_interfaces/component_interfaces_comparison/pipes/README.md
@@ -2,7 +2,7 @@
 
 Deprecation Notice: The Intel® oneAPI DPC++/C++ Compiler integrated support for Altera FPGA is now deprecated and will be removed with the compiler's release in the first quarter of 2025. Altera* will continue to provide FPGA support through their dedicated FPGA software development tools. Existing customers can continue to use the Intel® oneAPI DPC++/C++ Compiler 2025.0 release which supports FPGA development and is available through Linux* package managers such as APT, YUM/DNF, or Zypper. Additionally, customers with an active support license can access the Intel® oneAPI DPC++/C++ Compiler 2025.0 via their customer support account. 
 
-Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the approriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
+Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the appropriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
 Find FPGA samples for 2025.0 and subsequent patches in the new Altera [hls-samples](https://github.com/altera-fpga/hls-samples) git repository.
 
 This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/Tutorials/Features/hls_flow_interfaces/component_interfaces_comparison/pipes/README.md).

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/hls_flow_interfaces/component_interfaces_comparison/streaming-invocation/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/hls_flow_interfaces/component_interfaces_comparison/streaming-invocation/README.md
@@ -5,4 +5,4 @@ Deprecation Notice: The Intel® oneAPI DPC++/C++ Compiler integrated support for
 Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the appropriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
 Find FPGA samples for 2025.0 and subsequent patches in the new Altera [hls-samples](https://github.com/altera-fpga/hls-samples) git repository.
 
-This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/Tutorials/Features/hls_flow_interfaces/component_interfaces_comparison/streaming-invocation/README.md).
+This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/tree/main/Tutorials/Features/hls_flow_interfaces/component_interfaces_comparison/streaming-invocation/README.md).

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/hls_flow_interfaces/component_interfaces_comparison/streaming-invocation/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/hls_flow_interfaces/component_interfaces_comparison/streaming-invocation/README.md
@@ -2,7 +2,7 @@
 
 Deprecation Notice: The Intel® oneAPI DPC++/C++ Compiler integrated support for Altera FPGA is now deprecated and will be removed with the compiler's release in the first quarter of 2025. Altera* will continue to provide FPGA support through their dedicated FPGA software development tools. Existing customers can continue to use the Intel® oneAPI DPC++/C++ Compiler 2025.0 release which supports FPGA development and is available through Linux* package managers such as APT, YUM/DNF, or Zypper. Additionally, customers with an active support license can access the Intel® oneAPI DPC++/C++ Compiler 2025.0 via their customer support account. 
 
-Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the approriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
+Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the appropriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
 Find FPGA samples for 2025.0 and subsequent patches in the new Altera [hls-samples](https://github.com/altera-fpga/hls-samples) git repository.
 
 This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/Tutorials/Features/hls_flow_interfaces/component_interfaces_comparison/streaming-invocation/README.md).

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/hls_flow_interfaces/invocation_interfaces/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/hls_flow_interfaces/invocation_interfaces/README.md
@@ -5,4 +5,4 @@ Deprecation Notice: The Intel® oneAPI DPC++/C++ Compiler integrated support for
 Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the appropriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
 Find FPGA samples for 2025.0 and subsequent patches in the new Altera [hls-samples](https://github.com/altera-fpga/hls-samples) git repository.
 
-This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/Tutorials/Features/hls_flow_interfaces/invocation_interfaces/README.md).
+This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/tree/main/Tutorials/Features/hls_flow_interfaces/invocation_interfaces/README.md).

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/hls_flow_interfaces/invocation_interfaces/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/hls_flow_interfaces/invocation_interfaces/README.md
@@ -2,7 +2,7 @@
 
 Deprecation Notice: The Intel® oneAPI DPC++/C++ Compiler integrated support for Altera FPGA is now deprecated and will be removed with the compiler's release in the first quarter of 2025. Altera* will continue to provide FPGA support through their dedicated FPGA software development tools. Existing customers can continue to use the Intel® oneAPI DPC++/C++ Compiler 2025.0 release which supports FPGA development and is available through Linux* package managers such as APT, YUM/DNF, or Zypper. Additionally, customers with an active support license can access the Intel® oneAPI DPC++/C++ Compiler 2025.0 via their customer support account. 
 
-Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the approriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
+Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the appropriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
 Find FPGA samples for 2025.0 and subsequent patches in the new Altera [hls-samples](https://github.com/altera-fpga/hls-samples) git repository.
 
 This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/Tutorials/Features/hls_flow_interfaces/invocation_interfaces/README.md).

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/hls_flow_interfaces/mmhost/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/hls_flow_interfaces/mmhost/README.md
@@ -5,4 +5,4 @@ Deprecation Notice: The Intel® oneAPI DPC++/C++ Compiler integrated support for
 Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the appropriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
 Find FPGA samples for 2025.0 and subsequent patches in the new Altera [hls-samples](https://github.com/altera-fpga/hls-samples) git repository.
 
-This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/Tutorials/Features/hls_flow_interfaces/mmhost/README.md).
+This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/tree/main/Tutorials/Features/hls_flow_interfaces/mmhost/README.md).

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/hls_flow_interfaces/mmhost/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/hls_flow_interfaces/mmhost/README.md
@@ -2,7 +2,7 @@
 
 Deprecation Notice: The Intel® oneAPI DPC++/C++ Compiler integrated support for Altera FPGA is now deprecated and will be removed with the compiler's release in the first quarter of 2025. Altera* will continue to provide FPGA support through their dedicated FPGA software development tools. Existing customers can continue to use the Intel® oneAPI DPC++/C++ Compiler 2025.0 release which supports FPGA development and is available through Linux* package managers such as APT, YUM/DNF, or Zypper. Additionally, customers with an active support license can access the Intel® oneAPI DPC++/C++ Compiler 2025.0 via their customer support account. 
 
-Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the approriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
+Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the appropriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
 Find FPGA samples for 2025.0 and subsequent patches in the new Altera [hls-samples](https://github.com/altera-fpga/hls-samples) git repository.
 
 This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/Tutorials/Features/hls_flow_interfaces/mmhost/README.md).

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/hls_flow_interfaces/streaming_data_interfaces/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/hls_flow_interfaces/streaming_data_interfaces/README.md
@@ -5,4 +5,4 @@ Deprecation Notice: The Intel® oneAPI DPC++/C++ Compiler integrated support for
 Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the appropriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
 Find FPGA samples for 2025.0 and subsequent patches in the new Altera [hls-samples](https://github.com/altera-fpga/hls-samples) git repository.
 
-This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/Tutorials/Features/hls_flow_interfaces/streaming_data_interfaces/README.md).
+This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/tree/main/Tutorials/Features/hls_flow_interfaces/streaming_data_interfaces/README.md).

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/hls_flow_interfaces/streaming_data_interfaces/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/hls_flow_interfaces/streaming_data_interfaces/README.md
@@ -2,7 +2,7 @@
 
 Deprecation Notice: The Intel® oneAPI DPC++/C++ Compiler integrated support for Altera FPGA is now deprecated and will be removed with the compiler's release in the first quarter of 2025. Altera* will continue to provide FPGA support through their dedicated FPGA software development tools. Existing customers can continue to use the Intel® oneAPI DPC++/C++ Compiler 2025.0 release which supports FPGA development and is available through Linux* package managers such as APT, YUM/DNF, or Zypper. Additionally, customers with an active support license can access the Intel® oneAPI DPC++/C++ Compiler 2025.0 via their customer support account. 
 
-Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the approriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
+Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the appropriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
 Find FPGA samples for 2025.0 and subsequent patches in the new Altera [hls-samples](https://github.com/altera-fpga/hls-samples) git repository.
 
 This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/Tutorials/Features/hls_flow_interfaces/streaming_data_interfaces/README.md).

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/kernel_args_restrict/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/kernel_args_restrict/README.md
@@ -5,4 +5,4 @@ Deprecation Notice: The Intel® oneAPI DPC++/C++ Compiler integrated support for
 Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the appropriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
 Find FPGA samples for 2025.0 and subsequent patches in the new Altera [hls-samples](https://github.com/altera-fpga/hls-samples) git repository.
 
-This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/Tutorials/Features/kernel_args_restrict/README.md).
+This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/tree/main/Tutorials/Features/kernel_args_restrict/README.md).

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/kernel_args_restrict/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/kernel_args_restrict/README.md
@@ -2,7 +2,7 @@
 
 Deprecation Notice: The Intel® oneAPI DPC++/C++ Compiler integrated support for Altera FPGA is now deprecated and will be removed with the compiler's release in the first quarter of 2025. Altera* will continue to provide FPGA support through their dedicated FPGA software development tools. Existing customers can continue to use the Intel® oneAPI DPC++/C++ Compiler 2025.0 release which supports FPGA development and is available through Linux* package managers such as APT, YUM/DNF, or Zypper. Additionally, customers with an active support license can access the Intel® oneAPI DPC++/C++ Compiler 2025.0 via their customer support account. 
 
-Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the approriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
+Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the appropriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
 Find FPGA samples for 2025.0 and subsequent patches in the new Altera [hls-samples](https://github.com/altera-fpga/hls-samples) git repository.
 
 This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/Tutorials/Features/kernel_args_restrict/README.md).

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/loop_coalesce/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/loop_coalesce/README.md
@@ -2,7 +2,7 @@
 
 Deprecation Notice: The Intel® oneAPI DPC++/C++ Compiler integrated support for Altera FPGA is now deprecated and will be removed with the compiler's release in the first quarter of 2025. Altera* will continue to provide FPGA support through their dedicated FPGA software development tools. Existing customers can continue to use the Intel® oneAPI DPC++/C++ Compiler 2025.0 release which supports FPGA development and is available through Linux* package managers such as APT, YUM/DNF, or Zypper. Additionally, customers with an active support license can access the Intel® oneAPI DPC++/C++ Compiler 2025.0 via their customer support account. 
 
-Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the approriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
+Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the appropriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
 Find FPGA samples for 2025.0 and subsequent patches in the new Altera [hls-samples](https://github.com/altera-fpga/hls-samples) git repository.
 
 This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/Tutorials/Features/loop_coalesce/README.md).

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/loop_coalesce/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/loop_coalesce/README.md
@@ -5,4 +5,4 @@ Deprecation Notice: The Intel® oneAPI DPC++/C++ Compiler integrated support for
 Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the appropriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
 Find FPGA samples for 2025.0 and subsequent patches in the new Altera [hls-samples](https://github.com/altera-fpga/hls-samples) git repository.
 
-This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/Tutorials/Features/loop_coalesce/README.md).
+This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/tree/main/Tutorials/Features/loop_coalesce/README.md).

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/loop_fusion/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/loop_fusion/README.md
@@ -2,7 +2,7 @@
 
 Deprecation Notice: The Intel® oneAPI DPC++/C++ Compiler integrated support for Altera FPGA is now deprecated and will be removed with the compiler's release in the first quarter of 2025. Altera* will continue to provide FPGA support through their dedicated FPGA software development tools. Existing customers can continue to use the Intel® oneAPI DPC++/C++ Compiler 2025.0 release which supports FPGA development and is available through Linux* package managers such as APT, YUM/DNF, or Zypper. Additionally, customers with an active support license can access the Intel® oneAPI DPC++/C++ Compiler 2025.0 via their customer support account. 
 
-Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the approriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
+Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the appropriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
 Find FPGA samples for 2025.0 and subsequent patches in the new Altera [hls-samples](https://github.com/altera-fpga/hls-samples) git repository.
 
 This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/Tutorials/Features/loop_fusion/README.md).

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/loop_fusion/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/loop_fusion/README.md
@@ -5,4 +5,4 @@ Deprecation Notice: The Intel® oneAPI DPC++/C++ Compiler integrated support for
 Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the appropriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
 Find FPGA samples for 2025.0 and subsequent patches in the new Altera [hls-samples](https://github.com/altera-fpga/hls-samples) git repository.
 
-This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/Tutorials/Features/loop_fusion/README.md).
+This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/tree/main/Tutorials/Features/loop_fusion/README.md).

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/loop_initiation_interval/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/loop_initiation_interval/README.md
@@ -2,7 +2,7 @@
 
 Deprecation Notice: The Intel® oneAPI DPC++/C++ Compiler integrated support for Altera FPGA is now deprecated and will be removed with the compiler's release in the first quarter of 2025. Altera* will continue to provide FPGA support through their dedicated FPGA software development tools. Existing customers can continue to use the Intel® oneAPI DPC++/C++ Compiler 2025.0 release which supports FPGA development and is available through Linux* package managers such as APT, YUM/DNF, or Zypper. Additionally, customers with an active support license can access the Intel® oneAPI DPC++/C++ Compiler 2025.0 via their customer support account. 
 
-Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the approriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
+Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the appropriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
 Find FPGA samples for 2025.0 and subsequent patches in the new Altera [hls-samples](https://github.com/altera-fpga/hls-samples) git repository.
 
 This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/Tutorials/Features/loop_initiation_interval/README.md).

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/loop_initiation_interval/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/loop_initiation_interval/README.md
@@ -5,4 +5,4 @@ Deprecation Notice: The Intel® oneAPI DPC++/C++ Compiler integrated support for
 Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the appropriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
 Find FPGA samples for 2025.0 and subsequent patches in the new Altera [hls-samples](https://github.com/altera-fpga/hls-samples) git repository.
 
-This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/Tutorials/Features/loop_initiation_interval/README.md).
+This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/tree/main/Tutorials/Features/loop_initiation_interval/README.md).

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/loop_ivdep/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/loop_ivdep/README.md
@@ -5,4 +5,4 @@ Deprecation Notice: The Intel® oneAPI DPC++/C++ Compiler integrated support for
 Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the appropriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
 Find FPGA samples for 2025.0 and subsequent patches in the new Altera [hls-samples](https://github.com/altera-fpga/hls-samples) git repository.
 
-This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/Tutorials/Features/loop_ivdep/README.md).
+This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/tree/main/Tutorials/Features/loop_ivdep/README.md).

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/loop_ivdep/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/loop_ivdep/README.md
@@ -2,7 +2,7 @@
 
 Deprecation Notice: The Intel® oneAPI DPC++/C++ Compiler integrated support for Altera FPGA is now deprecated and will be removed with the compiler's release in the first quarter of 2025. Altera* will continue to provide FPGA support through their dedicated FPGA software development tools. Existing customers can continue to use the Intel® oneAPI DPC++/C++ Compiler 2025.0 release which supports FPGA development and is available through Linux* package managers such as APT, YUM/DNF, or Zypper. Additionally, customers with an active support license can access the Intel® oneAPI DPC++/C++ Compiler 2025.0 via their customer support account. 
 
-Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the approriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
+Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the appropriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
 Find FPGA samples for 2025.0 and subsequent patches in the new Altera [hls-samples](https://github.com/altera-fpga/hls-samples) git repository.
 
 This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/Tutorials/Features/loop_ivdep/README.md).

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/loop_unroll/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/loop_unroll/README.md
@@ -5,4 +5,4 @@ Deprecation Notice: The Intel® oneAPI DPC++/C++ Compiler integrated support for
 Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the appropriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
 Find FPGA samples for 2025.0 and subsequent patches in the new Altera [hls-samples](https://github.com/altera-fpga/hls-samples) git repository.
 
-This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/Tutorials/Features/loop_unroll/README.md).
+This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/tree/main/Tutorials/Features/loop_unroll/README.md).

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/loop_unroll/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/loop_unroll/README.md
@@ -2,7 +2,7 @@
 
 Deprecation Notice: The Intel® oneAPI DPC++/C++ Compiler integrated support for Altera FPGA is now deprecated and will be removed with the compiler's release in the first quarter of 2025. Altera* will continue to provide FPGA support through their dedicated FPGA software development tools. Existing customers can continue to use the Intel® oneAPI DPC++/C++ Compiler 2025.0 release which supports FPGA development and is available through Linux* package managers such as APT, YUM/DNF, or Zypper. Additionally, customers with an active support license can access the Intel® oneAPI DPC++/C++ Compiler 2025.0 via their customer support account. 
 
-Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the approriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
+Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the appropriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
 Find FPGA samples for 2025.0 and subsequent patches in the new Altera [hls-samples](https://github.com/altera-fpga/hls-samples) git repository.
 
 This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/Tutorials/Features/loop_unroll/README.md).

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/lsu_control/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/lsu_control/README.md
@@ -2,7 +2,7 @@
 
 Deprecation Notice: The Intel® oneAPI DPC++/C++ Compiler integrated support for Altera FPGA is now deprecated and will be removed with the compiler's release in the first quarter of 2025. Altera* will continue to provide FPGA support through their dedicated FPGA software development tools. Existing customers can continue to use the Intel® oneAPI DPC++/C++ Compiler 2025.0 release which supports FPGA development and is available through Linux* package managers such as APT, YUM/DNF, or Zypper. Additionally, customers with an active support license can access the Intel® oneAPI DPC++/C++ Compiler 2025.0 via their customer support account. 
 
-Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the approriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
+Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the appropriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
 Find FPGA samples for 2025.0 and subsequent patches in the new Altera [hls-samples](https://github.com/altera-fpga/hls-samples) git repository.
 
 This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/Tutorials/Features/lsu_control/README.md).

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/lsu_control/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/lsu_control/README.md
@@ -5,4 +5,4 @@ Deprecation Notice: The Intel® oneAPI DPC++/C++ Compiler integrated support for
 Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the appropriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
 Find FPGA samples for 2025.0 and subsequent patches in the new Altera [hls-samples](https://github.com/altera-fpga/hls-samples) git repository.
 
-This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/Tutorials/Features/lsu_control/README.md).
+This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/tree/main/Tutorials/Features/lsu_control/README.md).

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/max_interleaving/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/max_interleaving/README.md
@@ -5,4 +5,4 @@ Deprecation Notice: The Intel® oneAPI DPC++/C++ Compiler integrated support for
 Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the appropriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
 Find FPGA samples for 2025.0 and subsequent patches in the new Altera [hls-samples](https://github.com/altera-fpga/hls-samples) git repository.
 
-This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/Tutorials/Features/max_interleaving/README.md).
+This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/tree/main/Tutorials/Features/max_interleaving/README.md).

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/max_interleaving/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/max_interleaving/README.md
@@ -2,7 +2,7 @@
 
 Deprecation Notice: The Intel® oneAPI DPC++/C++ Compiler integrated support for Altera FPGA is now deprecated and will be removed with the compiler's release in the first quarter of 2025. Altera* will continue to provide FPGA support through their dedicated FPGA software development tools. Existing customers can continue to use the Intel® oneAPI DPC++/C++ Compiler 2025.0 release which supports FPGA development and is available through Linux* package managers such as APT, YUM/DNF, or Zypper. Additionally, customers with an active support license can access the Intel® oneAPI DPC++/C++ Compiler 2025.0 via their customer support account. 
 
-Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the approriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
+Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the appropriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
 Find FPGA samples for 2025.0 and subsequent patches in the new Altera [hls-samples](https://github.com/altera-fpga/hls-samples) git repository.
 
 This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/Tutorials/Features/max_interleaving/README.md).

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/max_reinvocation_delay/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/max_reinvocation_delay/README.md
@@ -2,7 +2,7 @@
 
 Deprecation Notice: The Intel® oneAPI DPC++/C++ Compiler integrated support for Altera FPGA is now deprecated and will be removed with the compiler's release in the first quarter of 2025. Altera* will continue to provide FPGA support through their dedicated FPGA software development tools. Existing customers can continue to use the Intel® oneAPI DPC++/C++ Compiler 2025.0 release which supports FPGA development and is available through Linux* package managers such as APT, YUM/DNF, or Zypper. Additionally, customers with an active support license can access the Intel® oneAPI DPC++/C++ Compiler 2025.0 via their customer support account. 
 
-Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the approriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
+Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the appropriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
 Find FPGA samples for 2025.0 and subsequent patches in the new Altera [hls-samples](https://github.com/altera-fpga/hls-samples) git repository.
 
 This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/Tutorials/Features/max_reinvocation_delay/README.md).

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/max_reinvocation_delay/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/max_reinvocation_delay/README.md
@@ -5,4 +5,4 @@ Deprecation Notice: The Intel® oneAPI DPC++/C++ Compiler integrated support for
 Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the appropriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
 Find FPGA samples for 2025.0 and subsequent patches in the new Altera [hls-samples](https://github.com/altera-fpga/hls-samples) git repository.
 
-This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/Tutorials/Features/max_reinvocation_delay/README.md).
+This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/tree/main/Tutorials/Features/max_reinvocation_delay/README.md).

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/mem_channel/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/mem_channel/README.md
@@ -2,7 +2,7 @@
 
 Deprecation Notice: The Intel® oneAPI DPC++/C++ Compiler integrated support for Altera FPGA is now deprecated and will be removed with the compiler's release in the first quarter of 2025. Altera* will continue to provide FPGA support through their dedicated FPGA software development tools. Existing customers can continue to use the Intel® oneAPI DPC++/C++ Compiler 2025.0 release which supports FPGA development and is available through Linux* package managers such as APT, YUM/DNF, or Zypper. Additionally, customers with an active support license can access the Intel® oneAPI DPC++/C++ Compiler 2025.0 via their customer support account. 
 
-Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the approriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
+Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the appropriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
 Find FPGA samples for 2025.0 and subsequent patches in the new Altera [hls-samples](https://github.com/altera-fpga/hls-samples) git repository.
 
 This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/Tutorials/Features/mem_channel/README.md).

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/mem_channel/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/mem_channel/README.md
@@ -5,4 +5,4 @@ Deprecation Notice: The Intel® oneAPI DPC++/C++ Compiler integrated support for
 Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the appropriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
 Find FPGA samples for 2025.0 and subsequent patches in the new Altera [hls-samples](https://github.com/altera-fpga/hls-samples) git repository.
 
-This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/Tutorials/Features/mem_channel/README.md).
+This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/tree/main/Tutorials/Features/mem_channel/README.md).

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/memory_attributes/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/memory_attributes/README.md
@@ -2,7 +2,7 @@
 
 Deprecation Notice: The Intel® oneAPI DPC++/C++ Compiler integrated support for Altera FPGA is now deprecated and will be removed with the compiler's release in the first quarter of 2025. Altera* will continue to provide FPGA support through their dedicated FPGA software development tools. Existing customers can continue to use the Intel® oneAPI DPC++/C++ Compiler 2025.0 release which supports FPGA development and is available through Linux* package managers such as APT, YUM/DNF, or Zypper. Additionally, customers with an active support license can access the Intel® oneAPI DPC++/C++ Compiler 2025.0 via their customer support account. 
 
-Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the approriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
+Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the appropriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
 Find FPGA samples for 2025.0 and subsequent patches in the new Altera [hls-samples](https://github.com/altera-fpga/hls-samples) git repository.
 
 This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/Tutorials/Features/memory_attributes/README.md).

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/memory_attributes/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/memory_attributes/README.md
@@ -5,4 +5,4 @@ Deprecation Notice: The Intel® oneAPI DPC++/C++ Compiler integrated support for
 Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the appropriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
 Find FPGA samples for 2025.0 and subsequent patches in the new Altera [hls-samples](https://github.com/altera-fpga/hls-samples) git repository.
 
-This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/Tutorials/Features/memory_attributes/README.md).
+This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/tree/main/Tutorials/Features/memory_attributes/README.md).

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/optimization_targets/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/optimization_targets/README.md
@@ -2,7 +2,7 @@
 
 Deprecation Notice: The Intel® oneAPI DPC++/C++ Compiler integrated support for Altera FPGA is now deprecated and will be removed with the compiler's release in the first quarter of 2025. Altera* will continue to provide FPGA support through their dedicated FPGA software development tools. Existing customers can continue to use the Intel® oneAPI DPC++/C++ Compiler 2025.0 release which supports FPGA development and is available through Linux* package managers such as APT, YUM/DNF, or Zypper. Additionally, customers with an active support license can access the Intel® oneAPI DPC++/C++ Compiler 2025.0 via their customer support account. 
 
-Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the approriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
+Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the appropriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
 Find FPGA samples for 2025.0 and subsequent patches in the new Altera [hls-samples](https://github.com/altera-fpga/hls-samples) git repository.
 
 This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/Tutorials/Features/optimization_targets/README.md).

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/optimization_targets/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/optimization_targets/README.md
@@ -5,4 +5,4 @@ Deprecation Notice: The Intel® oneAPI DPC++/C++ Compiler integrated support for
 Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the appropriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
 Find FPGA samples for 2025.0 and subsequent patches in the new Altera [hls-samples](https://github.com/altera-fpga/hls-samples) git repository.
 
-This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/Tutorials/Features/optimization_targets/README.md).
+This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/tree/main/Tutorials/Features/optimization_targets/README.md).

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/pipes/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/pipes/README.md
@@ -5,4 +5,4 @@ Deprecation Notice: The Intel® oneAPI DPC++/C++ Compiler integrated support for
 Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the appropriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
 Find FPGA samples for 2025.0 and subsequent patches in the new Altera [hls-samples](https://github.com/altera-fpga/hls-samples) git repository.
 
-This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/Tutorials/Features/pipes/README.md).
+This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/tree/main/Tutorials/Features/pipes/README.md).

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/pipes/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/pipes/README.md
@@ -2,7 +2,7 @@
 
 Deprecation Notice: The Intel® oneAPI DPC++/C++ Compiler integrated support for Altera FPGA is now deprecated and will be removed with the compiler's release in the first quarter of 2025. Altera* will continue to provide FPGA support through their dedicated FPGA software development tools. Existing customers can continue to use the Intel® oneAPI DPC++/C++ Compiler 2025.0 release which supports FPGA development and is available through Linux* package managers such as APT, YUM/DNF, or Zypper. Additionally, customers with an active support license can access the Intel® oneAPI DPC++/C++ Compiler 2025.0 via their customer support account. 
 
-Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the approriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
+Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the appropriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
 Find FPGA samples for 2025.0 and subsequent patches in the new Altera [hls-samples](https://github.com/altera-fpga/hls-samples) git repository.
 
 This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/Tutorials/Features/pipes/README.md).

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/printf/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/printf/README.md
@@ -2,7 +2,7 @@
 
 Deprecation Notice: The Intel® oneAPI DPC++/C++ Compiler integrated support for Altera FPGA is now deprecated and will be removed with the compiler's release in the first quarter of 2025. Altera* will continue to provide FPGA support through their dedicated FPGA software development tools. Existing customers can continue to use the Intel® oneAPI DPC++/C++ Compiler 2025.0 release which supports FPGA development and is available through Linux* package managers such as APT, YUM/DNF, or Zypper. Additionally, customers with an active support license can access the Intel® oneAPI DPC++/C++ Compiler 2025.0 via their customer support account. 
 
-Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the approriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
+Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the appropriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
 Find FPGA samples for 2025.0 and subsequent patches in the new Altera [hls-samples](https://github.com/altera-fpga/hls-samples) git repository.
 
 This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/Tutorials/Features/printf/README.md).

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/printf/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/printf/README.md
@@ -5,4 +5,4 @@ Deprecation Notice: The Intel® oneAPI DPC++/C++ Compiler integrated support for
 Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the appropriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
 Find FPGA samples for 2025.0 and subsequent patches in the new Altera [hls-samples](https://github.com/altera-fpga/hls-samples) git repository.
 
-This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/Tutorials/Features/printf/README.md).
+This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/tree/main/Tutorials/Features/printf/README.md).

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/private_copies/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/private_copies/README.md
@@ -5,4 +5,4 @@ Deprecation Notice: The Intel® oneAPI DPC++/C++ Compiler integrated support for
 Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the appropriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
 Find FPGA samples for 2025.0 and subsequent patches in the new Altera [hls-samples](https://github.com/altera-fpga/hls-samples) git repository.
 
-This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/Tutorials/Features/private_copies/README.md).
+This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/tree/main/Tutorials/Features/private_copies/README.md).

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/private_copies/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/private_copies/README.md
@@ -2,7 +2,7 @@
 
 Deprecation Notice: The Intel® oneAPI DPC++/C++ Compiler integrated support for Altera FPGA is now deprecated and will be removed with the compiler's release in the first quarter of 2025. Altera* will continue to provide FPGA support through their dedicated FPGA software development tools. Existing customers can continue to use the Intel® oneAPI DPC++/C++ Compiler 2025.0 release which supports FPGA development and is available through Linux* package managers such as APT, YUM/DNF, or Zypper. Additionally, customers with an active support license can access the Intel® oneAPI DPC++/C++ Compiler 2025.0 via their customer support account. 
 
-Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the approriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
+Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the appropriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
 Find FPGA samples for 2025.0 and subsequent patches in the new Altera [hls-samples](https://github.com/altera-fpga/hls-samples) git repository.
 
 This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/Tutorials/Features/private_copies/README.md).

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/read_only_cache/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/read_only_cache/README.md
@@ -5,4 +5,4 @@ Deprecation Notice: The Intel® oneAPI DPC++/C++ Compiler integrated support for
 Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the appropriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
 Find FPGA samples for 2025.0 and subsequent patches in the new Altera [hls-samples](https://github.com/altera-fpga/hls-samples) git repository.
 
-This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/Tutorials/Features/read_only_cache/README.md).
+This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/tree/main/Tutorials/Features/read_only_cache/README.md).

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/read_only_cache/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/read_only_cache/README.md
@@ -2,7 +2,7 @@
 
 Deprecation Notice: The Intel® oneAPI DPC++/C++ Compiler integrated support for Altera FPGA is now deprecated and will be removed with the compiler's release in the first quarter of 2025. Altera* will continue to provide FPGA support through their dedicated FPGA software development tools. Existing customers can continue to use the Intel® oneAPI DPC++/C++ Compiler 2025.0 release which supports FPGA development and is available through Linux* package managers such as APT, YUM/DNF, or Zypper. Additionally, customers with an active support license can access the Intel® oneAPI DPC++/C++ Compiler 2025.0 via their customer support account. 
 
-Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the approriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
+Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the appropriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
 Find FPGA samples for 2025.0 and subsequent patches in the new Altera [hls-samples](https://github.com/altera-fpga/hls-samples) git repository.
 
 This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/Tutorials/Features/read_only_cache/README.md).

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/scheduler_target_fmax/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/scheduler_target_fmax/README.md
@@ -2,7 +2,7 @@
 
 Deprecation Notice: The Intel® oneAPI DPC++/C++ Compiler integrated support for Altera FPGA is now deprecated and will be removed with the compiler's release in the first quarter of 2025. Altera* will continue to provide FPGA support through their dedicated FPGA software development tools. Existing customers can continue to use the Intel® oneAPI DPC++/C++ Compiler 2025.0 release which supports FPGA development and is available through Linux* package managers such as APT, YUM/DNF, or Zypper. Additionally, customers with an active support license can access the Intel® oneAPI DPC++/C++ Compiler 2025.0 via their customer support account. 
 
-Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the approriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
+Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the appropriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
 Find FPGA samples for 2025.0 and subsequent patches in the new Altera [hls-samples](https://github.com/altera-fpga/hls-samples) git repository.
 
 This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/Tutorials/Features/scheduler_target_fmax/README.md).

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/scheduler_target_fmax/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/scheduler_target_fmax/README.md
@@ -5,4 +5,4 @@ Deprecation Notice: The Intel® oneAPI DPC++/C++ Compiler integrated support for
 Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the appropriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
 Find FPGA samples for 2025.0 and subsequent patches in the new Altera [hls-samples](https://github.com/altera-fpga/hls-samples) git repository.
 
-This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/Tutorials/Features/scheduler_target_fmax/README.md).
+This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/tree/main/Tutorials/Features/scheduler_target_fmax/README.md).

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/speculated_iterations/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/speculated_iterations/README.md
@@ -5,4 +5,4 @@ Deprecation Notice: The Intel® oneAPI DPC++/C++ Compiler integrated support for
 Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the appropriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
 Find FPGA samples for 2025.0 and subsequent patches in the new Altera [hls-samples](https://github.com/altera-fpga/hls-samples) git repository.
 
-This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/Tutorials/Features/speculated_iterations/README.md).
+This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/tree/main/Tutorials/Features/speculated_iterations/README.md).

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/speculated_iterations/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/speculated_iterations/README.md
@@ -2,7 +2,7 @@
 
 Deprecation Notice: The Intel® oneAPI DPC++/C++ Compiler integrated support for Altera FPGA is now deprecated and will be removed with the compiler's release in the first quarter of 2025. Altera* will continue to provide FPGA support through their dedicated FPGA software development tools. Existing customers can continue to use the Intel® oneAPI DPC++/C++ Compiler 2025.0 release which supports FPGA development and is available through Linux* package managers such as APT, YUM/DNF, or Zypper. Additionally, customers with an active support license can access the Intel® oneAPI DPC++/C++ Compiler 2025.0 via their customer support account. 
 
-Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the approriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
+Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the appropriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
 Find FPGA samples for 2025.0 and subsequent patches in the new Altera [hls-samples](https://github.com/altera-fpga/hls-samples) git repository.
 
 This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/Tutorials/Features/speculated_iterations/README.md).

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/stall_enable/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/stall_enable/README.md
@@ -5,4 +5,4 @@ Deprecation Notice: The Intel® oneAPI DPC++/C++ Compiler integrated support for
 Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the appropriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
 Find FPGA samples for 2025.0 and subsequent patches in the new Altera [hls-samples](https://github.com/altera-fpga/hls-samples) git repository.
 
-This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/Tutorials/Features/stall_enable/README.md).
+This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/tree/main/Tutorials/Features/stall_enable/README.md).

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/stall_enable/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/stall_enable/README.md
@@ -2,7 +2,7 @@
 
 Deprecation Notice: The Intel® oneAPI DPC++/C++ Compiler integrated support for Altera FPGA is now deprecated and will be removed with the compiler's release in the first quarter of 2025. Altera* will continue to provide FPGA support through their dedicated FPGA software development tools. Existing customers can continue to use the Intel® oneAPI DPC++/C++ Compiler 2025.0 release which supports FPGA development and is available through Linux* package managers such as APT, YUM/DNF, or Zypper. Additionally, customers with an active support license can access the Intel® oneAPI DPC++/C++ Compiler 2025.0 via their customer support account. 
 
-Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the approriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
+Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the appropriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
 Find FPGA samples for 2025.0 and subsequent patches in the new Altera [hls-samples](https://github.com/altera-fpga/hls-samples) git repository.
 
 This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/Tutorials/Features/stall_enable/README.md).

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/task_sequence/hardware_reuse/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/task_sequence/hardware_reuse/README.md
@@ -5,4 +5,4 @@ Deprecation Notice: The Intel® oneAPI DPC++/C++ Compiler integrated support for
 Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the appropriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
 Find FPGA samples for 2025.0 and subsequent patches in the new Altera [hls-samples](https://github.com/altera-fpga/hls-samples) git repository.
 
-This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/Tutorials/Features/task_sequence/hardware_reuse/README.md).
+This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/tree/main/Tutorials/Features/task_sequence/hardware_reuse/README.md).

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/task_sequence/hardware_reuse/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/task_sequence/hardware_reuse/README.md
@@ -2,7 +2,7 @@
 
 Deprecation Notice: The Intel® oneAPI DPC++/C++ Compiler integrated support for Altera FPGA is now deprecated and will be removed with the compiler's release in the first quarter of 2025. Altera* will continue to provide FPGA support through their dedicated FPGA software development tools. Existing customers can continue to use the Intel® oneAPI DPC++/C++ Compiler 2025.0 release which supports FPGA development and is available through Linux* package managers such as APT, YUM/DNF, or Zypper. Additionally, customers with an active support license can access the Intel® oneAPI DPC++/C++ Compiler 2025.0 via their customer support account. 
 
-Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the approriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
+Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the appropriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
 Find FPGA samples for 2025.0 and subsequent patches in the new Altera [hls-samples](https://github.com/altera-fpga/hls-samples) git repository.
 
 This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/Tutorials/Features/task_sequence/hardware_reuse/README.md).

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/task_sequence/parallel_loops/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/task_sequence/parallel_loops/README.md
@@ -2,7 +2,7 @@
 
 Deprecation Notice: The Intel® oneAPI DPC++/C++ Compiler integrated support for Altera FPGA is now deprecated and will be removed with the compiler's release in the first quarter of 2025. Altera* will continue to provide FPGA support through their dedicated FPGA software development tools. Existing customers can continue to use the Intel® oneAPI DPC++/C++ Compiler 2025.0 release which supports FPGA development and is available through Linux* package managers such as APT, YUM/DNF, or Zypper. Additionally, customers with an active support license can access the Intel® oneAPI DPC++/C++ Compiler 2025.0 via their customer support account. 
 
-Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the approriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
+Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the appropriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
 Find FPGA samples for 2025.0 and subsequent patches in the new Altera [hls-samples](https://github.com/altera-fpga/hls-samples) git repository.
 
 This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/Tutorials/Features/task_sequence/parallel_loops/README.md).

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/task_sequence/parallel_loops/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/task_sequence/parallel_loops/README.md
@@ -5,4 +5,4 @@ Deprecation Notice: The Intel® oneAPI DPC++/C++ Compiler integrated support for
 Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the appropriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
 Find FPGA samples for 2025.0 and subsequent patches in the new Altera [hls-samples](https://github.com/altera-fpga/hls-samples) git repository.
 
-This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/Tutorials/Features/task_sequence/parallel_loops/README.md).
+This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/tree/main/Tutorials/Features/task_sequence/parallel_loops/README.md).

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/GettingStarted/fast_recompile/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/GettingStarted/fast_recompile/README.md
@@ -5,4 +5,4 @@ Deprecation Notice: The Intel® oneAPI DPC++/C++ Compiler integrated support for
 Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the appropriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
 Find FPGA samples for 2025.0 and subsequent patches in the new Altera [hls-samples](https://github.com/altera-fpga/hls-samples) git repository.
 
-This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/Tutorials/GettingStarted/fast_recompile/README.md).
+This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/tree/main/Tutorials/GettingStarted/fast_recompile/README.md).

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/GettingStarted/fast_recompile/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/GettingStarted/fast_recompile/README.md
@@ -2,7 +2,7 @@
 
 Deprecation Notice: The Intel® oneAPI DPC++/C++ Compiler integrated support for Altera FPGA is now deprecated and will be removed with the compiler's release in the first quarter of 2025. Altera* will continue to provide FPGA support through their dedicated FPGA software development tools. Existing customers can continue to use the Intel® oneAPI DPC++/C++ Compiler 2025.0 release which supports FPGA development and is available through Linux* package managers such as APT, YUM/DNF, or Zypper. Additionally, customers with an active support license can access the Intel® oneAPI DPC++/C++ Compiler 2025.0 via their customer support account. 
 
-Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the approriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
+Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the appropriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
 Find FPGA samples for 2025.0 and subsequent patches in the new Altera [hls-samples](https://github.com/altera-fpga/hls-samples) git repository.
 
 This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/Tutorials/GettingStarted/fast_recompile/README.md).

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/GettingStarted/fpga_compile/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/GettingStarted/fpga_compile/README.md
@@ -5,4 +5,4 @@ Deprecation Notice: The Intel® oneAPI DPC++/C++ Compiler integrated support for
 Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the appropriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
 Find FPGA samples for 2025.0 and subsequent patches in the new Altera [hls-samples](https://github.com/altera-fpga/hls-samples) git repository.
 
-This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/Tutorials/GettingStarted/fpga_compile/README.md).
+This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/tree/main/Tutorials/GettingStarted/fpga_compile/README.md).

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/GettingStarted/fpga_compile/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/GettingStarted/fpga_compile/README.md
@@ -2,7 +2,7 @@
 
 Deprecation Notice: The Intel® oneAPI DPC++/C++ Compiler integrated support for Altera FPGA is now deprecated and will be removed with the compiler's release in the first quarter of 2025. Altera* will continue to provide FPGA support through their dedicated FPGA software development tools. Existing customers can continue to use the Intel® oneAPI DPC++/C++ Compiler 2025.0 release which supports FPGA development and is available through Linux* package managers such as APT, YUM/DNF, or Zypper. Additionally, customers with an active support license can access the Intel® oneAPI DPC++/C++ Compiler 2025.0 via their customer support account. 
 
-Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the approriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
+Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the appropriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
 Find FPGA samples for 2025.0 and subsequent patches in the new Altera [hls-samples](https://github.com/altera-fpga/hls-samples) git repository.
 
 This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/Tutorials/GettingStarted/fpga_compile/README.md).

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/GettingStarted/fpga_template/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/GettingStarted/fpga_template/README.md
@@ -2,7 +2,7 @@
 
 Deprecation Notice: The Intel® oneAPI DPC++/C++ Compiler integrated support for Altera FPGA is now deprecated and will be removed with the compiler's release in the first quarter of 2025. Altera* will continue to provide FPGA support through their dedicated FPGA software development tools. Existing customers can continue to use the Intel® oneAPI DPC++/C++ Compiler 2025.0 release which supports FPGA development and is available through Linux* package managers such as APT, YUM/DNF, or Zypper. Additionally, customers with an active support license can access the Intel® oneAPI DPC++/C++ Compiler 2025.0 via their customer support account. 
 
-Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the approriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
+Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the appropriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
 Find FPGA samples for 2025.0 and subsequent patches in the new Altera [hls-samples](https://github.com/altera-fpga/hls-samples) git repository.
 
 This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/Tutorials/GettingStarted/fpga_template/README.md).

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/GettingStarted/fpga_template/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/GettingStarted/fpga_template/README.md
@@ -5,4 +5,4 @@ Deprecation Notice: The Intel® oneAPI DPC++/C++ Compiler integrated support for
 Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the appropriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
 Find FPGA samples for 2025.0 and subsequent patches in the new Altera [hls-samples](https://github.com/altera-fpga/hls-samples) git repository.
 
-This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/Tutorials/GettingStarted/fpga_template/README.md).
+This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/tree/main/Tutorials/GettingStarted/fpga_template/README.md).

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Tools/dynamic_profiler/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Tools/dynamic_profiler/README.md
@@ -5,4 +5,4 @@ Deprecation Notice: The Intel® oneAPI DPC++/C++ Compiler integrated support for
 Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the appropriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
 Find FPGA samples for 2025.0 and subsequent patches in the new Altera [hls-samples](https://github.com/altera-fpga/hls-samples) git repository.
 
-This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/Tutorials/Tools/dynamic_profiler/README.md).
+This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/tree/main/Tutorials/Tools/dynamic_profiler/README.md).

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Tools/dynamic_profiler/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Tools/dynamic_profiler/README.md
@@ -2,7 +2,7 @@
 
 Deprecation Notice: The Intel® oneAPI DPC++/C++ Compiler integrated support for Altera FPGA is now deprecated and will be removed with the compiler's release in the first quarter of 2025. Altera* will continue to provide FPGA support through their dedicated FPGA software development tools. Existing customers can continue to use the Intel® oneAPI DPC++/C++ Compiler 2025.0 release which supports FPGA development and is available through Linux* package managers such as APT, YUM/DNF, or Zypper. Additionally, customers with an active support license can access the Intel® oneAPI DPC++/C++ Compiler 2025.0 via their customer support account. 
 
-Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the approriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
+Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the appropriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
 Find FPGA samples for 2025.0 and subsequent patches in the new Altera [hls-samples](https://github.com/altera-fpga/hls-samples) git repository.
 
 This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/Tutorials/Tools/dynamic_profiler/README.md).

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Tools/platform_designer/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Tools/platform_designer/README.md
@@ -2,7 +2,7 @@
 
 Deprecation Notice: The Intel® oneAPI DPC++/C++ Compiler integrated support for Altera FPGA is now deprecated and will be removed with the compiler's release in the first quarter of 2025. Altera* will continue to provide FPGA support through their dedicated FPGA software development tools. Existing customers can continue to use the Intel® oneAPI DPC++/C++ Compiler 2025.0 release which supports FPGA development and is available through Linux* package managers such as APT, YUM/DNF, or Zypper. Additionally, customers with an active support license can access the Intel® oneAPI DPC++/C++ Compiler 2025.0 via their customer support account. 
 
-Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the approriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
+Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the appropriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
 Find FPGA samples for 2025.0 and subsequent patches in the new Altera [hls-samples](https://github.com/altera-fpga/hls-samples) git repository.
 
 This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/Tutorials/Tools/platform_designer/README.md).

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Tools/platform_designer/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Tools/platform_designer/README.md
@@ -5,4 +5,4 @@ Deprecation Notice: The Intel® oneAPI DPC++/C++ Compiler integrated support for
 Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the appropriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
 Find FPGA samples for 2025.0 and subsequent patches in the new Altera [hls-samples](https://github.com/altera-fpga/hls-samples) git repository.
 
-This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/Tutorials/Tools/platform_designer/README.md).
+This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/tree/main/Tutorials/Tools/platform_designer/README.md).

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Tools/platform_designer_standard/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Tools/platform_designer_standard/README.md
@@ -2,7 +2,7 @@
 
 Deprecation Notice: The Intel® oneAPI DPC++/C++ Compiler integrated support for Altera FPGA is now deprecated and will be removed with the compiler's release in the first quarter of 2025. Altera* will continue to provide FPGA support through their dedicated FPGA software development tools. Existing customers can continue to use the Intel® oneAPI DPC++/C++ Compiler 2025.0 release which supports FPGA development and is available through Linux* package managers such as APT, YUM/DNF, or Zypper. Additionally, customers with an active support license can access the Intel® oneAPI DPC++/C++ Compiler 2025.0 via their customer support account. 
 
-Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the approriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
+Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the appropriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
 Find FPGA samples for 2025.0 and subsequent patches in the new Altera [hls-samples](https://github.com/altera-fpga/hls-samples) git repository.
 
 This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/Tutorials/Tools/platform_designer_standard/README.md).

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Tools/platform_designer_standard/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Tools/platform_designer_standard/README.md
@@ -5,4 +5,4 @@ Deprecation Notice: The Intel® oneAPI DPC++/C++ Compiler integrated support for
 Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the appropriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
 Find FPGA samples for 2025.0 and subsequent patches in the new Altera [hls-samples](https://github.com/altera-fpga/hls-samples) git repository.
 
-This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/Tutorials/Tools/platform_designer_standard/README.md).
+This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/tree/main/Tutorials/Tools/platform_designer_standard/README.md).

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Tools/system_profiling/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Tools/system_profiling/README.md
@@ -2,7 +2,7 @@
 
 Deprecation Notice: The Intel® oneAPI DPC++/C++ Compiler integrated support for Altera FPGA is now deprecated and will be removed with the compiler's release in the first quarter of 2025. Altera* will continue to provide FPGA support through their dedicated FPGA software development tools. Existing customers can continue to use the Intel® oneAPI DPC++/C++ Compiler 2025.0 release which supports FPGA development and is available through Linux* package managers such as APT, YUM/DNF, or Zypper. Additionally, customers with an active support license can access the Intel® oneAPI DPC++/C++ Compiler 2025.0 via their customer support account. 
 
-Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the approriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
+Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the appropriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
 Find FPGA samples for 2025.0 and subsequent patches in the new Altera [hls-samples](https://github.com/altera-fpga/hls-samples) git repository.
 
 This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/Tutorials/Tools/system_profiling/README.md).

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Tools/system_profiling/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Tools/system_profiling/README.md
@@ -5,4 +5,4 @@ Deprecation Notice: The Intel® oneAPI DPC++/C++ Compiler integrated support for
 Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the appropriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
 Find FPGA samples for 2025.0 and subsequent patches in the new Altera [hls-samples](https://github.com/altera-fpga/hls-samples) git repository.
 
-This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/Tutorials/Tools/system_profiling/README.md).
+This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/tree/main/Tutorials/Tools/system_profiling/README.md).

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Tools/use_library/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Tools/use_library/README.md
@@ -5,4 +5,4 @@ Deprecation Notice: The Intel® oneAPI DPC++/C++ Compiler integrated support for
 Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the appropriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
 Find FPGA samples for 2025.0 and subsequent patches in the new Altera [hls-samples](https://github.com/altera-fpga/hls-samples) git repository.
 
-This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/Tutorials/Tools/use_library/README.md).
+This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/tree/main/Tutorials/Tools/use_library/README.md).

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Tools/use_library/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Tools/use_library/README.md
@@ -2,7 +2,7 @@
 
 Deprecation Notice: The Intel® oneAPI DPC++/C++ Compiler integrated support for Altera FPGA is now deprecated and will be removed with the compiler's release in the first quarter of 2025. Altera* will continue to provide FPGA support through their dedicated FPGA software development tools. Existing customers can continue to use the Intel® oneAPI DPC++/C++ Compiler 2025.0 release which supports FPGA development and is available through Linux* package managers such as APT, YUM/DNF, or Zypper. Additionally, customers with an active support license can access the Intel® oneAPI DPC++/C++ Compiler 2025.0 via their customer support account. 
 
-Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the approriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
+Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the appropriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
 Find FPGA samples for 2025.0 and subsequent patches in the new Altera [hls-samples](https://github.com/altera-fpga/hls-samples) git repository.
 
 This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/Tutorials/Tools/use_library/README.md).

--- a/DirectProgramming/C++SYCL_FPGA/include/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/include/README.md
@@ -2,7 +2,7 @@
 
 Deprecation Notice: The Intel® oneAPI DPC++/C++ Compiler integrated support for Altera FPGA is now deprecated and will be removed with the compiler's release in the first quarter of 2025. Altera* will continue to provide FPGA support through their dedicated FPGA software development tools. Existing customers can continue to use the Intel® oneAPI DPC++/C++ Compiler 2025.0 release which supports FPGA development and is available through Linux* package managers such as APT, YUM/DNF, or Zypper. Additionally, customers with an active support license can access the Intel® oneAPI DPC++/C++ Compiler 2025.0 via their customer support account. 
 
-Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the approriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
+Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the appropriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
 Find FPGA samples for 2025.0 and subsequent patches in the new Altera [hls-samples](https://github.com/altera-fpga/hls-samples) git repository.
 
 This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/include/README.md).

--- a/DirectProgramming/C++SYCL_FPGA/include/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/include/README.md
@@ -5,4 +5,4 @@ Deprecation Notice: The Intel® oneAPI DPC++/C++ Compiler integrated support for
 Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the appropriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
 Find FPGA samples for 2025.0 and subsequent patches in the new Altera [hls-samples](https://github.com/altera-fpga/hls-samples) git repository.
 
-This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/include/README.md).
+This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/tree/main/include/README.md).


### PR DESCRIPTION
This PR fixes broken links that allow users to navigate directly from a sample `README.md` to the equivalent `altera-fpga/hls-samples` sample.Signed-off-by: Yohann Uguen <yohann.uguen@intel.com>