### PR TITLE
Enable exceptions on Windows for oneMKL RNG samples

### DIFF
--- a/Libraries/oneMKL/binomial/makefile
+++ b/Libraries/oneMKL/binomial/makefile
@@ -4,7 +4,7 @@ all: binomial_sycl.exe
 	INIT_ON_HOST=/DINIT_ON_HOST=1
 !endif
 
-DPCPP_OPTS=-O3 /I"$(MKLROOT)\include" /DMKL_ILP64 /DVERBOSE=1 /DSMALL_OPT_N=0 /DREPORT_COLD=1 /DREPORT_WARM=1 $(INIT_ON_HOST) /EHsc -fsycl /Qmkl /Qmkl-sycl-impl=rng OpenCL.lib
+DPCPP_OPTS=-O3 /I"$(MKLROOT)\include" /DMKL_ILP64 /DVERBOSE=1 /DSMALL_OPT_N=0 /DREPORT_COLD=1 /DREPORT_WARM=1 $(INIT_ON_HOST) -fsycl /EHsc /Qmkl /Qmkl-sycl-impl=rng OpenCL.lib
 
 binomial_sycl.exe: src\binomial_sycl.cpp src\binomial_main.cpp src\binomial.hpp
 	icx $(DPCPP_OPTS) src\binomial_sycl.cpp src\binomial_main.cpp /obinomial_sycl.exe

--- a/Libraries/oneMKL/black_scholes/makefile
+++ b/Libraries/oneMKL/black_scholes/makefile
@@ -4,7 +4,7 @@ all: black_scholes_sycl.exe
         INIT_ON_HOST=/DINIT_ON_HOST=1
 !endif
 
-DPCPP_OPTS=-O3 /I"$(MKLROOT)\include" /DMKL_ILP64 /DVERBOSE=1 /DSMALL_OPT_N=0 $(INIT_ON_HOST) /EHsc -fsycl /Qmkl /Qmkl-sycl-impl=rng OpenCL.lib
+DPCPP_OPTS=-O3 /I"$(MKLROOT)\include" /DMKL_ILP64 /DVERBOSE=1 /DSMALL_OPT_N=0 $(INIT_ON_HOST) -fsycl /EHsc /Qmkl /Qmkl-sycl-impl=rng OpenCL.lib
 
 black_scholes_sycl.exe: src\black_scholes_sycl.cpp
 	icx $(DPCPP_OPTS) src\black_scholes_sycl.cpp /oblack_scholes_sycl.exe


### PR DESCRIPTION
# Existing Sample Changes
## Description

Enabled exceptions for RNG samples. This might be relevant depending on default compiler behavior. Also removed duplicate options.

## External Dependencies

None

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Command Line
- [ ] oneapi-cli
- [ ] Visual Studio
- [ ] Eclipse IDE
- [ ] VSCode
- [ ] When compiling the compliler flag "-Wall -Wformat-security -Werror=format-security" was used
