### PR TITLE
Replaced deprecated intel::reqd_sub_group_size with sycl::reqd_sub_group_size

### DIFF
--- a/DirectProgramming/C++SYCL/SYCLMigration/guided_inlinePtx_SYCLMigration/01_dpct_output/Samples/2_Concepts_and_Techniques/inlinePTX/inlinePTX.dp.cpp
+++ b/DirectProgramming/C++SYCL/SYCLMigration/guided_inlinePtx_SYCLMigration/01_dpct_output/Samples/2_Concepts_and_Techniques/inlinePTX/inlinePTX.dp.cpp
@@ -94,7 +94,7 @@ int main(int argc, char **argv)
     */
     dpct::get_in_order_queue().parallel_for(
         sycl::nd_range<3>(cudaGridSize * cudaBlockSize, cudaBlockSize),
-        [=](sycl::nd_item<3> item_ct1)[[intel::reqd_sub_group_size(32)]] {
+        [=](sycl::nd_item<3> item_ct1)[[sycl::reqd_sub_group_size(32)]] {
             sequence_gpu(d_ptr, N, item_ct1);
         });
     /*

--- a/DirectProgramming/C++SYCL/SYCLMigration/guided_inlinePtx_SYCLMigration/02_sycl_migrated/Samples/2_Concepts_and_Techniques/inlinePTX/inlinePTX.dp.cpp
+++ b/DirectProgramming/C++SYCL/SYCLMigration/guided_inlinePtx_SYCLMigration/02_sycl_migrated/Samples/2_Concepts_and_Techniques/inlinePTX/inlinePTX.dp.cpp
@@ -90,7 +90,7 @@ int main(int argc, char **argv)
 
     dpct::get_in_order_queue().parallel_for(
         sycl::nd_range<3>(cudaGridSize * cudaBlockSize, cudaBlockSize),
-        [=](sycl::nd_item<3> item_ct1) [[intel::reqd_sub_group_size(32)]] {
+        [=](sycl::nd_item<3> item_ct1) [[sycl::reqd_sub_group_size(32)]] {
             sequence_gpu(d_ptr, N, item_ct1);
         });
 

--- a/DirectProgramming/C++SYCL/SYCLMigration/guided_inlinePtx_SYCLMigration/README.md
+++ b/DirectProgramming/C++SYCL/SYCLMigration/guided_inlinePtx_SYCLMigration/README.md
@@ -78,7 +78,7 @@ For this sample, the SYCLomatic tool automatically migrates 100% of the CUDA cod
 ## Manual Workarounds
 The following manual change has been done to complete the migration.
    
-1. The warp size in CUDA is a fixed constant 32, but in SYCL sub-group size usually can be 16 or 32. Use intel extension [[intel::reqd_sub_group_size(32)]] to restrict the sub-group size to 32.
+1. The warp size in CUDA is a fixed constant 32, but in SYCL sub-group size usually can be 16 or 32. Use intel extension [[sycl::reqd_sub_group_size(32)]] to restrict the sub-group size to 32.
       ```
       dpct::get_in_order_queue().parallel_for(
         sycl::nd_range<3>(cudaGridSize * cudaBlockSize, cudaBlockSize),
@@ -90,7 +90,7 @@ The following manual change has been done to complete the migration.
       ```
       dpct::get_in_order_queue().parallel_for(
         sycl::nd_range<3>(cudaGridSize * cudaBlockSize, cudaBlockSize),
-        [=](sycl::nd_item<3> item_ct1) [[intel::reqd_sub_group_size(32)]] {
+        [=](sycl::nd_item<3> item_ct1) [[sycl::reqd_sub_group_size(32)]] {
             sequence_gpu(d_ptr, N, item_ct1);
         });
       ```

--- a/DirectProgramming/C++SYCL/SYCLMigration/guided_shflScan_SYCLMigration/01_dpct_output/Samples/2_Concepts_and_Techniques/shfl_scan/shfl_scan.dp.cpp
+++ b/DirectProgramming/C++SYCL/SYCLMigration/guided_shflScan_SYCLMigration/01_dpct_output/Samples/2_Concepts_and_Techniques/shfl_scan/shfl_scan.dp.cpp
@@ -386,7 +386,7 @@ bool shuffle_simple_test(int argc, char **argv) {
         sycl::nd_range<3>(sycl::range<3>(1, 1, gridSize) *
                               sycl::range<3>(1, 1, blockSize),
                           sycl::range<3>(1, 1, blockSize)),
-        [=](sycl::nd_item<3> item_ct1) [[intel::reqd_sub_group_size(32)]] {
+        [=](sycl::nd_item<3> item_ct1) [[sycl::reqd_sub_group_size(32)]] {
           shfl_scan_test(
               d_data, 32, item_ct1,
               dpct_local_acc_ct1.get_multi_ptr<sycl::access::decorated::no>()
@@ -407,7 +407,7 @@ bool shuffle_simple_test(int argc, char **argv) {
         sycl::nd_range<3>(sycl::range<3>(1, 1, p_gridSize) *
                               sycl::range<3>(1, 1, p_blockSize),
                           sycl::range<3>(1, 1, p_blockSize)),
-        [=](sycl::nd_item<3> item_ct1) [[intel::reqd_sub_group_size(32)]] {
+        [=](sycl::nd_item<3> item_ct1) [[sycl::reqd_sub_group_size(32)]] {
           shfl_scan_test(
               d_partial_sums, 32, item_ct1,
               dpct_local_acc_ct1.get_multi_ptr<sycl::access::decorated::no>()
@@ -533,7 +533,7 @@ bool shuffle_integral_image_test() {
         sycl::nd_range<3>(sycl::range<3>(1, 1, gridSize) *
                               sycl::range<3>(1, 1, blockSize),
                           sycl::range<3>(1, 1, blockSize)),
-        [=](sycl::nd_item<3> item_ct1) [[intel::reqd_sub_group_size(32)]] {
+        [=](sycl::nd_item<3> item_ct1) [[sycl::reqd_sub_group_size(32)]] {
           shfl_intimage_rows(
               reinterpret_cast<sycl::uint4 *>(d_data),
               reinterpret_cast<sycl::uint4 *>(d_integral_image), item_ct1,
@@ -571,7 +571,7 @@ bool shuffle_integral_image_test() {
 
     cgh.parallel_for(sycl::nd_range<3>(testGrid * blockSz, blockSz),
                      [=](sycl::nd_item<3> item_ct1)
-                         [[intel::reqd_sub_group_size(32)]] {
+                         [[sycl::reqd_sub_group_size(32)]] {
                            shfl_vertical_shfl((unsigned int *)d_integral_image,
                                               w, h, item_ct1, sums_acc_ct1);
                          });

--- a/DirectProgramming/C++SYCL/SYCLMigration/guided_shflScan_SYCLMigration/02_sycl_migrated/Samples/2_Concepts_and_Techniques/shfl_scan/shfl_scan.dp.cpp
+++ b/DirectProgramming/C++SYCL/SYCLMigration/guided_shflScan_SYCLMigration/02_sycl_migrated/Samples/2_Concepts_and_Techniques/shfl_scan/shfl_scan.dp.cpp
@@ -305,7 +305,7 @@ bool shuffle_simple_test(int argc, char **argv) {
         sycl::nd_range<3>(sycl::range<3>(1, 1, gridSize) *
                               sycl::range<3>(1, 1, blockSize),
                           sycl::range<3>(1, 1, blockSize)),
-        [=](sycl::nd_item<3> item_ct1) [[intel::reqd_sub_group_size(32)]] {
+        [=](sycl::nd_item<3> item_ct1) [[sycl::reqd_sub_group_size(32)]] {
           shfl_scan_test(
               d_data, 32, item_ct1,
               dpct_local_acc_ct1.get_multi_ptr<sycl::access::decorated::no>()
@@ -322,7 +322,7 @@ bool shuffle_simple_test(int argc, char **argv) {
         sycl::nd_range<3>(sycl::range<3>(1, 1, p_gridSize) *
                               sycl::range<3>(1, 1, p_blockSize),
                           sycl::range<3>(1, 1, p_blockSize)),
-        [=](sycl::nd_item<3> item_ct1) [[intel::reqd_sub_group_size(32)]] {
+        [=](sycl::nd_item<3> item_ct1) [[sycl::reqd_sub_group_size(32)]] {
           shfl_scan_test(
               d_partial_sums, 32, item_ct1,
               dpct_local_acc_ct1.get_multi_ptr<sycl::access::decorated::no>()
@@ -438,7 +438,7 @@ bool shuffle_integral_image_test() {
         sycl::nd_range<3>(sycl::range<3>(1, 1, gridSize) *
                               sycl::range<3>(1, 1, blockSize),
                           sycl::range<3>(1, 1, blockSize)),
-        [=](sycl::nd_item<3> item_ct1) [[intel::reqd_sub_group_size(32)]] {
+        [=](sycl::nd_item<3> item_ct1) [[sycl::reqd_sub_group_size(32)]] {
           shfl_intimage_rows(
               reinterpret_cast<sycl::uint4 *>(d_data),
               reinterpret_cast<sycl::uint4 *>(d_integral_image), item_ct1,
@@ -473,7 +473,7 @@ bool shuffle_integral_image_test() {
 
     cgh.parallel_for(sycl::nd_range<3>(testGrid * blockSz, blockSz),
                      [=](sycl::nd_item<3> item_ct1)
-                         [[intel::reqd_sub_group_size(32)]] {
+                         [[sycl::reqd_sub_group_size(32)]] {
                            shfl_vertical_shfl((unsigned int *)d_integral_image,
                                               w, h, item_ct1, sums_acc_ct1);
                          });

--- a/DirectProgramming/C++SYCL/SYCLMigration/guided_threadFenceReduction_SYCLMigration/01_dpct_output/Samples/2_Concepts_and_Techniques/threadFenceReduction/threadFenceReduction_kernel.dp.hpp
+++ b/DirectProgramming/C++SYCL/SYCLMigration/guided_threadFenceReduction_SYCLMigration/01_dpct_output/Samples/2_Concepts_and_Techniques/threadFenceReduction/threadFenceReduction_kernel.dp.hpp
@@ -281,7 +281,7 @@ extern "C" void reduce(int size, int threads, int blocks, float *d_idata,
 
         cgh.parallel_for(
             sycl::nd_range<3>(dimGrid * dimBlock, dimBlock),
-            [=](sycl::nd_item<3> item_ct1) [[intel::reqd_sub_group_size(32)]] {
+            [=](sycl::nd_item<3> item_ct1) [[sycl::reqd_sub_group_size(32)]] {
               reduceMultiPass<512, true>(
                   d_idata, d_odata, size, item_ct1,
                   dpct_local_acc_ct1
@@ -303,7 +303,7 @@ extern "C" void reduce(int size, int threads, int blocks, float *d_idata,
 
         cgh.parallel_for(
             sycl::nd_range<3>(dimGrid * dimBlock, dimBlock),
-            [=](sycl::nd_item<3> item_ct1) [[intel::reqd_sub_group_size(32)]] {
+            [=](sycl::nd_item<3> item_ct1) [[sycl::reqd_sub_group_size(32)]] {
               reduceMultiPass<256, true>(
                   d_idata, d_odata, size, item_ct1,
                   dpct_local_acc_ct1
@@ -325,7 +325,7 @@ extern "C" void reduce(int size, int threads, int blocks, float *d_idata,
 
         cgh.parallel_for(
             sycl::nd_range<3>(dimGrid * dimBlock, dimBlock),
-            [=](sycl::nd_item<3> item_ct1) [[intel::reqd_sub_group_size(32)]] {
+            [=](sycl::nd_item<3> item_ct1) [[sycl::reqd_sub_group_size(32)]] {
               reduceMultiPass<128, true>(
                   d_idata, d_odata, size, item_ct1,
                   dpct_local_acc_ct1
@@ -347,7 +347,7 @@ extern "C" void reduce(int size, int threads, int blocks, float *d_idata,
 
         cgh.parallel_for(
             sycl::nd_range<3>(dimGrid * dimBlock, dimBlock),
-            [=](sycl::nd_item<3> item_ct1) [[intel::reqd_sub_group_size(32)]] {
+            [=](sycl::nd_item<3> item_ct1) [[sycl::reqd_sub_group_size(32)]] {
               reduceMultiPass<64, true>(
                   d_idata, d_odata, size, item_ct1,
                   dpct_local_acc_ct1
@@ -369,7 +369,7 @@ extern "C" void reduce(int size, int threads, int blocks, float *d_idata,
 
         cgh.parallel_for(
             sycl::nd_range<3>(dimGrid * dimBlock, dimBlock),
-            [=](sycl::nd_item<3> item_ct1) [[intel::reqd_sub_group_size(32)]] {
+            [=](sycl::nd_item<3> item_ct1) [[sycl::reqd_sub_group_size(32)]] {
               reduceMultiPass<32, true>(
                   d_idata, d_odata, size, item_ct1,
                   dpct_local_acc_ct1
@@ -391,7 +391,7 @@ extern "C" void reduce(int size, int threads, int blocks, float *d_idata,
 
         cgh.parallel_for(
             sycl::nd_range<3>(dimGrid * dimBlock, dimBlock),
-            [=](sycl::nd_item<3> item_ct1) [[intel::reqd_sub_group_size(32)]] {
+            [=](sycl::nd_item<3> item_ct1) [[sycl::reqd_sub_group_size(32)]] {
               reduceMultiPass<16, true>(
                   d_idata, d_odata, size, item_ct1,
                   dpct_local_acc_ct1
@@ -413,7 +413,7 @@ extern "C" void reduce(int size, int threads, int blocks, float *d_idata,
 
         cgh.parallel_for(
             sycl::nd_range<3>(dimGrid * dimBlock, dimBlock),
-            [=](sycl::nd_item<3> item_ct1) [[intel::reqd_sub_group_size(32)]] {
+            [=](sycl::nd_item<3> item_ct1) [[sycl::reqd_sub_group_size(32)]] {
               reduceMultiPass<8, true>(
                   d_idata, d_odata, size, item_ct1,
                   dpct_local_acc_ct1
@@ -435,7 +435,7 @@ extern "C" void reduce(int size, int threads, int blocks, float *d_idata,
 
         cgh.parallel_for(
             sycl::nd_range<3>(dimGrid * dimBlock, dimBlock),
-            [=](sycl::nd_item<3> item_ct1) [[intel::reqd_sub_group_size(32)]] {
+            [=](sycl::nd_item<3> item_ct1) [[sycl::reqd_sub_group_size(32)]] {
               reduceMultiPass<4, true>(
                   d_idata, d_odata, size, item_ct1,
                   dpct_local_acc_ct1
@@ -457,7 +457,7 @@ extern "C" void reduce(int size, int threads, int blocks, float *d_idata,
 
         cgh.parallel_for(
             sycl::nd_range<3>(dimGrid * dimBlock, dimBlock),
-            [=](sycl::nd_item<3> item_ct1) [[intel::reqd_sub_group_size(32)]] {
+            [=](sycl::nd_item<3> item_ct1) [[sycl::reqd_sub_group_size(32)]] {
               reduceMultiPass<2, true>(
                   d_idata, d_odata, size, item_ct1,
                   dpct_local_acc_ct1
@@ -479,7 +479,7 @@ extern "C" void reduce(int size, int threads, int blocks, float *d_idata,
 
         cgh.parallel_for(
             sycl::nd_range<3>(dimGrid * dimBlock, dimBlock),
-            [=](sycl::nd_item<3> item_ct1) [[intel::reqd_sub_group_size(32)]] {
+            [=](sycl::nd_item<3> item_ct1) [[sycl::reqd_sub_group_size(32)]] {
               reduceMultiPass<1, true>(
                   d_idata, d_odata, size, item_ct1,
                   dpct_local_acc_ct1
@@ -503,7 +503,7 @@ extern "C" void reduce(int size, int threads, int blocks, float *d_idata,
 
         cgh.parallel_for(
             sycl::nd_range<3>(dimGrid * dimBlock, dimBlock),
-            [=](sycl::nd_item<3> item_ct1) [[intel::reqd_sub_group_size(32)]] {
+            [=](sycl::nd_item<3> item_ct1) [[sycl::reqd_sub_group_size(32)]] {
               reduceMultiPass<512, false>(
                   d_idata, d_odata, size, item_ct1,
                   dpct_local_acc_ct1
@@ -525,7 +525,7 @@ extern "C" void reduce(int size, int threads, int blocks, float *d_idata,
 
         cgh.parallel_for(
             sycl::nd_range<3>(dimGrid * dimBlock, dimBlock),
-            [=](sycl::nd_item<3> item_ct1) [[intel::reqd_sub_group_size(32)]] {
+            [=](sycl::nd_item<3> item_ct1) [[sycl::reqd_sub_group_size(32)]] {
               reduceMultiPass<256, false>(
                   d_idata, d_odata, size, item_ct1,
                   dpct_local_acc_ct1
@@ -547,7 +547,7 @@ extern "C" void reduce(int size, int threads, int blocks, float *d_idata,
 
         cgh.parallel_for(
             sycl::nd_range<3>(dimGrid * dimBlock, dimBlock),
-            [=](sycl::nd_item<3> item_ct1) [[intel::reqd_sub_group_size(32)]] {
+            [=](sycl::nd_item<3> item_ct1) [[sycl::reqd_sub_group_size(32)]] {
               reduceMultiPass<128, false>(
                   d_idata, d_odata, size, item_ct1,
                   dpct_local_acc_ct1
@@ -569,7 +569,7 @@ extern "C" void reduce(int size, int threads, int blocks, float *d_idata,
 
         cgh.parallel_for(
             sycl::nd_range<3>(dimGrid * dimBlock, dimBlock),
-            [=](sycl::nd_item<3> item_ct1) [[intel::reqd_sub_group_size(32)]] {
+            [=](sycl::nd_item<3> item_ct1) [[sycl::reqd_sub_group_size(32)]] {
               reduceMultiPass<64, false>(
                   d_idata, d_odata, size, item_ct1,
                   dpct_local_acc_ct1
@@ -591,7 +591,7 @@ extern "C" void reduce(int size, int threads, int blocks, float *d_idata,
 
         cgh.parallel_for(
             sycl::nd_range<3>(dimGrid * dimBlock, dimBlock),
-            [=](sycl::nd_item<3> item_ct1) [[intel::reqd_sub_group_size(32)]] {
+            [=](sycl::nd_item<3> item_ct1) [[sycl::reqd_sub_group_size(32)]] {
               reduceMultiPass<32, false>(
                   d_idata, d_odata, size, item_ct1,
                   dpct_local_acc_ct1
@@ -613,7 +613,7 @@ extern "C" void reduce(int size, int threads, int blocks, float *d_idata,
 
         cgh.parallel_for(
             sycl::nd_range<3>(dimGrid * dimBlock, dimBlock),
-            [=](sycl::nd_item<3> item_ct1) [[intel::reqd_sub_group_size(32)]] {
+            [=](sycl::nd_item<3> item_ct1) [[sycl::reqd_sub_group_size(32)]] {
               reduceMultiPass<16, false>(
                   d_idata, d_odata, size, item_ct1,
                   dpct_local_acc_ct1
@@ -635,7 +635,7 @@ extern "C" void reduce(int size, int threads, int blocks, float *d_idata,
 
         cgh.parallel_for(
             sycl::nd_range<3>(dimGrid * dimBlock, dimBlock),
-            [=](sycl::nd_item<3> item_ct1) [[intel::reqd_sub_group_size(32)]] {
+            [=](sycl::nd_item<3> item_ct1) [[sycl::reqd_sub_group_size(32)]] {
               reduceMultiPass<8, false>(
                   d_idata, d_odata, size, item_ct1,
                   dpct_local_acc_ct1
@@ -657,7 +657,7 @@ extern "C" void reduce(int size, int threads, int blocks, float *d_idata,
 
         cgh.parallel_for(
             sycl::nd_range<3>(dimGrid * dimBlock, dimBlock),
-            [=](sycl::nd_item<3> item_ct1) [[intel::reqd_sub_group_size(32)]] {
+            [=](sycl::nd_item<3> item_ct1) [[sycl::reqd_sub_group_size(32)]] {
               reduceMultiPass<4, false>(
                   d_idata, d_odata, size, item_ct1,
                   dpct_local_acc_ct1
@@ -679,7 +679,7 @@ extern "C" void reduce(int size, int threads, int blocks, float *d_idata,
 
         cgh.parallel_for(
             sycl::nd_range<3>(dimGrid * dimBlock, dimBlock),
-            [=](sycl::nd_item<3> item_ct1) [[intel::reqd_sub_group_size(32)]] {
+            [=](sycl::nd_item<3> item_ct1) [[sycl::reqd_sub_group_size(32)]] {
               reduceMultiPass<2, false>(
                   d_idata, d_odata, size, item_ct1,
                   dpct_local_acc_ct1
@@ -701,7 +701,7 @@ extern "C" void reduce(int size, int threads, int blocks, float *d_idata,
 
         cgh.parallel_for(
             sycl::nd_range<3>(dimGrid * dimBlock, dimBlock),
-            [=](sycl::nd_item<3> item_ct1) [[intel::reqd_sub_group_size(32)]] {
+            [=](sycl::nd_item<3> item_ct1) [[sycl::reqd_sub_group_size(32)]] {
               reduceMultiPass<1, false>(
                   d_idata, d_odata, size, item_ct1,
                   dpct_local_acc_ct1
@@ -747,7 +747,7 @@ extern "C" void reduceSinglePass(int size, int threads, int blocks,
           cgh.parallel_for(
               sycl::nd_range<3>(dimGrid * dimBlock, dimBlock),
               [=](sycl::nd_item<3> item_ct1)
-                  [[intel::reqd_sub_group_size(32)]] {
+                  [[sycl::reqd_sub_group_size(32)]] {
                     reduceSinglePass<512, true>(
                         d_idata, d_odata, size, item_ct1,
                         dpct_local_acc_ct1
@@ -778,7 +778,7 @@ extern "C" void reduceSinglePass(int size, int threads, int blocks,
           cgh.parallel_for(
               sycl::nd_range<3>(dimGrid * dimBlock, dimBlock),
               [=](sycl::nd_item<3> item_ct1)
-                  [[intel::reqd_sub_group_size(32)]] {
+                  [[sycl::reqd_sub_group_size(32)]] {
                     reduceSinglePass<256, true>(
                         d_idata, d_odata, size, item_ct1,
                         dpct_local_acc_ct1
@@ -809,7 +809,7 @@ extern "C" void reduceSinglePass(int size, int threads, int blocks,
           cgh.parallel_for(
               sycl::nd_range<3>(dimGrid * dimBlock, dimBlock),
               [=](sycl::nd_item<3> item_ct1)
-                  [[intel::reqd_sub_group_size(32)]] {
+                  [[sycl::reqd_sub_group_size(32)]] {
                     reduceSinglePass<128, true>(
                         d_idata, d_odata, size, item_ct1,
                         dpct_local_acc_ct1
@@ -840,7 +840,7 @@ extern "C" void reduceSinglePass(int size, int threads, int blocks,
           cgh.parallel_for(
               sycl::nd_range<3>(dimGrid * dimBlock, dimBlock),
               [=](sycl::nd_item<3> item_ct1)
-                  [[intel::reqd_sub_group_size(32)]] {
+                  [[sycl::reqd_sub_group_size(32)]] {
                     reduceSinglePass<64, true>(
                         d_idata, d_odata, size, item_ct1,
                         dpct_local_acc_ct1
@@ -871,7 +871,7 @@ extern "C" void reduceSinglePass(int size, int threads, int blocks,
           cgh.parallel_for(
               sycl::nd_range<3>(dimGrid * dimBlock, dimBlock),
               [=](sycl::nd_item<3> item_ct1)
-                  [[intel::reqd_sub_group_size(32)]] {
+                  [[sycl::reqd_sub_group_size(32)]] {
                     reduceSinglePass<32, true>(
                         d_idata, d_odata, size, item_ct1,
                         dpct_local_acc_ct1
@@ -902,7 +902,7 @@ extern "C" void reduceSinglePass(int size, int threads, int blocks,
           cgh.parallel_for(
               sycl::nd_range<3>(dimGrid * dimBlock, dimBlock),
               [=](sycl::nd_item<3> item_ct1)
-                  [[intel::reqd_sub_group_size(32)]] {
+                  [[sycl::reqd_sub_group_size(32)]] {
                     reduceSinglePass<16, true>(
                         d_idata, d_odata, size, item_ct1,
                         dpct_local_acc_ct1
@@ -933,7 +933,7 @@ extern "C" void reduceSinglePass(int size, int threads, int blocks,
           cgh.parallel_for(
               sycl::nd_range<3>(dimGrid * dimBlock, dimBlock),
               [=](sycl::nd_item<3> item_ct1)
-                  [[intel::reqd_sub_group_size(32)]] {
+                  [[sycl::reqd_sub_group_size(32)]] {
                     reduceSinglePass<8, true>(
                         d_idata, d_odata, size, item_ct1,
                         dpct_local_acc_ct1
@@ -964,7 +964,7 @@ extern "C" void reduceSinglePass(int size, int threads, int blocks,
           cgh.parallel_for(
               sycl::nd_range<3>(dimGrid * dimBlock, dimBlock),
               [=](sycl::nd_item<3> item_ct1)
-                  [[intel::reqd_sub_group_size(32)]] {
+                  [[sycl::reqd_sub_group_size(32)]] {
                     reduceSinglePass<4, true>(
                         d_idata, d_odata, size, item_ct1,
                         dpct_local_acc_ct1
@@ -995,7 +995,7 @@ extern "C" void reduceSinglePass(int size, int threads, int blocks,
           cgh.parallel_for(
               sycl::nd_range<3>(dimGrid * dimBlock, dimBlock),
               [=](sycl::nd_item<3> item_ct1)
-                  [[intel::reqd_sub_group_size(32)]] {
+                  [[sycl::reqd_sub_group_size(32)]] {
                     reduceSinglePass<2, true>(
                         d_idata, d_odata, size, item_ct1,
                         dpct_local_acc_ct1
@@ -1026,7 +1026,7 @@ extern "C" void reduceSinglePass(int size, int threads, int blocks,
           cgh.parallel_for(
               sycl::nd_range<3>(dimGrid * dimBlock, dimBlock),
               [=](sycl::nd_item<3> item_ct1)
-                  [[intel::reqd_sub_group_size(32)]] {
+                  [[sycl::reqd_sub_group_size(32)]] {
                     reduceSinglePass<1, true>(
                         d_idata, d_odata, size, item_ct1,
                         dpct_local_acc_ct1
@@ -1059,7 +1059,7 @@ extern "C" void reduceSinglePass(int size, int threads, int blocks,
           cgh.parallel_for(
               sycl::nd_range<3>(dimGrid * dimBlock, dimBlock),
               [=](sycl::nd_item<3> item_ct1)
-                  [[intel::reqd_sub_group_size(32)]] {
+                  [[sycl::reqd_sub_group_size(32)]] {
                     reduceSinglePass<512, false>(
                         d_idata, d_odata, size, item_ct1,
                         dpct_local_acc_ct1
@@ -1090,7 +1090,7 @@ extern "C" void reduceSinglePass(int size, int threads, int blocks,
           cgh.parallel_for(
               sycl::nd_range<3>(dimGrid * dimBlock, dimBlock),
               [=](sycl::nd_item<3> item_ct1)
-                  [[intel::reqd_sub_group_size(32)]] {
+                  [[sycl::reqd_sub_group_size(32)]] {
                     reduceSinglePass<256, false>(
                         d_idata, d_odata, size, item_ct1,
                         dpct_local_acc_ct1
@@ -1121,7 +1121,7 @@ extern "C" void reduceSinglePass(int size, int threads, int blocks,
           cgh.parallel_for(
               sycl::nd_range<3>(dimGrid * dimBlock, dimBlock),
               [=](sycl::nd_item<3> item_ct1)
-                  [[intel::reqd_sub_group_size(32)]] {
+                  [[sycl::reqd_sub_group_size(32)]] {
                     reduceSinglePass<128, false>(
                         d_idata, d_odata, size, item_ct1,
                         dpct_local_acc_ct1
@@ -1152,7 +1152,7 @@ extern "C" void reduceSinglePass(int size, int threads, int blocks,
           cgh.parallel_for(
               sycl::nd_range<3>(dimGrid * dimBlock, dimBlock),
               [=](sycl::nd_item<3> item_ct1)
-                  [[intel::reqd_sub_group_size(32)]] {
+                  [[sycl::reqd_sub_group_size(32)]] {
                     reduceSinglePass<64, false>(
                         d_idata, d_odata, size, item_ct1,
                         dpct_local_acc_ct1
@@ -1183,7 +1183,7 @@ extern "C" void reduceSinglePass(int size, int threads, int blocks,
           cgh.parallel_for(
               sycl::nd_range<3>(dimGrid * dimBlock, dimBlock),
               [=](sycl::nd_item<3> item_ct1)
-                  [[intel::reqd_sub_group_size(32)]] {
+                  [[sycl::reqd_sub_group_size(32)]] {
                     reduceSinglePass<32, false>(
                         d_idata, d_odata, size, item_ct1,
                         dpct_local_acc_ct1
@@ -1214,7 +1214,7 @@ extern "C" void reduceSinglePass(int size, int threads, int blocks,
           cgh.parallel_for(
               sycl::nd_range<3>(dimGrid * dimBlock, dimBlock),
               [=](sycl::nd_item<3> item_ct1)
-                  [[intel::reqd_sub_group_size(32)]] {
+                  [[sycl::reqd_sub_group_size(32)]] {
                     reduceSinglePass<16, false>(
                         d_idata, d_odata, size, item_ct1,
                         dpct_local_acc_ct1
@@ -1245,7 +1245,7 @@ extern "C" void reduceSinglePass(int size, int threads, int blocks,
           cgh.parallel_for(
               sycl::nd_range<3>(dimGrid * dimBlock, dimBlock),
               [=](sycl::nd_item<3> item_ct1)
-                  [[intel::reqd_sub_group_size(32)]] {
+                  [[sycl::reqd_sub_group_size(32)]] {
                     reduceSinglePass<8, false>(
                         d_idata, d_odata, size, item_ct1,
                         dpct_local_acc_ct1
@@ -1276,7 +1276,7 @@ extern "C" void reduceSinglePass(int size, int threads, int blocks,
           cgh.parallel_for(
               sycl::nd_range<3>(dimGrid * dimBlock, dimBlock),
               [=](sycl::nd_item<3> item_ct1)
-                  [[intel::reqd_sub_group_size(32)]] {
+                  [[sycl::reqd_sub_group_size(32)]] {
                     reduceSinglePass<4, false>(
                         d_idata, d_odata, size, item_ct1,
                         dpct_local_acc_ct1
@@ -1307,7 +1307,7 @@ extern "C" void reduceSinglePass(int size, int threads, int blocks,
           cgh.parallel_for(
               sycl::nd_range<3>(dimGrid * dimBlock, dimBlock),
               [=](sycl::nd_item<3> item_ct1)
-                  [[intel::reqd_sub_group_size(32)]] {
+                  [[sycl::reqd_sub_group_size(32)]] {
                     reduceSinglePass<2, false>(
                         d_idata, d_odata, size, item_ct1,
                         dpct_local_acc_ct1
@@ -1338,7 +1338,7 @@ extern "C" void reduceSinglePass(int size, int threads, int blocks,
           cgh.parallel_for(
               sycl::nd_range<3>(dimGrid * dimBlock, dimBlock),
               [=](sycl::nd_item<3> item_ct1)
-                  [[intel::reqd_sub_group_size(32)]] {
+                  [[sycl::reqd_sub_group_size(32)]] {
                     reduceSinglePass<1, false>(
                         d_idata, d_odata, size, item_ct1,
                         dpct_local_acc_ct1

--- a/DirectProgramming/C++SYCL/SYCLMigration/guided_threadFenceReduction_SYCLMigration/02_sycl_migrated/Samples/2_Concepts_and_Techniques/threadFenceReduction/threadFenceReduction_kernel.dp.hpp
+++ b/DirectProgramming/C++SYCL/SYCLMigration/guided_threadFenceReduction_SYCLMigration/02_sycl_migrated/Samples/2_Concepts_and_Techniques/threadFenceReduction/threadFenceReduction_kernel.dp.hpp
@@ -241,7 +241,7 @@ extern "C" void reduce(int size, int threads, int blocks, float *d_idata,
 
         cgh.parallel_for(
             sycl::nd_range<3>(dimGrid * dimBlock, dimBlock),
-            [=](sycl::nd_item<3> item_ct1) [[intel::reqd_sub_group_size(32)]] {
+            [=](sycl::nd_item<3> item_ct1) [[sycl::reqd_sub_group_size(32)]] {
               reduceMultiPass<512, true>(
                   d_idata, d_odata, size, item_ct1,
                   dpct_local_acc_ct1
@@ -258,7 +258,7 @@ extern "C" void reduce(int size, int threads, int blocks, float *d_idata,
 
         cgh.parallel_for(
             sycl::nd_range<3>(dimGrid * dimBlock, dimBlock),
-            [=](sycl::nd_item<3> item_ct1) [[intel::reqd_sub_group_size(32)]] {
+            [=](sycl::nd_item<3> item_ct1) [[sycl::reqd_sub_group_size(32)]] {
               reduceMultiPass<256, true>(
                   d_idata, d_odata, size, item_ct1,
                   dpct_local_acc_ct1
@@ -276,7 +276,7 @@ extern "C" void reduce(int size, int threads, int blocks, float *d_idata,
 
         cgh.parallel_for(
             sycl::nd_range<3>(dimGrid * dimBlock, dimBlock),
-            [=](sycl::nd_item<3> item_ct1) [[intel::reqd_sub_group_size(32)]] {
+            [=](sycl::nd_item<3> item_ct1) [[sycl::reqd_sub_group_size(32)]] {
               reduceMultiPass<128, true>(
                   d_idata, d_odata, size, item_ct1,
                   dpct_local_acc_ct1
@@ -293,7 +293,7 @@ extern "C" void reduce(int size, int threads, int blocks, float *d_idata,
 
         cgh.parallel_for(
             sycl::nd_range<3>(dimGrid * dimBlock, dimBlock),
-            [=](sycl::nd_item<3> item_ct1) [[intel::reqd_sub_group_size(32)]] {
+            [=](sycl::nd_item<3> item_ct1) [[sycl::reqd_sub_group_size(32)]] {
               reduceMultiPass<64, true>(
                   d_idata, d_odata, size, item_ct1,
                   dpct_local_acc_ct1
@@ -311,7 +311,7 @@ extern "C" void reduce(int size, int threads, int blocks, float *d_idata,
 
         cgh.parallel_for(
             sycl::nd_range<3>(dimGrid * dimBlock, dimBlock),
-            [=](sycl::nd_item<3> item_ct1) [[intel::reqd_sub_group_size(32)]] {
+            [=](sycl::nd_item<3> item_ct1) [[sycl::reqd_sub_group_size(32)]] {
               reduceMultiPass<32, true>(
                   d_idata, d_odata, size, item_ct1,
                   dpct_local_acc_ct1
@@ -329,7 +329,7 @@ extern "C" void reduce(int size, int threads, int blocks, float *d_idata,
 
         cgh.parallel_for(
             sycl::nd_range<3>(dimGrid * dimBlock, dimBlock),
-            [=](sycl::nd_item<3> item_ct1) [[intel::reqd_sub_group_size(32)]] {
+            [=](sycl::nd_item<3> item_ct1) [[sycl::reqd_sub_group_size(32)]] {
               reduceMultiPass<16, true>(
                   d_idata, d_odata, size, item_ct1,
                   dpct_local_acc_ct1
@@ -347,7 +347,7 @@ extern "C" void reduce(int size, int threads, int blocks, float *d_idata,
 
         cgh.parallel_for(
             sycl::nd_range<3>(dimGrid * dimBlock, dimBlock),
-            [=](sycl::nd_item<3> item_ct1) [[intel::reqd_sub_group_size(32)]] {
+            [=](sycl::nd_item<3> item_ct1) [[sycl::reqd_sub_group_size(32)]] {
               reduceMultiPass<8, true>(
                   d_idata, d_odata, size, item_ct1,
                   dpct_local_acc_ct1
@@ -365,7 +365,7 @@ extern "C" void reduce(int size, int threads, int blocks, float *d_idata,
 
         cgh.parallel_for(
             sycl::nd_range<3>(dimGrid * dimBlock, dimBlock),
-            [=](sycl::nd_item<3> item_ct1) [[intel::reqd_sub_group_size(32)]] {
+            [=](sycl::nd_item<3> item_ct1) [[sycl::reqd_sub_group_size(32)]] {
               reduceMultiPass<4, true>(
                   d_idata, d_odata, size, item_ct1,
                   dpct_local_acc_ct1
@@ -383,7 +383,7 @@ extern "C" void reduce(int size, int threads, int blocks, float *d_idata,
 
         cgh.parallel_for(
             sycl::nd_range<3>(dimGrid * dimBlock, dimBlock),
-            [=](sycl::nd_item<3> item_ct1) [[intel::reqd_sub_group_size(32)]] {
+            [=](sycl::nd_item<3> item_ct1) [[sycl::reqd_sub_group_size(32)]] {
               reduceMultiPass<2, true>(
                   d_idata, d_odata, size, item_ct1,
                   dpct_local_acc_ct1
@@ -401,7 +401,7 @@ extern "C" void reduce(int size, int threads, int blocks, float *d_idata,
 
         cgh.parallel_for(
             sycl::nd_range<3>(dimGrid * dimBlock, dimBlock),
-            [=](sycl::nd_item<3> item_ct1) [[intel::reqd_sub_group_size(32)]] {
+            [=](sycl::nd_item<3> item_ct1) [[sycl::reqd_sub_group_size(32)]] {
               reduceMultiPass<1, true>(
                   d_idata, d_odata, size, item_ct1,
                   dpct_local_acc_ct1
@@ -421,7 +421,7 @@ extern "C" void reduce(int size, int threads, int blocks, float *d_idata,
 
         cgh.parallel_for(
             sycl::nd_range<3>(dimGrid * dimBlock, dimBlock),
-            [=](sycl::nd_item<3> item_ct1) [[intel::reqd_sub_group_size(32)]] {
+            [=](sycl::nd_item<3> item_ct1) [[sycl::reqd_sub_group_size(32)]] {
               reduceMultiPass<512, false>(
                   d_idata, d_odata, size, item_ct1,
                   dpct_local_acc_ct1
@@ -439,7 +439,7 @@ extern "C" void reduce(int size, int threads, int blocks, float *d_idata,
 
         cgh.parallel_for(
             sycl::nd_range<3>(dimGrid * dimBlock, dimBlock),
-            [=](sycl::nd_item<3> item_ct1) [[intel::reqd_sub_group_size(32)]] {
+            [=](sycl::nd_item<3> item_ct1) [[sycl::reqd_sub_group_size(32)]] {
               reduceMultiPass<256, false>(
                   d_idata, d_odata, size, item_ct1,
                   dpct_local_acc_ct1
@@ -457,7 +457,7 @@ extern "C" void reduce(int size, int threads, int blocks, float *d_idata,
 
         cgh.parallel_for(
             sycl::nd_range<3>(dimGrid * dimBlock, dimBlock),
-            [=](sycl::nd_item<3> item_ct1) [[intel::reqd_sub_group_size(32)]] {
+            [=](sycl::nd_item<3> item_ct1) [[sycl::reqd_sub_group_size(32)]] {
               reduceMultiPass<128, false>(
                   d_idata, d_odata, size, item_ct1,
                   dpct_local_acc_ct1
@@ -475,7 +475,7 @@ extern "C" void reduce(int size, int threads, int blocks, float *d_idata,
 
         cgh.parallel_for(
             sycl::nd_range<3>(dimGrid * dimBlock, dimBlock),
-            [=](sycl::nd_item<3> item_ct1) [[intel::reqd_sub_group_size(32)]] {
+            [=](sycl::nd_item<3> item_ct1) [[sycl::reqd_sub_group_size(32)]] {
               reduceMultiPass<64, false>(
                   d_idata, d_odata, size, item_ct1,
                   dpct_local_acc_ct1
@@ -493,7 +493,7 @@ extern "C" void reduce(int size, int threads, int blocks, float *d_idata,
 
         cgh.parallel_for(
             sycl::nd_range<3>(dimGrid * dimBlock, dimBlock),
-            [=](sycl::nd_item<3> item_ct1) [[intel::reqd_sub_group_size(32)]] {
+            [=](sycl::nd_item<3> item_ct1) [[sycl::reqd_sub_group_size(32)]] {
               reduceMultiPass<32, false>(
                   d_idata, d_odata, size, item_ct1,
                   dpct_local_acc_ct1
@@ -511,7 +511,7 @@ extern "C" void reduce(int size, int threads, int blocks, float *d_idata,
 
         cgh.parallel_for(
             sycl::nd_range<3>(dimGrid * dimBlock, dimBlock),
-            [=](sycl::nd_item<3> item_ct1) [[intel::reqd_sub_group_size(32)]] {
+            [=](sycl::nd_item<3> item_ct1) [[sycl::reqd_sub_group_size(32)]] {
               reduceMultiPass<16, false>(
                   d_idata, d_odata, size, item_ct1,
                   dpct_local_acc_ct1
@@ -529,7 +529,7 @@ extern "C" void reduce(int size, int threads, int blocks, float *d_idata,
 
         cgh.parallel_for(
             sycl::nd_range<3>(dimGrid * dimBlock, dimBlock),
-            [=](sycl::nd_item<3> item_ct1) [[intel::reqd_sub_group_size(32)]] {
+            [=](sycl::nd_item<3> item_ct1) [[sycl::reqd_sub_group_size(32)]] {
               reduceMultiPass<8, false>(
                   d_idata, d_odata, size, item_ct1,
                   dpct_local_acc_ct1
@@ -547,7 +547,7 @@ extern "C" void reduce(int size, int threads, int blocks, float *d_idata,
 
         cgh.parallel_for(
             sycl::nd_range<3>(dimGrid * dimBlock, dimBlock),
-            [=](sycl::nd_item<3> item_ct1) [[intel::reqd_sub_group_size(32)]] {
+            [=](sycl::nd_item<3> item_ct1) [[sycl::reqd_sub_group_size(32)]] {
               reduceMultiPass<4, false>(
                   d_idata, d_odata, size, item_ct1,
                   dpct_local_acc_ct1
@@ -565,7 +565,7 @@ extern "C" void reduce(int size, int threads, int blocks, float *d_idata,
 
         cgh.parallel_for(
             sycl::nd_range<3>(dimGrid * dimBlock, dimBlock),
-            [=](sycl::nd_item<3> item_ct1) [[intel::reqd_sub_group_size(32)]] {
+            [=](sycl::nd_item<3> item_ct1) [[sycl::reqd_sub_group_size(32)]] {
               reduceMultiPass<2, false>(
                   d_idata, d_odata, size, item_ct1,
                   dpct_local_acc_ct1
@@ -583,7 +583,7 @@ extern "C" void reduce(int size, int threads, int blocks, float *d_idata,
 
         cgh.parallel_for(
             sycl::nd_range<3>(dimGrid * dimBlock, dimBlock),
-            [=](sycl::nd_item<3> item_ct1) [[intel::reqd_sub_group_size(32)]] {
+            [=](sycl::nd_item<3> item_ct1) [[sycl::reqd_sub_group_size(32)]] {
               reduceMultiPass<1, false>(
                   d_idata, d_odata, size, item_ct1,
                   dpct_local_acc_ct1
@@ -621,7 +621,7 @@ extern "C" void reduceSinglePass(int size, int threads, int blocks,
           cgh.parallel_for(
               sycl::nd_range<3>(dimGrid * dimBlock, dimBlock),
               [=](sycl::nd_item<3> item_ct1)
-                  [[intel::reqd_sub_group_size(32)]] {
+                  [[sycl::reqd_sub_group_size(32)]] {
                     reduceSinglePass<512, true>(
                         d_idata, d_odata, size, item_ct1,
                         dpct_local_acc_ct1
@@ -648,7 +648,7 @@ extern "C" void reduceSinglePass(int size, int threads, int blocks,
           cgh.parallel_for(
               sycl::nd_range<3>(dimGrid * dimBlock, dimBlock),
               [=](sycl::nd_item<3> item_ct1)
-                  [[intel::reqd_sub_group_size(32)]] {
+                  [[sycl::reqd_sub_group_size(32)]] {
                     reduceSinglePass<256, true>(
                         d_idata, d_odata, size, item_ct1,
                         dpct_local_acc_ct1
@@ -675,7 +675,7 @@ extern "C" void reduceSinglePass(int size, int threads, int blocks,
           cgh.parallel_for(
               sycl::nd_range<3>(dimGrid * dimBlock, dimBlock),
               [=](sycl::nd_item<3> item_ct1)
-                  [[intel::reqd_sub_group_size(32)]] {
+                  [[sycl::reqd_sub_group_size(32)]] {
                     reduceSinglePass<128, true>(
                         d_idata, d_odata, size, item_ct1,
                         dpct_local_acc_ct1
@@ -702,7 +702,7 @@ extern "C" void reduceSinglePass(int size, int threads, int blocks,
           cgh.parallel_for(
               sycl::nd_range<3>(dimGrid * dimBlock, dimBlock),
               [=](sycl::nd_item<3> item_ct1)
-                  [[intel::reqd_sub_group_size(32)]] {
+                  [[sycl::reqd_sub_group_size(32)]] {
                     reduceSinglePass<64, true>(
                         d_idata, d_odata, size, item_ct1,
                         dpct_local_acc_ct1
@@ -729,7 +729,7 @@ extern "C" void reduceSinglePass(int size, int threads, int blocks,
           cgh.parallel_for(
               sycl::nd_range<3>(dimGrid * dimBlock, dimBlock),
               [=](sycl::nd_item<3> item_ct1)
-                  [[intel::reqd_sub_group_size(32)]] {
+                  [[sycl::reqd_sub_group_size(32)]] {
                     reduceSinglePass<32, true>(
                         d_idata, d_odata, size, item_ct1,
                         dpct_local_acc_ct1
@@ -756,7 +756,7 @@ extern "C" void reduceSinglePass(int size, int threads, int blocks,
           cgh.parallel_for(
               sycl::nd_range<3>(dimGrid * dimBlock, dimBlock),
               [=](sycl::nd_item<3> item_ct1)
-                  [[intel::reqd_sub_group_size(32)]] {
+                  [[sycl::reqd_sub_group_size(32)]] {
                     reduceSinglePass<16, true>(
                         d_idata, d_odata, size, item_ct1,
                         dpct_local_acc_ct1
@@ -783,7 +783,7 @@ extern "C" void reduceSinglePass(int size, int threads, int blocks,
           cgh.parallel_for(
               sycl::nd_range<3>(dimGrid * dimBlock, dimBlock),
               [=](sycl::nd_item<3> item_ct1)
-                  [[intel::reqd_sub_group_size(32)]] {
+                  [[sycl::reqd_sub_group_size(32)]] {
                     reduceSinglePass<8, true>(
                         d_idata, d_odata, size, item_ct1,
                         dpct_local_acc_ct1
@@ -810,7 +810,7 @@ extern "C" void reduceSinglePass(int size, int threads, int blocks,
           cgh.parallel_for(
               sycl::nd_range<3>(dimGrid * dimBlock, dimBlock),
               [=](sycl::nd_item<3> item_ct1)
-                  [[intel::reqd_sub_group_size(32)]] {
+                  [[sycl::reqd_sub_group_size(32)]] {
                     reduceSinglePass<4, true>(
                         d_idata, d_odata, size, item_ct1,
                         dpct_local_acc_ct1
@@ -837,7 +837,7 @@ extern "C" void reduceSinglePass(int size, int threads, int blocks,
           cgh.parallel_for(
               sycl::nd_range<3>(dimGrid * dimBlock, dimBlock),
               [=](sycl::nd_item<3> item_ct1)
-                  [[intel::reqd_sub_group_size(32)]] {
+                  [[sycl::reqd_sub_group_size(32)]] {
                     reduceSinglePass<2, true>(
                         d_idata, d_odata, size, item_ct1,
                         dpct_local_acc_ct1
@@ -864,7 +864,7 @@ extern "C" void reduceSinglePass(int size, int threads, int blocks,
           cgh.parallel_for(
               sycl::nd_range<3>(dimGrid * dimBlock, dimBlock),
               [=](sycl::nd_item<3> item_ct1)
-                  [[intel::reqd_sub_group_size(32)]] {
+                  [[sycl::reqd_sub_group_size(32)]] {
                     reduceSinglePass<1, true>(
                         d_idata, d_odata, size, item_ct1,
                         dpct_local_acc_ct1
@@ -893,7 +893,7 @@ extern "C" void reduceSinglePass(int size, int threads, int blocks,
           cgh.parallel_for(
               sycl::nd_range<3>(dimGrid * dimBlock, dimBlock),
               [=](sycl::nd_item<3> item_ct1)
-                  [[intel::reqd_sub_group_size(32)]] {
+                  [[sycl::reqd_sub_group_size(32)]] {
                     reduceSinglePass<512, false>(
                         d_idata, d_odata, size, item_ct1,
                         dpct_local_acc_ct1
@@ -920,7 +920,7 @@ extern "C" void reduceSinglePass(int size, int threads, int blocks,
           cgh.parallel_for(
               sycl::nd_range<3>(dimGrid * dimBlock, dimBlock),
               [=](sycl::nd_item<3> item_ct1)
-                  [[intel::reqd_sub_group_size(32)]] {
+                  [[sycl::reqd_sub_group_size(32)]] {
                     reduceSinglePass<256, false>(
                         d_idata, d_odata, size, item_ct1,
                         dpct_local_acc_ct1
@@ -947,7 +947,7 @@ extern "C" void reduceSinglePass(int size, int threads, int blocks,
           cgh.parallel_for(
               sycl::nd_range<3>(dimGrid * dimBlock, dimBlock),
               [=](sycl::nd_item<3> item_ct1)
-                  [[intel::reqd_sub_group_size(32)]] {
+                  [[sycl::reqd_sub_group_size(32)]] {
                     reduceSinglePass<128, false>(
                         d_idata, d_odata, size, item_ct1,
                         dpct_local_acc_ct1
@@ -974,7 +974,7 @@ extern "C" void reduceSinglePass(int size, int threads, int blocks,
           cgh.parallel_for(
               sycl::nd_range<3>(dimGrid * dimBlock, dimBlock),
               [=](sycl::nd_item<3> item_ct1)
-                  [[intel::reqd_sub_group_size(32)]] {
+                  [[sycl::reqd_sub_group_size(32)]] {
                     reduceSinglePass<64, false>(
                         d_idata, d_odata, size, item_ct1,
                         dpct_local_acc_ct1
@@ -1001,7 +1001,7 @@ extern "C" void reduceSinglePass(int size, int threads, int blocks,
           cgh.parallel_for(
               sycl::nd_range<3>(dimGrid * dimBlock, dimBlock),
               [=](sycl::nd_item<3> item_ct1)
-                  [[intel::reqd_sub_group_size(32)]] {
+                  [[sycl::reqd_sub_group_size(32)]] {
                     reduceSinglePass<32, false>(
                         d_idata, d_odata, size, item_ct1,
                         dpct_local_acc_ct1
@@ -1028,7 +1028,7 @@ extern "C" void reduceSinglePass(int size, int threads, int blocks,
           cgh.parallel_for(
               sycl::nd_range<3>(dimGrid * dimBlock, dimBlock),
               [=](sycl::nd_item<3> item_ct1)
-                  [[intel::reqd_sub_group_size(32)]] {
+                  [[sycl::reqd_sub_group_size(32)]] {
                     reduceSinglePass<16, false>(
                         d_idata, d_odata, size, item_ct1,
                         dpct_local_acc_ct1
@@ -1055,7 +1055,7 @@ extern "C" void reduceSinglePass(int size, int threads, int blocks,
           cgh.parallel_for(
               sycl::nd_range<3>(dimGrid * dimBlock, dimBlock),
               [=](sycl::nd_item<3> item_ct1)
-                  [[intel::reqd_sub_group_size(32)]] {
+                  [[sycl::reqd_sub_group_size(32)]] {
                     reduceSinglePass<8, false>(
                         d_idata, d_odata, size, item_ct1,
                         dpct_local_acc_ct1
@@ -1082,7 +1082,7 @@ extern "C" void reduceSinglePass(int size, int threads, int blocks,
           cgh.parallel_for(
               sycl::nd_range<3>(dimGrid * dimBlock, dimBlock),
               [=](sycl::nd_item<3> item_ct1)
-                  [[intel::reqd_sub_group_size(32)]] {
+                  [[sycl::reqd_sub_group_size(32)]] {
                     reduceSinglePass<4, false>(
                         d_idata, d_odata, size, item_ct1,
                         dpct_local_acc_ct1
@@ -1109,7 +1109,7 @@ extern "C" void reduceSinglePass(int size, int threads, int blocks,
           cgh.parallel_for(
               sycl::nd_range<3>(dimGrid * dimBlock, dimBlock),
               [=](sycl::nd_item<3> item_ct1)
-                  [[intel::reqd_sub_group_size(32)]] {
+                  [[sycl::reqd_sub_group_size(32)]] {
                     reduceSinglePass<2, false>(
                         d_idata, d_odata, size, item_ct1,
                         dpct_local_acc_ct1
@@ -1136,7 +1136,7 @@ extern "C" void reduceSinglePass(int size, int threads, int blocks,
           cgh.parallel_for(
               sycl::nd_range<3>(dimGrid * dimBlock, dimBlock),
               [=](sycl::nd_item<3> item_ct1)
-                  [[intel::reqd_sub_group_size(32)]] {
+                  [[sycl::reqd_sub_group_size(32)]] {
                     reduceSinglePass<1, false>(
                         d_idata, d_odata, size, item_ct1,
                         dpct_local_acc_ct1


### PR DESCRIPTION
# Existing Sample Changes
## Description

This PR replaces deprecated (in 2025.1) aspect `intel::reqd_sub_group_size` with `sycl::reqd_sub_group_size` for below samples
- guided_inlinePtx_SYCLMigration
- guided_shflScan_SYCLMigration
- guided_threadFenceReduction_SYCLMigration

### Fixes Issue
```shell
warning: attribute 'intel::reqd_sub_group_size' is deprecated [-Wdeprecated-attributes]
note: did you mean to use 'sycl::reqd_sub_group_size' instead?
```

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [X] Command Line