### PR TITLE
Updates for oneAPI 2025.1

### DIFF
--- a/Tools/ApplicationDebugger/guided_matrix_mult_Exceptions/README.md
+++ b/Tools/ApplicationDebugger/guided_matrix_mult_Exceptions/README.md
@@ -35,7 +35,7 @@ The sample includes three different versions of some simple matrix multiplicatio
 |:---                 |:---
 | OS                      | Ubuntu* 24.04 LTS
 | Hardware                | GEN9 or newer
-| Software                | Intel® oneAPI DPC++/C++ Compiler 2025.0 <br> Intel® Distribution for GDB* 2025.0 
+| Software                | Intel® oneAPI DPC++/C++ Compiler 2025.1 <br> Intel® Distribution for GDB* 2025.1 
 
 
 ## Key Implementation Details
@@ -127,7 +127,10 @@ If you receive an error message, troubleshoot the problem using the **Diagnostic
 
 These instructions assume you have installed the Intel® Distribution for GDB* and have a basic working knowledge of GDB.
 
-To learn how setup and use Intel® Distribution for GDB*, see the *[Get Started with Intel® Distribution for GDB* on Linux* OS Host](https://www.intel.com/content/www/us/en/docs/distribution-for-gdb/get-started-guide-linux/current/overview.html)*.
+### Setting up to Debug on the GPU
+To learn how setup and use Intel® Distribution for GDB*, see the *[Get Started with Intel® Distribution for GDB* on Linux* OS Host](https://www.intel.com/content/www/us/en/docs/distribution-for-gdb/get-started-guide-linux/current/overview.html)*.  Additional setup instructions you should follow are at *[GDB-PVC debugger](https://dgpu-docs.intel.com/system-user-guides/DNP-Max-1100-userguide/DNP-Max-1100-userguide.html#gdb-pvc-debugger)* and *[Configuring Kernel Boot Parameters](https://dgpu-docs.intel.com/driver/configuring-kernel-boot-parameters.html)*. 
+
+Documentation on using the debugger in a variety of situations can be found at *[Debug Examples in Linux](https://www.intel.com/content/www/us/en/docs/distribution-for-gdb/tutorial-debugging-dpcpp-linux/current/overview.html)*
 
 >**Note**: SYCL applications will use the oneAPI Level Zero runtime by default. oneAPI Level Zero provides a low-level, direct-to-metal interface for the devices in a oneAPI platform. For more information see the *[Level Zero Specification Documentation - Introduction](https://oneapi-src.github.io/level-zero-spec/level-zero/latest/core/INTRO.html)* and *[Intel® oneAPI Level Zero](https://www.intel.com/content/www/us/en/docs/dpcpp-cpp-compiler/developer-guide-reference/current/intel-oneapi-level-zero.html)*.
 
@@ -189,17 +192,19 @@ As an exercise, let's find this a debugger (any host debugger will work; however
    ```
 5. Examine the last frame using the following (it may be different from the output above):
    ```
-   (gdb) frame 9
+   (gdb) frame 11
    ```
-   You may need to issues this command twice before you see output similar to the following example:
+   You may need to issue this command twice before you see output similar to the following example:
    ```
    #11 0x0000000000403dfa in main ()
       at 1_matrix_mul_null_pointer.cpp:95
    95          q.memcpy(dev_b, 0, N*P * sizeof(float));
    (gdb)
    ```
+   Notice that in this case a `0` was passed as one of the pointers in the `memcpy`, which is clearly the error described in the exception. In a real application you will need to examine each of the input variables to `memcpy` using the gdb `print` command, and then trace the pointers back to where they were initialized (possibly in another source file).
 
-  Notice that in this case a `0` was passed as one of the pointers in the `memcpy`, which is clearly the error described in the exception. In a real application you will need to examine each of the input variables to `memcpy` using the gdb `print` command, and then trace the pointers back to where they were initialized (possibly in another source file).
+6.  Exit the debugger using the `quit`command.
+
 
 ### Fixing the Multiple Offload Version
 
@@ -226,7 +231,7 @@ In the second version, the code attempts to execute more than one offload statem
    (gdb) backtrace
    ```
 
-4. Notice in the results that the exception was triggered around line 98 (frame 13):
+4. Notice in the results (which should look something like the following) that the exception (frame 8) was triggered around line 98 (frame 19):
    ```
    #0  __pthread_kill_implementation (no_tid=0, signo=6, threadid=<optimized out>) at ./nptl/pthread_kill.c:44
    #1  __pthread_kill_internal (signo=6, threadid=<optimized out>) at ./nptl/pthread_kill.c:78
@@ -237,33 +242,37 @@ In the second version, the code attempts to execute more than one offload statem
    #6  0x00007ffff78bb0da in ?? () from /lib/x86_64-linux-gnu/libstdc++.so.6
    #7  0x00007ffff78a5a55 in std::terminate() () from /lib/x86_64-linux-gnu/libstdc++.so.6
    #8  0x00007ffff78bb391 in __cxa_throw () from /lib/x86_64-linux-gnu/libstdc++.so.6
-   #9  0x00007ffff7f3b940 in sycl::_V1::handler::memcpy(void*, void const*, unsigned long) ()
-      from /opt/intel/oneapi/compiler/2025.0/lib/libsycl.so.8
-   #10 0x0000000000404a72 in main::{lambda(auto:1&)#1}::operator()<sycl::_V1::handler>(sycl::_V1::handler&) const (
-      this=0x7fffffffb480, h=sycl::handler& = {...})
-      at /nfs/site/home/cwcongdo/oneAPI-samples/Tools/ApplicationDebugger/guided_matrix_mult_Exceptions/src/2_matrix_mul_multi_offload.cpp:100
-   #11 0x0000000000404a0d in std::__invoke_impl<void, main::{lambda(auto:1&)#1}&, sycl::_V1::handler&>(std::__invoke_other, main::{lambda(auto:1&)#1}&, sycl::_V1::handler&) (__f=..., __args=sycl::handler& = {...})
+   #9  0x00007ffff7f076a0 in sycl::_V1::handler::memcpy(void*, void const*, unsigned long) ()
+      from /opt/intel/oneapi/compiler/2025.1/lib/libsycl.so.8
+   #10 0x0000000000404ba2 in main::{lambda(auto:1&)#1}::operator()<sycl::_V1::handler>(sycl::_V1::handler&) const (
+      this=0x7fffffffb2d8, h=sycl::handler& = {...})
+      at /nfs/site/home/cwcongdo/oneAPI-samples-true/Tools/ApplicationDebugger/guided_matrix_mult_Exceptions/src/2_matrix_mul_multi_offload.cpp:100
+   #11 0x0000000000404b3d in std::__invoke_impl<void, main::{lambda(auto:1&)#1}&, sycl::_V1::handler&>(std::__invoke_other, main::{lambda(auto:1&)#1}&, sycl::_V1::handler&) (__f=..., __args=sycl::handler& = {...})
       at /usr/lib/gcc/x86_64-linux-gnu/13/../../../../include/c++/13/bits/invoke.h:61
-   #12 0x00000000004049ad in std::__invoke_r<void, main::{lambda(auto:1&)#1}&, sycl::_V1::handler&>(main::{lambda(auto:1&)#1}&, sycl::_V1::handler&) (__fn=..., __args=sycl::handler& = {...})
+   #12 0x0000000000404add in std::__invoke_r<void, main::{lambda(auto:1&)#1}&, sycl::_V1::handler&>(main::{lambda(auto:1&)#1}&, sycl::_V1::handler&) (__fn=..., __args=sycl::handler& = {...})
       at /usr/lib/gcc/x86_64-linux-gnu/13/../../../../include/c++/13/bits/invoke.h:111
-   #13 0x00000000004048c5 in std::_Function_handler<void (sycl::_V1::handler&), main::{lambda(auto:1&)#1}>::_M_invoke(std::_Any_data const&, sycl::_V1::handler&) (__functor=..., __args=sycl::handler& = {...})
+   #13 0x00000000004049f5 in std::_Function_handler<void (sycl::_V1::handler&), main::{lambda(auto:1&)#1}>::_M_invoke(std::_Any_data const&, sycl::_V1::handler&) (__functor=..., __args=sycl::handler& = {...})
       at /usr/lib/gcc/x86_64-linux-gnu/13/../../../../include/c++/13/bits/std_function.h:290
-   #14 0x00007ffff7ebc47a in sycl::_V1::detail::queue_impl::submit_impl(std::function<void (sycl::_V1::handler&)> const&, std::shared_ptr<sycl::_V1::detail::queue_impl> const&, std::shared_ptr<sycl::_V1::detail::queue_impl> const&, std::shared_ptr<sycl::_V1::detail::queue_impl> const&, bool, sycl::_V1::detail::code_location const&, std::function<void (bool, bool, sycl::_V1::event&)> const*) () from /opt/intel/oneapi/compiler/2025.0/lib/libsycl.so.8
-   #15 0x00007ffff7ec16e8 in sycl::_V1::detail::queue_impl::submit(std::function<void (sycl::_V1::handler&)> const&, std::shared_ptr<sycl::_V1::detail::queue_impl> const&, sycl::_V1::detail::code_location const&, std::function<void (bool, bool, sycl::_V1::event&)> const*) () from /opt/intel/oneapi/compiler/2025.0/lib/libsycl.so.8
-   #16 0x00007ffff7f63099 in sycl::_V1::queue::submit_impl(std::function<void (sycl::_V1::handler&)>, sycl::_V1::detail::code_location const&) () from /opt/intel/oneapi/compiler/2025.0/lib/libsycl.so.8
-   #17 0x0000000000404285 in sycl::_V1::queue::submit<main::{lambda(auto:1&)#1}>(main::{lambda(auto:1&)#1}, sycl::_V1::detail::code_location const&) (this=0x7fffffffb990, CGF=..., CodeLoc=...)
-      at /opt/intel/oneapi/compiler/2025.0/bin/compiler/../../include/sycl/queue.hpp:359
-   #18 0x0000000000403e7c in main ()
+   #14 0x00007ffff7e83121 in sycl::_V1::detail::queue_impl::submit_impl(std::function<void (sycl::_V1::handler&)> const&, std::shared_ptr<sycl::_V1::detail::queue_impl> const&, std::shared_ptr<sycl::_V1::detail::queue_impl> const&, std::shared_ptr<sycl::_V1::detail::queue_impl> const&, bool, sycl::_V1::detail::code_location const&, bool, sycl::_V1::detail::SubmissionInfo const&) () from /opt/intel/oneapi/compiler/2025.1/lib/libsycl.so.8
+   #15 0x00007ffff7e895c8 in sycl::_V1::detail::queue_impl::submit_with_event(std::function<void (sycl::_V1::handler&)> const&, std::shared_ptr<sycl::_V1::detail::queue_impl> const&, sycl::_V1::detail::SubmissionInfo const&, sycl::_V1::detail::code_location const&, bool) () from /opt/intel/oneapi/compiler/2025.1/lib/libsycl.so.8
+   #16 0x00007ffff7f33afa in sycl::_V1::queue::submit_with_event_impl(std::function<void (sycl::_V1::handler&)>, sycl::_V1::detail::SubmissionInfo const&, sycl::_V1::detail::code_location const&, bool) ()
+      from /opt/intel/oneapi/compiler/2025.1/lib/libsycl.so.8
+   #17 0x00000000004048b3 in sycl::_V1::queue::submit_with_event<main::{lambda(auto:1&)#1}>(main::{lambda(auto:1&)#1}, sycl::_V1::queue*, sycl::_V1::detail::code_location const&) (this=0x7fffffffb860, CGF=..., SecondaryQueuePtr=0x0,
+      CodeLoc=...) at /opt/intel/oneapi/compiler/2025.1/bin/compiler/../../include/sycl/queue.hpp:2826
+   #18 0x00000000004042cd in sycl::_V1::queue::submit<main::{lambda(auto:1&)#1}>(main::{lambda(auto:1&)#1}, sycl::_V1::detail::code_location const&) (this=0x7fffffffb860, CGF=..., CodeLoc=...)
+      at /opt/intel/oneapi/compiler/2025.1/bin/compiler/../../include/sycl/queue.hpp:365
+   #19 0x0000000000403edc in main ()
       at 2_matrix_mul_multi_offload.cpp:98
+
    ```
 
-5. Examine the last frame using the following (it may be different from the output above):
+5. Examine the last frame (it may be different from the output above) using the following command:
    ```
-   (gdb) frame 18
+   (gdb) frame 19
    ```
-   You may need to issues this command twice before you see output similar to the following example:
+   You may need to issue this command twice before you see output similar to the following example:
    ```
-   #18 0x0000000000403e7c in main ()
+   #19 0x0000000000403e7c in main ()
        at 2_matrix_mul_multi_offload.cpp:98
    98          q.submit([&](auto &h) {
    ```
@@ -281,14 +290,19 @@ In the second version, the code attempts to execute more than one offload statem
    101         });
    ```
 
-   As the exception reported, we are trying to do two memory copies to the device within the `submit` statement, where only a single `parallel_for` or `memcpy` is allowed. This code needs to be recoded to use a single `memcpy` per `submit`
+   As the exception reported, we are trying to do two memory copies to the device within the `submit` statement, where only a single `parallel_for` or `memcpy` is allowed. 
 
-7. To fix the error, update the code to use a single `memcpy` in the `submit`.
+7. To fix the error, remove the extra `memcpy` from the code above.   If this statement were actually issuing two different `memcpy` statements, you would update the code to break this up into two `submit` statements, each with a single `memcpy` .
    ```
     q.submit([&](auto &h) {
-        h.memcpy(dev_c, &c_back[0], M*P * sizeof(float));
+        h.memcpy(<arguments for first memcpy>);
+    });
+    q.submit([&](auto &h) {
+        h.memcpy(<arguments for second memcpy>);
     });
    ```
+
+8.  Exit the debugger using the `quit` command.
 
 ## License
 

--- a/Tools/ApplicationDebugger/guided_matrix_mult_RaceCondition/README.md
+++ b/Tools/ApplicationDebugger/guided_matrix_mult_RaceCondition/README.md
@@ -31,8 +31,8 @@ The sample includes different versions of a simple matrix multiplication program
 |:---                     |:---
 | OS                      | Ubuntu* 24.04 LTS
 | Hardware                | GEN9 or newer
-| Software                | Intel® oneAPI DPC++/C++ Compiler 2025.0 <br> Intel® Distribution for GDB* 2025.0 <br> Unified Tracing and Profiling Tool 2.1.2, which is available from the [following Github repository](https://github.com/intel/pti-gpu/tree/master/tools/unitrace).
-| Intel GPU Driver | Intel® General-Purpose GPU Rolling Release driver 2506.18 or newer from https://dgpu-docs.intel.com/releases/releases.html
+| Software                | Intel® oneAPI DPC++/C++ Compiler 2025.1 <br> Intel® Distribution for GDB* 2025.1 <br> Unified Tracing and Profiling Tool 2.1.2, which is available from the [following Github repository](https://github.com/intel/pti-gpu/tree/master/tools/unitrace).
+| Intel GPU Driver | Intel® General-Purpose GPU Rolling Release driver 2507.12 or later from https://dgpu-docs.intel.com/releases/releases.html
 
 ## Key Implementation Details
 
@@ -124,7 +124,10 @@ This example shows what happens when code tries to access data provided by the d
 
 These instructions assume you have installed the Intel® Distribution for GDB* and have a basic working knowledge of GDB.
 
-To learn how setup and use Intel® Distribution for GDB*, see the *[Get Started with Intel® Distribution for GDB* on Linux* OS Host](https://www.intel.com/content/www/us/en/docs/distribution-for-gdb/get-started-guide-linux/current/overview.html)*.
+### Setting up to Debug on the GPU
+To learn how setup and use Intel® Distribution for GDB*, see the *[Get Started with Intel® Distribution for GDB* on Linux* OS Host](https://www.intel.com/content/www/us/en/docs/distribution-for-gdb/get-started-guide-linux/current/overview.html)*.  Additional setup instructions you should follow are at *[GDB-PVC debugger](https://dgpu-docs.intel.com/system-user-guides/DNP-Max-1100-userguide/DNP-Max-1100-userguide.html#gdb-pvc-debugger)* and *[Configuring Kernel Boot Parameters](https://dgpu-docs.intel.com/driver/configuring-kernel-boot-parameters.html)*. 
+
+Documentation on using the debugger in a variety of situations can be found at *[Debug Examples in Linux](https://www.intel.com/content/www/us/en/docs/distribution-for-gdb/tutorial-debugging-dpcpp-linux/current/overview.html)*
 
 >**Note**: SYCL applications will use the oneAPI Level Zero runtime by default. oneAPI Level Zero provides a low-level, direct-to-metal interface for the devices in a oneAPI platform. For more information see the *[Level Zero Specification Documentation - Introduction](https://oneapi-src.github.io/level-zero-spec/level-zero/latest/core/INTRO.html)* and *[Intel® oneAPI Level Zero](https://www.intel.com/content/www/us/en/docs/dpcpp-cpp-compiler/developer-guide-reference/current/intel-oneapi-level-zero.html)*.
 
@@ -138,7 +141,7 @@ To complete the steps in the following section, you must download the [Unified T
 
 As you might have noticed, when you attempt to run `1_matrix_mul_race_condition.cpp` the code reports bad results and then exits. We can use the Intel® Distribution for GDB* to get a backtrace of the entire stack to understand the problem.  
 
-In case we need view code running on the GPU, we need to enable GPU debugging.  This will require [some setup on your system](https://www.intel.com/content/www/us/en/docs/distribution-for-gdb/get-started-guide-linux/current/overview.html) before you can see code running on the GPU.
+In case we need view code running on the GPU, we need to enable GPU debugging.  This will require [some setup on your system](#setting-up-to-debug-on-the-gpu) before you can see code running on the GPU.
 
 1. Run the Intel® Distribution for GDB*.  
    ```
@@ -168,11 +171,12 @@ In case we need view code running on the GPU, we need to enable GPU debugging.  
    intelgt: inferior 3 (gdbserver-ze) has been removed.
    (gbd)
    ```
-   As we saw outside the debugger, it ran to completion.   But note that the inferior (the code running on the GPU), exited with an error code.   Let's see if we can trap that error.
+   As we saw outside the debugger, it ran to completion.   But note that the inferior (the code running on the GPU), exited with an error code (0377).   Let's see if we can trap that error.
 
 4. Run again, telling the debugger to stop if the application throws an exception
    ```
    (gdb) catch throw
+   Catchpoint 1 (throw)
    (gdb) run
    ```
    We run, and stop with this:
@@ -198,45 +202,41 @@ In case we need view code running on the GPU, we need to enable GPU debugging.  
    ```
    The output might look similar to the following:
    ```
-   #0  0x00007ffff78bb35a in __cxa_throw () from /lib/x86_64-linux-gnu/libstdc++.so.6
-   #1  0x00007ffff7d148e8 in void sycl::_V1::detail::plugin::checkUrResult<(sycl::_V1::errc)1>(ur_result_t) const ()
-      from /opt/intel/oneapi/compiler/2025.0/lib/libsycl.so.8
-   #2  0x00007ffff7e7058e in sycl::_V1::detail::copyD2H(sycl::_V1::detail::SYCLMemObjI*, ur_mem_handle_t_*, std::shared_ptr<sycl::_V1::detail::queue_impl>, unsigned int, sycl::_V1::range<3>, sycl::_V1::range<3>, sycl::_V1::id<3>, unsigned int, char*, std::shared_ptr<sycl::_V1::detail::queue_impl>, unsigned int, sycl::_V1::range<3>, sycl::_V1::range<3>, sycl::_V1::id<3>, unsigned int, std::vector<ur_event_handle_t_*, std::allocator<ur_event_handle_t_*> >, ur_event_handle_t_*&, std::shared_ptr<sycl::_V1::detail::event_impl> const&) () from /opt/intel/oneapi/compiler/2025.0/lib/libsycl.so.8
-   #3  0x00007ffff7e710ac in sycl::_V1::detail::MemoryManager::copy(sycl::_V1::detail::SYCLMemObjI*, void*, std::shared_ptr<sycl::_V1::detail::queue_impl>, unsigned int, sycl::_V1::range<3>, sycl::_V1::range<3>, sycl::_V1::id<3>, unsigned int, void*, std::shared_ptr<sycl::_V1::detail::queue_impl>, unsigned int, sycl::_V1::range<3>, sycl::_V1::range<3>, sycl::_V1::id<3>, unsigned int, std::vector<ur_event_handle_t_*, std::allocator<ur_event_handle_t_*> >, ur_event_handle_t_*&, std::shared_ptr<sycl::_V1::detail::event_impl> const&) () from /opt/intel/oneapi/compiler/2025.0/lib/libsycl.so.8
-   #4  0x00007ffff7ee4c1f in sycl::_V1::detail::MemCpyCommandHost::enqueueImp() ()
-      from /opt/intel/oneapi/compiler/2025.0/lib/libsycl.so.8
-   #5  0x00007ffff7edb6ca in sycl::_V1::detail::Command::enqueue(sycl::_V1::detail::EnqueueResultT&, sycl::_V1::detail::BlockingT, std::vector<sycl::_V1::detail::Command*, std::allocator<sycl::_V1::detail::Command*> >&) ()
-      from /opt/intel/oneapi/compiler/2025.0/lib/libsycl.so.8
-   #6  0x00007ffff7f00fc7 in sycl::_V1::detail::Scheduler::GraphProcessor::enqueueCommand(sycl::_V1::detail::Command*, std::shared_lock<std::shared_timed_mutex>&, sycl::_V1::detail::EnqueueResultT&, std::vector<sycl::_V1::detail::Command*, std::allocator<sycl::_V1::detail::Command*> >&, sycl::_V1::detail::Command*, sycl::_V1::detail::BlockingT) ()
-      from /opt/intel/oneapi/compiler/2025.0/lib/libsycl.so.8
-   #7  0x00007ffff7efbd9a in sycl::_V1::detail::Scheduler::addCopyBack(sycl::_V1::detail::AccessorImplHost*) ()
-      from /opt/intel/oneapi/compiler/2025.0/lib/libsycl.so.8
-   #8  0x00007ffff7f11c16 in sycl::_V1::detail::SYCLMemObjT::updateHostMemory(void*) ()
-      from /opt/intel/oneapi/compiler/2025.0/lib/libsycl.so.8
-   #9  0x00007ffff7f20563 in std::_Function_handler<void (std::function<void (void*)> const&), sycl::_V1::detail::SYCLMemObjT::handleHostData(void*, unsigned long)::{lambda(std::function<void (void*)> const&)#1}>::_M_invoke(std::_Any_data const&, std::function<void (void*)> const&) () from /opt/intel/oneapi/compiler/2025.0/lib/libsycl.so.8
-   #10 0x00007ffff7f1fb7a in std::_Function_handler<void (), sycl::_V1::detail::SYCLMemObjT::set_final_data(std::function<void (std::function<void (void*)> const&)> const&)::{lambda()#1}>::_M_invoke(std::_Any_data const&) ()
-      from /opt/intel/oneapi/compiler/2025.0/lib/libsycl.so.8
-   #11 0x00007ffff7f11e88 in sycl::_V1::detail::SYCLMemObjT::updateHostMemory() ()
-      from /opt/intel/oneapi/compiler/2025.0/lib/libsycl.so.8
-   #12 0x00007ffff7f20044 in std::_Sp_counted_ptr_inplace<sycl::_V1::detail::buffer_impl, std::allocator<sycl::_V1::detail::buffer_impl>, (__gnu_cxx::_Lock_policy)2>::_M_dispose() () from /opt/intel/oneapi/compiler/2025.0/lib/libsycl.so.8
-   #13 0x000000000040945a in std::_Sp_counted_base<(__gnu_cxx::_Lock_policy)2>::_M_release (this=0x1fb99f0)
+   #0  0x00007ffff78bb35a in __cxa_throw () from /usr/lib/x86_64-linux-gnu/libstdc++.so.6
+   #1  0x00007ffff7cbebf4 in void sycl::_V1::detail::Adapter::checkUrResult<(sycl::_V1::errc)1>(ur_result_t) const () from /opt/intel/oneapi/compiler/2025.1/lib/libsycl.so.8
+   #2  0x00007ffff7e2abde in sycl::_V1::detail::copyD2H(sycl::_V1::detail::SYCLMemObjI*, ur_mem_handle_t_*, std::shared_ptr<sycl::_V1::detail::queue_impl>, unsigned int, sycl::_V1::range<3>, sycl::_V1::range<3>, sycl::_V1::id<3>, unsigned int, char*, std::shared_ptr<sycl::_V1::detail::queue_impl>, unsigned int, sycl::_V1::range<3>, sycl::_V1::range<3>, sycl::_V1::id<3>, unsigned int, std::vector<ur_event_handle_t_*, std::allocator<ur_event_handle_t_*> >, ur_event_handle_t_*&, std::shared_ptr<sycl::_V1::detail::event_impl> const&) ()
+      from /opt/intel/oneapi/compiler/2025.1/lib/libsycl.so.8
+   #3  0x00007ffff7e2b73c in sycl::_V1::detail::MemoryManager::copy(sycl::_V1::detail::SYCLMemObjI*, void*, std::shared_ptr<sycl::_V1::detail::queue_impl>, unsigned int, sycl::_V1::range<3>, sycl::_V1::range<3>, sycl::_V1::id<3>, unsigned int, void*, std::shared_ptr<sycl::_V1::detail::queue_impl>, unsigned int, sycl::_V1::range<3>, sycl::_V1::range<3>, sycl::_V1::id<3>, unsigned int, std::vector<ur_event_handle_t_*, std::allocator<ur_event_handle_t_*> >, ur_event_handle_t_*&, std::shared_ptr<sycl::_V1::detail::event_impl> const&) ()
+      from /opt/intel/oneapi/compiler/2025.1/lib/libsycl.so.8
+   #4  0x00007ffff7eb31e9 in ur_result_t sycl::_V1::detail::callMemOpHelper<void (sycl::_V1::detail::SYCLMemObjI*, void*, std::shared_ptr<sycl::_V1::detail::queue_impl>, unsigned int, sycl::_V1::range<3>, sycl::_V1::range<3>, sycl::_V1::id<3>, unsigned int, void*, std::shared_ptr<sycl::_V1::detail::queue_impl>, unsigned int, sycl::_V1::range<3>, sycl::_V1::range<3>, sycl::_V1::id<3>, unsigned int, std::vector<ur_event_handle_t_*, std::allocator<ur_event_handle_t_*> >, ur_event_handle_t_*&, std::shared_ptr<sycl::_V1::detail::event_impl> const&), sycl::_V1::detail::SYCLMemObjI*, void*, std::shared_ptr<sycl::_V1::detail::queue_impl>&, unsigned int&, sycl::_V1::range<3>&, sycl::_V1::range<3>&, sycl::_V1::id<3>&, unsigned int&, void*&, std::shared_ptr<sycl::_V1::detail::queue_impl>&, unsigned int&, sycl::_V1::range<3>&, sycl::_V1::range<3>&, sycl::_V1::id<3>&, unsigned int&, std::vector<ur_event_handle_t_*, std::allocator<ur_event_handle_t_*> >, ur_event_handle_t_*&, std::shared_ptr<sycl::_V1::detail::event_impl>&>(void (&)(sycl::_V1::detail::SYCLMemObjI*, void*, std::shared_ptr<sycl::_V1::detail::queue_impl>, unsigned int, sycl::_V1::range<3>, sycl::_V1::range<3>, sycl::_V1::id<3>, unsigned int, void*, std::shared_ptr<sycl::_V1::detail::queue_impl>, unsigned int, sycl::_V1::range<3>, sycl::_V1::range<3>, sycl::_V1::id<3>, unsigned int, std::vector<ur_event_handle_t_*, std::allocator<ur_event_handle_t_*> >, ur_event_handle_t_*&, std::shared_ptr<sycl::_V1::detail::event_impl> const&), sycl::_V1::detail::SYCLMemObjI*&&, void*&&, std::shared_ptr<sycl::_V1::detail::queue_impl>&, unsigned int&, sycl::_V1::range<3>&, sycl::_V1::range<3>&, sycl::_V1::id<3>&, unsigned int&, void*&, std::shared_ptr<sycl::_V1::detail::queue_impl>&, unsigned int&, sycl::_V1::range<3>&, sycl::_V1::range<3>&, sycl::_V1::id<3>&, unsigned int&, std::vector<ur_event_handle_t_*, std::allocator<ur_event_handle_t_*> >&&, ur_event_handle_t_*&, std::shared_ptr<sycl::_V1::detail::event_impl>&) () from /opt/intel/oneapi/compiler/2025.1/lib/libsycl.so.8
+   #5  0x00007ffff7eb2c4e in sycl::_V1::detail::MemCpyCommandHost::enqueueImp() () from /opt/intel/oneapi/compiler/2025.1/lib/libsycl.so.8
+   #6  0x00007ffff7ea90fb in sycl::_V1::detail::Command::enqueue(sycl::_V1::detail::EnqueueResultT&, sycl::_V1::detail::BlockingT, std::vector<sycl::_V1::detail::Command*, std::allocator<sycl::_V1::detail::Command*> >&) () from /opt/intel/oneapi/compiler/2025.1/lib/libsycl.so.8
+   #7  0x00007ffff7ecec2e in sycl::_V1::detail::Scheduler::GraphProcessor::enqueueCommand(sycl::_V1::detail::Command*, std::shared_lock<std::shared_timed_mutex>&, sycl::_V1::detail::EnqueueResultT&, std::vector<sycl::_V1::detail::Command*, std::allocator<sycl::_V1::detail::Command*> >&, sycl::_V1::detail::Command*, sycl::_V1::detail::BlockingT) ()
+      from /opt/intel/oneapi/compiler/2025.1/lib/libsycl.so.8
+   #8  0x00007ffff7eca5ba in sycl::_V1::detail::Scheduler::addCopyBack(sycl::_V1::detail::AccessorImplHost*) () from /opt/intel/oneapi/compiler/2025.1/lib/libsycl.so.8
+   #9  0x00007ffff7edd2e6 in sycl::_V1::detail::SYCLMemObjT::updateHostMemory(void*) () from /opt/intel/oneapi/compiler/2025.1/lib/libsycl.so.8
+   #10 0x00007ffff7eebdd3 in std::_Function_handler<void (std::function<void (void*)> const&), sycl::_V1::detail::SYCLMemObjT::handleHostData(void*, unsigned long)::{lambda(std::function<void (void*)> const&)#1}>::_M_invoke(std::_Any_data const&, std::function<void (void*)> const&) () from /opt/intel/oneapi/compiler/2025.1/lib/libsycl.so.8
+   #11 0x00007ffff7eeb3ea in std::_Function_handler<void (), sycl::_V1::detail::SYCLMemObjT::set_final_data(std::function<void (std::function<void (void*)> const&)> const&)::{lambda()#1}>::_M_invoke(std::_Any_data const&) () from /opt/intel/oneapi/compiler/2025.1/lib/libsycl.so.8
+   #12 0x00007ffff7edd558 in sycl::_V1::detail::SYCLMemObjT::updateHostMemory() () from /opt/intel/oneapi/compiler/2025.1/lib/libsycl.so.8
+   #13 0x00007ffff7eeb8b4 in std::_Sp_counted_ptr_inplace<sycl::_V1::detail::buffer_impl, std::allocator<sycl::_V1::detail::buffer_impl>, (__gnu_cxx::_Lock_policy)2>::_M_dispose() ()
+      from /opt/intel/oneapi/compiler/2025.1/lib/libsycl.so.8
+   #14 0x00000000004097ea in std::_Sp_counted_base<(__gnu_cxx::_Lock_policy)2>::_M_release (this=0x3923630)
       at /usr/lib/gcc/x86_64-linux-gnu/13/../../../../include/c++/13/bits/shared_ptr_base.h:346
-   #14 0x00000000004093d6 in std::__shared_count<(__gnu_cxx::_Lock_policy)2>::~__shared_count (this=0x7fffffffb810)
+   #15 0x0000000000409766 in std::__shared_count<(__gnu_cxx::_Lock_policy)2>::~__shared_count (this=0x7fffffffb480)
       at /usr/lib/gcc/x86_64-linux-gnu/13/../../../../include/c++/13/bits/shared_ptr_base.h:1071
-   #15 0x000000000040b879 in std::__shared_ptr<sycl::_V1::detail::buffer_impl, (__gnu_cxx::_Lock_policy)2>::~__shared_ptr
-      (this=0x7fffffffb808) at /usr/lib/gcc/x86_64-linux-gnu/13/../../../../include/c++/13/bits/shared_ptr_base.h:1524
-   #16 0x000000000040b855 in std::shared_ptr<sycl::_V1::detail::buffer_impl>::~shared_ptr (this=0x7fffffffb808)
+   #16 0x000000000040bc09 in std::__shared_ptr<sycl::_V1::detail::buffer_impl, (__gnu_cxx::_Lock_policy)2>::~__shared_ptr (this=0x7fffffffb478)
+      at /usr/lib/gcc/x86_64-linux-gnu/13/../../../../include/c++/13/bits/shared_ptr_base.h:1524
+   #17 0x000000000040bbe5 in std::shared_ptr<sycl::_V1::detail::buffer_impl>::~shared_ptr (this=0x7fffffffb478)
       at /usr/lib/gcc/x86_64-linux-gnu/13/../../../../include/c++/13/bits/shared_ptr.h:175
-   #17 0x000000000040ad75 in sycl::_V1::detail::buffer_plain::~buffer_plain (this=0x7fffffffb808)
-      at /opt/intel/oneapi/compiler/2025.0/bin/compiler/../../include/sycl/buffer.hpp:87
-   #18 0x0000000000409182 in sycl::_V1::buffer<float, 2, sycl::_V1::detail::aligned_allocator<float>, void>::~buffer (
-      this=0x7fffffffb808) at /opt/intel/oneapi/compiler/2025.0/bin/compiler/../../include/sycl/buffer.hpp:485
-   #19 0x0000000000403c66 in main ()
-      at 1_matrix_mul_race_condition.cpp:129
+   #18 0x000000000040b105 in sycl::_V1::detail::buffer_plain::~buffer_plain (this=0x7fffffffb478) at /opt/intel/oneapi/compiler/2025.1/bin/compiler/../../include/sycl/buffer.hpp:87
+   #19 0x0000000000409512 in sycl::_V1::buffer<float, 2, sycl::_V1::detail::aligned_allocator<float>, void>::~buffer (this=0x7fffffffb478)
+      at /opt/intel/oneapi/compiler/2025.1/bin/compiler/../../include/sycl/buffer.hpp:485
+   #20 0x0000000000403c96 in main () at 1_matrix_mul_race_condition.cpp:129
+   (gdb)
    ````
 6. Look at the final frame. (Your frame number might differ.)
     ```
-    (gdb) frame 19
+    (gdb) frame 20
     ```
    You should see something similar to the following:
     ```
@@ -284,17 +284,16 @@ In case we need view code running on the GPU, we need to enable GPU debugging.  
    <<<< [211022976856153] zeCommandListAppendMemoryCopyRegion [46127 ns] hWaitEvents = 37882840 -> ZE_RESULT_SUCCESS(0x0)
    >>>> [211022976862571] zeEventHostSynchronize: hEvent = 37883384 timeout = 18446744073709551615
    <<<< [211022979801501] zeEventHostSynchronize [2937354 ns] -> ZE_RESULT_SUCCESS(0x0)
-   corrupted double-linked list
-   Aborted (core dumped)
+   Segmentation fault (core dumped)
     ```
 
 ### Interpret the Results
 
 The first clue here is that the program throws an exception after it has completed checking the results and finding them bad. That behavior is worrying.
 
-Next, looking at the crash in the debugger, there are a couple of odd things that stand out.   Look at stack `frame 8`.  This frame shows us attempting to update the host memory from the device, while `frame 19` shows we are already at the end of the program and have started cleaning up the SYCL buffers (`frame 18`).  The only variable containing data returned from the device is `c_back`.  But the developer has already deleted `c_back` in line 126, so the *data the buffer being copied into (`c_back`) no longer exists*.
+Next, looking at the crash in the debugger, there are a couple of odd things that stand out.   Look at stack `frame 9`.  This frame shows us attempting to update the host memory from the device, while `frame 20` shows we are already at the end of the program and have started cleaning up the SYCL buffers (`frame 19`).  The only variable containing data returned from the device is `c_back`.  But the developer has already deleted `c_back` in line 126, so the *data the buffer being copied into (`c_back`) no longer exists*.
 
-We see something like this in the `unitrace` output above.   The kernel is executed, the results are immediately checked, we create and wait on some events, and then the last thing we try to do before crashing is to copy some memory from the device memory (`srcptr = 18374967954634571776`) to a host pointer (`dstptr = 35936816`) that previously was used to initialize this same device memory (around line 101).   Since `c_buf` is the only accessor that is defined as writeable, it again is a likely suspect.  The message about a corrupted double-linked list is also troubling.
+We see something like this in the `unitrace` output above.   The kernel is executed, the results are immediately checked, we create and wait on some events, and then the last thing we try to do before crashing is to copy some memory from the device memory (`srcptr = 18374967954634571776`) to a host pointer (`dstptr = 35936816`) that previously was used to initialize this same device memory (around line 101).   Since `c_buf` is the only accessor that is defined as writeable in the `q.submit` at line 97, it again is a likely suspect.  
 
 But what if the developer didn't delete `c_back`, and let program termination clean it up?  Try it!  Unfortunately, in that case your program complains about bad results, but it exits cleanly (shutdown will wait for the GPU to copy memory back to the host buffer before it kills the buffer).
 
@@ -339,7 +338,7 @@ So in conclusion, it looks like the third kernel is still executing and/or its r
 
 ### Understand the Problem
 
-Because we are using SYCL buffers, even though the `q.submit` statements that populate `a_buf` and `b_buf` execute asynchronously, the third `q.submit` statement does not execute until those first two submits are complete because the SYCL runtime realizes that the third `q.submit` depends on the `a_buf` and `b_buf` buffers, which are being used in the first two kernels.   Once the first two kernels complete, the third `q.submit` kernel starts executing because its input data are ready. The SYCL runtime then immediately returns control to the host and we proceed to the code which verifies the result - ***while the third `q.submit` keeps running***.
+Because we are using SYCL buffers, even though the `q.submit` statements that populate `a_buf` and `b_buf` execute asynchronously, the third `q.submit` statement does not execute until those first two submits are complete because the SYCL runtime realizes that the third `q.submit` depends on the `a_buf` and `b_buf` buffers, which are being used in the first two kernels.   Once the first two kernels complete, the third `q.submit` kernel starts executing because both its inputs are ready. The SYCL runtime then immediately returns control to the host and we proceed to the code which verifies the result - ***while the third `q.submit` keeps running***.
 
 There are three errors in this code:
 
@@ -347,7 +346,7 @@ There are three errors in this code:
 
 2. We  should be using a host accessor pointing to SYCL buffer `c_buf` to access its contents, which would also indicate that we need to wait for the third `q.submit kernel` to complete **and** for the *data to be copied back to the host* before accessing the data in `c_back`.
 
-3. For buffers initialized with a pointer to host memory (like `c_buf`), the developer "make a contract" to not reference the host pointer again until the SYCL buffer is destroyed.  This, deleting the host memory before the SYCL buffer is destroyed is illegal (the call to `delete[] c_back;`). The buffer cannot detect that the memory was deallocated.
+3. For buffers initialized with a pointer to host memory (like `c_buf`), the developer "makes a contract with the SYCL runtime" to not reference the host pointer again until the SYCL buffer is destroyed.  Thus, deleting the host memory before the SYCL buffer is destroyed is illegal (the call to `delete[] c_back;`). The buffer cannot detect that the memory was deallocated.
 
 ### Fix the Code
 
@@ -396,9 +395,9 @@ int VerifyResult(sycl::host_accessor<float, 2, sycl::access::mode::read> c_back)
 int i, j, k;
 :
 ```
-The result should look like `3_matrix_mul.cpp`.  With these changes we did the following:
+The result should look like `3_matrix_mul.cpp`.  Reiterating, with these changes :
 1.  We created a host accessor to pull the values of out `c_buf` on the host, forcing the data to be transferred from the device to the host before the first access (one of the race conditions in this code).
-2.  We are waiting for the third `q.submit` kernel to complete before asking for the values in `c_buf`, fixing the other race condition.
+2.  We waited for the third `q.submit` kernel to complete before asking for the values in `c_buf`, fixing the other race condition.
 3.  We are no longer deleting `c_back` before the SYCL buffer that makes use of it (`c_buf`) is destroyed on program exit.
 4.  We changed `VerifyResult` to pass down the host accessor, with which we are able to read the contents of the accessor the same way we would access the original `c_back` array (which we "made a contract" not to look at while a SYCL buffer was making use of it).
 
@@ -414,7 +413,7 @@ Note that the source files differ by **two characters** (parentheses) only.
 123d121
 <   }
 ```
-This is a more detailed region of the code.
+This is a more detailed look at this region of the code.
 ```
   {   // This is unique to 2_matrix_mul.cpp
     queue q(default_selector{});
@@ -448,7 +447,7 @@ As a result, because the device queue `q` exists only in the scope of those brac
 
 Note that `2_matrix_mul.cpp` still has a bug.  It is an example of problem (2) above - it's not using a host accessor to access the data in `c_back`, which is still being managed by SYCL buffer `c_buf`.   This violates the contract (3 above) that we are not allowed to look at the host data while it is being managed by a SYCL buffer.  We just got lucky.
 
-This points out a potential trap in the training documentation you may have read while learning SYCL.   You could easily get the impression that if you use the SYCL buffer-accessor mechanism, synchronization will be taken care of for you.  The use of parenthesis may be mentioned in passing with little explanation.   Even though the documentation may say "the { } block ensures all SYCL work has concluded," this is not stressed.
+This points out a potential trap in the training documentation you may have read while learning SYCL.   You can easily get the impression that if you use the SYCL buffer-accessor mechanism, synchronization will be taken care of for you.  The use of parenthesis may be mentioned in passing with little explanation.   Even though the documentation may say "the { } block ensures all SYCL work has concluded," this is not stressed.
 
 This is the trap of the SYCL buffer-accessor mechanism - you may assume that the automatic synchronization mechanism is smarter than it really is.  In `1_matrix_mul_race_condition.cpp`, the SYCL runtime does not realize that we cannot call `VerifyResult` with the `c_back` array until the third `q.submit` kernel completes and the data are copied back to the host - it assumes you know what you are doing. 
 
@@ -461,8 +460,8 @@ As we saw, `1_matrix_mul_race_condition.cpp` suffered from multiple race conditi
 But this gives us some hints on how to find these types of problems in any sort of code.
 
 1.  The kernel *is* producing correct results, but they are not getting to the host when the host tries to access them.
-2.  The host crashes when your host code calls a buffer destructor (frames 17 and 18 above).
-3.  The host crashes when the SYCL runtime attempts to copy device data to a buffer on the host (frame 11 above).
+2.  The host crashes when your host code calls a buffer destructor (frames 15-19 above).
+3.  The host crashes when the SYCL runtime attempts to copy device data to a buffer on the host (frame 9 above).
 
 ## License
 

--- a/Tools/ApplicationDebugger/guided_matrix_mult_SLMSize/README.md
+++ b/Tools/ApplicationDebugger/guided_matrix_mult_SLMSize/README.md
@@ -31,8 +31,8 @@ The sample includes different versions of a simple matrix multiplication program
 |:---                 |:---
 | OS                      | Ubuntu* 24.04 LTS
 | Hardware                | GEN9 or newer
-| Software                | Intel® oneAPI DPC++/C++ Compiler 2025.0 <br> Intel® Distribution for GDB* 2025.0 <br> Unified Tracing and Profiling Tool 2.1.2, which is available from the [following Github repository](https://github.com/intel/pti-gpu/tree/master/tools/unitrace).
-| Intel GPU Driver | Intel® General-Purpose GPU Rolling Release driver 2506.18 or newer from https://dgpu-docs.intel.com/releases/releases.html
+| Software                | Intel® oneAPI DPC++/C++ Compiler 2025.1 <br> Intel® Distribution for GDB* 2025.1 <br> Unified Tracing and Profiling Tool 2.1.2, which is available from the [following Github repository](https://github.com/intel/pti-gpu/tree/master/tools/unitrace).
+| Intel GPU Driver | Intel® General-Purpose GPU Rolling Release driver 2507.12 or later from https://dgpu-docs.intel.com/releases/releases.html
 
 ## Key Implementation Details
 
@@ -124,7 +124,10 @@ If you receive an error message, troubleshoot the problem using the **Diagnostic
 
 These instructions assume you have installed the Intel® Distribution for GDB* and have a basic working knowledge of GDB.
 
-To learn how setup and use Intel® Distribution for GDB*, see the *[Get Started with Intel® Distribution for GDB* on Linux* OS Host](https://www.intel.com/content/www/us/en/docs/distribution-for-gdb/get-started-guide-linux/current/overview.html)*.
+### Setting up to Debug on the GPU
+To learn how setup and use Intel® Distribution for GDB*, see the *[Get Started with Intel® Distribution for GDB* on Linux* OS Host](https://www.intel.com/content/www/us/en/docs/distribution-for-gdb/get-started-guide-linux/current/overview.html)*.  Additional setup instructions you should follow are at *[GDB-PVC debugger](https://dgpu-docs.intel.com/system-user-guides/DNP-Max-1100-userguide/DNP-Max-1100-userguide.html#gdb-pvc-debugger)* and *[Configuring Kernel Boot Parameters](https://dgpu-docs.intel.com/driver/configuring-kernel-boot-parameters.html)*. 
+
+Documentation on using the debugger in a variety of situations can be found at *[Debug Examples in Linux](https://www.intel.com/content/www/us/en/docs/distribution-for-gdb/tutorial-debugging-dpcpp-linux/current/overview.html)*
 
 >**Note**: SYCL applications will use the oneAPI Level Zero runtime by default. oneAPI Level Zero provides a low-level, direct-to-metal interface for the devices in a oneAPI platform. For more information see the *[Level Zero Specification Documentation - Introduction](https://oneapi-src.github.io/level-zero-spec/level-zero/latest/core/INTRO.html)* and *[Intel® oneAPI Level Zero](https://www.intel.com/content/www/us/en/docs/dpcpp-cpp-compiler/developer-guide-reference/current/intel-oneapi-level-zero.html)*.
 
@@ -172,8 +175,9 @@ In `1_matrix_mul_SLM_size`, the local_accessor class is used to reserve an illeg
    ```
    (gdb) run
    ```
-   The application will fail and display the same message when we ran it outside of the debugger (Please ignore the `Debugging of GPU offloaded code is not enabled.` error messages and answer "n" when gdb-oneapi asks `Quit anyway? (y or n)`).
+   When you get the error message `Debugging of GPU offloaded code is not enabled`, ignore it and answer `n` to the question `Quit anyway? (y or n)`
 
+   The application will fail and display the same message when we ran it outside of the debugger.
    ```
    :
    Problem size: c(150,600) = a(150,300) * b(300,600)
@@ -201,27 +205,31 @@ In `1_matrix_mul_SLM_size`, the local_accessor class is used to reserve an illeg
    #6  0x00007ffff78bb0da in ?? () from /lib/x86_64-linux-gnu/libstdc++.so.6
    #7  0x00007ffff78a5a55 in std::terminate() () from /lib/x86_64-linux-gnu/libstdc++.so.6
    #8  0x00007ffff78bb391 in __cxa_throw () from /lib/x86_64-linux-gnu/libstdc++.so.6
-   #9  0x00007ffff7e1f763 in sycl::_V1::detail::enqueue_kernel_launch::handleOutOfResources(sycl::_V1::detail::device_impl const&, ur_kernel_handle_t_*, sycl::_V1::detail::NDRDescT const&) ()
-      from /opt/intel/oneapi/compiler/2025.0/lib/libsycl.so.8
-   #10 0x00007ffff7e261ea in sycl::_V1::detail::enqueue_kernel_launch::handleErrorOrWarning(ur_result_t, sycl::_V1::detail::device_impl const&, ur_kernel_handle_t_*, sycl::_V1::detail::NDRDescT const&) ()
-      from /opt/intel/oneapi/compiler/2025.0/lib/libsycl.so.8
-   #11 0x00007ffff7eeaa72 in sycl::_V1::detail::enqueueImpKernel(std::shared_ptr<sycl::_V1::detail::queue_impl> const&, sycl::_V1::detail::NDRDescT&, std::vector<sycl::_V1::detail::ArgDesc, std::allocator<sycl::_V1::detail::ArgDesc> >&, std::shared_ptr<sycl::_V1::detail::kernel_bundle_impl> const&, std::shared_ptr<sycl::_V1::detail::kernel_impl> const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::vector<ur_event_handle_t_*, std::allocator<ur_event_handle_t_*> >&, std::shared_ptr<sycl::_V1::detail::event_impl> const&, std::function<void* (sycl::_V1::detail::AccessorImplHost*)> const&, ur_kernel_cache_config_t, bool, bool, sycl::_V1::detail::RTDeviceBinaryImage const*) () from /opt/intel/oneapi/compiler/2025.0/lib/libsycl.so.8
-   #12 0x00007ffff7f37cb5 in sycl::_V1::handler::finalize()::$_0::operator()() const ()
-      from /opt/intel/oneapi/compiler/2025.0/lib/libsycl.so.8
-   #13 0x00007ffff7f34960 in sycl::_V1::handler::finalize() () from /opt/intel/oneapi/compiler/2025.0/lib/libsycl.so.8
-   #14 0x00007ffff7ebd481 in void sycl::_V1::detail::queue_impl::finalizeHandler<sycl::_V1::handler>(sycl::_V1::handler&, sycl::_V1::event&) () from /opt/intel/oneapi/compiler/2025.0/lib/libsycl.so.8
-   #15 0x00007ffff7ebc5e8 in sycl::_V1::detail::queue_impl::submit_impl(std::function<void (sycl::_V1::handler&)> const&, std::shared_ptr<sycl::_V1::detail::queue_impl> const&, std::shared_ptr<sycl::_V1::detail::queue_impl> const&, std::shared_ptr<sycl::_V1::detail::queue_impl> const&, bool, sycl::_V1::detail::code_location const&, std::function<void (bool, bool, sycl::_V1::event&)> const*) () from /opt/intel/oneapi/compiler/2025.0/lib/libsycl.so.8
-   #16 0x00007ffff7ec16e8 in sycl::_V1::detail::queue_impl::submit(std::function<void (sycl::_V1::handler&)> const&, std::shared_ptr<sycl::_V1::detail::queue_impl> const&, sycl::_V1::detail::code_location const&, std::function<void (bool, bool, sycl::_V1::event&)> const*) () from /opt/intel/oneapi/compiler/2025.0/lib/libsycl.so.8
-   #17 0x00007ffff7f63099 in sycl::_V1::queue::submit_impl(std::function<void (sycl::_V1::handler&)>, sycl::_V1::detail::code_location const&) () from /opt/intel/oneapi/compiler/2025.0/lib/libsycl.so.8
-   #18 0x000000000040442d in sycl::_V1::queue::submit<main::{lambda(sycl::_V1::handler&)#1}>(main::{lambda(sycl::_V1::handler&)#1}, sycl::_V1::detail::code_location const&) (this=0x7fffffffb9a0, CGF=..., CodeLoc=...)
-      at /opt/intel/oneapi/compiler/2025.0/bin/compiler/../../include/sycl/queue.hpp:359
-   #19 0x0000000000403f83 in main ()
-      at 1_matrix_mul_SLM_size.cpp:104
+   #9  0x00007ffff7dcc4c9 in sycl::_V1::detail::enqueue_kernel_launch::handleOutOfResources(sycl::_V1::detail::device_impl const&, ur_kernel_handle_t_*, sycl::_V1::detail::NDRDescT const&) ()
+      from /opt/intel/oneapi/compiler/2025.1/lib/libsycl.so.8
+   #10 0x00007ffff7dd6214 in sycl::_V1::detail::enqueue_kernel_launch::handleErrorOrWarning(ur_result_t, sycl::_V1::detail::device_impl const&, ur_kernel_handle_t_*, sycl::_V1::detail::NDRDescT const&) () from /opt/intel/oneapi/compiler/2025.1/lib/libsycl.so.8
+   #11 0x00007ffff7eb9b71 in sycl::_V1::detail::enqueueImpKernel(std::shared_ptr<sycl::_V1::detail::queue_impl> const&, sycl::_V1::detail::NDRDescT&, std::vector<sycl::_V1::detail::ArgDesc, std::allocator<sycl::_V1::detail::ArgDesc> >&, std::shared_ptr<sycl::_V1::detail::kernel_bundle_impl> const&, std::shared_ptr<sycl::_V1::detail::kernel_impl> const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::vector<ur_event_handle_t_*, std::allocator<ur_event_handle_t_*> >&, std::shared_ptr<sycl::_V1::detail::event_impl> const&, std::function<void* (sycl::_V1::detail::AccessorImplHost*)> const&, ur_kernel_cache_config_t, bool, bool, unsigned long, sycl::_V1::detail::RTDeviceBinaryImage const*) ()
+      from /opt/intel/oneapi/compiler/2025.1/lib/libsycl.so.8
+   #12 0x00007ffff7f02e52 in sycl::_V1::handler::finalize()::$_0::operator()() const () from /opt/intel/oneapi/compiler/2025.1/lib/libsycl.so.8
+   #13 0x00007ffff7effe3a in sycl::_V1::handler::finalize() () from /opt/intel/oneapi/compiler/2025.1/lib/libsycl.so.8
+   #14 0x00007ffff7e84277 in void sycl::_V1::detail::queue_impl::finalizeHandler<sycl::_V1::handler>(sycl::_V1::handler&, sycl::_V1::event&) ()
+      from /opt/intel/oneapi/compiler/2025.1/lib/libsycl.so.8
+   #15 0x00007ffff7e832b7 in sycl::_V1::detail::queue_impl::submit_impl(std::function<void (sycl::_V1::handler&)> const&, std::shared_ptr<sycl::_V1::detail::queue_impl> const&, std::shared_ptr<sycl::_V1::detail::queue_impl> const&, std::shared_ptr<sycl::_V1::detail::queue_impl> const&, bool, sycl::_V1::detail::code_location const&, bool, sycl::_V1::detail::SubmissionInfo const&)
+      () from /opt/intel/oneapi/compiler/2025.1/lib/libsycl.so.8
+   #16 0x00007ffff7e895c8 in sycl::_V1::detail::queue_impl::submit_with_event(std::function<void (sycl::_V1::handler&)> const&, std::shared_ptr<sycl::_V1::detail::queue_impl> const&, sycl::_V1::detail::SubmissionInfo const&, sycl::_V1::detail::code_location const&, bool) () from /opt/intel/oneapi/compiler/2025.1/lib/libsycl.so.8
+   #17 0x00007ffff7f33afa in sycl::_V1::queue::submit_with_event_impl(std::function<void (sycl::_V1::handler&)>, sycl::_V1::detail::SubmissionInfo const&, sycl::_V1::detail::code_location const&, bool) () from /opt/intel/oneapi/compiler/2025.1/lib/libsycl.so.8
+   #18 0x0000000000404f54 in sycl::_V1::queue::submit_with_event<main::{lambda(sycl::_V1::handler&)#1}>(main::{lambda(sycl::_V1::handler&)#1}, sycl::_V1::queue*, sycl::_V1::detail::code_location const&) (this=0x7fffffffb8f0, CGF=..., SecondaryQueuePtr=0x0, CodeLoc=...) at /opt/intel/oneapi/compiler/2025.1/bin/compiler/../../include/sycl/queue.hpp:2826
+   #19 0x000000000040440c in sycl::_V1::queue::submit<main::{lambda(sycl::_V1::handler&)#1}>(main::{lambda(sycl::_V1::handler&)#1}, sycl::_V1::detail::code_location const&) (
+      this=0x7fffffffb8f0, CGF=..., CodeLoc=...) at /opt/intel/oneapi/compiler/2025.1/bin/compiler/../../include/sycl/queue.hpp:365
+   #20 0x0000000000403fe3 in main () at /nfs/site/home/cwcongdo/oneAPI-samples-true/Tools/ApplicationDebugger/guided_matrix_mult_SLMSize/src/1_matrix_mul_SLM_size.cpp:104
    ```
 
-4. Look at the final frame. (Your frame number might differ, and you might have to repeat this commend).
+4. Look at the final frame. (Your frame number might differ, and you might have to repeat this command to get the frame to change).
    ```
-   (gdb) frame 19
+   (gdb) frame 20
+   #20 0x0000000000403fe3 in main () at /nfs/site/home/cwcongdo/oneAPI-samples-true/Tools/ApplicationDebugger/guided_matrix_mult_SLMSize/src/1_matrix_mul_SLM_size.cpp:104
+   104         q.submit([&](handler &h){
+   (gdb)
    ```
 
 5. Examine the code in that region of code that caused the crash.
@@ -261,17 +269,17 @@ Among other things, the Tracing and Profiling utility can print every low-level 
 
 3. Let the output continue until the error occurs and the program stops.
    ```
-      :
-   >>>> [1318232902142699] zeKernelSetGroupSize: hKernel = 51602008 groupSizeX = 10 groupSizeY = 1 groupSizeZ = 1
-   <<<< [1318232902148340] zeKernelSetGroupSize [1253 ns] -> ZE_RESULT_SUCCESS(0x0)
-   >>>> [1318232902153233] zeCommandListCreateImmediate: hContext = 49997792 hDevice = 45298968 altdesc = 140727474880176 {ZE_STRUCTURE_TYPE_COMMAND_QUEUE_DESC(0xe) 0 0 0 0 2 0} phCommandList = 140727474880160 (hCommandList = 0)
-   <<<< [1318232902418068] zeCommandListCreateImmediate [259479 ns] hCommandList = 51583896 -> ZE_RESULT_SUCCESS(0x0)
-   >>>> [1318232902426142] zeEventHostReset: hEvent = 49925848
-   <<<< [1318232902429796] zeEventHostReset [1372 ns] -> ZE_RESULT_SUCCESS(0x0)
-   >>>> [1318232911894375] zeCommandListAppendLaunchKernel: hCommandList = 51583896 hKernel = 51602008 (_ZTSZZ4mainENKUlRN4sycl3_V17handlerEE_clES2_EUlNS0_7nd_itemILi1EEEE_) pLaunchFuncArgs = 140727474881304 {16385, 1, 1} hSignalEvent = 49925848 numWaitEvents = 0 phWaitEvents = 0
-   <<<< [1318232911950754] zeCommandListAppendLaunchKernel [45519 ns] -> ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY(0x1879048195)
+   :
+   >>>> [776257970958971] zeKernelSetGroupSize: hKernel = 54646808 groupSizeX = 10 groupSizeY = 1 groupSizeZ = 1
+   <<<< [776257970963072] zeKernelSetGroupSize [1237 ns] -> ZE_RESULT_SUCCESS(0x0)
+   >>>> [776257970967552] zeCommandListCreateImmediate: hContext = 53065840 hDevice = 48614248 altdesc = 140735243323376 {ZE_STRUCTURE_TYPE_COMMAND_QUEUE_DESC(0xe) 0 0 0 0 2 0} phCommandList = 140735243323360 (hCommandList = 0)
+   <<<< [776257971129090] zeCommandListCreateImmediate [157138 ns] hCommandList = 54788792 -> ZE_RESULT_SUCCESS(0x0)
+   >>>> [776257971135996] zeEventHostReset: hEvent = 49803640
+   <<<< [776257971139385] zeEventHostReset [1296 ns] -> ZE_RESULT_SUCCESS(0x0)
+   >>>> [776257972254927] zeCommandListAppendLaunchKernel: hCommandList = 54788792 hKernel = 54646808 (_ZTSZZ4mainENKUlRN4sycl3_V17handlerEE_clES2_EUlNS0_7nd_itemILi1EEEE_) pLaunchFuncArgs = 140735243324504 {16385, 1, 1} hSignalEvent = 49803640 numWaitEvents = 0 phWaitEvents = 0
+   <<<< [776257972338436] zeCommandListAppendLaunchKernel [56440 ns] -> ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY(0x1879048195)
    terminate called after throwing an instance of 'sycl::_V1::exception'
-     what():  UR backend failed. UR backend returns:40 (UR_RESULT_ERROR_OUT_OF_RESOURCES)
+   what():  UR backend failed. UR backend returns:40 (UR_RESULT_ERROR_OUT_OF_RESOURCES)
    Aborted (core dumped)
    ```
 
@@ -280,9 +288,9 @@ Among other things, the Tracing and Profiling utility can print every low-level 
    A note about the output above. You will see that is has two lines that read:
 
    ```
-   >>>> [1318232902142699] zeKernelSetGroupSize: hKernel = 51602008 groupSizeX = 10 groupSizeY = 1 groupSizeZ = 1
+   >>>> [776257970958971] zeKernelSetGroupSize: hKernel = 54646808 groupSizeX = 10 groupSizeY = 1 groupSizeZ = 1
    :
-   >>>> [1318232911894375] zeCommandListAppendLaunchKernel: hCommandList = 51583896 hKernel = 51602008 (_ZTSZZ4mainENKUlRN4sycl3_V17handlerEE_clES2_EUlNS0_7nd_itemILi1EEEE_) pLaunchFuncArgs = 140727474881304 {16385, 1, 1} hSignalEvent = 49925848 numWaitEvents = 0 phWaitEvents = 0
+   >>>> [776257972254927] zeCommandListAppendLaunchKernel: hCommandList = 54788792 hKernel = 54646808 (_ZTSZZ4mainENKUlRN4sycl3_V17handlerEE_clES2_EUlNS0_7nd_itemILi1EEEE_) pLaunchFuncArgs = 140735243324504 {16385, 1, 1} hSignalEvent = 49803640 numWaitEvents = 0 phWaitEvents = 0
    ```
 
    We used the form of `parallel_for` that takes the `nd_range`, which specifies the global iteration range (163850) and the local work-group size (10) like so:  `nd_range<1>{{163850}, {10}}`. The first line above shows the workgroup size (`groupSizeX = 10 groupSizeY = 1 groupSizeZ = 1`), and the second shows how many total workgroups will be needed to process the global iteration range (`{16385, 1, 1}`).
@@ -324,17 +332,17 @@ Finally, running under `unitrace -c` you see:
 
 ```
 :
->>>> [1318685383432507] zeKernelSetGroupSize: hKernel = 61899240 groupSizeX = 10 groupSizeY = 1 groupSizeZ = 1
-<<<< [1318685383437033] zeKernelSetGroupSize [1000 ns] -> ZE_RESULT_SUCCESS(0x0)
->>>> [1318685383440955] zeCommandListCreateImmediate: hContext = 60295024 hDevice = 55597352 altdesc = 140733556795888 {ZE_STRUCTURE_TYPE_COMMAND_QUEUE_DESC(0xe) 0 0 0 0 2 0} phCommandList = 140733556795872 (hCommandList = 0)
+>>>> [776708418226802] zeKernelSetGroupSize: hKernel = 57133096 groupSizeX = 10 groupSizeY = 1 groupSizeZ = 1
+<<<< [776708418230893] zeKernelSetGroupSize [1154 ns] -> ZE_RESULT_SUCCESS(0x0)
+>>>> [776708418235549] zeCommandListCreateImmediate: hContext = 55553168 hDevice = 51101560 altdesc = 140722633379296 {ZE_STRUCTURE_TYPE_COMMAND_QUEUE_DESC(0xe) 0 0 0 0 2 0} phCommandList = 140722633379280 (hCommandList = 0)
 Flush Task for Immediate command list : Enabled
-Using PCI barrier ptr: 0xf7c9818f000
-<<<< [1318685383694442] zeCommandListCreateImmediate [247603 ns] hCommandList = 61881128 -> ZE_RESULT_SUCCESS(0x0)
->>>> [1318685383702292] zeEventHostReset: hEvent = 60224120
-<<<< [1318685383706720] zeEventHostReset [1427 ns] -> ZE_RESULT_SUCCESS(0x0)
->>>> [1318685383716840] zeCommandListAppendLaunchKernel: hCommandList = 61881128 hKernel = 61899240 (_ZTSZZ4mainENKUlRN4sycl3_V17handlerEE_clES2_EUlNS0_7nd_itemILi1EEEE_) pLaunchFuncArgs = 140733556797016 {16385, 1, 1} hSignalEvent = 60224120 numWaitEvents = 0 phWaitEvents = 0
+Using PCI barrier ptr: 0x141f77d49000
+<<<< [776708418401199] zeCommandListCreateImmediate [160724 ns] hCommandList = 57275080 -> ZE_RESULT_SUCCESS(0x0)
+>>>> [776708418408270] zeEventHostReset: hEvent = 52290952
+<<<< [776708418411693] zeEventHostReset [997 ns] -> ZE_RESULT_SUCCESS(0x0)
+>>>> [776708418417397] zeCommandListAppendLaunchKernel: hCommandList = 57275080 hKernel = 57133096 (_ZTSZZ4mainENKUlRN4sycl3_V17handlerEE_clES2_EUlNS0_7nd_itemILi1EEEE_) pLaunchFuncArgs = 140722633380424 {16385, 1, 1} hSignalEvent = 52290952 numWaitEvents = 0 phWaitEvents = 0
 Size of SLM (656384) larger than available (131072)
-<<<< [1318685383768499] zeCommandListAppendLaunchKernel [43385 ns] -> ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY(0x1879048195)
+<<<< [776708418485438] zeCommandListAppendLaunchKernel [60634 ns] -> ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY(0x1879048195)
 terminate called after throwing an instance of 'sycl::_V1::exception'
   what():  UR backend failed. UR backend returns:40 (UR_RESULT_ERROR_OUT_OF_RESOURCES)
 Aborted (core dumped)


### PR DESCRIPTION
# Existing Sample Changes
## Description

Behavior/output changed between 2025.0 and 2025.1, so updated for the changes in the documentation

Fixes Issue#  none

## External Dependencies

Behavior depends on specific oneAPI (2025.1) and driver versions (Rolling Stable 2507.12) to attain desired behavior.

## Type of change

- [X] Implement fixes for ONSAM Jiras - proactive fixes

## How Has This Been Tested?

- Command Line
- Followed tutorial directions line-by-line, updating any observed changes in behavior, and otherwise verifying correct operation