### PR TITLE
Add nnz argument to set_csr_data in sparse CG examples

### DIFF
--- a/Libraries/oneMKL/sparse_conjugate_gradient/sparse_cg.cpp
+++ b/Libraries/oneMKL/sparse_conjugate_gradient/sparse_cg.cpp
@@ -380,7 +380,7 @@ int run_sparse_pcg_example(const sycl::device &dev)
         // setup optimizations and properties we know about A matrix
         oneapi::mkl::sparse::init_matrix_handle(&A);
 
-        auto ev_set = oneapi::mkl::sparse::set_csr_data(q, A, n, n,
+        auto ev_set = oneapi::mkl::sparse::set_csr_data(q, A, n, n, nnz,
                 oneapi::mkl::index_base::zero, ia_d, ja_d, a_d, {});
 
         oneapi::mkl::sparse::set_matrix_property(A, oneapi::mkl::sparse::property::symmetric);

--- a/Libraries/oneMKL/sparse_conjugate_gradient/sparse_cg2.cpp
+++ b/Libraries/oneMKL/sparse_conjugate_gradient/sparse_cg2.cpp
@@ -453,7 +453,7 @@ int run_sparse_pcg_example(const sycl::device &dev)
         // setup optimizations and properties we know about A matrix
         oneapi::mkl::sparse::init_matrix_handle(&A);
 
-        auto ev_set = oneapi::mkl::sparse::set_csr_data(q, A, n, n,
+        auto ev_set = oneapi::mkl::sparse::set_csr_data(q, A, n, n, nnz,
                 oneapi::mkl::index_base::zero, ia_d, ja_d, a_d, {});
 
         oneapi::mkl::sparse::set_matrix_property(A, oneapi::mkl::sparse::property::symmetric);


### PR DESCRIPTION
# Change in sparse_cg sample examples required for the 2025.3 tag
## Description

Add `nnz` (number of non-zero elements in the sparse matrix) to the `set_csr_data` call, to be aligned with the API's updated signature in the oneMKL 2025.3 release, and to prevent build warnings when using the deprecated API without `nnz`.

## Type of change

- [x] Build warnings fix. Not a bug per se since the call to the deprecated `set_csr_data` API still works, but there should be no warnings when building the example.

## How Has This Been Tested?

I used `make` to build and run the example on a PVC Linux system, using a oneMKL 2025.3 Release Candidate build.
Note that:
- running the example **without** the current fix against oneMKL **2025.3** will work but there will be warnings:
```sparse_cg.cpp:383:44: warning: 'set_csr_data' is deprecated: Use oneapi::mkl::sparse::set_csr_data(queue, spmat, nrows, ncols, nnz, ...) instead.```.
- running the example **with** the current fix against oneMKL **2025.2** (or previous releases) will cause a build failure.

- [x] Command Line
- [ ] oneapi-cli
- [ ] Visual Studio
- [ ] Eclipse IDE
- [ ] VSCode

Building:
```
icpx sparse_cg.cpp -fsycl -o sparse_cg -DMKL_ILP64  -qmkl -qmkl-sycl-impl="blas,sparse" -fsycl-device-code-split=per_kernel
icpx sparse_cg2.cpp -fsycl -o sparse_cg2 -DMKL_ILP64  -qmkl -qmkl-sycl-impl="blas,sparse" -fsycl-device-code-split=per_kernel
```

Running:
```
./sparse_cg
########################################################################
# Sparse Preconditioned Conjugate Gradient Solver with USM
#
# Uses the preconditioned conjugate gradient algorithm to
# iteratively solve the symmetric linear system
#
#     A * x = b
#
# where A is a symmetric sparse matrix in CSR format, and
#       x and b are dense vectors.
#
# Uses the symmetric Gauss-Seidel preconditioner.
#
# alpha and beta constants in PCG algorithm are host side.
#
########################################################################

Running tests on Intel(R) Data Center GPU Max 1550.
        Running with single precision real data type:

                sparse PCG parameters:
                        A size: (4096, 4096)
                        Preconditioner = Symmetric Gauss-Seidel
                        max iterations = 500
                        relative tolerance limit = 1e-05
                        absolute tolerance limit = 0.0005
                                relative norm of residual on    1 iteration: 0.178532
                                relative norm of residual on    2 iteration: 0.0280123
                                relative norm of residual on    3 iteration: 0.0048948
                                relative norm of residual on    4 iteration: 0.000796108
                                relative norm of residual on    5 iteration: 0.000119025
                                relative norm of residual on    6 iteration: 1.86945e-05
                                absolute norm of residual on    6 iteration: 0.000149556

                Preconditioned CG process has successfully converged in absolute error in    6 steps with
                 relative error ||r||_2 / ||r_0||_2 = 1.86945e-05 > 1e-05
                 absolute error ||r||_2             = 0.000149556 < 0.0005

        Running with double precision real data type:

                sparse PCG parameters:
                        A size: (4096, 4096)
                        Preconditioner = Symmetric Gauss-Seidel
                        max iterations = 500
                        relative tolerance limit = 1e-05
                        absolute tolerance limit = 0.0005
                                relative norm of residual on    1 iteration: 0.178532
                                relative norm of residual on    2 iteration: 0.0280123
                                relative norm of residual on    3 iteration: 0.0048948
                                relative norm of residual on    4 iteration: 0.000796108
                                relative norm of residual on    5 iteration: 0.000119025
                                relative norm of residual on    6 iteration: 1.86945e-05
                                absolute norm of residual on    6 iteration: 0.000149556

                Preconditioned CG process has successfully converged in absolute error in    6 steps with
                 relative error ||r||_2 / ||r_0||_2 = 1.86945e-05 > 1e-05
                 absolute error ||r||_2             = 0.000149556 < 0.0005
./sparse_cg2
########################################################################
# Sparse Preconditioned Conjugate Gradient Solver with USM 2
#
# Uses the preconditioned conjugate gradient algorithm to
# iteratively solve the symmetric linear system
#
#     A * x = b
#
# where A is a symmetric sparse matrix in CSR format, and
#       x and b are dense vectors.
#
# Uses the symmetric Gauss-Seidel preconditioner.
#
# alpha and beta constants in PCG algorithm are kept
# device side.
#
########################################################################

Running tests on Intel(R) Data Center GPU Max 1550.
        Running with single precision real data type:

                sparse PCG parameters:
                        A size: (4096, 4096)
                        Preconditioner = Symmetric Gauss-Seidel
                        max iterations = 500
                        relative tolerance limit = 1e-05
                        absolute tolerance limit = 0.0005
                                relative norm of residual on    1 iteration: 0.178532
                                relative norm of residual on    2 iteration: 0.0280123
                                relative norm of residual on    3 iteration: 0.0048948
                                relative norm of residual on    4 iteration: 0.000796109
                                relative norm of residual on    5 iteration: 0.000119025
                                relative norm of residual on    6 iteration: 1.86945e-05
                                absolute norm of residual on    6 iteration: 0.000149556

                Preconditioned CG process has successfully converged in absolute error in    6 steps with
                 relative error ||r||_2 / ||r_0||_2 = 1.86945e-05 > 1e-05
                 absolute error ||r||_2             = 0.000149556 < 0.0005

        Running with double precision real data type:

                sparse PCG parameters:
                        A size: (4096, 4096)
                        Preconditioner = Symmetric Gauss-Seidel
                        max iterations = 500
                        relative tolerance limit = 1e-05
                        absolute tolerance limit = 0.0005
                                relative norm of residual on    1 iteration: 0.178532
                                relative norm of residual on    2 iteration: 0.0280123
                                relative norm of residual on    3 iteration: 0.0048948
                                relative norm of residual on    4 iteration: 0.000796108
                                relative norm of residual on    5 iteration: 0.000119025
                                relative norm of residual on    6 iteration: 1.86945e-05
                                absolute norm of residual on    6 iteration: 0.000149556

                Preconditioned CG process has successfully converged in absolute error in    6 steps with
                 relative error ||r||_2 / ||r_0||_2 = 1.86945e-05 > 1e-05
                 absolute error ||r||_2             = 0.000149556 < 0.0005
```