### PR TITLE
fixed MTL configs in GPU occupancy calculator

### DIFF
--- a/Tools/GPU-Occupancy-Calculator/index.html
+++ b/Tools/GPU-Occupancy-Calculator/index.html
@@ -284,8 +284,8 @@ var targets = [
 		"SLM_Size_Per_Work_Group": 64,
 		"TG_SLM_Sizes": [0, 1, 2, 4, 8, 16, 32, 64],
 		"Max_Work_Group_Size": 1024,
-		"Max_Num_Of_Workgroups": 64,
-		"Max_Num_Of_Barrier_Registers": 64
+		"Max_Num_Of_Workgroups": 128,
+		"Max_Num_Of_Barrier_Registers": 128
 	}
 },
 {
@@ -1205,8 +1205,8 @@ var pci_targets=[
 		"SLM_Size_Per_Work_Group": 64,
 		"TG_SLM_Sizes": [0, 1, 2, 4, 8, 16, 32, 64],
 		"Max_Work_Group_Size": 1024,
-		"Max_Num_Of_Workgroups": 64,
-		"Max_Num_Of_Barrier_Registers": 64
+		"Max_Num_Of_Workgroups": 128,
+		"Max_Num_Of_Barrier_Registers": 128
 	}
 },
 {
@@ -1225,8 +1225,8 @@ var pci_targets=[
 		"SLM_Size_Per_Work_Group": 64,
 		"TG_SLM_Sizes": [0, 1, 2, 4, 8, 16, 32, 64],
 		"Max_Work_Group_Size": 1024,
-		"Max_Num_Of_Workgroups": 64,
-		"Max_Num_Of_Barrier_Registers": 64
+		"Max_Num_Of_Workgroups": 128,
+		"Max_Num_Of_Barrier_Registers": 128
 	}
 },
 // LNL


### PR DESCRIPTION
# Existing Sample Changes
## Description

fixed MTL configs in GPU occupancy calculator, from max WG per Xe-core from 64 to 128

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
- [X] Browser