### PR TITLE
Removed requirements.txt reference from README file

### DIFF
--- a/AI-and-Analytics/Features-and-Functionality/IntelPyTorch_TrainingOptimizations_AMX_BF16/README.md
+++ b/AI-and-Analytics/Features-and-Functionality/IntelPyTorch_TrainingOptimizations_AMX_BF16/README.md
@@ -66,8 +66,7 @@ cd oneAPI-samples/AI-and-Analytics/Features-and-Functionality/IntelPyTorch_Train
 >**Note**: Before running the following commands, make sure your Conda/Python environment with AI Tools installed is activated
 
 ```
-pip install -r requirements.txt
-pip install notebook
+pip install matplotlib notebook
 ``` 
 For Jupyter Notebook, refer to [Installing Jupyter](https://jupyter.org/install) for detailed installation instructions.
 

--- a/AI-and-Analytics/Getting-Started-Samples/Modin_GettingStarted/README.md
+++ b/AI-and-Analytics/Getting-Started-Samples/Modin_GettingStarted/README.md
@@ -68,7 +68,6 @@ cd oneAPI-samples/AI-and-Analytics/Getting-Started-Samples/Modin_GettingStarted
 >**Note**: Before running the following commands, make sure your Conda/Python environment with AI Tools installed is activated
 
 ```
-pip install -r requirements.txt
 pip install notebook
 ``` 
 For Jupyter Notebook, refer to [Installing Jupyter](https://jupyter.org/install) for detailed installation instructions.

--- a/AI-and-Analytics/Getting-Started-Samples/Modin_GettingStarted/README.md
+++ b/AI-and-Analytics/Getting-Started-Samples/Modin_GettingStarted/README.md
@@ -68,6 +68,7 @@ cd oneAPI-samples/AI-and-Analytics/Getting-Started-Samples/Modin_GettingStarted
 >**Note**: Before running the following commands, make sure your Conda/Python environment with AI Tools installed is activated
 
 ```
+pip install -r requirements.txt
 pip install notebook
 ``` 
 For Jupyter Notebook, refer to [Installing Jupyter](https://jupyter.org/install) for detailed installation instructions.

--- a/AI-and-Analytics/Getting-Started-Samples/Modin_GettingStarted/requirements.txt
+++ b/AI-and-Analytics/Getting-Started-Samples/Modin_GettingStarted/requirements.txt
@@ -1,1 +1,0 @@
-matplotlib

--- a/AI-and-Analytics/Getting-Started-Samples/Modin_GettingStarted/requirements.txt
+++ b/AI-and-Analytics/Getting-Started-Samples/Modin_GettingStarted/requirements.txt
@@ -1,2 +1,1 @@
 matplotlib
-modin[all]

--- a/AI-and-Analytics/Getting-Started-Samples/Modin_GettingStarted/sample.json
+++ b/AI-and-Analytics/Getting-Started-Samples/Modin_GettingStarted/sample.json
@@ -13,7 +13,7 @@
   		"env": [],
   		"id": "Intel_Modin_GS_py",
   		"steps": [
-			"source /intel/oneapi/intelpython/bin/activate",
+			"source /intel/oneapi/intelpython/bin/activate modin",
 			"pip install -r requirements.txt",
 			"pip install jupyter ipykernel",
 			"jupyter nbconvert --ExecutePreprocessor.enabled=True --to notebook Modin_GettingStarted.ipynb"

--- a/AI-and-Analytics/Getting-Started-Samples/Modin_GettingStarted/sample.json
+++ b/AI-and-Analytics/Getting-Started-Samples/Modin_GettingStarted/sample.json
@@ -14,7 +14,7 @@
   		"id": "Intel_Modin_GS_py",
   		"steps": [
 			"source /intel/oneapi/intelpython/bin/activate modin",
-			"pip install -r requirements.txt",
+			"pip install matplotlib",
 			"pip install jupyter ipykernel",
 			"jupyter nbconvert --ExecutePreprocessor.enabled=True --to notebook Modin_GettingStarted.ipynb"
   		]

--- a/AI-and-Analytics/Getting-Started-Samples/Modin_Vs_Pandas/README.md
+++ b/AI-and-Analytics/Getting-Started-Samples/Modin_Vs_Pandas/README.md
@@ -73,7 +73,6 @@ cd oneAPI-samples/AI-and-Analytics/Getting-Started-Samples/Modin_Vs_Pandas
 >**Note**: Before running the following commands, make sure your Conda/Python environment with AI Tools installed is activated
 
 ```
-pip install -r requirements.txt
 pip install notebook
 ``` 
 For Jupyter Notebook, refer to [Installing Jupyter](https://jupyter.org/install) for detailed installation instructions.

--- a/AI-and-Analytics/Getting-Started-Samples/Modin_Vs_Pandas/sample.json
+++ b/AI-and-Analytics/Getting-Started-Samples/Modin_Vs_Pandas/sample.json
@@ -13,8 +13,7 @@
 		"linux": [{
 			"id": "modin_pandas_performance",
 			"steps": [
-				"source /intel/oneapi/intelpython/bin/activate",
-				"pip install numpy pandas modin[all]",
+				"source /intel/oneapi/intelpython/bin/activate modin",
 				"pip install jupyter ipykernel",
 				"jupyter nbconvert --ExecutePreprocessor.enabled=True --to notebook Modin_Vs_Pandas.ipynb"
 			]


### PR DESCRIPTION
# Existing Sample Changes
## Description

Removed requirements.txt reference since is an unnecessary step to run the sample in README file

Fixes Issue# Improve documentation

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Command Line
- [ ] oneapi-cli
- [x] Visual Studio
- [ ] Eclipse IDE
- [ ] VSCode
- [ ] When compiling the compliler flag "-Wall -Wformat-security -Werror=format-security" was used