### PR TITLE
[SYCL] Fix 5_GPU_optimized sample

### DIFF
--- a/DirectProgramming/C++SYCL/StructuredGrids/guided_iso3dfd_GPUOptimization/src/5_GPU_optimized.cpp
+++ b/DirectProgramming/C++SYCL/StructuredGrids/guided_iso3dfd_GPUOptimization/src/5_GPU_optimized.cpp
@@ -131,6 +131,10 @@ void iso3dfd(queue& q, float* next, float* prev, float* vel, float* coeff,
               next_acc[idx] = 2.0f * front[0] - next_acc[idx] +
                                   value * vel_acc[idx];
 
+              // Don't prepare data for the next iteration if this is the last one.
+              if (i == end_i - 1)
+                break;
+
               // Increase linear index, jump to the next cell in first dimension
               idx += n2n3;
 


### PR DESCRIPTION
# Existing Sample Changes
## Description

Currently there is an out-of-bound access in last iteration of the main loop in iso3dfd kernel (5_GPU_optimized sample):
https://github.com/oneapi-src/oneAPI-samples/blob/ffc4fce22f860dce969ea63f5ec89de6f8ffa36a/DirectProgramming/C%2B%2BSYCL/StructuredGrids/guided_iso3dfd_GPUOptimization/src/5_GPU_optimized.cpp#L146
`prev_acc` is accessed out-of-bounds in the last iteration.
To avoid this, don't prepare unnecessary data for the next iteration if the current iteration is the last one.


Fixes Issue# 
CMPLRLLVM-69572

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Verified on
Intel(R) Data Center GPU Max 1550
with gpu driver 25.05.32567.17
OS: Ubuntu 22.04

intel/llvm compiler: https://github.com/intel/llvm/commit/e8c85559239d6e13d0d70306d4adbc497100b049

Commands:
clang++ -fsycl 5_GPU_optimized.cpp -o 5_GPU_optimized
./5_GPU_optimized 256 256 256 100 256 16 16 verify

Hangs without the fix, passes verification with the fix.