### PR TITLE
FPGA: Update all REAME URLs to point to new samples folder

### DIFF
--- a/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/anr/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/anr/README.md
@@ -5,4 +5,4 @@ Deprecation Notice: The Intel® oneAPI DPC++/C++ Compiler integrated support for
 Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the appropriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
 Find FPGA samples for 2025.0 and subsequent patches in the new Altera [hls-samples](https://github.com/altera-fpga/hls-samples) git repository.
 
-This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/tree/main/ReferenceDesigns/anr/README.md).
+This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/tree/main/ReferenceDesigns/anr).

--- a/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/board_test/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/board_test/README.md
@@ -5,4 +5,4 @@ Deprecation Notice: The Intel® oneAPI DPC++/C++ Compiler integrated support for
 Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the appropriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
 Find FPGA samples for 2025.0 and subsequent patches in the new Altera [hls-samples](https://github.com/altera-fpga/hls-samples) git repository.
 
-This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/tree/main/ReferenceDesigns/board_test/README.md).
+This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/tree/main/ReferenceDesigns/board_test).

--- a/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/cholesky/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/cholesky/README.md
@@ -5,4 +5,4 @@ Deprecation Notice: The Intel® oneAPI DPC++/C++ Compiler integrated support for
 Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the appropriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
 Find FPGA samples for 2025.0 and subsequent patches in the new Altera [hls-samples](https://github.com/altera-fpga/hls-samples) git repository.
 
-This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/tree/main/ReferenceDesigns/cholesky/README.md).
+This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/tree/main/ReferenceDesigns/cholesky).

--- a/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/cholesky_inversion/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/cholesky_inversion/README.md
@@ -5,4 +5,4 @@ Deprecation Notice: The Intel® oneAPI DPC++/C++ Compiler integrated support for
 Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the appropriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
 Find FPGA samples for 2025.0 and subsequent patches in the new Altera [hls-samples](https://github.com/altera-fpga/hls-samples) git repository.
 
-This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/tree/main/ReferenceDesigns/cholesky_inversion/README.md).
+This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/tree/main/ReferenceDesigns/cholesky_inversion).

--- a/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/convolution2d/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/convolution2d/README.md
@@ -5,4 +5,4 @@ Deprecation Notice: The Intel® oneAPI DPC++/C++ Compiler integrated support for
 Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the appropriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
 Find FPGA samples for 2025.0 and subsequent patches in the new Altera [hls-samples](https://github.com/altera-fpga/hls-samples) git repository.
 
-This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/tree/main/ReferenceDesigns/convolution2d/README.md).
+This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/tree/main/ReferenceDesigns/convolution2d).

--- a/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/crr/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/crr/README.md
@@ -5,4 +5,4 @@ Deprecation Notice: The Intel® oneAPI DPC++/C++ Compiler integrated support for
 Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the appropriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
 Find FPGA samples for 2025.0 and subsequent patches in the new Altera [hls-samples](https://github.com/altera-fpga/hls-samples) git repository.
 
-This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/tree/main/ReferenceDesigns/crr/README.md).
+This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/tree/main/ReferenceDesigns/crr).

--- a/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/db/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/db/README.md
@@ -5,4 +5,4 @@ Deprecation Notice: The Intel® oneAPI DPC++/C++ Compiler integrated support for
 Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the appropriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
 Find FPGA samples for 2025.0 and subsequent patches in the new Altera [hls-samples](https://github.com/altera-fpga/hls-samples) git repository.
 
-This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/tree/main/ReferenceDesigns/db/README.md).
+This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/tree/main/ReferenceDesigns/db).

--- a/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/decompress/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/decompress/README.md
@@ -5,4 +5,4 @@ Deprecation Notice: The Intel® oneAPI DPC++/C++ Compiler integrated support for
 Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the appropriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
 Find FPGA samples for 2025.0 and subsequent patches in the new Altera [hls-samples](https://github.com/altera-fpga/hls-samples) git repository.
 
-This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/tree/main/ReferenceDesigns/decompress/README.md).
+This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/tree/main/ReferenceDesigns/decompress).

--- a/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/fft2d/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/fft2d/README.md
@@ -5,4 +5,4 @@ Deprecation Notice: The Intel® oneAPI DPC++/C++ Compiler integrated support for
 Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the appropriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
 Find FPGA samples for 2025.0 and subsequent patches in the new Altera [hls-samples](https://github.com/altera-fpga/hls-samples) git repository.
 
-This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/tree/main/ReferenceDesigns/fft2d/README.md).
+This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/tree/main/ReferenceDesigns/fft2d).

--- a/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/gzip/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/gzip/README.md
@@ -5,4 +5,4 @@ Deprecation Notice: The Intel® oneAPI DPC++/C++ Compiler integrated support for
 Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the appropriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
 Find FPGA samples for 2025.0 and subsequent patches in the new Altera [hls-samples](https://github.com/altera-fpga/hls-samples) git repository.
 
-This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/tree/main/ReferenceDesigns/gzip/README.md).
+This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/tree/main/ReferenceDesigns/gzip).

--- a/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/matmul/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/matmul/README.md
@@ -5,4 +5,4 @@ Deprecation Notice: The Intel® oneAPI DPC++/C++ Compiler integrated support for
 Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the appropriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
 Find FPGA samples for 2025.0 and subsequent patches in the new Altera [hls-samples](https://github.com/altera-fpga/hls-samples) git repository.
 
-This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/tree/main/ReferenceDesigns/matmul/README.md).
+This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/tree/main/ReferenceDesigns/matmul).

--- a/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/merge_sort/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/merge_sort/README.md
@@ -5,4 +5,4 @@ Deprecation Notice: The Intel® oneAPI DPC++/C++ Compiler integrated support for
 Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the appropriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
 Find FPGA samples for 2025.0 and subsequent patches in the new Altera [hls-samples](https://github.com/altera-fpga/hls-samples) git repository.
 
-This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/tree/main/ReferenceDesigns/merge_sort/README.md).
+This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/tree/main/ReferenceDesigns/merge_sort).

--- a/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/mvdr_beamforming/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/mvdr_beamforming/README.md
@@ -5,4 +5,4 @@ Deprecation Notice: The Intel® oneAPI DPC++/C++ Compiler integrated support for
 Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the appropriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
 Find FPGA samples for 2025.0 and subsequent patches in the new Altera [hls-samples](https://github.com/altera-fpga/hls-samples) git repository.
 
-This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/tree/main/ReferenceDesigns/mvdr_beamforming/README.md).
+This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/tree/main/ReferenceDesigns/mvdr_beamforming).

--- a/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/niosv/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/niosv/README.md
@@ -5,4 +5,4 @@ Deprecation Notice: The Intel® oneAPI DPC++/C++ Compiler integrated support for
 Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the appropriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
 Find FPGA samples for 2025.0 and subsequent patches in the new Altera [hls-samples](https://github.com/altera-fpga/hls-samples) git repository.
 
-This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/tree/main/ReferenceDesigns/niosv/README.md).
+This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/tree/main/ReferenceDesigns/niosv).

--- a/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/pca/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/pca/README.md
@@ -5,4 +5,4 @@ Deprecation Notice: The Intel® oneAPI DPC++/C++ Compiler integrated support for
 Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the appropriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
 Find FPGA samples for 2025.0 and subsequent patches in the new Altera [hls-samples](https://github.com/altera-fpga/hls-samples) git repository.
 
-This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/tree/main/ReferenceDesigns/pca/README.md).
+This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/tree/main/ReferenceDesigns/pca).

--- a/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/qrd/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/qrd/README.md
@@ -5,4 +5,4 @@ Deprecation Notice: The Intel® oneAPI DPC++/C++ Compiler integrated support for
 Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the appropriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
 Find FPGA samples for 2025.0 and subsequent patches in the new Altera [hls-samples](https://github.com/altera-fpga/hls-samples) git repository.
 
-This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/tree/main/ReferenceDesigns/qrd/README.md).
+This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/tree/main/ReferenceDesigns/qrd).

--- a/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/qri/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/qri/README.md
@@ -5,4 +5,4 @@ Deprecation Notice: The Intel® oneAPI DPC++/C++ Compiler integrated support for
 Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the appropriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
 Find FPGA samples for 2025.0 and subsequent patches in the new Altera [hls-samples](https://github.com/altera-fpga/hls-samples) git repository.
 
-This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/tree/main/ReferenceDesigns/qri/README.md).
+This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/tree/main/ReferenceDesigns/qri).

--- a/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/svd/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/ReferenceDesigns/svd/README.md
@@ -5,4 +5,4 @@ Deprecation Notice: The Intel® oneAPI DPC++/C++ Compiler integrated support for
 Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the appropriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
 Find FPGA samples for 2025.0 and subsequent patches in the new Altera [hls-samples](https://github.com/altera-fpga/hls-samples) git repository.
 
-This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/tree/main/ReferenceDesigns/svd/README.md).
+This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/tree/main/ReferenceDesigns/svd).

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/autorun/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/autorun/README.md
@@ -5,4 +5,4 @@ Deprecation Notice: The Intel® oneAPI DPC++/C++ Compiler integrated support for
 Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the appropriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
 Find FPGA samples for 2025.0 and subsequent patches in the new Altera [hls-samples](https://github.com/altera-fpga/hls-samples) git repository.
 
-This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/tree/main/Tutorials/DesignPatterns/autorun/README.md).
+This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/tree/main/Tutorials/DesignPatterns/autorun).

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/banked_memory_system/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/banked_memory_system/README.md
@@ -5,4 +5,4 @@ Deprecation Notice: The Intel® oneAPI DPC++/C++ Compiler integrated support for
 Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the appropriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
 Find FPGA samples for 2025.0 and subsequent patches in the new Altera [hls-samples](https://github.com/altera-fpga/hls-samples) git repository.
 
-This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/tree/main/Tutorials/DesignPatterns/banked_memory_system/README.md).
+This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/tree/main/Tutorials/DesignPatterns/banked_memory_system).

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/buffered_host_streaming/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/buffered_host_streaming/README.md
@@ -5,4 +5,4 @@ Deprecation Notice: The Intel® oneAPI DPC++/C++ Compiler integrated support for
 Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the appropriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
 Find FPGA samples for 2025.0 and subsequent patches in the new Altera [hls-samples](https://github.com/altera-fpga/hls-samples) git repository.
 
-This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/tree/main/Tutorials/DesignPatterns/buffered_host_streaming/README.md).
+This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/tree/main/Tutorials/DesignPatterns/buffered_host_streaming).

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/compute_units/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/compute_units/README.md
@@ -5,4 +5,4 @@ Deprecation Notice: The Intel® oneAPI DPC++/C++ Compiler integrated support for
 Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the appropriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
 Find FPGA samples for 2025.0 and subsequent patches in the new Altera [hls-samples](https://github.com/altera-fpga/hls-samples) git repository.
 
-This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/tree/main/Tutorials/DesignPatterns/compute_units/README.md).
+This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/tree/main/Tutorials/DesignPatterns/compute_units).

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/double_buffering/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/double_buffering/README.md
@@ -5,4 +5,4 @@ Deprecation Notice: The Intel® oneAPI DPC++/C++ Compiler integrated support for
 Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the appropriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
 Find FPGA samples for 2025.0 and subsequent patches in the new Altera [hls-samples](https://github.com/altera-fpga/hls-samples) git repository.
 
-This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/tree/main/Tutorials/DesignPatterns/double_buffering/README.md).
+This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/tree/main/Tutorials/DesignPatterns/double_buffering).

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/explicit_data_movement/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/explicit_data_movement/README.md
@@ -5,4 +5,4 @@ Deprecation Notice: The Intel® oneAPI DPC++/C++ Compiler integrated support for
 Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the appropriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
 Find FPGA samples for 2025.0 and subsequent patches in the new Altera [hls-samples](https://github.com/altera-fpga/hls-samples) git repository.
 
-This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/tree/main/Tutorials/DesignPatterns/explicit_data_movement/README.md).
+This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/tree/main/Tutorials/DesignPatterns/explicit_data_movement).

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/io_streaming/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/io_streaming/README.md
@@ -5,4 +5,4 @@ Deprecation Notice: The Intel® oneAPI DPC++/C++ Compiler integrated support for
 Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the appropriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
 Find FPGA samples for 2025.0 and subsequent patches in the new Altera [hls-samples](https://github.com/altera-fpga/hls-samples) git repository.
 
-This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/tree/main/Tutorials/DesignPatterns/io_streaming/README.md).
+This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/tree/main/Tutorials/DesignPatterns/io_streaming).

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/loop_carried_dependency/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/loop_carried_dependency/README.md
@@ -5,4 +5,4 @@ Deprecation Notice: The Intel® oneAPI DPC++/C++ Compiler integrated support for
 Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the appropriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
 Find FPGA samples for 2025.0 and subsequent patches in the new Altera [hls-samples](https://github.com/altera-fpga/hls-samples) git repository.
 
-This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/tree/main/Tutorials/DesignPatterns/loop_carried_dependency/README.md).
+This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/tree/main/Tutorials/DesignPatterns/loop_carried_dependency).

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/n_way_buffering/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/n_way_buffering/README.md
@@ -5,4 +5,4 @@ Deprecation Notice: The Intel® oneAPI DPC++/C++ Compiler integrated support for
 Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the appropriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
 Find FPGA samples for 2025.0 and subsequent patches in the new Altera [hls-samples](https://github.com/altera-fpga/hls-samples) git repository.
 
-This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/tree/main/Tutorials/DesignPatterns/n_way_buffering/README.md).
+This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/tree/main/Tutorials/DesignPatterns/n_way_buffering).

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/onchip_memory_cache/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/onchip_memory_cache/README.md
@@ -5,4 +5,4 @@ Deprecation Notice: The Intel® oneAPI DPC++/C++ Compiler integrated support for
 Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the appropriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
 Find FPGA samples for 2025.0 and subsequent patches in the new Altera [hls-samples](https://github.com/altera-fpga/hls-samples) git repository.
 
-This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/tree/main/Tutorials/DesignPatterns/onchip_memory_cache/README.md).
+This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/tree/main/Tutorials/DesignPatterns/onchip_memory_cache).

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/optimize_inner_loop/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/optimize_inner_loop/README.md
@@ -5,4 +5,4 @@ Deprecation Notice: The Intel® oneAPI DPC++/C++ Compiler integrated support for
 Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the appropriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
 Find FPGA samples for 2025.0 and subsequent patches in the new Altera [hls-samples](https://github.com/altera-fpga/hls-samples) git repository.
 
-This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/tree/main/Tutorials/DesignPatterns/optimize_inner_loop/README.md).
+This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/tree/main/Tutorials/DesignPatterns/optimize_inner_loop).

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/pipe_array/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/pipe_array/README.md
@@ -5,4 +5,4 @@ Deprecation Notice: The Intel® oneAPI DPC++/C++ Compiler integrated support for
 Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the appropriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
 Find FPGA samples for 2025.0 and subsequent patches in the new Altera [hls-samples](https://github.com/altera-fpga/hls-samples) git repository.
 
-This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/tree/main/Tutorials/DesignPatterns/pipe_array/README.md).
+This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/tree/main/Tutorials/DesignPatterns/pipe_array).

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/restartable_streaming_kernel/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/restartable_streaming_kernel/README.md
@@ -5,4 +5,4 @@ Deprecation Notice: The Intel® oneAPI DPC++/C++ Compiler integrated support for
 Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the appropriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
 Find FPGA samples for 2025.0 and subsequent patches in the new Altera [hls-samples](https://github.com/altera-fpga/hls-samples) git repository.
 
-This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/tree/main/Tutorials/DesignPatterns/restartable_streaming_kernel/README.md).
+This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/tree/main/Tutorials/DesignPatterns/restartable_streaming_kernel).

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/shannonization/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/shannonization/README.md
@@ -5,4 +5,4 @@ Deprecation Notice: The Intel® oneAPI DPC++/C++ Compiler integrated support for
 Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the appropriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
 Find FPGA samples for 2025.0 and subsequent patches in the new Altera [hls-samples](https://github.com/altera-fpga/hls-samples) git repository.
 
-This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/tree/main/Tutorials/DesignPatterns/shannonization/README.md).
+This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/tree/main/Tutorials/DesignPatterns/shannonization).

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/simple_host_streaming/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/simple_host_streaming/README.md
@@ -5,4 +5,4 @@ Deprecation Notice: The Intel® oneAPI DPC++/C++ Compiler integrated support for
 Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the appropriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
 Find FPGA samples for 2025.0 and subsequent patches in the new Altera [hls-samples](https://github.com/altera-fpga/hls-samples) git repository.
 
-This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/tree/main/Tutorials/DesignPatterns/simple_host_streaming/README.md).
+This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/tree/main/Tutorials/DesignPatterns/simple_host_streaming).

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/triangular_loop/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/triangular_loop/README.md
@@ -5,4 +5,4 @@ Deprecation Notice: The Intel® oneAPI DPC++/C++ Compiler integrated support for
 Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the appropriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
 Find FPGA samples for 2025.0 and subsequent patches in the new Altera [hls-samples](https://github.com/altera-fpga/hls-samples) git repository.
 
-This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/tree/main/Tutorials/DesignPatterns/triangular_loop/README.md).
+This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/tree/main/Tutorials/DesignPatterns/triangular_loop).

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/zero_copy_data_transfer/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/DesignPatterns/zero_copy_data_transfer/README.md
@@ -5,4 +5,4 @@ Deprecation Notice: The Intel® oneAPI DPC++/C++ Compiler integrated support for
 Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the appropriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
 Find FPGA samples for 2025.0 and subsequent patches in the new Altera [hls-samples](https://github.com/altera-fpga/hls-samples) git repository.
 
-This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/tree/main/Tutorials/DesignPatterns/zero_copy_data_transfer/README.md).
+This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/tree/main/Tutorials/DesignPatterns/zero_copy_data_transfer).

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/ac_fixed/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/ac_fixed/README.md
@@ -5,4 +5,4 @@ Deprecation Notice: The Intel® oneAPI DPC++/C++ Compiler integrated support for
 Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the appropriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
 Find FPGA samples for 2025.0 and subsequent patches in the new Altera [hls-samples](https://github.com/altera-fpga/hls-samples) git repository.
 
-This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/tree/main/Tutorials/Features/ac_fixed/README.md).
+This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/tree/main/Tutorials/Features/ac_fixed).

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/ac_int/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/ac_int/README.md
@@ -5,4 +5,4 @@ Deprecation Notice: The Intel® oneAPI DPC++/C++ Compiler integrated support for
 Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the appropriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
 Find FPGA samples for 2025.0 and subsequent patches in the new Altera [hls-samples](https://github.com/altera-fpga/hls-samples) git repository.
 
-This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/tree/main/Tutorials/Features/ac_int/README.md).
+This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/tree/main/Tutorials/Features/ac_int).

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/dsp_control/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/dsp_control/README.md
@@ -5,4 +5,4 @@ Deprecation Notice: The Intel® oneAPI DPC++/C++ Compiler integrated support for
 Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the appropriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
 Find FPGA samples for 2025.0 and subsequent patches in the new Altera [hls-samples](https://github.com/altera-fpga/hls-samples) git repository.
 
-This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/tree/main/Tutorials/Features/dsp_control/README.md).
+This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/tree/main/Tutorials/Features/dsp_control).

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/experimental/annotated_class_clean_coding/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/experimental/annotated_class_clean_coding/README.md
@@ -5,4 +5,4 @@ Deprecation Notice: The Intel® oneAPI DPC++/C++ Compiler integrated support for
 Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the appropriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
 Find FPGA samples for 2025.0 and subsequent patches in the new Altera [hls-samples](https://github.com/altera-fpga/hls-samples) git repository.
 
-This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/tree/main/Tutorials/Features/experimental/annotated_class_clean_coding/README.md).
+This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/tree/main/Tutorials/Features/experimental/annotated_class_clean_coding).

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/experimental/annotated_ptr/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/experimental/annotated_ptr/README.md
@@ -5,4 +5,4 @@ Deprecation Notice: The Intel® oneAPI DPC++/C++ Compiler integrated support for
 Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the appropriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
 Find FPGA samples for 2025.0 and subsequent patches in the new Altera [hls-samples](https://github.com/altera-fpga/hls-samples) git repository.
 
-This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/tree/main/Tutorials/Features/experimental/annotated_ptr/README.md).
+This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/tree/main/Tutorials/Features/experimental/annotated_ptr).

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/experimental/device_global/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/experimental/device_global/README.md
@@ -5,4 +5,4 @@ Deprecation Notice: The Intel® oneAPI DPC++/C++ Compiler integrated support for
 Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the appropriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
 Find FPGA samples for 2025.0 and subsequent patches in the new Altera [hls-samples](https://github.com/altera-fpga/hls-samples) git repository.
 
-This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/tree/main/Tutorials/Features/experimental/device_global/README.md).
+This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/tree/main/Tutorials/Features/experimental/device_global).

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/experimental/hostpipes/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/experimental/hostpipes/README.md
@@ -5,4 +5,4 @@ Deprecation Notice: The Intel® oneAPI DPC++/C++ Compiler integrated support for
 Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the appropriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
 Find FPGA samples for 2025.0 and subsequent patches in the new Altera [hls-samples](https://github.com/altera-fpga/hls-samples) git repository.
 
-This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/tree/main/Tutorials/Features/experimental/hostpipes/README.md).
+This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/tree/main/Tutorials/Features/experimental/hostpipes).

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/experimental/latency_control/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/experimental/latency_control/README.md
@@ -5,4 +5,4 @@ Deprecation Notice: The Intel® oneAPI DPC++/C++ Compiler integrated support for
 Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the appropriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
 Find FPGA samples for 2025.0 and subsequent patches in the new Altera [hls-samples](https://github.com/altera-fpga/hls-samples) git repository.
 
-This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/tree/main/Tutorials/Features/experimental/latency_control/README.md).
+This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/tree/main/Tutorials/Features/experimental/latency_control).

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/fpga_reg/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/fpga_reg/README.md
@@ -5,4 +5,4 @@ Deprecation Notice: The Intel® oneAPI DPC++/C++ Compiler integrated support for
 Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the appropriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
 Find FPGA samples for 2025.0 and subsequent patches in the new Altera [hls-samples](https://github.com/altera-fpga/hls-samples) git repository.
 
-This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/tree/main/Tutorials/Features/fpga_reg/README.md).
+This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/tree/main/Tutorials/Features/fpga_reg).

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/hls_flow_interfaces/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/hls_flow_interfaces/README.md
@@ -5,4 +5,4 @@ Deprecation Notice: The Intel® oneAPI DPC++/C++ Compiler integrated support for
 Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the appropriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
 Find FPGA samples for 2025.0 and subsequent patches in the new Altera [hls-samples](https://github.com/altera-fpga/hls-samples) git repository.
 
-This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/tree/main/Tutorials/Features/hls_flow_interfaces/README.md).
+This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/tree/main/Tutorials/Features/hls_flow_interfaces).

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/hls_flow_interfaces/component_interfaces_comparison/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/hls_flow_interfaces/component_interfaces_comparison/README.md
@@ -5,4 +5,4 @@ Deprecation Notice: The Intel® oneAPI DPC++/C++ Compiler integrated support for
 Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the appropriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
 Find FPGA samples for 2025.0 and subsequent patches in the new Altera [hls-samples](https://github.com/altera-fpga/hls-samples) git repository.
 
-This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/tree/main/Tutorials/Features/hls_flow_interfaces/component_interfaces_comparison/README.md).
+This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/tree/main/Tutorials/Features/hls_flow_interfaces/component_interfaces_comparison).

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/hls_flow_interfaces/component_interfaces_comparison/csr-pipes/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/hls_flow_interfaces/component_interfaces_comparison/csr-pipes/README.md
@@ -5,4 +5,4 @@ Deprecation Notice: The Intel® oneAPI DPC++/C++ Compiler integrated support for
 Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the appropriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
 Find FPGA samples for 2025.0 and subsequent patches in the new Altera [hls-samples](https://github.com/altera-fpga/hls-samples) git repository.
 
-This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/tree/main/Tutorials/Features/hls_flow_interfaces/component_interfaces_comparison/csr-pipes/README.md).
+This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/tree/main/Tutorials/Features/hls_flow_interfaces/component_interfaces_comparison/csr-pipes).

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/hls_flow_interfaces/component_interfaces_comparison/mm-host/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/hls_flow_interfaces/component_interfaces_comparison/mm-host/README.md
@@ -5,4 +5,4 @@ Deprecation Notice: The Intel® oneAPI DPC++/C++ Compiler integrated support for
 Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the appropriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
 Find FPGA samples for 2025.0 and subsequent patches in the new Altera [hls-samples](https://github.com/altera-fpga/hls-samples) git repository.
 
-This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/tree/main/Tutorials/Features/hls_flow_interfaces/component_interfaces_comparison/mm-host/README.md).
+This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/tree/main/Tutorials/Features/hls_flow_interfaces/component_interfaces_comparison/mm-host).

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/hls_flow_interfaces/component_interfaces_comparison/naive/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/hls_flow_interfaces/component_interfaces_comparison/naive/README.md
@@ -5,4 +5,4 @@ Deprecation Notice: The Intel® oneAPI DPC++/C++ Compiler integrated support for
 Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the appropriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
 Find FPGA samples for 2025.0 and subsequent patches in the new Altera [hls-samples](https://github.com/altera-fpga/hls-samples) git repository.
 
-This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/tree/main/Tutorials/Features/hls_flow_interfaces/component_interfaces_comparison/naive/README.md).
+This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/tree/main/Tutorials/Features/hls_flow_interfaces/component_interfaces_comparison/naive).

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/hls_flow_interfaces/component_interfaces_comparison/pipes/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/hls_flow_interfaces/component_interfaces_comparison/pipes/README.md
@@ -5,4 +5,4 @@ Deprecation Notice: The Intel® oneAPI DPC++/C++ Compiler integrated support for
 Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the appropriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
 Find FPGA samples for 2025.0 and subsequent patches in the new Altera [hls-samples](https://github.com/altera-fpga/hls-samples) git repository.
 
-This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/tree/main/Tutorials/Features/hls_flow_interfaces/component_interfaces_comparison/pipes/README.md).
+This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/tree/main/Tutorials/Features/hls_flow_interfaces/component_interfaces_comparison/pipes).

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/hls_flow_interfaces/component_interfaces_comparison/streaming-invocation/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/hls_flow_interfaces/component_interfaces_comparison/streaming-invocation/README.md
@@ -5,4 +5,4 @@ Deprecation Notice: The Intel® oneAPI DPC++/C++ Compiler integrated support for
 Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the appropriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
 Find FPGA samples for 2025.0 and subsequent patches in the new Altera [hls-samples](https://github.com/altera-fpga/hls-samples) git repository.
 
-This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/tree/main/Tutorials/Features/hls_flow_interfaces/component_interfaces_comparison/streaming-invocation/README.md).
+This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/tree/main/Tutorials/Features/hls_flow_interfaces/component_interfaces_comparison/streaming-invocation).

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/hls_flow_interfaces/invocation_interfaces/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/hls_flow_interfaces/invocation_interfaces/README.md
@@ -5,4 +5,4 @@ Deprecation Notice: The Intel® oneAPI DPC++/C++ Compiler integrated support for
 Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the appropriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
 Find FPGA samples for 2025.0 and subsequent patches in the new Altera [hls-samples](https://github.com/altera-fpga/hls-samples) git repository.
 
-This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/tree/main/Tutorials/Features/hls_flow_interfaces/invocation_interfaces/README.md).
+This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/tree/main/Tutorials/Features/hls_flow_interfaces/invocation_interfaces).

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/hls_flow_interfaces/mmhost/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/hls_flow_interfaces/mmhost/README.md
@@ -5,4 +5,4 @@ Deprecation Notice: The Intel® oneAPI DPC++/C++ Compiler integrated support for
 Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the appropriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
 Find FPGA samples for 2025.0 and subsequent patches in the new Altera [hls-samples](https://github.com/altera-fpga/hls-samples) git repository.
 
-This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/tree/main/Tutorials/Features/hls_flow_interfaces/mmhost/README.md).
+This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/tree/main/Tutorials/Features/hls_flow_interfaces/mmhost).

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/hls_flow_interfaces/streaming_data_interfaces/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/hls_flow_interfaces/streaming_data_interfaces/README.md
@@ -5,4 +5,4 @@ Deprecation Notice: The Intel® oneAPI DPC++/C++ Compiler integrated support for
 Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the appropriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
 Find FPGA samples for 2025.0 and subsequent patches in the new Altera [hls-samples](https://github.com/altera-fpga/hls-samples) git repository.
 
-This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/tree/main/Tutorials/Features/hls_flow_interfaces/streaming_data_interfaces/README.md).
+This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/tree/main/Tutorials/Features/hls_flow_interfaces/streaming_data_interfaces).

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/kernel_args_restrict/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/kernel_args_restrict/README.md
@@ -5,4 +5,4 @@ Deprecation Notice: The Intel® oneAPI DPC++/C++ Compiler integrated support for
 Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the appropriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
 Find FPGA samples for 2025.0 and subsequent patches in the new Altera [hls-samples](https://github.com/altera-fpga/hls-samples) git repository.
 
-This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/tree/main/Tutorials/Features/kernel_args_restrict/README.md).
+This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/tree/main/Tutorials/Features/kernel_args_restrict).

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/loop_coalesce/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/loop_coalesce/README.md
@@ -5,4 +5,4 @@ Deprecation Notice: The Intel® oneAPI DPC++/C++ Compiler integrated support for
 Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the appropriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
 Find FPGA samples for 2025.0 and subsequent patches in the new Altera [hls-samples](https://github.com/altera-fpga/hls-samples) git repository.
 
-This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/tree/main/Tutorials/Features/loop_coalesce/README.md).
+This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/tree/main/Tutorials/Features/loop_coalesce).

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/loop_fusion/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/loop_fusion/README.md
@@ -5,4 +5,4 @@ Deprecation Notice: The Intel® oneAPI DPC++/C++ Compiler integrated support for
 Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the appropriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
 Find FPGA samples for 2025.0 and subsequent patches in the new Altera [hls-samples](https://github.com/altera-fpga/hls-samples) git repository.
 
-This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/tree/main/Tutorials/Features/loop_fusion/README.md).
+This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/tree/main/Tutorials/Features/loop_fusion).

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/loop_initiation_interval/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/loop_initiation_interval/README.md
@@ -5,4 +5,4 @@ Deprecation Notice: The Intel® oneAPI DPC++/C++ Compiler integrated support for
 Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the appropriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
 Find FPGA samples for 2025.0 and subsequent patches in the new Altera [hls-samples](https://github.com/altera-fpga/hls-samples) git repository.
 
-This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/tree/main/Tutorials/Features/loop_initiation_interval/README.md).
+This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/tree/main/Tutorials/Features/loop_initiation_interval).

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/loop_ivdep/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/loop_ivdep/README.md
@@ -5,4 +5,4 @@ Deprecation Notice: The Intel® oneAPI DPC++/C++ Compiler integrated support for
 Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the appropriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
 Find FPGA samples for 2025.0 and subsequent patches in the new Altera [hls-samples](https://github.com/altera-fpga/hls-samples) git repository.
 
-This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/tree/main/Tutorials/Features/loop_ivdep/README.md).
+This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/tree/main/Tutorials/Features/loop_ivdep).

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/loop_unroll/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/loop_unroll/README.md
@@ -5,4 +5,4 @@ Deprecation Notice: The Intel® oneAPI DPC++/C++ Compiler integrated support for
 Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the appropriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
 Find FPGA samples for 2025.0 and subsequent patches in the new Altera [hls-samples](https://github.com/altera-fpga/hls-samples) git repository.
 
-This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/tree/main/Tutorials/Features/loop_unroll/README.md).
+This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/tree/main/Tutorials/Features/loop_unroll).

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/lsu_control/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/lsu_control/README.md
@@ -5,4 +5,4 @@ Deprecation Notice: The Intel® oneAPI DPC++/C++ Compiler integrated support for
 Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the appropriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
 Find FPGA samples for 2025.0 and subsequent patches in the new Altera [hls-samples](https://github.com/altera-fpga/hls-samples) git repository.
 
-This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/tree/main/Tutorials/Features/lsu_control/README.md).
+This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/tree/main/Tutorials/Features/lsu_control).

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/max_interleaving/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/max_interleaving/README.md
@@ -5,4 +5,4 @@ Deprecation Notice: The Intel® oneAPI DPC++/C++ Compiler integrated support for
 Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the appropriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
 Find FPGA samples for 2025.0 and subsequent patches in the new Altera [hls-samples](https://github.com/altera-fpga/hls-samples) git repository.
 
-This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/tree/main/Tutorials/Features/max_interleaving/README.md).
+This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/tree/main/Tutorials/Features/max_interleaving).

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/max_reinvocation_delay/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/max_reinvocation_delay/README.md
@@ -5,4 +5,4 @@ Deprecation Notice: The Intel® oneAPI DPC++/C++ Compiler integrated support for
 Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the appropriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
 Find FPGA samples for 2025.0 and subsequent patches in the new Altera [hls-samples](https://github.com/altera-fpga/hls-samples) git repository.
 
-This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/tree/main/Tutorials/Features/max_reinvocation_delay/README.md).
+This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/tree/main/Tutorials/Features/max_reinvocation_delay).

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/mem_channel/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/mem_channel/README.md
@@ -5,4 +5,4 @@ Deprecation Notice: The Intel® oneAPI DPC++/C++ Compiler integrated support for
 Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the appropriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
 Find FPGA samples for 2025.0 and subsequent patches in the new Altera [hls-samples](https://github.com/altera-fpga/hls-samples) git repository.
 
-This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/tree/main/Tutorials/Features/mem_channel/README.md).
+This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/tree/main/Tutorials/Features/mem_channel).

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/memory_attributes/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/memory_attributes/README.md
@@ -5,4 +5,4 @@ Deprecation Notice: The Intel® oneAPI DPC++/C++ Compiler integrated support for
 Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the appropriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
 Find FPGA samples for 2025.0 and subsequent patches in the new Altera [hls-samples](https://github.com/altera-fpga/hls-samples) git repository.
 
-This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/tree/main/Tutorials/Features/memory_attributes/README.md).
+This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/tree/main/Tutorials/Features/memory_attributes).

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/optimization_targets/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/optimization_targets/README.md
@@ -5,4 +5,4 @@ Deprecation Notice: The Intel® oneAPI DPC++/C++ Compiler integrated support for
 Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the appropriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
 Find FPGA samples for 2025.0 and subsequent patches in the new Altera [hls-samples](https://github.com/altera-fpga/hls-samples) git repository.
 
-This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/tree/main/Tutorials/Features/optimization_targets/README.md).
+This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/tree/main/Tutorials/Features/optimization_targets).

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/pipes/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/pipes/README.md
@@ -5,4 +5,4 @@ Deprecation Notice: The Intel® oneAPI DPC++/C++ Compiler integrated support for
 Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the appropriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
 Find FPGA samples for 2025.0 and subsequent patches in the new Altera [hls-samples](https://github.com/altera-fpga/hls-samples) git repository.
 
-This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/tree/main/Tutorials/Features/pipes/README.md).
+This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/tree/main/Tutorials/Features/pipes).

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/printf/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/printf/README.md
@@ -5,4 +5,4 @@ Deprecation Notice: The Intel® oneAPI DPC++/C++ Compiler integrated support for
 Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the appropriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
 Find FPGA samples for 2025.0 and subsequent patches in the new Altera [hls-samples](https://github.com/altera-fpga/hls-samples) git repository.
 
-This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/tree/main/Tutorials/Features/printf/README.md).
+This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/tree/main/Tutorials/Features/printf).

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/private_copies/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/private_copies/README.md
@@ -5,4 +5,4 @@ Deprecation Notice: The Intel® oneAPI DPC++/C++ Compiler integrated support for
 Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the appropriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
 Find FPGA samples for 2025.0 and subsequent patches in the new Altera [hls-samples](https://github.com/altera-fpga/hls-samples) git repository.
 
-This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/tree/main/Tutorials/Features/private_copies/README.md).
+This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/tree/main/Tutorials/Features/private_copies).

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/read_only_cache/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/read_only_cache/README.md
@@ -5,4 +5,4 @@ Deprecation Notice: The Intel® oneAPI DPC++/C++ Compiler integrated support for
 Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the appropriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
 Find FPGA samples for 2025.0 and subsequent patches in the new Altera [hls-samples](https://github.com/altera-fpga/hls-samples) git repository.
 
-This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/tree/main/Tutorials/Features/read_only_cache/README.md).
+This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/tree/main/Tutorials/Features/read_only_cache).

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/scheduler_target_fmax/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/scheduler_target_fmax/README.md
@@ -5,4 +5,4 @@ Deprecation Notice: The Intel® oneAPI DPC++/C++ Compiler integrated support for
 Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the appropriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
 Find FPGA samples for 2025.0 and subsequent patches in the new Altera [hls-samples](https://github.com/altera-fpga/hls-samples) git repository.
 
-This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/tree/main/Tutorials/Features/scheduler_target_fmax/README.md).
+This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/tree/main/Tutorials/Features/scheduler_target_fmax).

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/speculated_iterations/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/speculated_iterations/README.md
@@ -5,4 +5,4 @@ Deprecation Notice: The Intel® oneAPI DPC++/C++ Compiler integrated support for
 Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the appropriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
 Find FPGA samples for 2025.0 and subsequent patches in the new Altera [hls-samples](https://github.com/altera-fpga/hls-samples) git repository.
 
-This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/tree/main/Tutorials/Features/speculated_iterations/README.md).
+This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/tree/main/Tutorials/Features/speculated_iterations).

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/stall_enable/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/stall_enable/README.md
@@ -5,4 +5,4 @@ Deprecation Notice: The Intel® oneAPI DPC++/C++ Compiler integrated support for
 Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the appropriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
 Find FPGA samples for 2025.0 and subsequent patches in the new Altera [hls-samples](https://github.com/altera-fpga/hls-samples) git repository.
 
-This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/tree/main/Tutorials/Features/stall_enable/README.md).
+This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/tree/main/Tutorials/Features/stall_enable).

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/task_sequence/hardware_reuse/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/task_sequence/hardware_reuse/README.md
@@ -5,4 +5,4 @@ Deprecation Notice: The Intel® oneAPI DPC++/C++ Compiler integrated support for
 Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the appropriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
 Find FPGA samples for 2025.0 and subsequent patches in the new Altera [hls-samples](https://github.com/altera-fpga/hls-samples) git repository.
 
-This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/tree/main/Tutorials/Features/task_sequence/hardware_reuse/README.md).
+This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/tree/main/Tutorials/Features/task_sequence/hardware_reuse).

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/task_sequence/parallel_loops/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Features/task_sequence/parallel_loops/README.md
@@ -5,4 +5,4 @@ Deprecation Notice: The Intel® oneAPI DPC++/C++ Compiler integrated support for
 Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the appropriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
 Find FPGA samples for 2025.0 and subsequent patches in the new Altera [hls-samples](https://github.com/altera-fpga/hls-samples) git repository.
 
-This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/tree/main/Tutorials/Features/task_sequence/parallel_loops/README.md).
+This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/tree/main/Tutorials/Features/task_sequence/parallel_loops).

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/GettingStarted/fast_recompile/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/GettingStarted/fast_recompile/README.md
@@ -5,4 +5,4 @@ Deprecation Notice: The Intel® oneAPI DPC++/C++ Compiler integrated support for
 Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the appropriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
 Find FPGA samples for 2025.0 and subsequent patches in the new Altera [hls-samples](https://github.com/altera-fpga/hls-samples) git repository.
 
-This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/tree/main/Tutorials/GettingStarted/fast_recompile/README.md).
+This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/tree/main/Tutorials/GettingStarted/fast_recompile).

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/GettingStarted/fpga_compile/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/GettingStarted/fpga_compile/README.md
@@ -5,4 +5,4 @@ Deprecation Notice: The Intel® oneAPI DPC++/C++ Compiler integrated support for
 Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the appropriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
 Find FPGA samples for 2025.0 and subsequent patches in the new Altera [hls-samples](https://github.com/altera-fpga/hls-samples) git repository.
 
-This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/tree/main/Tutorials/GettingStarted/fpga_compile/README.md).
+This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/tree/main/Tutorials/GettingStarted/fpga_compile).

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/GettingStarted/fpga_template/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/GettingStarted/fpga_template/README.md
@@ -5,4 +5,4 @@ Deprecation Notice: The Intel® oneAPI DPC++/C++ Compiler integrated support for
 Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the appropriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
 Find FPGA samples for 2025.0 and subsequent patches in the new Altera [hls-samples](https://github.com/altera-fpga/hls-samples) git repository.
 
-This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/tree/main/Tutorials/GettingStarted/fpga_template/README.md).
+This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/tree/main/Tutorials/GettingStarted/fpga_template).

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Tools/dynamic_profiler/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Tools/dynamic_profiler/README.md
@@ -5,4 +5,4 @@ Deprecation Notice: The Intel® oneAPI DPC++/C++ Compiler integrated support for
 Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the appropriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
 Find FPGA samples for 2025.0 and subsequent patches in the new Altera [hls-samples](https://github.com/altera-fpga/hls-samples) git repository.
 
-This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/tree/main/Tutorials/Tools/dynamic_profiler/README.md).
+This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/tree/main/Tutorials/Tools/dynamic_profiler).

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Tools/platform_designer/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Tools/platform_designer/README.md
@@ -5,4 +5,4 @@ Deprecation Notice: The Intel® oneAPI DPC++/C++ Compiler integrated support for
 Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the appropriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
 Find FPGA samples for 2025.0 and subsequent patches in the new Altera [hls-samples](https://github.com/altera-fpga/hls-samples) git repository.
 
-This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/tree/main/Tutorials/Tools/platform_designer/README.md).
+This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/tree/main/Tutorials/Tools/platform_designer).

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Tools/platform_designer_standard/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Tools/platform_designer_standard/README.md
@@ -5,4 +5,4 @@ Deprecation Notice: The Intel® oneAPI DPC++/C++ Compiler integrated support for
 Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the appropriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
 Find FPGA samples for 2025.0 and subsequent patches in the new Altera [hls-samples](https://github.com/altera-fpga/hls-samples) git repository.
 
-This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/tree/main/Tutorials/Tools/platform_designer_standard/README.md).
+This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/tree/main/Tutorials/Tools/platform_designer_standard).

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Tools/system_profiling/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Tools/system_profiling/README.md
@@ -5,4 +5,4 @@ Deprecation Notice: The Intel® oneAPI DPC++/C++ Compiler integrated support for
 Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the appropriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
 Find FPGA samples for 2025.0 and subsequent patches in the new Altera [hls-samples](https://github.com/altera-fpga/hls-samples) git repository.
 
-This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/tree/main/Tutorials/Tools/system_profiling/README.md).
+This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/tree/main/Tutorials/Tools/system_profiling).

--- a/DirectProgramming/C++SYCL_FPGA/Tutorials/Tools/use_library/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/Tutorials/Tools/use_library/README.md
@@ -5,4 +5,4 @@ Deprecation Notice: The Intel® oneAPI DPC++/C++ Compiler integrated support for
 Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the appropriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
 Find FPGA samples for 2025.0 and subsequent patches in the new Altera [hls-samples](https://github.com/altera-fpga/hls-samples) git repository.
 
-This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/tree/main/Tutorials/Tools/use_library/README.md).
+This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/tree/main/Tutorials/Tools/use_library).

--- a/DirectProgramming/C++SYCL_FPGA/include/README.md
+++ b/DirectProgramming/C++SYCL_FPGA/include/README.md
@@ -5,4 +5,4 @@ Deprecation Notice: The Intel® oneAPI DPC++/C++ Compiler integrated support for
 Find FPGA samples for earlier versions of the compiler than 2025.0 by selecting the appropriate [tag](https://github.com/oneapi-src/oneAPI-samples/tags) in this repository.
 Find FPGA samples for 2025.0 and subsequent patches in the new Altera [hls-samples](https://github.com/altera-fpga/hls-samples) git repository.
 
-This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/tree/main/include/README.md).
+This specific sample can be found in the hls-samples repository [here](https://github.com/altera-fpga/hls-samples/tree/main/include).


### PR DESCRIPTION
The samples in the `oneapi-src/oneAPI-samples` repository point to their equivalent sample in the `altera-fpga/hls-samples` repository through a link in the individual samples `README.md` files.
This changed the URL to point to the new sample rather than pointing to the sample `README.md` file.