### PR TITLE
DataFrame.applymap has been deprecated

### DIFF
--- a/AI-and-Analytics/Getting-Started-Samples/Modin_GettingStarted/Modin_GettingStarted.ipynb
+++ b/AI-and-Analytics/Getting-Started-Samples/Modin_GettingStarted/Modin_GettingStarted.ipynb
@@ -312,7 +312,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### `df.applymap`"
+    "### `df.map`"
    ]
   },
   {
@@ -323,9 +323,9 @@
    },
    "outputs": [],
    "source": [
-    "# Long apply function\n",
+    "# Long map function\n",
     "t6 = time.time()\n",
-    "print(pandas_df.applymap(lambda x: x + 1))\n",
+    "print(pandas_df.map(lambda x: x + 1))\n",
     "pandas_time = time.time() - t6\n",
     "print(\" stock Pandas wall time for completion in seconds:\",pandas_time)"
    ]
@@ -338,9 +338,9 @@
    },
    "outputs": [],
    "source": [
-    "# Long apply function\n",
+    "# Long map function\n",
     "t7 = time.time()\n",
-    "print(modin_df.applymap(lambda x: x + 1))\n",
+    "print(modin_df.map(lambda x: x + 1))\n",
     "modin_time = time.time() - t7\n",
     "print(\"Modin wall time for completion in seconds:\",modin_time)"
    ]
@@ -567,7 +567,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.9"
+   "version": "3.11.9"
   }
  },
  "nbformat": 4,

--- a/AI-and-Analytics/Getting-Started-Samples/Modin_Vs_Pandas/Modin_Vs_Pandas.ipynb
+++ b/AI-and-Analytics/Getting-Started-Samples/Modin_Vs_Pandas/Modin_Vs_Pandas.ipynb
@@ -177,7 +177,7 @@
     "id": "ktbKmh_Kvy1o"
    },
    "source": [
-    "##applymap() method"
+    "##map() method"
    ]
   },
   {
@@ -194,7 +194,7 @@
    "outputs": [],
    "source": [
     "#Element-wise multiplication of each element by 2 using Pandas\n",
-    "%time p_df.applymap(lambda i:i*2)"
+    "%time p_df.map(lambda i:i*2)"
    ]
   },
   {
@@ -211,7 +211,7 @@
    "outputs": [],
    "source": [
     "#Element-wise multiplication of each element by 2 using Pandas\n",
-    "%time m_df.applymap(lambda i:i*2)"
+    "%time m_df.map(lambda i:i*2)"
    ]
   }
  ],
@@ -237,7 +237,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.13"
+   "version": "3.11.9"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
# Existing Sample Changes
## Description

DataFrame.applymap has been deprecated
Update Modin examples to use `df.map` instead of `df.applymap`

## Type of change

Please delete options that are not relevant. Add a 'X' to the one that is applicable. 

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Implement fixes for ONSAM Jiras

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Command Line
- [ ] oneapi-cli
- [ ] Visual Studio
- [ ] Eclipse IDE
- [ ] VSCode
- [ ] When compiling the compliler flag "-Wall -Wformat-security -Werror=format-security" was used
